### PR TITLE
Support bundled dependencies in resolver plugin

### DIFF
--- a/common/changes/@microsoft/rush/bundled-dependencies_2024-08-24-01-03.json
+++ b/common/changes/@microsoft/rush/bundled-dependencies_2024-08-24-01-03.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Support \"bundledDependencies\" in rush-resolver-cache-plugin.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/bundled-dependencies_2024-08-24-01-03.json
+++ b/common/changes/@microsoft/rush/bundled-dependencies_2024-08-24-01-03.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Support \"bundledDependencies\" in rush-resolver-cache-plugin.",
+      "comment": "Support `bundledDependencies` in rush-resolver-cache-plugin.",
       "type": "none"
     }
   ],

--- a/common/changes/@rushstack/lookup-by-path/bundled-dependencies_2024-08-26-18-08.json
+++ b/common/changes/@rushstack/lookup-by-path/bundled-dependencies_2024-08-26-18-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/lookup-by-path",
+      "comment": "Return a linked list of matches in `findLongestPrefixMatch` in the event that multiple prefixes match. The head of the list is the most specific match.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/lookup-by-path"
+}

--- a/common/changes/@rushstack/webpack-workspace-resolve-plugin/bundled-dependencies_2024-08-24-01-03.json
+++ b/common/changes/@rushstack/webpack-workspace-resolve-plugin/bundled-dependencies_2024-08-24-01-03.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/webpack-workspace-resolve-plugin",
+      "comment": "Support hierarchical node_modules.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/webpack-workspace-resolve-plugin"
+}

--- a/common/changes/@rushstack/webpack-workspace-resolve-plugin/bundled-dependencies_2024-08-24-01-03.json
+++ b/common/changes/@rushstack/webpack-workspace-resolve-plugin/bundled-dependencies_2024-08-24-01-03.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@rushstack/webpack-workspace-resolve-plugin",
-      "comment": "Support hierarchical node_modules.",
+      "comment": "Support hierarchical `node_modules` folders.",
       "type": "minor"
     }
   ],

--- a/common/reviews/api/lookup-by-path.api.md
+++ b/common/reviews/api/lookup-by-path.api.md
@@ -7,6 +7,7 @@
 // @beta
 export interface IPrefixMatch<TItem> {
     index: number;
+    lastMatch?: IPrefixMatch<TItem>;
     value: TItem;
 }
 

--- a/common/reviews/api/webpack-workspace-resolve-plugin.api.md
+++ b/common/reviews/api/webpack-workspace-resolve-plugin.api.md
@@ -25,7 +25,7 @@ export interface IResolverCacheFile {
 
 // @beta
 export interface ISerializedResolveContext {
-    deps: Record<string, number>;
+    deps?: Record<string, number>;
     dirInfoFiles?: string[];
     name: string;
     root: string;
@@ -46,7 +46,7 @@ export interface IWorkspaceResolvePluginOptions {
 // @beta
 export class WorkspaceLayoutCache {
     constructor(options: IWorkspaceLayoutCacheOptions);
-    readonly contextForPackage: WeakMap<object, IResolveContext>;
+    readonly contextForPackage: WeakMap<object, IPrefixMatch<IResolveContext>>;
     readonly contextLookup: LookupByPath<IResolveContext>;
     // (undocumented)
     readonly normalizeToPlatform: IPathNormalizationFunction;

--- a/libraries/lookup-by-path/src/LookupByPath.test.ts
+++ b/libraries/lookup-by-path/src/LookupByPath.test.ts
@@ -133,7 +133,11 @@ describe(LookupByPath.prototype.findLongestPrefixMatch.name, () => {
       ['foo/bar', 4]
     ]);
 
-    expect(tree.findLongestPrefixMatch('foo/bar')).toEqual({ value: 4, index: 7 });
+    expect(tree.findLongestPrefixMatch('foo/bar')).toEqual({
+      value: 4,
+      index: 7,
+      lastMatch: { value: 1, index: 3 }
+    });
     expect(tree.findLongestPrefixMatch('barbar/baz')).toEqual({ value: 2, index: 6 });
     expect(tree.findLongestPrefixMatch('baz/foo')).toEqual({ value: 3, index: 3 });
     expect(tree.findLongestPrefixMatch('foo/foo')).toEqual({ value: 1, index: 3 });

--- a/libraries/lookup-by-path/src/LookupByPath.ts
+++ b/libraries/lookup-by-path/src/LookupByPath.ts
@@ -40,6 +40,10 @@ export interface IPrefixMatch<TItem> {
    * The index of the first character after the matched prefix
    */
   index: number;
+  /**
+   * The last match found (with a shorter prefix), if any
+   */
+  lastMatch?: IPrefixMatch<TItem>;
 }
 
 /**
@@ -255,7 +259,8 @@ export class LookupByPath<TItem> {
     let best: IPrefixMatch<TItem> | undefined = node.value
       ? {
           value: node.value,
-          index: 0
+          index: 0,
+          lastMatch: undefined
         }
       : undefined;
     // Trivial cases
@@ -269,7 +274,8 @@ export class LookupByPath<TItem> {
         if (node.value !== undefined) {
           best = {
             value: node.value,
-            index
+            index,
+            lastMatch: best
           };
         }
         if (!node.children) {

--- a/libraries/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
+++ b/libraries/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
@@ -59,6 +59,8 @@ export interface IPnpmShrinkwrapDependencyYaml {
     /** The name of the tarball, if this was from a TGZ file */
     tarball?: string;
   };
+  /** The list of bundled dependencies in this package */
+  bundledDependencies?: ReadonlyArray<string>;
   /** The list of dependencies and the resolved version */
   dependencies?: Record<string, IPnpmVersionSpecifier>;
   /** The list of optional dependencies and the resolved version */

--- a/rush-plugins/rush-resolver-cache-plugin/src/afterInstallAsync.ts
+++ b/rush-plugins/rush-resolver-cache-plugin/src/afterInstallAsync.ts
@@ -117,7 +117,7 @@ export async function afterInstallAsync(
 
         const filteredFiles: string[] = Object.keys(files).filter((file) => file.endsWith('/package.json'));
         if (filteredFiles.length > 0) {
-          const nestedPackageDirs: string[] = filteredFiles.map((x) => x.slice(0, -13));
+          const nestedPackageDirs: string[] = filteredFiles.map((x) => x.slice(0, /* -'/package.json'.length */ -13));
 
           if (nestedPackageDirs.length > 0) {
             // eslint-disable-next-line require-atomic-updates

--- a/rush-plugins/rush-resolver-cache-plugin/src/afterInstallAsync.ts
+++ b/rush-plugins/rush-resolver-cache-plugin/src/afterInstallAsync.ts
@@ -117,8 +117,12 @@ export async function afterInstallAsync(
 
         const filteredFiles: string[] = Object.keys(files).filter((file) => file.endsWith('/package.json'));
         if (filteredFiles.length > 0) {
-          // eslint-disable-next-line require-atomic-updates
-          context.files = filteredFiles.map((x) => x.slice(0, -13));
+          const nestedPackageDirs: string[] = filteredFiles.map((x) => x.slice(0, -13));
+
+          if (nestedPackageDirs.length > 0) {
+            // eslint-disable-next-line require-atomic-updates
+            context.nestedPackageDirs = nestedPackageDirs;
+          }
         }
       } catch (error) {
         if (!context.optional) {

--- a/rush-plugins/rush-resolver-cache-plugin/src/computeResolverCacheFromLockfileAsync.ts
+++ b/rush-plugins/rush-resolver-cache-plugin/src/computeResolverCacheFromLockfileAsync.ts
@@ -45,6 +45,59 @@ function isPackageCompatible(
   return true;
 }
 
+function extractBundledDependencies(
+  contexts: Map<string, IResolverContext>,
+  context: IResolverContext
+): void {
+  const { nestedPackageDirs } = context;
+  if (!nestedPackageDirs) {
+    return;
+  }
+
+  for (let i: number = nestedPackageDirs.length - 1; i >= 0; i--) {
+    const nestedDir: string = nestedPackageDirs[i];
+    if (!nestedDir.startsWith('node_modules/')) {
+      continue;
+    }
+
+    const isScoped: boolean = nestedDir.charAt(13) === '@';
+    let index: number = nestedDir.indexOf('/', 13);
+    if (isScoped) {
+      index = nestedDir.indexOf('/', index + 1);
+    }
+
+    const name: string = index === -1 ? nestedDir.slice(13) : nestedDir.slice(13, index);
+    if (name.startsWith('.')) {
+      continue;
+    }
+
+    // Remove this nested package from the list
+    nestedPackageDirs.splice(i, 1);
+
+    const remainder: string = index === -1 ? '' : nestedDir.slice(index + 1);
+    const nestedRoot: string = `${context.descriptionFileRoot}/node_modules/${name}`;
+    let nestedContext: IResolverContext | undefined = contexts.get(nestedRoot);
+    if (!nestedContext) {
+      nestedContext = {
+        descriptionFileRoot: nestedRoot,
+        descriptionFileHash: undefined,
+        isProject: false,
+        name,
+        deps: new Map(),
+        ordinal: -1
+      };
+      contexts.set(nestedRoot, nestedContext);
+    }
+
+    context.deps.set(name, nestedRoot);
+
+    if (remainder) {
+      nestedContext.nestedPackageDirs ??= [];
+      nestedContext.nestedPackageDirs.push(remainder);
+    }
+  }
+}
+
 /**
  * Options for computing the resolver cache from a lockfile.
  */
@@ -130,7 +183,7 @@ export async function computeResolverCacheFromLockfileAsync(
       isProject: false,
       name,
       deps: new Map(),
-      ordinal: contexts.size,
+      ordinal: -1,
       optional: pack.optional
     };
 
@@ -146,6 +199,12 @@ export async function computeResolverCacheFromLockfileAsync(
 
   if (afterExternalPackagesAsync) {
     await afterExternalPackagesAsync(contexts, missingOptionalDependencies);
+  }
+
+  for (const context of contexts.values()) {
+    if (context.nestedPackageDirs) {
+      extractBundledDependencies(contexts, context);
+    }
   }
 
   // Add the data for workspace projects
@@ -167,7 +226,7 @@ export async function computeResolverCacheFromLockfileAsync(
       name: project.packageJson.name,
       isProject: true,
       deps: new Map(),
-      ordinal: contexts.size
+      ordinal: -1
     };
 
     contexts.set(project.projectFolder, context);
@@ -181,6 +240,11 @@ export async function computeResolverCacheFromLockfileAsync(
     if (importer.optionalDependencies) {
       resolveDependencies(workspaceRoot, importer.optionalDependencies, context);
     }
+  }
+
+  let ordinal: number = 0;
+  for (const context of contexts.values()) {
+    context.ordinal = ordinal++;
   }
 
   // Convert the intermediate representation to the final cache file

--- a/rush-plugins/rush-resolver-cache-plugin/src/computeResolverCacheFromLockfileAsync.ts
+++ b/rush-plugins/rush-resolver-cache-plugin/src/computeResolverCacheFromLockfileAsync.ts
@@ -60,7 +60,7 @@ function extractBundledDependencies(
       continue;
     }
 
-    const isScoped: boolean = nestedDir.charAt(13) === '@';
+    const isScoped: boolean = nestedDir.charAt(/* 'node_modules/'.length */ 13) === '@';
     let index: number = nestedDir.indexOf('/', 13);
     if (isScoped) {
       index = nestedDir.indexOf('/', index + 1);

--- a/rush-plugins/rush-resolver-cache-plugin/src/helpers.ts
+++ b/rush-plugins/rush-resolver-cache-plugin/src/helpers.ts
@@ -145,8 +145,11 @@ export function createContextSerializer(
   commonPathPrefix: string
 ): (entry: [string, IResolverContext]) => ISerializedResolveContext {
   return ([descriptionFileRoot, context]: [string, IResolverContext]): ISerializedResolveContext => {
-    const deps: ISerializedResolveContext['deps'] = {};
-    for (const [key, contextRoot] of context.deps) {
+    const { deps } = context;
+
+    let hasAnyDeps: boolean = false;
+    const serializedDeps: ISerializedResolveContext['deps'] = {};
+    for (const [key, contextRoot] of deps) {
       if (missingOptionalDependencies.has(contextRoot)) {
         continue;
       }
@@ -155,7 +158,8 @@ export function createContextSerializer(
       if (!resolutionContext) {
         throw new Error(`Missing context for ${contextRoot}!`);
       }
-      deps[key] = resolutionContext.ordinal;
+      serializedDeps[key] = resolutionContext.ordinal;
+      hasAnyDeps = true;
     }
 
     if (!context.name) {
@@ -165,8 +169,8 @@ export function createContextSerializer(
     const serializedContext: ISerializedResolveContext = {
       name: context.name,
       root: descriptionFileRoot.slice(commonPathPrefix.length),
-      dirInfoFiles: context.files,
-      deps
+      dirInfoFiles: context.nestedPackageDirs?.length ? context.nestedPackageDirs : undefined,
+      deps: hasAnyDeps ? serializedDeps : undefined
     };
 
     return serializedContext;

--- a/rush-plugins/rush-resolver-cache-plugin/src/test/__snapshots__/computeResolverCacheFromLockfileAsync.test.ts.snap
+++ b/rush-plugins/rush-resolver-cache-plugin/src/test/__snapshots__/computeResolverCacheFromLockfileAsync.test.ts.snap
@@ -20,7 +20,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/@babel+code-frame@7.24.2/node_modules/@babel/code-frame",
     },
     Object {
-      "deps": Object {},
       "name": "@babel/compat-data",
       "root": "/common/temp/build-tests/node_modules/.pnpm/@babel+compat-data@7.24.4/node_modules/@babel/compat-data",
     },
@@ -67,7 +66,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/@babel+helper-compilation-targets@7.23.6/node_modules/@babel/helper-compilation-targets",
     },
     Object {
-      "deps": Object {},
       "name": "@babel/helper-environment-visitor",
       "root": "/common/temp/build-tests/node_modules/.pnpm/@babel+helper-environment-visitor@7.22.20/node_modules/@babel/helper-environment-visitor",
     },
@@ -106,7 +104,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/@babel+helper-module-transforms@7.24.5_@babel+core@7.24.5/node_modules/@babel/helper-module-transforms",
     },
     Object {
-      "deps": Object {},
       "name": "@babel/helper-plugin-utils",
       "root": "/common/temp/build-tests/node_modules/.pnpm/@babel+helper-plugin-utils@7.24.5/node_modules/@babel/helper-plugin-utils",
     },
@@ -125,17 +122,14 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/@babel+helper-split-export-declaration@7.24.5/node_modules/@babel/helper-split-export-declaration",
     },
     Object {
-      "deps": Object {},
       "name": "@babel/helper-string-parser",
       "root": "/common/temp/build-tests/node_modules/.pnpm/@babel+helper-string-parser@7.24.1/node_modules/@babel/helper-string-parser",
     },
     Object {
-      "deps": Object {},
       "name": "@babel/helper-validator-identifier",
       "root": "/common/temp/build-tests/node_modules/.pnpm/@babel+helper-validator-identifier@7.24.5/node_modules/@babel/helper-validator-identifier",
     },
     Object {
-      "deps": Object {},
       "name": "@babel/helper-validator-option",
       "root": "/common/temp/build-tests/node_modules/.pnpm/@babel+helper-validator-option@7.23.5/node_modules/@babel/helper-validator-option",
     },
@@ -159,7 +153,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/@babel+highlight@7.24.5/node_modules/@babel/highlight",
     },
     Object {
-      "deps": Object {},
       "name": "@babel/parser",
       "root": "/common/temp/build-tests/node_modules/.pnpm/@babel+parser@7.24.5/node_modules/@babel/parser",
     },
@@ -310,7 +303,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/@babel+types@7.24.5/node_modules/@babel/types",
     },
     Object {
-      "deps": Object {},
       "name": "@bcoe/v8-coverage",
       "root": "/common/temp/build-tests/node_modules/.pnpm/@bcoe+v8-coverage@0.2.3/node_modules/@bcoe/v8-coverage",
     },
@@ -339,7 +331,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/@eslint-community+eslint-utils@4.4.0_eslint@8.57.0/node_modules/@eslint-community/eslint-utils",
     },
     Object {
-      "deps": Object {},
       "name": "@eslint-community/regexpp",
       "root": "/common/temp/build-tests/node_modules/.pnpm/@eslint-community+regexpp@4.10.0/node_modules/@eslint-community/regexpp",
     },
@@ -359,7 +350,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/@eslint+eslintrc@2.1.4/node_modules/@eslint/eslintrc",
     },
     Object {
-      "deps": Object {},
       "name": "@eslint/js",
       "root": "/common/temp/build-tests/node_modules/.pnpm/@eslint+js@8.57.0/node_modules/@eslint/js",
     },
@@ -373,12 +363,10 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/@humanwhocodes+config-array@0.11.14/node_modules/@humanwhocodes/config-array",
     },
     Object {
-      "deps": Object {},
       "name": "@humanwhocodes/module-importer",
       "root": "/common/temp/build-tests/node_modules/.pnpm/@humanwhocodes+module-importer@1.0.1/node_modules/@humanwhocodes/module-importer",
     },
     Object {
-      "deps": Object {},
       "name": "@humanwhocodes/object-schema",
       "root": "/common/temp/build-tests/node_modules/.pnpm/@humanwhocodes+object-schema@2.0.3/node_modules/@humanwhocodes/object-schema",
     },
@@ -394,7 +382,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/@istanbuljs+load-nyc-config@1.1.0/node_modules/@istanbuljs/load-nyc-config",
     },
     Object {
-      "deps": Object {},
       "name": "@istanbuljs/schema",
       "root": "/common/temp/build-tests/node_modules/.pnpm/@istanbuljs+schema@0.1.3/node_modules/@istanbuljs/schema",
     },
@@ -624,17 +611,14 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/@jridgewell+gen-mapping@0.3.5/node_modules/@jridgewell/gen-mapping",
     },
     Object {
-      "deps": Object {},
       "name": "@jridgewell/resolve-uri",
       "root": "/common/temp/build-tests/node_modules/.pnpm/@jridgewell+resolve-uri@3.1.2/node_modules/@jridgewell/resolve-uri",
     },
     Object {
-      "deps": Object {},
       "name": "@jridgewell/set-array",
       "root": "/common/temp/build-tests/node_modules/.pnpm/@jridgewell+set-array@1.2.1/node_modules/@jridgewell/set-array",
     },
     Object {
-      "deps": Object {},
       "name": "@jridgewell/sourcemap-codec",
       "root": "/common/temp/build-tests/node_modules/.pnpm/@jridgewell+sourcemap-codec@1.4.15/node_modules/@jridgewell/sourcemap-codec",
     },
@@ -657,7 +641,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/@microsoft+tsdoc-config@0.17.0/node_modules/@microsoft/tsdoc-config",
     },
     Object {
-      "deps": Object {},
       "name": "@microsoft/tsdoc",
       "root": "/common/temp/build-tests/node_modules/.pnpm/@microsoft+tsdoc@0.15.0/node_modules/@microsoft/tsdoc",
     },
@@ -670,7 +653,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/@nodelib+fs.scandir@2.1.5/node_modules/@nodelib/fs.scandir",
     },
     Object {
-      "deps": Object {},
       "name": "@nodelib/fs.stat",
       "root": "/common/temp/build-tests/node_modules/.pnpm/@nodelib+fs.stat@2.0.5/node_modules/@nodelib/fs.stat",
     },
@@ -707,7 +689,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/@pnpm+dependency-path@2.1.8/node_modules/@pnpm/dependency-path",
     },
     Object {
-      "deps": Object {},
       "name": "@pnpm/error",
       "root": "/common/temp/build-tests/node_modules/.pnpm/@pnpm+error@1.4.0/node_modules/@pnpm/error",
     },
@@ -775,17 +756,14 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/@pnpm+read-project-manifest@1.1.7/node_modules/@pnpm/read-project-manifest",
     },
     Object {
-      "deps": Object {},
       "name": "@pnpm/types",
       "root": "/common/temp/build-tests/node_modules/.pnpm/@pnpm+types@6.4.0/node_modules/@pnpm/types",
     },
     Object {
-      "deps": Object {},
       "name": "@pnpm/types",
       "root": "/common/temp/build-tests/node_modules/.pnpm/@pnpm+types@8.9.0/node_modules/@pnpm/types",
     },
     Object {
-      "deps": Object {},
       "name": "@pnpm/types",
       "root": "/common/temp/build-tests/node_modules/.pnpm/@pnpm+types@9.4.2/node_modules/@pnpm/types",
     },
@@ -801,12 +779,10 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/@pnpm+write-project-manifest@1.1.7/node_modules/@pnpm/write-project-manifest",
     },
     Object {
-      "deps": Object {},
       "name": "@sinclair/typebox",
       "root": "/common/temp/build-tests/node_modules/.pnpm/@sinclair+typebox@0.27.8/node_modules/@sinclair/typebox",
     },
     Object {
-      "deps": Object {},
       "name": "@sindresorhus/is",
       "root": "/common/temp/build-tests/node_modules/.pnpm/@sindresorhus+is@4.6.0/node_modules/@sindresorhus/is",
     },
@@ -832,7 +808,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/@szmarczak+http-timer@4.0.6/node_modules/@szmarczak/http-timer",
     },
     Object {
-      "deps": Object {},
       "name": "@types/argparse",
       "root": "/common/temp/build-tests/node_modules/.pnpm/@types+argparse@1.0.38/node_modules/@types/argparse",
     },
@@ -894,17 +869,14 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/@types+heft-jest@1.0.1/node_modules/@types/heft-jest",
     },
     Object {
-      "deps": Object {},
       "name": "@types/http-cache-semantics",
       "root": "/common/temp/build-tests/node_modules/.pnpm/@types+http-cache-semantics@4.0.4/node_modules/@types/http-cache-semantics",
     },
     Object {
-      "deps": Object {},
       "name": "@types/istanbul-lib-coverage",
       "root": "/common/temp/build-tests/node_modules/.pnpm/@types+istanbul-lib-coverage@2.0.4/node_modules/@types/istanbul-lib-coverage",
     },
     Object {
-      "deps": Object {},
       "name": "@types/istanbul-lib-coverage",
       "root": "/common/temp/build-tests/node_modules/.pnpm/@types+istanbul-lib-coverage@2.0.6/node_modules/@types/istanbul-lib-coverage",
     },
@@ -931,12 +903,10 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/@types+jest@29.5.12/node_modules/@types/jest",
     },
     Object {
-      "deps": Object {},
       "name": "@types/json-schema",
       "root": "/common/temp/build-tests/node_modules/.pnpm/@types+json-schema@7.0.15/node_modules/@types/json-schema",
     },
     Object {
-      "deps": Object {},
       "name": "@types/json5",
       "root": "/common/temp/build-tests/node_modules/.pnpm/@types+json5@0.0.29/node_modules/@types/json5",
     },
@@ -948,17 +918,14 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/@types+keyv@3.1.4/node_modules/@types/keyv",
     },
     Object {
-      "deps": Object {},
       "name": "@types/lodash",
       "root": "/common/temp/build-tests/node_modules/.pnpm/@types+lodash@4.17.1/node_modules/@types/lodash",
     },
     Object {
-      "deps": Object {},
       "name": "@types/minimatch",
       "root": "/common/temp/build-tests/node_modules/.pnpm/@types+minimatch@3.0.5/node_modules/@types/minimatch",
     },
     Object {
-      "deps": Object {},
       "name": "@types/minimist",
       "root": "/common/temp/build-tests/node_modules/.pnpm/@types+minimist@1.2.5/node_modules/@types/minimist",
     },
@@ -971,22 +938,18 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/@types+node-fetch@2.6.2/node_modules/@types/node-fetch",
     },
     Object {
-      "deps": Object {},
       "name": "@types/node",
       "root": "/common/temp/build-tests/node_modules/.pnpm/@types+node@18.17.15/node_modules/@types/node",
     },
     Object {
-      "deps": Object {},
       "name": "@types/normalize-package-data",
       "root": "/common/temp/build-tests/node_modules/.pnpm/@types+normalize-package-data@2.4.4/node_modules/@types/normalize-package-data",
     },
     Object {
-      "deps": Object {},
       "name": "@types/parse-json",
       "root": "/common/temp/build-tests/node_modules/.pnpm/@types+parse-json@4.0.2/node_modules/@types/parse-json",
     },
     Object {
-      "deps": Object {},
       "name": "@types/prettier",
       "root": "/common/temp/build-tests/node_modules/.pnpm/@types+prettier@2.7.3/node_modules/@types/prettier",
     },
@@ -998,22 +961,18 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/@types+responselike@1.0.3/node_modules/@types/responselike",
     },
     Object {
-      "deps": Object {},
       "name": "@types/semver",
       "root": "/common/temp/build-tests/node_modules/.pnpm/@types+semver@7.5.8/node_modules/@types/semver",
     },
     Object {
-      "deps": Object {},
       "name": "@types/stack-utils",
       "root": "/common/temp/build-tests/node_modules/.pnpm/@types+stack-utils@2.0.3/node_modules/@types/stack-utils",
     },
     Object {
-      "deps": Object {},
       "name": "@types/tapable",
       "root": "/common/temp/build-tests/node_modules/.pnpm/@types+tapable@1.0.6/node_modules/@types/tapable",
     },
     Object {
-      "deps": Object {},
       "name": "@types/yargs-parser",
       "root": "/common/temp/build-tests/node_modules/.pnpm/@types+yargs-parser@21.0.3/node_modules/@types/yargs-parser",
     },
@@ -1259,7 +1218,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/@typescript-eslint+visitor-keys@8.1.0_typescript@5.4.5/node_modules/@typescript-eslint/visitor-keys",
     },
     Object {
-      "deps": Object {},
       "name": "@ungap/structured-clone",
       "root": "/common/temp/build-tests/node_modules/.pnpm/@ungap+structured-clone@1.2.0/node_modules/@ungap/structured-clone",
     },
@@ -1306,12 +1264,10 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/@vue+compiler-ssr@3.4.27/node_modules/@vue/compiler-ssr",
     },
     Object {
-      "deps": Object {},
       "name": "@vue/shared",
       "root": "/common/temp/build-tests/node_modules/.pnpm/@vue+shared@3.4.27/node_modules/@vue/shared",
     },
     Object {
-      "deps": Object {},
       "name": "@yarnpkg/lockfile",
       "root": "/common/temp/build-tests/node_modules/.pnpm/@yarnpkg+lockfile@1.0.2/node_modules/@yarnpkg/lockfile",
     },
@@ -1332,7 +1288,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/acorn-jsx@5.3.2_acorn@8.11.3/node_modules/acorn-jsx",
     },
     Object {
-      "deps": Object {},
       "name": "acorn",
       "root": "/common/temp/build-tests/node_modules/.pnpm/acorn@8.11.3/node_modules/acorn",
     },
@@ -1402,12 +1357,10 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/ansi-escapes@4.3.2/node_modules/ansi-escapes",
     },
     Object {
-      "deps": Object {},
       "name": "ansi-regex",
       "root": "/common/temp/build-tests/node_modules/.pnpm/ansi-regex@4.1.1/node_modules/ansi-regex",
     },
     Object {
-      "deps": Object {},
       "name": "ansi-regex",
       "root": "/common/temp/build-tests/node_modules/.pnpm/ansi-regex@5.0.1/node_modules/ansi-regex",
     },
@@ -1426,12 +1379,10 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/ansi-styles@4.3.0/node_modules/ansi-styles",
     },
     Object {
-      "deps": Object {},
       "name": "ansi-styles",
       "root": "/common/temp/build-tests/node_modules/.pnpm/ansi-styles@5.2.0/node_modules/ansi-styles",
     },
     Object {
-      "deps": Object {},
       "name": "any-promise",
       "root": "/common/temp/build-tests/node_modules/.pnpm/any-promise@1.3.0/node_modules/any-promise",
     },
@@ -1451,7 +1402,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/argparse@1.0.10/node_modules/argparse",
     },
     Object {
-      "deps": Object {},
       "name": "argparse",
       "root": "/common/temp/build-tests/node_modules/.pnpm/argparse@2.0.1/node_modules/argparse",
     },
@@ -1464,7 +1414,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/array-buffer-byte-length@1.0.1/node_modules/array-buffer-byte-length",
     },
     Object {
-      "deps": Object {},
       "name": "array-differ",
       "root": "/common/temp/build-tests/node_modules/.pnpm/array-differ@3.0.0/node_modules/array-differ",
     },
@@ -1481,7 +1430,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/array-includes@3.1.8/node_modules/array-includes",
     },
     Object {
-      "deps": Object {},
       "name": "array-union",
       "root": "/common/temp/build-tests/node_modules/.pnpm/array-union@2.1.0/node_modules/array-union",
     },
@@ -1531,22 +1479,18 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/arraybuffer.prototype.slice@1.0.3/node_modules/arraybuffer.prototype.slice",
     },
     Object {
-      "deps": Object {},
       "name": "arrify",
       "root": "/common/temp/build-tests/node_modules/.pnpm/arrify@1.0.1/node_modules/arrify",
     },
     Object {
-      "deps": Object {},
       "name": "arrify",
       "root": "/common/temp/build-tests/node_modules/.pnpm/arrify@2.0.1/node_modules/arrify",
     },
     Object {
-      "deps": Object {},
       "name": "asap",
       "root": "/common/temp/build-tests/node_modules/.pnpm/asap@2.0.6/node_modules/asap",
     },
     Object {
-      "deps": Object {},
       "name": "asynckit",
       "root": "/common/temp/build-tests/node_modules/.pnpm/asynckit@0.4.0/node_modules/asynckit",
     },
@@ -1621,12 +1565,10 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/babel-preset-jest@29.6.3_@babel+core@7.24.5/node_modules/babel-preset-jest",
     },
     Object {
-      "deps": Object {},
       "name": "balanced-match",
       "root": "/common/temp/build-tests/node_modules/.pnpm/balanced-match@1.0.2/node_modules/balanced-match",
     },
     Object {
-      "deps": Object {},
       "name": "base64-js",
       "root": "/common/temp/build-tests/node_modules/.pnpm/base64-js@1.5.1/node_modules/base64-js",
     },
@@ -1700,7 +1642,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/bser@2.1.1/node_modules/bser",
     },
     Object {
-      "deps": Object {},
       "name": "buffer-from",
       "root": "/common/temp/build-tests/node_modules/.pnpm/buffer-from@1.1.2/node_modules/buffer-from",
     },
@@ -1713,22 +1654,18 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/buffer@5.7.1/node_modules/buffer",
     },
     Object {
-      "deps": Object {},
       "name": "builtin-modules",
       "root": "/common/temp/build-tests/node_modules/.pnpm/builtin-modules@1.1.1/node_modules/builtin-modules",
     },
     Object {
-      "deps": Object {},
       "name": "builtin-modules",
       "root": "/common/temp/build-tests/node_modules/.pnpm/builtin-modules@3.1.0/node_modules/builtin-modules",
     },
     Object {
-      "deps": Object {},
       "name": "builtins",
       "root": "/common/temp/build-tests/node_modules/.pnpm/builtins@1.0.3/node_modules/builtins",
     },
     Object {
-      "deps": Object {},
       "name": "cacheable-lookup",
       "root": "/common/temp/build-tests/node_modules/.pnpm/cacheable-lookup@5.0.4/node_modules/cacheable-lookup",
     },
@@ -1770,12 +1707,10 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/callsite-record@4.1.5/node_modules/callsite-record",
     },
     Object {
-      "deps": Object {},
       "name": "callsite",
       "root": "/common/temp/build-tests/node_modules/.pnpm/callsite@1.0.0/node_modules/callsite",
     },
     Object {
-      "deps": Object {},
       "name": "callsites",
       "root": "/common/temp/build-tests/node_modules/.pnpm/callsites@3.1.0/node_modules/callsites",
     },
@@ -1789,17 +1724,14 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/camelcase-keys@6.2.2/node_modules/camelcase-keys",
     },
     Object {
-      "deps": Object {},
       "name": "camelcase",
       "root": "/common/temp/build-tests/node_modules/.pnpm/camelcase@5.3.1/node_modules/camelcase",
     },
     Object {
-      "deps": Object {},
       "name": "camelcase",
       "root": "/common/temp/build-tests/node_modules/.pnpm/camelcase@6.3.0/node_modules/camelcase",
     },
     Object {
-      "deps": Object {},
       "name": "caniuse-lite",
       "root": "/common/temp/build-tests/node_modules/.pnpm/caniuse-lite@1.0.30001618/node_modules/caniuse-lite",
     },
@@ -1821,37 +1753,30 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/chalk@4.1.2/node_modules/chalk",
     },
     Object {
-      "deps": Object {},
       "name": "char-regex",
       "root": "/common/temp/build-tests/node_modules/.pnpm/char-regex@1.0.2/node_modules/char-regex",
     },
     Object {
-      "deps": Object {},
       "name": "chardet",
       "root": "/common/temp/build-tests/node_modules/.pnpm/chardet@0.7.0/node_modules/chardet",
     },
     Object {
-      "deps": Object {},
       "name": "chownr",
       "root": "/common/temp/build-tests/node_modules/.pnpm/chownr@2.0.0/node_modules/chownr",
     },
     Object {
-      "deps": Object {},
       "name": "ci-info",
       "root": "/common/temp/build-tests/node_modules/.pnpm/ci-info@2.0.0/node_modules/ci-info",
     },
     Object {
-      "deps": Object {},
       "name": "ci-info",
       "root": "/common/temp/build-tests/node_modules/.pnpm/ci-info@3.9.0/node_modules/ci-info",
     },
     Object {
-      "deps": Object {},
       "name": "cjs-module-lexer",
       "root": "/common/temp/build-tests/node_modules/.pnpm/cjs-module-lexer@1.3.1/node_modules/cjs-module-lexer",
     },
     Object {
-      "deps": Object {},
       "name": "cli-boxes",
       "root": "/common/temp/build-tests/node_modules/.pnpm/cli-boxes@2.2.1/node_modules/cli-boxes",
     },
@@ -1863,7 +1788,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/cli-cursor@3.1.0/node_modules/cli-cursor",
     },
     Object {
-      "deps": Object {},
       "name": "cli-spinners",
       "root": "/common/temp/build-tests/node_modules/.pnpm/cli-spinners@2.9.2/node_modules/cli-spinners",
     },
@@ -1875,7 +1799,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/cli-table@0.3.11/node_modules/cli-table",
     },
     Object {
-      "deps": Object {},
       "name": "cli-width",
       "root": "/common/temp/build-tests/node_modules/.pnpm/cli-width@3.0.0/node_modules/cli-width",
     },
@@ -1896,17 +1819,14 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/clone-response@1.0.3/node_modules/clone-response",
     },
     Object {
-      "deps": Object {},
       "name": "clone",
       "root": "/common/temp/build-tests/node_modules/.pnpm/clone@1.0.4/node_modules/clone",
     },
     Object {
-      "deps": Object {},
       "name": "cmd-extension",
       "root": "/common/temp/build-tests/node_modules/.pnpm/cmd-extension@1.0.2/node_modules/cmd-extension",
     },
     Object {
-      "deps": Object {},
       "name": "co",
       "root": "/common/temp/build-tests/node_modules/.pnpm/co@4.6.0/node_modules/co",
     },
@@ -1932,17 +1852,14 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/color-convert@2.0.1/node_modules/color-convert",
     },
     Object {
-      "deps": Object {},
       "name": "color-name",
       "root": "/common/temp/build-tests/node_modules/.pnpm/color-name@1.1.3/node_modules/color-name",
     },
     Object {
-      "deps": Object {},
       "name": "color-name",
       "root": "/common/temp/build-tests/node_modules/.pnpm/color-name@1.1.4/node_modules/color-name",
     },
     Object {
-      "deps": Object {},
       "name": "colors",
       "root": "/common/temp/build-tests/node_modules/.pnpm/colors@1.0.3/node_modules/colors",
     },
@@ -1954,17 +1871,14 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/combined-stream@1.0.8/node_modules/combined-stream",
     },
     Object {
-      "deps": Object {},
       "name": "commander",
       "root": "/common/temp/build-tests/node_modules/.pnpm/commander@2.20.3/node_modules/commander",
     },
     Object {
-      "deps": Object {},
       "name": "comment-parser",
       "root": "/common/temp/build-tests/node_modules/.pnpm/comment-parser@1.3.0/node_modules/comment-parser",
     },
     Object {
-      "deps": Object {},
       "name": "concat-map",
       "root": "/common/temp/build-tests/node_modules/.pnpm/concat-map@0.0.1/node_modules/concat-map",
     },
@@ -1981,12 +1895,10 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/configstore@5.0.1/node_modules/configstore",
     },
     Object {
-      "deps": Object {},
       "name": "convert-source-map",
       "root": "/common/temp/build-tests/node_modules/.pnpm/convert-source-map@2.0.0/node_modules/convert-source-map",
     },
     Object {
-      "deps": Object {},
       "name": "core-util-is",
       "root": "/common/temp/build-tests/node_modules/.pnpm/core-util-is@1.0.3/node_modules/core-util-is",
     },
@@ -2011,7 +1923,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/cross-spawn@7.0.3/node_modules/cross-spawn",
     },
     Object {
-      "deps": Object {},
       "name": "crypto-random-string",
       "root": "/common/temp/build-tests/node_modules/.pnpm/crypto-random-string@2.0.0/node_modules/crypto-random-string",
     },
@@ -2064,7 +1975,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/debug@4.3.4/node_modules/debug",
     },
     Object {
-      "deps": Object {},
       "name": "debuglog",
       "root": "/common/temp/build-tests/node_modules/.pnpm/debuglog@1.0.1/node_modules/debuglog",
     },
@@ -2077,7 +1987,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/decamelize-keys@1.1.1/node_modules/decamelize-keys",
     },
     Object {
-      "deps": Object {},
       "name": "decamelize",
       "root": "/common/temp/build-tests/node_modules/.pnpm/decamelize@1.2.0/node_modules/decamelize",
     },
@@ -2089,22 +1998,18 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/decompress-response@6.0.0/node_modules/decompress-response",
     },
     Object {
-      "deps": Object {},
       "name": "dedent",
       "root": "/common/temp/build-tests/node_modules/.pnpm/dedent@1.5.3/node_modules/dedent",
     },
     Object {
-      "deps": Object {},
       "name": "deep-extend",
       "root": "/common/temp/build-tests/node_modules/.pnpm/deep-extend@0.6.0/node_modules/deep-extend",
     },
     Object {
-      "deps": Object {},
       "name": "deep-is",
       "root": "/common/temp/build-tests/node_modules/.pnpm/deep-is@0.1.4/node_modules/deep-is",
     },
     Object {
-      "deps": Object {},
       "name": "deepmerge",
       "root": "/common/temp/build-tests/node_modules/.pnpm/deepmerge@4.3.1/node_modules/deepmerge",
     },
@@ -2116,7 +2021,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/defaults@1.0.4/node_modules/defaults",
     },
     Object {
-      "deps": Object {},
       "name": "defer-to-connect",
       "root": "/common/temp/build-tests/node_modules/.pnpm/defer-to-connect@2.0.1/node_modules/defer-to-connect",
     },
@@ -2139,7 +2043,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/define-properties@1.2.1/node_modules/define-properties",
     },
     Object {
-      "deps": Object {},
       "name": "delayed-stream",
       "root": "/common/temp/build-tests/node_modules/.pnpm/delayed-stream@1.0.0/node_modules/delayed-stream",
     },
@@ -2183,22 +2086,18 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/dependency-path@9.2.8/node_modules/dependency-path",
     },
     Object {
-      "deps": Object {},
       "name": "deps-regex",
       "root": "/common/temp/build-tests/node_modules/.pnpm/deps-regex@0.2.0/node_modules/deps-regex",
     },
     Object {
-      "deps": Object {},
       "name": "detect-file",
       "root": "/common/temp/build-tests/node_modules/.pnpm/detect-file@1.0.0/node_modules/detect-file",
     },
     Object {
-      "deps": Object {},
       "name": "detect-indent",
       "root": "/common/temp/build-tests/node_modules/.pnpm/detect-indent@6.1.0/node_modules/detect-indent",
     },
     Object {
-      "deps": Object {},
       "name": "detect-newline",
       "root": "/common/temp/build-tests/node_modules/.pnpm/detect-newline@3.1.0/node_modules/detect-newline",
     },
@@ -2211,12 +2110,10 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/dezalgo@1.0.4/node_modules/dezalgo",
     },
     Object {
-      "deps": Object {},
       "name": "diff-sequences",
       "root": "/common/temp/build-tests/node_modules/.pnpm/diff-sequences@29.6.3/node_modules/diff-sequences",
     },
     Object {
-      "deps": Object {},
       "name": "diff",
       "root": "/common/temp/build-tests/node_modules/.pnpm/diff@4.0.2/node_modules/diff",
     },
@@ -2249,17 +2146,14 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/dot-prop@5.3.0/node_modules/dot-prop",
     },
     Object {
-      "deps": Object {},
       "name": "electron-to-chromium",
       "root": "/common/temp/build-tests/node_modules/.pnpm/electron-to-chromium@1.4.770/node_modules/electron-to-chromium",
     },
     Object {
-      "deps": Object {},
       "name": "emittery",
       "root": "/common/temp/build-tests/node_modules/.pnpm/emittery@0.13.1/node_modules/emittery",
     },
     Object {
-      "deps": Object {},
       "name": "emoji-regex",
       "root": "/common/temp/build-tests/node_modules/.pnpm/emoji-regex@8.0.0/node_modules/emoji-regex",
     },
@@ -2278,7 +2172,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/end-of-stream@1.4.4/node_modules/end-of-stream",
     },
     Object {
-      "deps": Object {},
       "name": "entities",
       "root": "/common/temp/build-tests/node_modules/.pnpm/entities@4.5.0/node_modules/entities",
     },
@@ -2349,7 +2242,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/es-define-property@1.0.0/node_modules/es-define-property",
     },
     Object {
-      "deps": Object {},
       "name": "es-errors",
       "root": "/common/temp/build-tests/node_modules/.pnpm/es-errors@1.3.0/node_modules/es-errors",
     },
@@ -2406,27 +2298,22 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/es-to-primitive@1.2.1/node_modules/es-to-primitive",
     },
     Object {
-      "deps": Object {},
       "name": "escalade",
       "root": "/common/temp/build-tests/node_modules/.pnpm/escalade@3.1.2/node_modules/escalade",
     },
     Object {
-      "deps": Object {},
       "name": "escape-goat",
       "root": "/common/temp/build-tests/node_modules/.pnpm/escape-goat@2.1.1/node_modules/escape-goat",
     },
     Object {
-      "deps": Object {},
       "name": "escape-string-regexp",
       "root": "/common/temp/build-tests/node_modules/.pnpm/escape-string-regexp@1.0.5/node_modules/escape-string-regexp",
     },
     Object {
-      "deps": Object {},
       "name": "escape-string-regexp",
       "root": "/common/temp/build-tests/node_modules/.pnpm/escape-string-regexp@2.0.0/node_modules/escape-string-regexp",
     },
     Object {
-      "deps": Object {},
       "name": "escape-string-regexp",
       "root": "/common/temp/build-tests/node_modules/.pnpm/escape-string-regexp@4.0.0/node_modules/escape-string-regexp",
     },
@@ -2554,7 +2441,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/eslint-scope@7.2.2/node_modules/eslint-scope",
     },
     Object {
-      "deps": Object {},
       "name": "eslint-visitor-keys",
       "root": "/common/temp/build-tests/node_modules/.pnpm/eslint-visitor-keys@3.4.3/node_modules/eslint-visitor-keys",
     },
@@ -2612,7 +2498,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/espree@9.6.1/node_modules/espree",
     },
     Object {
-      "deps": Object {},
       "name": "esprima",
       "root": "/common/temp/build-tests/node_modules/.pnpm/esprima@4.0.1/node_modules/esprima",
     },
@@ -2631,17 +2516,14 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/esrecurse@4.3.0/node_modules/esrecurse",
     },
     Object {
-      "deps": Object {},
       "name": "estraverse",
       "root": "/common/temp/build-tests/node_modules/.pnpm/estraverse@5.3.0/node_modules/estraverse",
     },
     Object {
-      "deps": Object {},
       "name": "estree-walker",
       "root": "/common/temp/build-tests/node_modules/.pnpm/estree-walker@2.0.2/node_modules/estree-walker",
     },
     Object {
-      "deps": Object {},
       "name": "esutils",
       "root": "/common/temp/build-tests/node_modules/.pnpm/esutils@2.0.3/node_modules/esutils",
     },
@@ -2661,7 +2543,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/execa@5.1.1/node_modules/execa",
     },
     Object {
-      "deps": Object {},
       "name": "exit",
       "root": "/common/temp/build-tests/node_modules/.pnpm/exit@0.1.2/node_modules/exit",
     },
@@ -2693,7 +2574,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/external-editor@3.1.0/node_modules/external-editor",
     },
     Object {
-      "deps": Object {},
       "name": "fast-deep-equal",
       "root": "/common/temp/build-tests/node_modules/.pnpm/fast-deep-equal@3.1.3/node_modules/fast-deep-equal",
     },
@@ -2709,12 +2589,10 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/fast-glob@3.3.2/node_modules/fast-glob",
     },
     Object {
-      "deps": Object {},
       "name": "fast-json-stable-stringify",
       "root": "/common/temp/build-tests/node_modules/.pnpm/fast-json-stable-stringify@2.1.0/node_modules/fast-json-stable-stringify",
     },
     Object {
-      "deps": Object {},
       "name": "fast-levenshtein",
       "root": "/common/temp/build-tests/node_modules/.pnpm/fast-levenshtein@2.0.6/node_modules/fast-levenshtein",
     },
@@ -2797,7 +2675,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/flat-cache@3.2.0/node_modules/flat-cache",
     },
     Object {
-      "deps": Object {},
       "name": "flatted",
       "root": "/common/temp/build-tests/node_modules/.pnpm/flatted@3.3.1/node_modules/flatted",
     },
@@ -2834,12 +2711,10 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/fs-minipass@2.1.0/node_modules/fs-minipass",
     },
     Object {
-      "deps": Object {},
       "name": "fs.realpath",
       "root": "/common/temp/build-tests/node_modules/.pnpm/fs.realpath@1.0.0/node_modules/fs.realpath",
     },
     Object {
-      "deps": Object {},
       "name": "function-bind",
       "root": "/common/temp/build-tests/node_modules/.pnpm/function-bind@1.1.2/node_modules/function-bind",
     },
@@ -2854,17 +2729,14 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/function.prototype.name@1.1.6/node_modules/function.prototype.name",
     },
     Object {
-      "deps": Object {},
       "name": "functions-have-names",
       "root": "/common/temp/build-tests/node_modules/.pnpm/functions-have-names@1.2.3/node_modules/functions-have-names",
     },
     Object {
-      "deps": Object {},
       "name": "gensync",
       "root": "/common/temp/build-tests/node_modules/.pnpm/gensync@1.0.0-beta.2/node_modules/gensync",
     },
     Object {
-      "deps": Object {},
       "name": "get-caller-file",
       "root": "/common/temp/build-tests/node_modules/.pnpm/get-caller-file@2.0.5/node_modules/get-caller-file",
     },
@@ -2880,7 +2752,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/get-intrinsic@1.2.4/node_modules/get-intrinsic",
     },
     Object {
-      "deps": Object {},
       "name": "get-package-type",
       "root": "/common/temp/build-tests/node_modules/.pnpm/get-package-type@0.1.0/node_modules/get-package-type",
     },
@@ -2892,7 +2763,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/get-stream@5.2.0/node_modules/get-stream",
     },
     Object {
-      "deps": Object {},
       "name": "get-stream",
       "root": "/common/temp/build-tests/node_modules/.pnpm/get-stream@6.0.1/node_modules/get-stream",
     },
@@ -2906,17 +2776,14 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/get-symbol-description@1.0.2/node_modules/get-symbol-description",
     },
     Object {
-      "deps": Object {},
       "name": "git-repo-info",
       "root": "/common/temp/build-tests/node_modules/.pnpm/git-repo-info@2.1.1/node_modules/git-repo-info",
     },
     Object {
-      "deps": Object {},
       "name": "giturl",
       "root": "/common/temp/build-tests/node_modules/.pnpm/giturl@1.0.3/node_modules/giturl",
     },
     Object {
-      "deps": Object {},
       "name": "glob-escape",
       "root": "/common/temp/build-tests/node_modules/.pnpm/glob-escape@0.0.2/node_modules/glob-escape",
     },
@@ -2935,7 +2802,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/glob-parent@6.0.2/node_modules/glob-parent",
     },
     Object {
-      "deps": Object {},
       "name": "glob-to-regexp",
       "root": "/common/temp/build-tests/node_modules/.pnpm/glob-to-regexp@0.4.1/node_modules/glob-to-regexp",
     },
@@ -2995,7 +2861,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/global-prefix@3.0.0/node_modules/global-prefix",
     },
     Object {
-      "deps": Object {},
       "name": "globals",
       "root": "/common/temp/build-tests/node_modules/.pnpm/globals@11.12.0/node_modules/globals",
     },
@@ -3051,37 +2916,30 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/got@11.8.6/node_modules/got",
     },
     Object {
-      "deps": Object {},
       "name": "graceful-fs",
       "root": "/common/temp/build-tests/node_modules/.pnpm/graceful-fs@4.2.11/node_modules/graceful-fs",
     },
     Object {
-      "deps": Object {},
       "name": "graceful-fs",
       "root": "/common/temp/build-tests/node_modules/.pnpm/graceful-fs@4.2.4/node_modules/graceful-fs",
     },
     Object {
-      "deps": Object {},
       "name": "graphemer",
       "root": "/common/temp/build-tests/node_modules/.pnpm/graphemer@1.4.0/node_modules/graphemer",
     },
     Object {
-      "deps": Object {},
       "name": "hard-rejection",
       "root": "/common/temp/build-tests/node_modules/.pnpm/hard-rejection@2.1.0/node_modules/hard-rejection",
     },
     Object {
-      "deps": Object {},
       "name": "has-bigints",
       "root": "/common/temp/build-tests/node_modules/.pnpm/has-bigints@1.0.2/node_modules/has-bigints",
     },
     Object {
-      "deps": Object {},
       "name": "has-flag",
       "root": "/common/temp/build-tests/node_modules/.pnpm/has-flag@3.0.0/node_modules/has-flag",
     },
     Object {
-      "deps": Object {},
       "name": "has-flag",
       "root": "/common/temp/build-tests/node_modules/.pnpm/has-flag@4.0.0/node_modules/has-flag",
     },
@@ -3093,12 +2951,10 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/has-property-descriptors@1.0.2/node_modules/has-property-descriptors",
     },
     Object {
-      "deps": Object {},
       "name": "has-proto",
       "root": "/common/temp/build-tests/node_modules/.pnpm/has-proto@1.0.3/node_modules/has-proto",
     },
     Object {
-      "deps": Object {},
       "name": "has-symbols",
       "root": "/common/temp/build-tests/node_modules/.pnpm/has-symbols@1.0.3/node_modules/has-symbols",
     },
@@ -3110,12 +2966,10 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/has-tostringtag@1.0.2/node_modules/has-tostringtag",
     },
     Object {
-      "deps": Object {},
       "name": "has-yarn",
       "root": "/common/temp/build-tests/node_modules/.pnpm/has-yarn@2.1.0/node_modules/has-yarn",
     },
     Object {
-      "deps": Object {},
       "name": "has",
       "root": "/common/temp/build-tests/node_modules/.pnpm/has@1.0.4/node_modules/has",
     },
@@ -3143,7 +2997,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/homedir-polyfill@1.0.3/node_modules/homedir-polyfill",
     },
     Object {
-      "deps": Object {},
       "name": "hosted-git-info",
       "root": "/common/temp/build-tests/node_modules/.pnpm/hosted-git-info@2.8.9/node_modules/hosted-git-info",
     },
@@ -3155,12 +3008,10 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/hosted-git-info@4.1.0/node_modules/hosted-git-info",
     },
     Object {
-      "deps": Object {},
       "name": "html-escaper",
       "root": "/common/temp/build-tests/node_modules/.pnpm/html-escaper@2.0.2/node_modules/html-escaper",
     },
     Object {
-      "deps": Object {},
       "name": "http-cache-semantics",
       "root": "/common/temp/build-tests/node_modules/.pnpm/http-cache-semantics@4.1.1/node_modules/http-cache-semantics",
     },
@@ -3181,7 +3032,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/https-proxy-agent@5.0.1/node_modules/https-proxy-agent",
     },
     Object {
-      "deps": Object {},
       "name": "human-signals",
       "root": "/common/temp/build-tests/node_modules/.pnpm/human-signals@2.1.0/node_modules/human-signals",
     },
@@ -3193,7 +3043,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/iconv-lite@0.4.24/node_modules/iconv-lite",
     },
     Object {
-      "deps": Object {},
       "name": "ieee754",
       "root": "/common/temp/build-tests/node_modules/.pnpm/ieee754@1.2.1/node_modules/ieee754",
     },
@@ -3205,17 +3054,14 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/ignore-walk@3.0.4/node_modules/ignore-walk",
     },
     Object {
-      "deps": Object {},
       "name": "ignore",
       "root": "/common/temp/build-tests/node_modules/.pnpm/ignore@5.1.9/node_modules/ignore",
     },
     Object {
-      "deps": Object {},
       "name": "ignore",
       "root": "/common/temp/build-tests/node_modules/.pnpm/ignore@5.3.1/node_modules/ignore",
     },
     Object {
-      "deps": Object {},
       "name": "immediate",
       "root": "/common/temp/build-tests/node_modules/.pnpm/immediate@3.0.6/node_modules/immediate",
     },
@@ -3228,22 +3074,18 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/import-fresh@3.3.0/node_modules/import-fresh",
     },
     Object {
-      "deps": Object {},
       "name": "import-lazy",
       "root": "/common/temp/build-tests/node_modules/.pnpm/import-lazy@2.1.0/node_modules/import-lazy",
     },
     Object {
-      "deps": Object {},
       "name": "import-lazy",
       "root": "/common/temp/build-tests/node_modules/.pnpm/import-lazy@4.0.0/node_modules/import-lazy",
     },
     Object {
-      "deps": Object {},
       "name": "imurmurhash",
       "root": "/common/temp/build-tests/node_modules/.pnpm/imurmurhash@0.1.4/node_modules/imurmurhash",
     },
     Object {
-      "deps": Object {},
       "name": "indent-string",
       "root": "/common/temp/build-tests/node_modules/.pnpm/indent-string@4.0.0/node_modules/indent-string",
     },
@@ -3256,17 +3098,14 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/inflight@1.0.6/node_modules/inflight",
     },
     Object {
-      "deps": Object {},
       "name": "inherits",
       "root": "/common/temp/build-tests/node_modules/.pnpm/inherits@2.0.4/node_modules/inherits",
     },
     Object {
-      "deps": Object {},
       "name": "ini",
       "root": "/common/temp/build-tests/node_modules/.pnpm/ini@1.3.8/node_modules/ini",
     },
     Object {
-      "deps": Object {},
       "name": "ini",
       "root": "/common/temp/build-tests/node_modules/.pnpm/ini@2.0.0/node_modules/ini",
     },
@@ -3307,7 +3146,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/is-array-buffer@3.0.4/node_modules/is-array-buffer",
     },
     Object {
-      "deps": Object {},
       "name": "is-arrayish",
       "root": "/common/temp/build-tests/node_modules/.pnpm/is-arrayish@0.2.1/node_modules/is-arrayish",
     },
@@ -3334,7 +3172,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/is-boolean-object@1.1.2/node_modules/is-boolean-object",
     },
     Object {
-      "deps": Object {},
       "name": "is-callable",
       "root": "/common/temp/build-tests/node_modules/.pnpm/is-callable@1.2.7/node_modules/is-callable",
     },
@@ -3367,12 +3204,10 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/is-date-object@1.0.5/node_modules/is-date-object",
     },
     Object {
-      "deps": Object {},
       "name": "is-es2016-keyword",
       "root": "/common/temp/build-tests/node_modules/.pnpm/is-es2016-keyword@1.0.0/node_modules/is-es2016-keyword",
     },
     Object {
-      "deps": Object {},
       "name": "is-extglob",
       "root": "/common/temp/build-tests/node_modules/.pnpm/is-extglob@2.1.1/node_modules/is-extglob",
     },
@@ -3384,12 +3219,10 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/is-finalizationregistry@1.0.2/node_modules/is-finalizationregistry",
     },
     Object {
-      "deps": Object {},
       "name": "is-fullwidth-code-point",
       "root": "/common/temp/build-tests/node_modules/.pnpm/is-fullwidth-code-point@3.0.0/node_modules/is-fullwidth-code-point",
     },
     Object {
-      "deps": Object {},
       "name": "is-generator-fn",
       "root": "/common/temp/build-tests/node_modules/.pnpm/is-generator-fn@2.1.0/node_modules/is-generator-fn",
     },
@@ -3416,22 +3249,18 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/is-installed-globally@0.4.0/node_modules/is-installed-globally",
     },
     Object {
-      "deps": Object {},
       "name": "is-interactive",
       "root": "/common/temp/build-tests/node_modules/.pnpm/is-interactive@1.0.0/node_modules/is-interactive",
     },
     Object {
-      "deps": Object {},
       "name": "is-map",
       "root": "/common/temp/build-tests/node_modules/.pnpm/is-map@2.0.3/node_modules/is-map",
     },
     Object {
-      "deps": Object {},
       "name": "is-negative-zero",
       "root": "/common/temp/build-tests/node_modules/.pnpm/is-negative-zero@2.0.3/node_modules/is-negative-zero",
     },
     Object {
-      "deps": Object {},
       "name": "is-npm",
       "root": "/common/temp/build-tests/node_modules/.pnpm/is-npm@5.0.0/node_modules/is-npm",
     },
@@ -3443,27 +3272,22 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/is-number-object@1.0.7/node_modules/is-number-object",
     },
     Object {
-      "deps": Object {},
       "name": "is-number",
       "root": "/common/temp/build-tests/node_modules/.pnpm/is-number@7.0.0/node_modules/is-number",
     },
     Object {
-      "deps": Object {},
       "name": "is-obj",
       "root": "/common/temp/build-tests/node_modules/.pnpm/is-obj@2.0.0/node_modules/is-obj",
     },
     Object {
-      "deps": Object {},
       "name": "is-path-inside",
       "root": "/common/temp/build-tests/node_modules/.pnpm/is-path-inside@3.0.3/node_modules/is-path-inside",
     },
     Object {
-      "deps": Object {},
       "name": "is-plain-obj",
       "root": "/common/temp/build-tests/node_modules/.pnpm/is-plain-obj@1.1.0/node_modules/is-plain-obj",
     },
     Object {
-      "deps": Object {},
       "name": "is-plain-obj",
       "root": "/common/temp/build-tests/node_modules/.pnpm/is-plain-obj@2.1.0/node_modules/is-plain-obj",
     },
@@ -3476,7 +3300,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/is-regex@1.1.4/node_modules/is-regex",
     },
     Object {
-      "deps": Object {},
       "name": "is-set",
       "root": "/common/temp/build-tests/node_modules/.pnpm/is-set@2.0.3/node_modules/is-set",
     },
@@ -3488,7 +3311,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/is-shared-array-buffer@1.0.3/node_modules/is-shared-array-buffer",
     },
     Object {
-      "deps": Object {},
       "name": "is-stream",
       "root": "/common/temp/build-tests/node_modules/.pnpm/is-stream@2.0.1/node_modules/is-stream",
     },
@@ -3521,17 +3343,14 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/is-typed-array@1.1.13/node_modules/is-typed-array",
     },
     Object {
-      "deps": Object {},
       "name": "is-typedarray",
       "root": "/common/temp/build-tests/node_modules/.pnpm/is-typedarray@1.0.0/node_modules/is-typedarray",
     },
     Object {
-      "deps": Object {},
       "name": "is-unicode-supported",
       "root": "/common/temp/build-tests/node_modules/.pnpm/is-unicode-supported@0.1.0/node_modules/is-unicode-supported",
     },
     Object {
-      "deps": Object {},
       "name": "is-weakmap",
       "root": "/common/temp/build-tests/node_modules/.pnpm/is-weakmap@2.0.2/node_modules/is-weakmap",
     },
@@ -3551,32 +3370,26 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/is-weakset@2.0.3/node_modules/is-weakset",
     },
     Object {
-      "deps": Object {},
       "name": "is-windows",
       "root": "/common/temp/build-tests/node_modules/.pnpm/is-windows@1.0.2/node_modules/is-windows",
     },
     Object {
-      "deps": Object {},
       "name": "is-yarn-global",
       "root": "/common/temp/build-tests/node_modules/.pnpm/is-yarn-global@0.3.0/node_modules/is-yarn-global",
     },
     Object {
-      "deps": Object {},
       "name": "isarray",
       "root": "/common/temp/build-tests/node_modules/.pnpm/isarray@1.0.0/node_modules/isarray",
     },
     Object {
-      "deps": Object {},
       "name": "isarray",
       "root": "/common/temp/build-tests/node_modules/.pnpm/isarray@2.0.5/node_modules/isarray",
     },
     Object {
-      "deps": Object {},
       "name": "isexe",
       "root": "/common/temp/build-tests/node_modules/.pnpm/isexe@2.0.0/node_modules/isexe",
     },
     Object {
-      "deps": Object {},
       "name": "istanbul-lib-coverage",
       "root": "/common/temp/build-tests/node_modules/.pnpm/istanbul-lib-coverage@3.2.2/node_modules/istanbul-lib-coverage",
     },
@@ -3745,7 +3558,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/jest-environment-node@29.7.0/node_modules/jest-environment-node",
     },
     Object {
-      "deps": Object {},
       "name": "jest-get-type",
       "root": "/common/temp/build-tests/node_modules/.pnpm/jest-get-type@29.6.3/node_modules/jest-get-type",
     },
@@ -3833,7 +3645,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/jest-pnp-resolver@1.2.3_jest-resolve@29.7.0/node_modules/jest-pnp-resolver",
     },
     Object {
-      "deps": Object {},
       "name": "jest-regex-util",
       "root": "/common/temp/build-tests/node_modules/.pnpm/jest-regex-util@29.6.3/node_modules/jest-regex-util",
     },
@@ -4034,17 +3845,14 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/jest-worker@29.7.0/node_modules/jest-worker",
     },
     Object {
-      "deps": Object {},
       "name": "jju",
       "root": "/common/temp/build-tests/node_modules/.pnpm/jju@1.4.0/node_modules/jju",
     },
     Object {
-      "deps": Object {},
       "name": "js-tokens",
       "root": "/common/temp/build-tests/node_modules/.pnpm/js-tokens@3.0.2/node_modules/js-tokens",
     },
     Object {
-      "deps": Object {},
       "name": "js-tokens",
       "root": "/common/temp/build-tests/node_modules/.pnpm/js-tokens@4.0.0/node_modules/js-tokens",
     },
@@ -4072,37 +3880,30 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/js-yaml@4.1.0/node_modules/js-yaml",
     },
     Object {
-      "deps": Object {},
       "name": "jsdoc-type-pratt-parser",
       "root": "/common/temp/build-tests/node_modules/.pnpm/jsdoc-type-pratt-parser@2.2.5/node_modules/jsdoc-type-pratt-parser",
     },
     Object {
-      "deps": Object {},
       "name": "jsesc",
       "root": "/common/temp/build-tests/node_modules/.pnpm/jsesc@2.5.2/node_modules/jsesc",
     },
     Object {
-      "deps": Object {},
       "name": "json-buffer",
       "root": "/common/temp/build-tests/node_modules/.pnpm/json-buffer@3.0.1/node_modules/json-buffer",
     },
     Object {
-      "deps": Object {},
       "name": "json-parse-even-better-errors",
       "root": "/common/temp/build-tests/node_modules/.pnpm/json-parse-even-better-errors@2.3.1/node_modules/json-parse-even-better-errors",
     },
     Object {
-      "deps": Object {},
       "name": "json-schema-traverse",
       "root": "/common/temp/build-tests/node_modules/.pnpm/json-schema-traverse@0.4.1/node_modules/json-schema-traverse",
     },
     Object {
-      "deps": Object {},
       "name": "json-schema-traverse",
       "root": "/common/temp/build-tests/node_modules/.pnpm/json-schema-traverse@1.0.0/node_modules/json-schema-traverse",
     },
     Object {
-      "deps": Object {},
       "name": "json-stable-stringify-without-jsonify",
       "root": "/common/temp/build-tests/node_modules/.pnpm/json-stable-stringify-without-jsonify@1.0.1/node_modules/json-stable-stringify-without-jsonify",
     },
@@ -4114,7 +3915,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/json5@1.0.2/node_modules/json5",
     },
     Object {
-      "deps": Object {},
       "name": "json5",
       "root": "/common/temp/build-tests/node_modules/.pnpm/json5@2.2.3/node_modules/json5",
     },
@@ -4126,7 +3926,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/jsonfile@4.0.0/node_modules/jsonfile",
     },
     Object {
-      "deps": Object {},
       "name": "jsonpath-plus",
       "root": "/common/temp/build-tests/node_modules/.pnpm/jsonpath-plus@4.0.0/node_modules/jsonpath-plus",
     },
@@ -4158,7 +3957,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/keyv@4.5.4/node_modules/keyv",
     },
     Object {
-      "deps": Object {},
       "name": "kind-of",
       "root": "/common/temp/build-tests/node_modules/.pnpm/kind-of@6.0.3/node_modules/kind-of",
     },
@@ -4170,7 +3968,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/latest-version@5.1.0/node_modules/latest-version",
     },
     Object {
-      "deps": Object {},
       "name": "leven",
       "root": "/common/temp/build-tests/node_modules/.pnpm/leven@3.1.0/node_modules/leven",
     },
@@ -4190,7 +3987,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/lie@3.3.0/node_modules/lie",
     },
     Object {
-      "deps": Object {},
       "name": "lines-and-columns",
       "root": "/common/temp/build-tests/node_modules/.pnpm/lines-and-columns@1.2.4/node_modules/lines-and-columns",
     },
@@ -4229,12 +4025,10 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/locate-path@6.0.0/node_modules/locate-path",
     },
     Object {
-      "deps": Object {},
       "name": "lodash.merge",
       "root": "/common/temp/build-tests/node_modules/.pnpm/lodash.merge@4.6.2/node_modules/lodash.merge",
     },
     Object {
-      "deps": Object {},
       "name": "lodash",
       "root": "/common/temp/build-tests/node_modules/.pnpm/lodash@4.17.21/node_modules/lodash",
     },
@@ -4254,7 +4048,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/loose-envify@1.4.0/node_modules/loose-envify",
     },
     Object {
-      "deps": Object {},
       "name": "lowercase-keys",
       "root": "/common/temp/build-tests/node_modules/.pnpm/lowercase-keys@2.0.0/node_modules/lowercase-keys",
     },
@@ -4308,12 +4101,10 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/map-age-cleaner@0.1.3/node_modules/map-age-cleaner",
     },
     Object {
-      "deps": Object {},
       "name": "map-obj",
       "root": "/common/temp/build-tests/node_modules/.pnpm/map-obj@1.0.1/node_modules/map-obj",
     },
     Object {
-      "deps": Object {},
       "name": "map-obj",
       "root": "/common/temp/build-tests/node_modules/.pnpm/map-obj@4.3.0/node_modules/map-obj",
     },
@@ -4344,12 +4135,10 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/meow@9.0.0/node_modules/meow",
     },
     Object {
-      "deps": Object {},
       "name": "merge-stream",
       "root": "/common/temp/build-tests/node_modules/.pnpm/merge-stream@2.0.0/node_modules/merge-stream",
     },
     Object {
-      "deps": Object {},
       "name": "merge2",
       "root": "/common/temp/build-tests/node_modules/.pnpm/merge2@1.4.1/node_modules/merge2",
     },
@@ -4362,7 +4151,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/micromatch@4.0.5/node_modules/micromatch",
     },
     Object {
-      "deps": Object {},
       "name": "mime-db",
       "root": "/common/temp/build-tests/node_modules/.pnpm/mime-db@1.52.0/node_modules/mime-db",
     },
@@ -4374,27 +4162,22 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/mime-types@2.1.35/node_modules/mime-types",
     },
     Object {
-      "deps": Object {},
       "name": "mimic-fn",
       "root": "/common/temp/build-tests/node_modules/.pnpm/mimic-fn@2.1.0/node_modules/mimic-fn",
     },
     Object {
-      "deps": Object {},
       "name": "mimic-fn",
       "root": "/common/temp/build-tests/node_modules/.pnpm/mimic-fn@3.1.0/node_modules/mimic-fn",
     },
     Object {
-      "deps": Object {},
       "name": "mimic-response",
       "root": "/common/temp/build-tests/node_modules/.pnpm/mimic-response@1.0.1/node_modules/mimic-response",
     },
     Object {
-      "deps": Object {},
       "name": "mimic-response",
       "root": "/common/temp/build-tests/node_modules/.pnpm/mimic-response@3.1.0/node_modules/mimic-response",
     },
     Object {
-      "deps": Object {},
       "name": "min-indent",
       "root": "/common/temp/build-tests/node_modules/.pnpm/min-indent@1.0.1/node_modules/min-indent",
     },
@@ -4443,7 +4226,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/minimist-options@4.1.0/node_modules/minimist-options",
     },
     Object {
-      "deps": Object {},
       "name": "minimist",
       "root": "/common/temp/build-tests/node_modules/.pnpm/minimist@1.2.8/node_modules/minimist",
     },
@@ -4455,7 +4237,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/minipass@3.3.6/node_modules/minipass",
     },
     Object {
-      "deps": Object {},
       "name": "minipass",
       "root": "/common/temp/build-tests/node_modules/.pnpm/minipass@5.0.0/node_modules/minipass",
     },
@@ -4475,22 +4256,18 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/mkdirp@0.5.6/node_modules/mkdirp",
     },
     Object {
-      "deps": Object {},
       "name": "mkdirp",
       "root": "/common/temp/build-tests/node_modules/.pnpm/mkdirp@1.0.4/node_modules/mkdirp",
     },
     Object {
-      "deps": Object {},
       "name": "ms",
       "root": "/common/temp/build-tests/node_modules/.pnpm/ms@2.0.0/node_modules/ms",
     },
     Object {
-      "deps": Object {},
       "name": "ms",
       "root": "/common/temp/build-tests/node_modules/.pnpm/ms@2.1.2/node_modules/ms",
     },
     Object {
-      "deps": Object {},
       "name": "ms",
       "root": "/common/temp/build-tests/node_modules/.pnpm/ms@2.1.3/node_modules/ms",
     },
@@ -4506,7 +4283,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/multimatch@5.0.0/node_modules/multimatch",
     },
     Object {
-      "deps": Object {},
       "name": "mute-stream",
       "root": "/common/temp/build-tests/node_modules/.pnpm/mute-stream@0.0.8/node_modules/mute-stream",
     },
@@ -4520,12 +4296,10 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/mz@2.7.0/node_modules/mz",
     },
     Object {
-      "deps": Object {},
       "name": "nanoid",
       "root": "/common/temp/build-tests/node_modules/.pnpm/nanoid@3.3.7/node_modules/nanoid",
     },
     Object {
-      "deps": Object {},
       "name": "natural-compare",
       "root": "/common/temp/build-tests/node_modules/.pnpm/natural-compare@1.4.0/node_modules/natural-compare",
     },
@@ -4544,12 +4318,10 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/node-fetch@2.6.7/node_modules/node-fetch",
     },
     Object {
-      "deps": Object {},
       "name": "node-int64",
       "root": "/common/temp/build-tests/node_modules/.pnpm/node-int64@0.4.0/node_modules/node-int64",
     },
     Object {
-      "deps": Object {},
       "name": "node-releases",
       "root": "/common/temp/build-tests/node_modules/.pnpm/node-releases@2.0.14/node_modules/node-releases",
     },
@@ -4574,12 +4346,10 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/normalize-package-data@3.0.3/node_modules/normalize-package-data",
     },
     Object {
-      "deps": Object {},
       "name": "normalize-path",
       "root": "/common/temp/build-tests/node_modules/.pnpm/normalize-path@3.0.0/node_modules/normalize-path",
     },
     Object {
-      "deps": Object {},
       "name": "normalize-url",
       "root": "/common/temp/build-tests/node_modules/.pnpm/normalize-url@6.1.0/node_modules/normalize-url",
     },
@@ -4624,7 +4394,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/npm-check@6.0.1/node_modules/npm-check",
     },
     Object {
-      "deps": Object {},
       "name": "npm-normalize-package-bin",
       "root": "/common/temp/build-tests/node_modules/.pnpm/npm-normalize-package-bin@1.0.1/node_modules/npm-normalize-package-bin",
     },
@@ -4656,17 +4425,14 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/npm-run-path@4.0.1/node_modules/npm-run-path",
     },
     Object {
-      "deps": Object {},
       "name": "object-assign",
       "root": "/common/temp/build-tests/node_modules/.pnpm/object-assign@4.1.1/node_modules/object-assign",
     },
     Object {
-      "deps": Object {},
       "name": "object-inspect",
       "root": "/common/temp/build-tests/node_modules/.pnpm/object-inspect@1.13.1/node_modules/object-inspect",
     },
     Object {
-      "deps": Object {},
       "name": "object-keys",
       "root": "/common/temp/build-tests/node_modules/.pnpm/object-keys@1.1.1/node_modules/object-keys",
     },
@@ -4759,12 +4525,10 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/ora@5.4.1/node_modules/ora",
     },
     Object {
-      "deps": Object {},
       "name": "os-homedir",
       "root": "/common/temp/build-tests/node_modules/.pnpm/os-homedir@1.0.2/node_modules/os-homedir",
     },
     Object {
-      "deps": Object {},
       "name": "os-tmpdir",
       "root": "/common/temp/build-tests/node_modules/.pnpm/os-tmpdir@1.0.2/node_modules/os-tmpdir",
     },
@@ -4777,12 +4541,10 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/osenv@0.1.5/node_modules/osenv",
     },
     Object {
-      "deps": Object {},
       "name": "p-cancelable",
       "root": "/common/temp/build-tests/node_modules/.pnpm/p-cancelable@2.1.1/node_modules/p-cancelable",
     },
     Object {
-      "deps": Object {},
       "name": "p-defer",
       "root": "/common/temp/build-tests/node_modules/.pnpm/p-defer@1.0.0/node_modules/p-defer",
     },
@@ -4815,7 +4577,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/p-locate@5.0.0/node_modules/p-locate",
     },
     Object {
-      "deps": Object {},
       "name": "p-reflect",
       "root": "/common/temp/build-tests/node_modules/.pnpm/p-reflect@2.1.0/node_modules/p-reflect",
     },
@@ -4828,7 +4589,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/p-settle@4.1.1/node_modules/p-settle",
     },
     Object {
-      "deps": Object {},
       "name": "p-try",
       "root": "/common/temp/build-tests/node_modules/.pnpm/p-try@2.2.0/node_modules/p-try",
     },
@@ -4843,7 +4603,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/package-json@7.0.0/node_modules/package-json",
     },
     Object {
-      "deps": Object {},
       "name": "pako",
       "root": "/common/temp/build-tests/node_modules/.pnpm/pako@1.0.11/node_modules/pako",
     },
@@ -4865,47 +4624,38 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/parse-json@5.2.0/node_modules/parse-json",
     },
     Object {
-      "deps": Object {},
       "name": "parse-passwd",
       "root": "/common/temp/build-tests/node_modules/.pnpm/parse-passwd@1.0.0/node_modules/parse-passwd",
     },
     Object {
-      "deps": Object {},
       "name": "path-exists",
       "root": "/common/temp/build-tests/node_modules/.pnpm/path-exists@4.0.0/node_modules/path-exists",
     },
     Object {
-      "deps": Object {},
       "name": "path-is-absolute",
       "root": "/common/temp/build-tests/node_modules/.pnpm/path-is-absolute@1.0.1/node_modules/path-is-absolute",
     },
     Object {
-      "deps": Object {},
       "name": "path-key",
       "root": "/common/temp/build-tests/node_modules/.pnpm/path-key@3.1.1/node_modules/path-key",
     },
     Object {
-      "deps": Object {},
       "name": "path-parse",
       "root": "/common/temp/build-tests/node_modules/.pnpm/path-parse@1.0.7/node_modules/path-parse",
     },
     Object {
-      "deps": Object {},
       "name": "path-type",
       "root": "/common/temp/build-tests/node_modules/.pnpm/path-type@4.0.0/node_modules/path-type",
     },
     Object {
-      "deps": Object {},
       "name": "picocolors",
       "root": "/common/temp/build-tests/node_modules/.pnpm/picocolors@1.0.1/node_modules/picocolors",
     },
     Object {
-      "deps": Object {},
       "name": "picomatch",
       "root": "/common/temp/build-tests/node_modules/.pnpm/picomatch@2.3.1/node_modules/picomatch",
     },
     Object {
-      "deps": Object {},
       "name": "pify",
       "root": "/common/temp/build-tests/node_modules/.pnpm/pify@4.0.1/node_modules/pify",
     },
@@ -4917,12 +4667,10 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/pinkie-promise@2.0.1/node_modules/pinkie-promise",
     },
     Object {
-      "deps": Object {},
       "name": "pinkie",
       "root": "/common/temp/build-tests/node_modules/.pnpm/pinkie@2.0.4/node_modules/pinkie",
     },
     Object {
-      "deps": Object {},
       "name": "pirates",
       "root": "/common/temp/build-tests/node_modules/.pnpm/pirates@4.0.6/node_modules/pirates",
     },
@@ -4956,7 +4704,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/pnpm-sync-lib@0.2.9/node_modules/pnpm-sync-lib",
     },
     Object {
-      "deps": Object {},
       "name": "possible-typed-array-names",
       "root": "/common/temp/build-tests/node_modules/.pnpm/possible-typed-array-names@1.0.0/node_modules/possible-typed-array-names",
     },
@@ -4980,7 +4727,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/preferred-pm@3.1.3/node_modules/preferred-pm",
     },
     Object {
-      "deps": Object {},
       "name": "prelude-ls",
       "root": "/common/temp/build-tests/node_modules/.pnpm/prelude-ls@1.2.1/node_modules/prelude-ls",
     },
@@ -4994,7 +4740,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/pretty-format@29.7.0/node_modules/pretty-format",
     },
     Object {
-      "deps": Object {},
       "name": "process-nextick-args",
       "root": "/common/temp/build-tests/node_modules/.pnpm/process-nextick-args@2.0.1/node_modules/process-nextick-args",
     },
@@ -5016,7 +4761,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/pump@3.0.0/node_modules/pump",
     },
     Object {
-      "deps": Object {},
       "name": "punycode",
       "root": "/common/temp/build-tests/node_modules/.pnpm/punycode@2.3.1/node_modules/punycode",
     },
@@ -5028,27 +4772,22 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/pupa@2.1.1/node_modules/pupa",
     },
     Object {
-      "deps": Object {},
       "name": "pure-rand",
       "root": "/common/temp/build-tests/node_modules/.pnpm/pure-rand@6.1.0/node_modules/pure-rand",
     },
     Object {
-      "deps": Object {},
       "name": "queue-microtask",
       "root": "/common/temp/build-tests/node_modules/.pnpm/queue-microtask@1.2.3/node_modules/queue-microtask",
     },
     Object {
-      "deps": Object {},
       "name": "quick-lru",
       "root": "/common/temp/build-tests/node_modules/.pnpm/quick-lru@4.0.1/node_modules/quick-lru",
     },
     Object {
-      "deps": Object {},
       "name": "quick-lru",
       "root": "/common/temp/build-tests/node_modules/.pnpm/quick-lru@5.1.1/node_modules/quick-lru",
     },
     Object {
-      "deps": Object {},
       "name": "ramda",
       "root": "/common/temp/build-tests/node_modules/.pnpm/ramda@0.27.2/node_modules/ramda",
     },
@@ -5073,12 +4812,10 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/rc@1.2.8/node_modules/rc",
     },
     Object {
-      "deps": Object {},
       "name": "react-is",
       "root": "/common/temp/build-tests/node_modules/.pnpm/react-is@16.13.1/node_modules/react-is",
     },
     Object {
-      "deps": Object {},
       "name": "react-is",
       "root": "/common/temp/build-tests/node_modules/.pnpm/react-is@18.3.1/node_modules/react-is",
     },
@@ -5201,7 +4938,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/regexp.prototype.flags@1.5.2/node_modules/regexp.prototype.flags",
     },
     Object {
-      "deps": Object {},
       "name": "regextras",
       "root": "/common/temp/build-tests/node_modules/.pnpm/regextras@0.8.0/node_modules/regextras",
     },
@@ -5220,22 +4956,18 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/registry-url@5.1.0/node_modules/registry-url",
     },
     Object {
-      "deps": Object {},
       "name": "require-directory",
       "root": "/common/temp/build-tests/node_modules/.pnpm/require-directory@2.1.1/node_modules/require-directory",
     },
     Object {
-      "deps": Object {},
       "name": "require-from-string",
       "root": "/common/temp/build-tests/node_modules/.pnpm/require-from-string@2.0.2/node_modules/require-from-string",
     },
     Object {
-      "deps": Object {},
       "name": "require-package-name",
       "root": "/common/temp/build-tests/node_modules/.pnpm/require-package-name@2.0.1/node_modules/require-package-name",
     },
     Object {
-      "deps": Object {},
       "name": "resolve-alpn",
       "root": "/common/temp/build-tests/node_modules/.pnpm/resolve-alpn@1.2.1/node_modules/resolve-alpn",
     },
@@ -5248,17 +4980,14 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/resolve-dir@1.0.1/node_modules/resolve-dir",
     },
     Object {
-      "deps": Object {},
       "name": "resolve-from",
       "root": "/common/temp/build-tests/node_modules/.pnpm/resolve-from@4.0.0/node_modules/resolve-from",
     },
     Object {
-      "deps": Object {},
       "name": "resolve-from",
       "root": "/common/temp/build-tests/node_modules/.pnpm/resolve-from@5.0.0/node_modules/resolve-from",
     },
     Object {
-      "deps": Object {},
       "name": "resolve.exports",
       "root": "/common/temp/build-tests/node_modules/.pnpm/resolve.exports@2.0.2/node_modules/resolve.exports",
     },
@@ -5296,12 +5025,10 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/restore-cursor@3.1.0/node_modules/restore-cursor",
     },
     Object {
-      "deps": Object {},
       "name": "reusify",
       "root": "/common/temp/build-tests/node_modules/.pnpm/reusify@1.0.4/node_modules/reusify",
     },
     Object {
-      "deps": Object {},
       "name": "rfc4648",
       "root": "/common/temp/build-tests/node_modules/.pnpm/rfc4648@1.5.3/node_modules/rfc4648",
     },
@@ -5313,7 +5040,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/rimraf@3.0.2/node_modules/rimraf",
     },
     Object {
-      "deps": Object {},
       "name": "run-async",
       "root": "/common/temp/build-tests/node_modules/.pnpm/run-async@2.4.1/node_modules/run-async",
     },
@@ -5342,12 +5068,10 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/safe-array-concat@1.1.2/node_modules/safe-array-concat",
     },
     Object {
-      "deps": Object {},
       "name": "safe-buffer",
       "root": "/common/temp/build-tests/node_modules/.pnpm/safe-buffer@5.1.2/node_modules/safe-buffer",
     },
     Object {
-      "deps": Object {},
       "name": "safe-buffer",
       "root": "/common/temp/build-tests/node_modules/.pnpm/safe-buffer@5.2.1/node_modules/safe-buffer",
     },
@@ -5361,12 +5085,10 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/safe-regex-test@1.0.3/node_modules/safe-regex-test",
     },
     Object {
-      "deps": Object {},
       "name": "safer-buffer",
       "root": "/common/temp/build-tests/node_modules/.pnpm/safer-buffer@2.1.2/node_modules/safer-buffer",
     },
     Object {
-      "deps": Object {},
       "name": "semver-compare",
       "root": "/common/temp/build-tests/node_modules/.pnpm/semver-compare@1.0.0/node_modules/semver-compare",
     },
@@ -5378,12 +5100,10 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/semver-diff@3.1.1/node_modules/semver-diff",
     },
     Object {
-      "deps": Object {},
       "name": "semver",
       "root": "/common/temp/build-tests/node_modules/.pnpm/semver@5.7.2/node_modules/semver",
     },
     Object {
-      "deps": Object {},
       "name": "semver",
       "root": "/common/temp/build-tests/node_modules/.pnpm/semver@6.3.1/node_modules/semver",
     },
@@ -5395,7 +5115,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/semver@7.5.4/node_modules/semver",
     },
     Object {
-      "deps": Object {},
       "name": "semver",
       "root": "/common/temp/build-tests/node_modules/.pnpm/semver@7.6.2/node_modules/semver",
     },
@@ -5422,7 +5141,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/set-function-name@2.0.2/node_modules/set-function-name",
     },
     Object {
-      "deps": Object {},
       "name": "set-immediate-shim",
       "root": "/common/temp/build-tests/node_modules/.pnpm/set-immediate-shim@1.0.1/node_modules/set-immediate-shim",
     },
@@ -5434,7 +5152,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/shebang-command@2.0.0/node_modules/shebang-command",
     },
     Object {
-      "deps": Object {},
       "name": "shebang-regex",
       "root": "/common/temp/build-tests/node_modules/.pnpm/shebang-regex@3.0.0/node_modules/shebang-regex",
     },
@@ -5449,12 +5166,10 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/side-channel@1.0.6/node_modules/side-channel",
     },
     Object {
-      "deps": Object {},
       "name": "signal-exit",
       "root": "/common/temp/build-tests/node_modules/.pnpm/signal-exit@3.0.7/node_modules/signal-exit",
     },
     Object {
-      "deps": Object {},
       "name": "slash",
       "root": "/common/temp/build-tests/node_modules/.pnpm/slash@3.0.0/node_modules/slash",
     },
@@ -5466,7 +5181,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/sort-keys@4.2.0/node_modules/sort-keys",
     },
     Object {
-      "deps": Object {},
       "name": "source-map-js",
       "root": "/common/temp/build-tests/node_modules/.pnpm/source-map-js@1.2.0/node_modules/source-map-js",
     },
@@ -5479,7 +5193,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/source-map-support@0.5.13/node_modules/source-map-support",
     },
     Object {
-      "deps": Object {},
       "name": "source-map",
       "root": "/common/temp/build-tests/node_modules/.pnpm/source-map@0.6.1/node_modules/source-map",
     },
@@ -5492,7 +5205,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/spdx-correct@3.2.0/node_modules/spdx-correct",
     },
     Object {
-      "deps": Object {},
       "name": "spdx-exceptions",
       "root": "/common/temp/build-tests/node_modules/.pnpm/spdx-exceptions@2.5.0/node_modules/spdx-exceptions",
     },
@@ -5505,12 +5217,10 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/spdx-expression-parse@3.0.1/node_modules/spdx-expression-parse",
     },
     Object {
-      "deps": Object {},
       "name": "spdx-license-ids",
       "root": "/common/temp/build-tests/node_modules/.pnpm/spdx-license-ids@3.0.17/node_modules/spdx-license-ids",
     },
     Object {
-      "deps": Object {},
       "name": "sprintf-js",
       "root": "/common/temp/build-tests/node_modules/.pnpm/sprintf-js@1.0.3/node_modules/sprintf-js",
     },
@@ -5529,17 +5239,14 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/stack-utils@2.0.6/node_modules/stack-utils",
     },
     Object {
-      "deps": Object {},
       "name": "stackframe",
       "root": "/common/temp/build-tests/node_modules/.pnpm/stackframe@1.3.4/node_modules/stackframe",
     },
     Object {
-      "deps": Object {},
       "name": "strict-uri-encode",
       "root": "/common/temp/build-tests/node_modules/.pnpm/strict-uri-encode@2.0.0/node_modules/strict-uri-encode",
     },
     Object {
-      "deps": Object {},
       "name": "string-argv",
       "root": "/common/temp/build-tests/node_modules/.pnpm/string-argv@0.3.2/node_modules/string-argv",
     },
@@ -5635,17 +5342,14 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/strip-ansi@6.0.1/node_modules/strip-ansi",
     },
     Object {
-      "deps": Object {},
       "name": "strip-bom",
       "root": "/common/temp/build-tests/node_modules/.pnpm/strip-bom@3.0.0/node_modules/strip-bom",
     },
     Object {
-      "deps": Object {},
       "name": "strip-bom",
       "root": "/common/temp/build-tests/node_modules/.pnpm/strip-bom@4.0.0/node_modules/strip-bom",
     },
     Object {
-      "deps": Object {},
       "name": "strip-final-newline",
       "root": "/common/temp/build-tests/node_modules/.pnpm/strip-final-newline@2.0.0/node_modules/strip-final-newline",
     },
@@ -5657,12 +5361,10 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/strip-indent@3.0.0/node_modules/strip-indent",
     },
     Object {
-      "deps": Object {},
       "name": "strip-json-comments",
       "root": "/common/temp/build-tests/node_modules/.pnpm/strip-json-comments@2.0.1/node_modules/strip-json-comments",
     },
     Object {
-      "deps": Object {},
       "name": "strip-json-comments",
       "root": "/common/temp/build-tests/node_modules/.pnpm/strip-json-comments@3.1.1/node_modules/strip-json-comments",
     },
@@ -5688,17 +5390,14 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/supports-color@8.1.1/node_modules/supports-color",
     },
     Object {
-      "deps": Object {},
       "name": "supports-preserve-symlinks-flag",
       "root": "/common/temp/build-tests/node_modules/.pnpm/supports-preserve-symlinks-flag@1.0.0/node_modules/supports-preserve-symlinks-flag",
     },
     Object {
-      "deps": Object {},
       "name": "tapable",
       "root": "/common/temp/build-tests/node_modules/.pnpm/tapable@1.1.3/node_modules/tapable",
     },
     Object {
-      "deps": Object {},
       "name": "tapable",
       "root": "/common/temp/build-tests/node_modules/.pnpm/tapable@2.2.1/node_modules/tapable",
     },
@@ -5724,7 +5423,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/test-exclude@6.0.0/node_modules/test-exclude",
     },
     Object {
-      "deps": Object {},
       "name": "text-table",
       "root": "/common/temp/build-tests/node_modules/.pnpm/text-table@0.2.0/node_modules/text-table",
     },
@@ -5743,12 +5441,10 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/thenify@3.3.1/node_modules/thenify",
     },
     Object {
-      "deps": Object {},
       "name": "throat",
       "root": "/common/temp/build-tests/node_modules/.pnpm/throat@6.0.2/node_modules/throat",
     },
     Object {
-      "deps": Object {},
       "name": "through",
       "root": "/common/temp/build-tests/node_modules/.pnpm/through@2.3.8/node_modules/through",
     },
@@ -5760,12 +5456,10 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/tmp@0.0.33/node_modules/tmp",
     },
     Object {
-      "deps": Object {},
       "name": "tmpl",
       "root": "/common/temp/build-tests/node_modules/.pnpm/tmpl@1.0.5/node_modules/tmpl",
     },
     Object {
-      "deps": Object {},
       "name": "to-fast-properties",
       "root": "/common/temp/build-tests/node_modules/.pnpm/to-fast-properties@2.0.0/node_modules/to-fast-properties",
     },
@@ -5777,17 +5471,14 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/to-regex-range@5.0.1/node_modules/to-regex-range",
     },
     Object {
-      "deps": Object {},
       "name": "tr46",
       "root": "/common/temp/build-tests/node_modules/.pnpm/tr46@0.0.3/node_modules/tr46",
     },
     Object {
-      "deps": Object {},
       "name": "trim-newlines",
       "root": "/common/temp/build-tests/node_modules/.pnpm/trim-newlines@3.0.1/node_modules/trim-newlines",
     },
     Object {
-      "deps": Object {},
       "name": "true-case-path",
       "root": "/common/temp/build-tests/node_modules/.pnpm/true-case-path@2.2.1/node_modules/true-case-path",
     },
@@ -5816,12 +5507,10 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/tsconfig-paths@3.15.0/node_modules/tsconfig-paths",
     },
     Object {
-      "deps": Object {},
       "name": "tslib",
       "root": "/common/temp/build-tests/node_modules/.pnpm/tslib@1.14.1/node_modules/tslib",
     },
     Object {
-      "deps": Object {},
       "name": "tslib",
       "root": "/common/temp/build-tests/node_modules/.pnpm/tslib@2.6.2/node_modules/tslib",
     },
@@ -5869,32 +5558,26 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/type-check@0.4.0/node_modules/type-check",
     },
     Object {
-      "deps": Object {},
       "name": "type-detect",
       "root": "/common/temp/build-tests/node_modules/.pnpm/type-detect@4.0.8/node_modules/type-detect",
     },
     Object {
-      "deps": Object {},
       "name": "type-fest",
       "root": "/common/temp/build-tests/node_modules/.pnpm/type-fest@0.18.1/node_modules/type-fest",
     },
     Object {
-      "deps": Object {},
       "name": "type-fest",
       "root": "/common/temp/build-tests/node_modules/.pnpm/type-fest@0.20.2/node_modules/type-fest",
     },
     Object {
-      "deps": Object {},
       "name": "type-fest",
       "root": "/common/temp/build-tests/node_modules/.pnpm/type-fest@0.21.3/node_modules/type-fest",
     },
     Object {
-      "deps": Object {},
       "name": "type-fest",
       "root": "/common/temp/build-tests/node_modules/.pnpm/type-fest@0.6.0/node_modules/type-fest",
     },
     Object {
-      "deps": Object {},
       "name": "type-fest",
       "root": "/common/temp/build-tests/node_modules/.pnpm/type-fest@0.8.1/node_modules/type-fest",
     },
@@ -5950,17 +5633,14 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/typedarray-to-buffer@3.1.5/node_modules/typedarray-to-buffer",
     },
     Object {
-      "deps": Object {},
       "name": "typescript",
       "root": "/common/temp/build-tests/node_modules/.pnpm/typescript@4.9.5/node_modules/typescript",
     },
     Object {
-      "deps": Object {},
       "name": "typescript",
       "root": "/common/temp/build-tests/node_modules/.pnpm/typescript@5.4.2/node_modules/typescript",
     },
     Object {
-      "deps": Object {},
       "name": "typescript",
       "root": "/common/temp/build-tests/node_modules/.pnpm/typescript@5.4.5/node_modules/typescript",
     },
@@ -5982,7 +5662,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/unique-string@2.0.0/node_modules/unique-string",
     },
     Object {
-      "deps": Object {},
       "name": "universalify",
       "root": "/common/temp/build-tests/node_modules/.pnpm/universalify@0.1.2/node_modules/universalify",
     },
@@ -6023,12 +5702,10 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/uri-js@4.4.1/node_modules/uri-js",
     },
     Object {
-      "deps": Object {},
       "name": "util-deprecate",
       "root": "/common/temp/build-tests/node_modules/.pnpm/util-deprecate@1.0.2/node_modules/util-deprecate",
     },
     Object {
-      "deps": Object {},
       "name": "uuid",
       "root": "/common/temp/build-tests/node_modules/.pnpm/uuid@8.3.2/node_modules/uuid",
     },
@@ -6079,7 +5756,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/wcwidth@1.0.1/node_modules/wcwidth",
     },
     Object {
-      "deps": Object {},
       "name": "webidl-conversions",
       "root": "/common/temp/build-tests/node_modules/.pnpm/webidl-conversions@3.0.1/node_modules/webidl-conversions",
     },
@@ -6171,7 +5847,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/widest-line@3.1.0/node_modules/widest-line",
     },
     Object {
-      "deps": Object {},
       "name": "word-wrap",
       "root": "/common/temp/build-tests/node_modules/.pnpm/word-wrap@1.2.5/node_modules/word-wrap",
     },
@@ -6185,7 +5860,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/wrap-ansi@7.0.0/node_modules/wrap-ansi",
     },
     Object {
-      "deps": Object {},
       "name": "wrappy",
       "root": "/common/temp/build-tests/node_modules/.pnpm/wrappy@1.0.2/node_modules/wrappy",
     },
@@ -6216,47 +5890,38 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/write-yaml-file@4.2.0/node_modules/write-yaml-file",
     },
     Object {
-      "deps": Object {},
       "name": "xdg-basedir",
       "root": "/common/temp/build-tests/node_modules/.pnpm/xdg-basedir@4.0.0/node_modules/xdg-basedir",
     },
     Object {
-      "deps": Object {},
       "name": "xml",
       "root": "/common/temp/build-tests/node_modules/.pnpm/xml@1.0.1/node_modules/xml",
     },
     Object {
-      "deps": Object {},
       "name": "xtend",
       "root": "/common/temp/build-tests/node_modules/.pnpm/xtend@4.0.2/node_modules/xtend",
     },
     Object {
-      "deps": Object {},
       "name": "y18n",
       "root": "/common/temp/build-tests/node_modules/.pnpm/y18n@5.0.8/node_modules/y18n",
     },
     Object {
-      "deps": Object {},
       "name": "yallist",
       "root": "/common/temp/build-tests/node_modules/.pnpm/yallist@3.1.1/node_modules/yallist",
     },
     Object {
-      "deps": Object {},
       "name": "yallist",
       "root": "/common/temp/build-tests/node_modules/.pnpm/yallist@4.0.0/node_modules/yallist",
     },
     Object {
-      "deps": Object {},
       "name": "yaml",
       "root": "/common/temp/build-tests/node_modules/.pnpm/yaml@1.10.2/node_modules/yaml",
     },
     Object {
-      "deps": Object {},
       "name": "yaml",
       "root": "/common/temp/build-tests/node_modules/.pnpm/yaml@2.4.1/node_modules/yaml",
     },
     Object {
-      "deps": Object {},
       "name": "yargs-parser",
       "root": "/common/temp/build-tests/node_modules/.pnpm/yargs-parser@20.2.9/node_modules/yargs-parser",
     },
@@ -6274,7 +5939,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/yargs@16.2.0/node_modules/yargs",
     },
     Object {
-      "deps": Object {},
       "name": "yocto-queue",
       "root": "/common/temp/build-tests/node_modules/.pnpm/yocto-queue@0.1.0/node_modules/yocto-queue",
     },
@@ -6355,7 +6019,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/file+..+..+..+eslint+eslint-config_eslint@8.57.0_typescript@5.4.5/node_modules/@rushstack/eslint-config",
     },
     Object {
-      "deps": Object {},
       "name": "@rushstack/eslint-patch",
       "root": "/common/temp/build-tests/node_modules/.pnpm/file+..+..+..+eslint+eslint-patch/node_modules/@rushstack/eslint-patch",
     },
@@ -6627,7 +6290,6 @@ Object {
       "root": "/common/temp/build-tests/node_modules/.pnpm/file+..+..+..+libraries+terminal_@types+node@18.17.15/node_modules/@rushstack/terminal",
     },
     Object {
-      "deps": Object {},
       "name": "@rushstack/tree-pattern",
       "root": "/common/temp/build-tests/node_modules/.pnpm/file+..+..+..+libraries+tree-pattern/node_modules/@rushstack/tree-pattern",
     },
@@ -6729,11 +6391,183 @@ Object {
 }
 `;
 
+exports[`computeResolverCacheFromLockfileAsync matches snapshot behavior: bundled-dependencies.yaml 1`] = `
+Object {
+  "contexts": Array [
+    Object {
+      "deps": Object {
+        "@baz/bar": 1,
+      },
+      "name": "foo",
+      "root": "/common/temp/bundled-dependencies/node_modules/.pnpm/foo@1.0.0/node_modules/foo",
+    },
+    Object {
+      "deps": Object {
+        "@graphql-codegen/cli": 2,
+        "@graphql-codegen/typescript-react-apollo": 3,
+        "@graphql-codegen/visitor-plugin-common": 4,
+        "@graphql-tools/optimize": 5,
+        "@graphql-tools/relay-operation-optimizer": 6,
+        "@graphql-tools/url-loader": 7,
+        "@graphql-tools/utils": 8,
+        "@graphql-tools/wrap": 9,
+        "@n1ru4l/graphql-live-query": 10,
+        "@typescript-eslint/parser": 11,
+        "@typescript-eslint/typescript-estree": 12,
+        "chokidar": 13,
+        "dset": 14,
+        "eslint-config-prettier": 15,
+        "eslint-plugin-prettier": 16,
+        "isomorphic-ws": 17,
+        "minimatch": 18,
+        "mkdirp": 19,
+        "semver": 20,
+        "string-width": 21,
+        "strip-ansi": 22,
+        "tslib": 23,
+        "ws": 24,
+        "y18n": 25,
+        "yargs": 27,
+        "yargs-parser": 26,
+      },
+      "dirInfoFiles": Array [
+        "node_modules/.ignored/eslint-plugin-prettier",
+        "node_modules/.ignored/eslint-config-prettier",
+        "node_modules/.ignored/@typescript-eslint/parser",
+        "node_modules/.ignored/@graphql-codegen/typescript-react-apollo",
+        "node_modules/.ignored/@graphql-codegen/cli",
+      ],
+      "name": "@baz/bar",
+      "root": "/common/temp/bundled-dependencies/node_modules/.pnpm/foo@1.0.0/node_modules/foo/node_modules/@baz/bar",
+    },
+    Object {
+      "name": "@graphql-codegen/cli",
+      "root": "/common/temp/bundled-dependencies/node_modules/.pnpm/foo@1.0.0/node_modules/foo/node_modules/@baz/bar/node_modules/@graphql-codegen/cli",
+    },
+    Object {
+      "name": "@graphql-codegen/typescript-react-apollo",
+      "root": "/common/temp/bundled-dependencies/node_modules/.pnpm/foo@1.0.0/node_modules/foo/node_modules/@baz/bar/node_modules/@graphql-codegen/typescript-react-apollo",
+    },
+    Object {
+      "name": "@graphql-codegen/visitor-plugin-common",
+      "root": "/common/temp/bundled-dependencies/node_modules/.pnpm/foo@1.0.0/node_modules/foo/node_modules/@baz/bar/node_modules/@graphql-codegen/visitor-plugin-common",
+    },
+    Object {
+      "name": "@graphql-tools/optimize",
+      "root": "/common/temp/bundled-dependencies/node_modules/.pnpm/foo@1.0.0/node_modules/foo/node_modules/@baz/bar/node_modules/@graphql-tools/optimize",
+    },
+    Object {
+      "name": "@graphql-tools/relay-operation-optimizer",
+      "root": "/common/temp/bundled-dependencies/node_modules/.pnpm/foo@1.0.0/node_modules/foo/node_modules/@baz/bar/node_modules/@graphql-tools/relay-operation-optimizer",
+    },
+    Object {
+      "name": "@graphql-tools/url-loader",
+      "root": "/common/temp/bundled-dependencies/node_modules/.pnpm/foo@1.0.0/node_modules/foo/node_modules/@baz/bar/node_modules/@graphql-tools/url-loader",
+    },
+    Object {
+      "name": "@graphql-tools/utils",
+      "root": "/common/temp/bundled-dependencies/node_modules/.pnpm/foo@1.0.0/node_modules/foo/node_modules/@baz/bar/node_modules/@graphql-tools/utils",
+    },
+    Object {
+      "name": "@graphql-tools/wrap",
+      "root": "/common/temp/bundled-dependencies/node_modules/.pnpm/foo@1.0.0/node_modules/foo/node_modules/@baz/bar/node_modules/@graphql-tools/wrap",
+    },
+    Object {
+      "dirInfoFiles": Array [
+        "esm",
+      ],
+      "name": "@n1ru4l/graphql-live-query",
+      "root": "/common/temp/bundled-dependencies/node_modules/.pnpm/foo@1.0.0/node_modules/foo/node_modules/@baz/bar/node_modules/@n1ru4l/graphql-live-query",
+    },
+    Object {
+      "name": "@typescript-eslint/parser",
+      "root": "/common/temp/bundled-dependencies/node_modules/.pnpm/foo@1.0.0/node_modules/foo/node_modules/@baz/bar/node_modules/@typescript-eslint/parser",
+    },
+    Object {
+      "deps": Object {
+        "globby": 28,
+      },
+      "name": "@typescript-eslint/typescript-estree",
+      "root": "/common/temp/bundled-dependencies/node_modules/.pnpm/foo@1.0.0/node_modules/foo/node_modules/@baz/bar/node_modules/@typescript-eslint/typescript-estree",
+    },
+    Object {
+      "name": "chokidar",
+      "root": "/common/temp/bundled-dependencies/node_modules/.pnpm/foo@1.0.0/node_modules/foo/node_modules/@baz/bar/node_modules/chokidar",
+    },
+    Object {
+      "name": "dset",
+      "root": "/common/temp/bundled-dependencies/node_modules/.pnpm/foo@1.0.0/node_modules/foo/node_modules/@baz/bar/node_modules/dset",
+    },
+    Object {
+      "name": "eslint-config-prettier",
+      "root": "/common/temp/bundled-dependencies/node_modules/.pnpm/foo@1.0.0/node_modules/foo/node_modules/@baz/bar/node_modules/eslint-config-prettier",
+    },
+    Object {
+      "name": "eslint-plugin-prettier",
+      "root": "/common/temp/bundled-dependencies/node_modules/.pnpm/foo@1.0.0/node_modules/foo/node_modules/@baz/bar/node_modules/eslint-plugin-prettier",
+    },
+    Object {
+      "name": "isomorphic-ws",
+      "root": "/common/temp/bundled-dependencies/node_modules/.pnpm/foo@1.0.0/node_modules/foo/node_modules/@baz/bar/node_modules/isomorphic-ws",
+    },
+    Object {
+      "name": "minimatch",
+      "root": "/common/temp/bundled-dependencies/node_modules/.pnpm/foo@1.0.0/node_modules/foo/node_modules/@baz/bar/node_modules/minimatch",
+    },
+    Object {
+      "name": "mkdirp",
+      "root": "/common/temp/bundled-dependencies/node_modules/.pnpm/foo@1.0.0/node_modules/foo/node_modules/@baz/bar/node_modules/mkdirp",
+    },
+    Object {
+      "name": "semver",
+      "root": "/common/temp/bundled-dependencies/node_modules/.pnpm/foo@1.0.0/node_modules/foo/node_modules/@baz/bar/node_modules/semver",
+    },
+    Object {
+      "name": "string-width",
+      "root": "/common/temp/bundled-dependencies/node_modules/.pnpm/foo@1.0.0/node_modules/foo/node_modules/@baz/bar/node_modules/string-width",
+    },
+    Object {
+      "name": "strip-ansi",
+      "root": "/common/temp/bundled-dependencies/node_modules/.pnpm/foo@1.0.0/node_modules/foo/node_modules/@baz/bar/node_modules/strip-ansi",
+    },
+    Object {
+      "dirInfoFiles": Array [
+        "modules",
+      ],
+      "name": "tslib",
+      "root": "/common/temp/bundled-dependencies/node_modules/.pnpm/foo@1.0.0/node_modules/foo/node_modules/@baz/bar/node_modules/tslib",
+    },
+    Object {
+      "name": "ws",
+      "root": "/common/temp/bundled-dependencies/node_modules/.pnpm/foo@1.0.0/node_modules/foo/node_modules/@baz/bar/node_modules/ws",
+    },
+    Object {
+      "name": "y18n",
+      "root": "/common/temp/bundled-dependencies/node_modules/.pnpm/foo@1.0.0/node_modules/foo/node_modules/@baz/bar/node_modules/y18n",
+    },
+    Object {
+      "name": "yargs-parser",
+      "root": "/common/temp/bundled-dependencies/node_modules/.pnpm/foo@1.0.0/node_modules/foo/node_modules/@baz/bar/node_modules/yargs-parser",
+    },
+    Object {
+      "dirInfoFiles": Array [
+        "helpers",
+      ],
+      "name": "yargs",
+      "root": "/common/temp/bundled-dependencies/node_modules/.pnpm/foo@1.0.0/node_modules/foo/node_modules/@baz/bar/node_modules/yargs",
+    },
+    Object {
+      "name": "globby",
+      "root": "/common/temp/bundled-dependencies/node_modules/.pnpm/foo@1.0.0/node_modules/foo/node_modules/@baz/bar/node_modules/@typescript-eslint/typescript-estree/node_modules/globby",
+    },
+  ],
+}
+`;
+
 exports[`computeResolverCacheFromLockfileAsync matches snapshot behavior: default-subspace.yaml 1`] = `
 Object {
   "contexts": Array [
     Object {
-      "deps": Object {},
       "name": "@aashutoshrathi/word-wrap",
       "root": "/common/temp/default/node_modules/.pnpm/@aashutoshrathi+word-wrap@1.2.6/node_modules/@aashutoshrathi/word-wrap",
     },
@@ -6746,17 +6580,14 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@ampproject+remapping@2.3.0/node_modules/@ampproject/remapping",
     },
     Object {
-      "deps": Object {},
       "name": "@aws-cdk/asset-awscli-v1",
       "root": "/common/temp/default/node_modules/.pnpm/@aws-cdk+asset-awscli-v1@2.2.202/node_modules/@aws-cdk/asset-awscli-v1",
     },
     Object {
-      "deps": Object {},
       "name": "@aws-cdk/asset-kubectl-v20",
       "root": "/common/temp/default/node_modules/.pnpm/@aws-cdk+asset-kubectl-v20@2.1.2/node_modules/@aws-cdk/asset-kubectl-v20",
     },
     Object {
-      "deps": Object {},
       "name": "@aws-cdk/asset-node-proxy-agent-v5",
       "root": "/common/temp/default/node_modules/.pnpm/@aws-cdk+asset-node-proxy-agent-v5@2.0.166/node_modules/@aws-cdk/asset-node-proxy-agent-v5",
     },
@@ -7388,7 +7219,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@azure+msal-browser@3.17.0/node_modules/@azure/msal-browser",
     },
     Object {
-      "deps": Object {},
       "name": "@azure/msal-common",
       "root": "/common/temp/default/node_modules/.pnpm/@azure+msal-common@14.12.0/node_modules/@azure/msal-common",
     },
@@ -7431,7 +7261,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@babel+code-frame@7.23.5/node_modules/@babel/code-frame",
     },
     Object {
-      "deps": Object {},
       "name": "@babel/compat-data",
       "root": "/common/temp/default/node_modules/.pnpm/@babel+compat-data@7.23.5/node_modules/@babel/compat-data",
     },
@@ -7600,7 +7429,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@babel+helper-define-polyfill-provider@0.6.1_@babel+core@7.20.12/node_modules/@babel/helper-define-polyfill-provider",
     },
     Object {
-      "deps": Object {},
       "name": "@babel/helper-environment-visitor",
       "root": "/common/temp/default/node_modules/.pnpm/@babel+helper-environment-visitor@7.22.20/node_modules/@babel/helper-environment-visitor",
     },
@@ -7677,12 +7505,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@babel+helper-optimise-call-expression@7.22.5/node_modules/@babel/helper-optimise-call-expression",
     },
     Object {
-      "deps": Object {},
       "name": "@babel/helper-plugin-utils",
       "root": "/common/temp/default/node_modules/.pnpm/@babel+helper-plugin-utils@7.10.4/node_modules/@babel/helper-plugin-utils",
     },
     Object {
-      "deps": Object {},
       "name": "@babel/helper-plugin-utils",
       "root": "/common/temp/default/node_modules/.pnpm/@babel+helper-plugin-utils@7.24.0/node_modules/@babel/helper-plugin-utils",
     },
@@ -7728,17 +7554,14 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@babel+helper-split-export-declaration@7.22.6/node_modules/@babel/helper-split-export-declaration",
     },
     Object {
-      "deps": Object {},
       "name": "@babel/helper-string-parser",
       "root": "/common/temp/default/node_modules/.pnpm/@babel+helper-string-parser@7.23.4/node_modules/@babel/helper-string-parser",
     },
     Object {
-      "deps": Object {},
       "name": "@babel/helper-validator-identifier",
       "root": "/common/temp/default/node_modules/.pnpm/@babel+helper-validator-identifier@7.22.20/node_modules/@babel/helper-validator-identifier",
     },
     Object {
-      "deps": Object {},
       "name": "@babel/helper-validator-option",
       "root": "/common/temp/default/node_modules/.pnpm/@babel+helper-validator-option@7.23.5/node_modules/@babel/helper-validator-option",
     },
@@ -7770,7 +7593,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@babel+highlight@7.23.4/node_modules/@babel/highlight",
     },
     Object {
-      "deps": Object {},
       "name": "@babel/parser",
       "root": "/common/temp/default/node_modules/.pnpm/@babel+parser@7.24.0/node_modules/@babel/parser",
     },
@@ -8741,7 +8563,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@babel+register@7.23.7_@babel+core@7.20.12/node_modules/@babel/register",
     },
     Object {
-      "deps": Object {},
       "name": "@babel/regjsgen",
       "root": "/common/temp/default/node_modules/.pnpm/@babel+regjsgen@0.8.0/node_modules/@babel/regjsgen",
     },
@@ -8787,22 +8608,18 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@babel+types@7.24.0/node_modules/@babel/types",
     },
     Object {
-      "deps": Object {},
       "name": "@balena/dockerignore",
       "root": "/common/temp/default/node_modules/.pnpm/@balena+dockerignore@1.0.2/node_modules/@balena/dockerignore",
     },
     Object {
-      "deps": Object {},
       "name": "@base2/pretty-print-object",
       "root": "/common/temp/default/node_modules/.pnpm/@base2+pretty-print-object@1.0.1/node_modules/@base2/pretty-print-object",
     },
     Object {
-      "deps": Object {},
       "name": "@bcoe/v8-coverage",
       "root": "/common/temp/default/node_modules/.pnpm/@bcoe+v8-coverage@0.2.3/node_modules/@bcoe/v8-coverage",
     },
     Object {
-      "deps": Object {},
       "name": "@bufbuild/protobuf",
       "root": "/common/temp/default/node_modules/.pnpm/@bufbuild+protobuf@1.8.0/node_modules/@bufbuild/protobuf",
     },
@@ -8815,7 +8632,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@cnakazawa+watch@1.0.4/node_modules/@cnakazawa/watch",
     },
     Object {
-      "deps": Object {},
       "name": "@colors/colors",
       "root": "/common/temp/default/node_modules/.pnpm/@colors+colors@1.5.0/node_modules/@colors/colors",
     },
@@ -8827,7 +8643,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@devexpress+error-stack-parser@2.0.6/node_modules/@devexpress/error-stack-parser",
     },
     Object {
-      "deps": Object {},
       "name": "@discoveryjs/json-ext",
       "root": "/common/temp/default/node_modules/.pnpm/@discoveryjs+json-ext@0.5.7/node_modules/@discoveryjs/json-ext",
     },
@@ -8865,12 +8680,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@emotion+css@10.0.27/node_modules/@emotion/css",
     },
     Object {
-      "deps": Object {},
       "name": "@emotion/hash",
       "root": "/common/temp/default/node_modules/.pnpm/@emotion+hash@0.8.0/node_modules/@emotion/hash",
     },
     Object {
-      "deps": Object {},
       "name": "@emotion/hash",
       "root": "/common/temp/default/node_modules/.pnpm/@emotion+hash@0.9.1/node_modules/@emotion/hash",
     },
@@ -8882,12 +8695,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@emotion+is-prop-valid@0.8.8/node_modules/@emotion/is-prop-valid",
     },
     Object {
-      "deps": Object {},
       "name": "@emotion/memoize",
       "root": "/common/temp/default/node_modules/.pnpm/@emotion+memoize@0.7.4/node_modules/@emotion/memoize",
     },
     Object {
-      "deps": Object {},
       "name": "@emotion/memoize",
       "root": "/common/temp/default/node_modules/.pnpm/@emotion+memoize@0.8.1/node_modules/@emotion/memoize",
     },
@@ -8914,7 +8725,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@emotion+serialize@1.1.3/node_modules/@emotion/serialize",
     },
     Object {
-      "deps": Object {},
       "name": "@emotion/sheet",
       "root": "/common/temp/default/node_modules/.pnpm/@emotion+sheet@0.9.4/node_modules/@emotion/sheet",
     },
@@ -8943,32 +8753,26 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@emotion+styled@10.3.0_@emotion+core@10.3.1_@types+react@17.0.74_react@17.0.2/node_modules/@emotion/styled",
     },
     Object {
-      "deps": Object {},
       "name": "@emotion/stylis",
       "root": "/common/temp/default/node_modules/.pnpm/@emotion+stylis@0.8.5/node_modules/@emotion/stylis",
     },
     Object {
-      "deps": Object {},
       "name": "@emotion/unitless",
       "root": "/common/temp/default/node_modules/.pnpm/@emotion+unitless@0.7.5/node_modules/@emotion/unitless",
     },
     Object {
-      "deps": Object {},
       "name": "@emotion/unitless",
       "root": "/common/temp/default/node_modules/.pnpm/@emotion+unitless@0.8.1/node_modules/@emotion/unitless",
     },
     Object {
-      "deps": Object {},
       "name": "@emotion/utils",
       "root": "/common/temp/default/node_modules/.pnpm/@emotion+utils@0.11.3/node_modules/@emotion/utils",
     },
     Object {
-      "deps": Object {},
       "name": "@emotion/utils",
       "root": "/common/temp/default/node_modules/.pnpm/@emotion+utils@1.2.1/node_modules/@emotion/utils",
     },
     Object {
-      "deps": Object {},
       "name": "@emotion/weak-memoize",
       "root": "/common/temp/default/node_modules/.pnpm/@emotion+weak-memoize@0.2.5/node_modules/@emotion/weak-memoize",
     },
@@ -8982,7 +8786,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@es-joy+jsdoccomment@0.17.0/node_modules/@es-joy/jsdoccomment",
     },
     Object {
-      "deps": Object {},
       "name": "@esbuild/linux-x64",
       "root": "/common/temp/default/node_modules/.pnpm/@esbuild+linux-x64@0.20.2/node_modules/@esbuild/linux-x64",
     },
@@ -9019,7 +8822,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@eslint-community+eslint-utils@4.4.0_eslint@8.57.0/node_modules/@eslint-community/eslint-utils",
     },
     Object {
-      "deps": Object {},
       "name": "@eslint-community/regexpp",
       "root": "/common/temp/default/node_modules/.pnpm/@eslint-community+regexpp@4.10.0/node_modules/@eslint-community/regexpp",
     },
@@ -9100,7 +8902,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@eslint+eslintrc@3.0.2/node_modules/@eslint/eslintrc",
     },
     Object {
-      "deps": Object {},
       "name": "@eslint/js",
       "root": "/common/temp/default/node_modules/.pnpm/@eslint+js@8.57.0/node_modules/@eslint/js",
     },
@@ -9112,7 +8913,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@fastify+ajv-compiler@1.1.0/node_modules/@fastify/ajv-compiler",
     },
     Object {
-      "deps": Object {},
       "name": "@fastify/forwarded",
       "root": "/common/temp/default/node_modules/.pnpm/@fastify+forwarded@1.0.0/node_modules/@fastify/forwarded",
     },
@@ -9147,7 +8947,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@floating-ui+dom@1.6.3/node_modules/@floating-ui/dom",
     },
     Object {
-      "deps": Object {},
       "name": "@floating-ui/utils",
       "root": "/common/temp/default/node_modules/.pnpm/@floating-ui+utils@0.2.1/node_modules/@floating-ui/utils",
     },
@@ -10275,7 +10074,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@fluentui+utilities@8.14.0_@types+react@17.0.74_react@17.0.2/node_modules/@fluentui/utilities",
     },
     Object {
-      "deps": Object {},
       "name": "@gar/promisify",
       "root": "/common/temp/default/node_modules/.pnpm/@gar+promisify@1.1.3/node_modules/@gar/promisify",
     },
@@ -10344,22 +10142,18 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@humanwhocodes+config-array@0.9.5/node_modules/@humanwhocodes/config-array",
     },
     Object {
-      "deps": Object {},
       "name": "@humanwhocodes/gitignore-to-minimatch",
       "root": "/common/temp/default/node_modules/.pnpm/@humanwhocodes+gitignore-to-minimatch@1.0.2/node_modules/@humanwhocodes/gitignore-to-minimatch",
     },
     Object {
-      "deps": Object {},
       "name": "@humanwhocodes/module-importer",
       "root": "/common/temp/default/node_modules/.pnpm/@humanwhocodes+module-importer@1.0.1/node_modules/@humanwhocodes/module-importer",
     },
     Object {
-      "deps": Object {},
       "name": "@humanwhocodes/object-schema",
       "root": "/common/temp/default/node_modules/.pnpm/@humanwhocodes+object-schema@1.2.1/node_modules/@humanwhocodes/object-schema",
     },
     Object {
-      "deps": Object {},
       "name": "@humanwhocodes/object-schema",
       "root": "/common/temp/default/node_modules/.pnpm/@humanwhocodes+object-schema@2.0.2/node_modules/@humanwhocodes/object-schema",
     },
@@ -10375,7 +10169,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@istanbuljs+load-nyc-config@1.1.0/node_modules/@istanbuljs/load-nyc-config",
     },
     Object {
-      "deps": Object {},
       "name": "@istanbuljs/schema",
       "root": "/common/temp/default/node_modules/.pnpm/@istanbuljs+schema@0.1.3/node_modules/@istanbuljs/schema",
     },
@@ -10748,12 +10541,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@jridgewell+gen-mapping@0.3.5/node_modules/@jridgewell/gen-mapping",
     },
     Object {
-      "deps": Object {},
       "name": "@jridgewell/resolve-uri",
       "root": "/common/temp/default/node_modules/.pnpm/@jridgewell+resolve-uri@3.1.2/node_modules/@jridgewell/resolve-uri",
     },
     Object {
-      "deps": Object {},
       "name": "@jridgewell/set-array",
       "root": "/common/temp/default/node_modules/.pnpm/@jridgewell+set-array@1.2.1/node_modules/@jridgewell/set-array",
     },
@@ -10766,7 +10557,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@jridgewell+source-map@0.3.6/node_modules/@jridgewell/source-map",
     },
     Object {
-      "deps": Object {},
       "name": "@jridgewell/sourcemap-codec",
       "root": "/common/temp/default/node_modules/.pnpm/@jridgewell+sourcemap-codec@1.4.15/node_modules/@jridgewell/sourcemap-codec",
     },
@@ -10779,12 +10569,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@jridgewell+trace-mapping@0.3.25/node_modules/@jridgewell/trace-mapping",
     },
     Object {
-      "deps": Object {},
       "name": "@leichtgewicht/ip-codec",
       "root": "/common/temp/default/node_modules/.pnpm/@leichtgewicht+ip-codec@2.0.4/node_modules/@leichtgewicht/ip-codec",
     },
     Object {
-      "deps": Object {},
       "name": "@lifaon/path",
       "root": "/common/temp/default/node_modules/.pnpm/@lifaon+path@2.1.0/node_modules/@lifaon/path",
     },
@@ -10830,7 +10618,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@mdx-js+react@1.6.22_react@17.0.2/node_modules/@mdx-js/react",
     },
     Object {
-      "deps": Object {},
       "name": "@mdx-js/util",
       "root": "/common/temp/default/node_modules/.pnpm/@mdx-js+util@1.6.22/node_modules/@mdx-js/util",
     },
@@ -10863,12 +10650,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@microsoft+api-extractor@7.46.2_@types+node@18.17.15/node_modules/@microsoft/api-extractor",
     },
     Object {
-      "deps": Object {},
       "name": "@microsoft/load-themed-styles",
       "root": "/common/temp/default/node_modules/.pnpm/@microsoft+load-themed-styles@1.10.295/node_modules/@microsoft/load-themed-styles",
     },
     Object {
-      "deps": Object {},
       "name": "@microsoft/teams-js",
       "root": "/common/temp/default/node_modules/.pnpm/@microsoft+teams-js@1.3.0-beta.4/node_modules/@microsoft/teams-js",
     },
@@ -10883,7 +10668,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@microsoft+tsdoc-config@0.17.0/node_modules/@microsoft/tsdoc-config",
     },
     Object {
-      "deps": Object {},
       "name": "@microsoft/tsdoc",
       "root": "/common/temp/default/node_modules/.pnpm/@microsoft+tsdoc@0.15.0/node_modules/@microsoft/tsdoc",
     },
@@ -10904,12 +10688,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@nodelib+fs.scandir@2.1.5/node_modules/@nodelib/fs.scandir",
     },
     Object {
-      "deps": Object {},
       "name": "@nodelib/fs.stat",
       "root": "/common/temp/default/node_modules/.pnpm/@nodelib+fs.stat@1.1.3/node_modules/@nodelib/fs.stat",
     },
     Object {
-      "deps": Object {},
       "name": "@nodelib/fs.stat",
       "root": "/common/temp/default/node_modules/.pnpm/@nodelib+fs.stat@2.0.5/node_modules/@nodelib/fs.stat",
     },
@@ -10938,7 +10720,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@npmcli+move-file@1.1.2/node_modules/@npmcli/move-file",
     },
     Object {
-      "deps": Object {},
       "name": "@opentelemetry/api",
       "root": "/common/temp/default/node_modules/.pnpm/@opentelemetry+api@1.8.0/node_modules/@opentelemetry/api",
     },
@@ -10984,7 +10765,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@pnpm+dependency-path@2.1.8/node_modules/@pnpm/dependency-path",
     },
     Object {
-      "deps": Object {},
       "name": "@pnpm/error",
       "root": "/common/temp/default/node_modules/.pnpm/@pnpm+error@1.4.0/node_modules/@pnpm/error",
     },
@@ -11067,17 +10847,14 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@pnpm+read-project-manifest@1.1.7/node_modules/@pnpm/read-project-manifest",
     },
     Object {
-      "deps": Object {},
       "name": "@pnpm/types",
       "root": "/common/temp/default/node_modules/.pnpm/@pnpm+types@6.4.0/node_modules/@pnpm/types",
     },
     Object {
-      "deps": Object {},
       "name": "@pnpm/types",
       "root": "/common/temp/default/node_modules/.pnpm/@pnpm+types@8.9.0/node_modules/@pnpm/types",
     },
     Object {
-      "deps": Object {},
       "name": "@pnpm/types",
       "root": "/common/temp/default/node_modules/.pnpm/@pnpm+types@9.4.2/node_modules/@pnpm/types",
     },
@@ -11093,12 +10870,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@pnpm+write-project-manifest@1.1.7/node_modules/@pnpm/write-project-manifest",
     },
     Object {
-      "deps": Object {},
       "name": "@polka/url",
       "root": "/common/temp/default/node_modules/.pnpm/@polka+url@1.0.0-next.25/node_modules/@polka/url",
     },
     Object {
-      "deps": Object {},
       "name": "@popperjs/core",
       "root": "/common/temp/default/node_modules/.pnpm/@popperjs+core@2.11.8/node_modules/@popperjs/core",
     },
@@ -11110,7 +10885,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@pothos+core@3.41.1_graphql@16.8.1/node_modules/@pothos/core",
     },
     Object {
-      "deps": Object {},
       "name": "@radix-ui/colors",
       "root": "/common/temp/default/node_modules/.pnpm/@radix-ui+colors@0.1.9/node_modules/@radix-ui/colors",
     },
@@ -11381,7 +11155,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@reduxjs+toolkit@1.8.6_react-redux@8.0.7_react@17.0.2/node_modules/@reduxjs/toolkit",
     },
     Object {
-      "deps": Object {},
       "name": "@remix-run/router",
       "root": "/common/temp/default/node_modules/.pnpm/@remix-run+router@1.15.3/node_modules/@remix-run/router",
     },
@@ -11481,7 +11254,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@rushstack+eslint-config@3.7.0_eslint@8.57.0_typescript@4.9.5/node_modules/@rushstack/eslint-config",
     },
     Object {
-      "deps": Object {},
       "name": "@rushstack/eslint-patch",
       "root": "/common/temp/default/node_modules/.pnpm/@rushstack+eslint-patch@1.10.3/node_modules/@rushstack/eslint-patch",
     },
@@ -11847,7 +11619,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@rushstack+terminal@0.13.0_@types+node@18.17.15/node_modules/@rushstack/terminal",
     },
     Object {
-      "deps": Object {},
       "name": "@rushstack/tree-pattern",
       "root": "/common/temp/default/node_modules/.pnpm/@rushstack+tree-pattern@0.3.3/node_modules/@rushstack/tree-pattern",
     },
@@ -11971,12 +11742,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@serverless-stack+resources@1.18.4_@aws-sdk+client-sso-oidc@3.567.0_@aws-sdk+client-sts@3.567.0/node_modules/@serverless-stack/resources",
     },
     Object {
-      "deps": Object {},
       "name": "@sinclair/typebox",
       "root": "/common/temp/default/node_modules/.pnpm/@sinclair+typebox@0.27.8/node_modules/@sinclair/typebox",
     },
     Object {
-      "deps": Object {},
       "name": "@sindresorhus/is",
       "root": "/common/temp/default/node_modules/.pnpm/@sindresorhus+is@4.6.0/node_modules/@sindresorhus/is",
     },
@@ -13358,32 +13127,26 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@szmarczak+http-timer@4.0.6/node_modules/@szmarczak/http-timer",
     },
     Object {
-      "deps": Object {},
       "name": "@tootallnate/once",
       "root": "/common/temp/default/node_modules/.pnpm/@tootallnate+once@1.1.2/node_modules/@tootallnate/once",
     },
     Object {
-      "deps": Object {},
       "name": "@tootallnate/once",
       "root": "/common/temp/default/node_modules/.pnpm/@tootallnate+once@2.0.0/node_modules/@tootallnate/once",
     },
     Object {
-      "deps": Object {},
       "name": "@trpc/server",
       "root": "/common/temp/default/node_modules/.pnpm/@trpc+server@9.27.4/node_modules/@trpc/server",
     },
     Object {
-      "deps": Object {},
       "name": "@trysound/sax",
       "root": "/common/temp/default/node_modules/.pnpm/@trysound+sax@0.2.0/node_modules/@trysound/sax",
     },
     Object {
-      "deps": Object {},
       "name": "@types/argparse",
       "root": "/common/temp/default/node_modules/.pnpm/@types+argparse@1.0.38/node_modules/@types/argparse",
     },
     Object {
-      "deps": Object {},
       "name": "@types/aws-lambda",
       "root": "/common/temp/default/node_modules/.pnpm/@types+aws-lambda@8.10.93/node_modules/@types/aws-lambda",
     },
@@ -13446,7 +13209,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@types+cacheable-request@6.0.3/node_modules/@types/cacheable-request",
     },
     Object {
-      "deps": Object {},
       "name": "@types/cli-table",
       "root": "/common/temp/default/node_modules/.pnpm/@types+cli-table@0.3.0/node_modules/@types/cli-table",
     },
@@ -13458,7 +13220,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@types+color-convert@2.0.3/node_modules/@types/color-convert",
     },
     Object {
-      "deps": Object {},
       "name": "@types/color-name",
       "root": "/common/temp/default/node_modules/.pnpm/@types+color-name@1.1.3/node_modules/@types/color-name",
     },
@@ -13470,7 +13231,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@types+compression@1.7.5_@types+express@4.17.21/node_modules/@types/compression",
     },
     Object {
-      "deps": Object {},
       "name": "@types/configstore",
       "root": "/common/temp/default/node_modules/.pnpm/@types+configstore@6.0.2/node_modules/@types/configstore",
     },
@@ -13497,7 +13257,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@types+cors@2.8.17/node_modules/@types/cors",
     },
     Object {
-      "deps": Object {},
       "name": "@types/diff",
       "root": "/common/temp/default/node_modules/.pnpm/@types+diff@5.0.1/node_modules/@types/diff",
     },
@@ -13518,12 +13277,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@types+eslint@8.2.0/node_modules/@types/eslint",
     },
     Object {
-      "deps": Object {},
       "name": "@types/estree",
       "root": "/common/temp/default/node_modules/.pnpm/@types+estree@1.0.5/node_modules/@types/estree",
     },
     Object {
-      "deps": Object {},
       "name": "@types/events",
       "root": "/common/temp/default/node_modules/.pnpm/@types+events@3.0.3/node_modules/@types/events",
     },
@@ -13593,22 +13350,18 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@types+hoist-non-react-statics@3.3.5/node_modules/@types/hoist-non-react-statics",
     },
     Object {
-      "deps": Object {},
       "name": "@types/html-minifier-terser",
       "root": "/common/temp/default/node_modules/.pnpm/@types+html-minifier-terser@5.1.2/node_modules/@types/html-minifier-terser",
     },
     Object {
-      "deps": Object {},
       "name": "@types/html-minifier-terser",
       "root": "/common/temp/default/node_modules/.pnpm/@types+html-minifier-terser@6.1.0/node_modules/@types/html-minifier-terser",
     },
     Object {
-      "deps": Object {},
       "name": "@types/http-cache-semantics",
       "root": "/common/temp/default/node_modules/.pnpm/@types+http-cache-semantics@4.0.4/node_modules/@types/http-cache-semantics",
     },
     Object {
-      "deps": Object {},
       "name": "@types/http-errors",
       "root": "/common/temp/default/node_modules/.pnpm/@types+http-errors@2.0.4/node_modules/@types/http-errors",
     },
@@ -13628,17 +13381,14 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@types+inquirer@7.3.1/node_modules/@types/inquirer",
     },
     Object {
-      "deps": Object {},
       "name": "@types/is-function",
       "root": "/common/temp/default/node_modules/.pnpm/@types+is-function@1.0.3/node_modules/@types/is-function",
     },
     Object {
-      "deps": Object {},
       "name": "@types/istanbul-lib-coverage",
       "root": "/common/temp/default/node_modules/.pnpm/@types+istanbul-lib-coverage@2.0.4/node_modules/@types/istanbul-lib-coverage",
     },
     Object {
-      "deps": Object {},
       "name": "@types/istanbul-lib-coverage",
       "root": "/common/temp/default/node_modules/.pnpm/@types+istanbul-lib-coverage@2.0.6/node_modules/@types/istanbul-lib-coverage",
     },
@@ -13657,7 +13407,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@types+istanbul-reports@3.0.4/node_modules/@types/istanbul-reports",
     },
     Object {
-      "deps": Object {},
       "name": "@types/jest",
       "root": "/common/temp/default/node_modules/.pnpm/@types+jest@23.3.13/node_modules/@types/jest",
     },
@@ -13686,12 +13435,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@types+jest@29.5.12/node_modules/@types/jest",
     },
     Object {
-      "deps": Object {},
       "name": "@types/jju",
       "root": "/common/temp/default/node_modules/.pnpm/@types+jju@1.4.1/node_modules/@types/jju",
     },
     Object {
-      "deps": Object {},
       "name": "@types/js-yaml",
       "root": "/common/temp/default/node_modules/.pnpm/@types+js-yaml@3.12.1/node_modules/@types/js-yaml",
     },
@@ -13705,12 +13452,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@types+jsdom@20.0.1/node_modules/@types/jsdom",
     },
     Object {
-      "deps": Object {},
       "name": "@types/json-schema",
       "root": "/common/temp/default/node_modules/.pnpm/@types+json-schema@7.0.15/node_modules/@types/json-schema",
     },
     Object {
-      "deps": Object {},
       "name": "@types/json5",
       "root": "/common/temp/default/node_modules/.pnpm/@types+json5@0.0.29/node_modules/@types/json5",
     },
@@ -13730,12 +13475,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@types+loader-utils@1.1.3/node_modules/@types/loader-utils",
     },
     Object {
-      "deps": Object {},
       "name": "@types/lodash",
       "root": "/common/temp/default/node_modules/.pnpm/@types+lodash@4.14.116/node_modules/@types/lodash",
     },
     Object {
-      "deps": Object {},
       "name": "@types/long",
       "root": "/common/temp/default/node_modules/.pnpm/@types+long@4.0.0/node_modules/@types/long",
     },
@@ -13747,32 +13490,26 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@types+mdast@3.0.15/node_modules/@types/mdast",
     },
     Object {
-      "deps": Object {},
       "name": "@types/mime-types",
       "root": "/common/temp/default/node_modules/.pnpm/@types+mime-types@2.1.4/node_modules/@types/mime-types",
     },
     Object {
-      "deps": Object {},
       "name": "@types/mime",
       "root": "/common/temp/default/node_modules/.pnpm/@types+mime@1.3.5/node_modules/@types/mime",
     },
     Object {
-      "deps": Object {},
       "name": "@types/mime",
       "root": "/common/temp/default/node_modules/.pnpm/@types+mime@3.0.4/node_modules/@types/mime",
     },
     Object {
-      "deps": Object {},
       "name": "@types/minimatch",
       "root": "/common/temp/default/node_modules/.pnpm/@types+minimatch@3.0.5/node_modules/@types/minimatch",
     },
     Object {
-      "deps": Object {},
       "name": "@types/minimist",
       "root": "/common/temp/default/node_modules/.pnpm/@types+minimist@1.2.5/node_modules/@types/minimist",
     },
     Object {
-      "deps": Object {},
       "name": "@types/mocha",
       "root": "/common/temp/default/node_modules/.pnpm/@types+mocha@10.0.6/node_modules/@types/mocha",
     },
@@ -13799,22 +13536,18 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@types+node-forge@1.3.11/node_modules/@types/node-forge",
     },
     Object {
-      "deps": Object {},
       "name": "@types/node",
       "root": "/common/temp/default/node_modules/.pnpm/@types+node@14.0.1/node_modules/@types/node",
     },
     Object {
-      "deps": Object {},
       "name": "@types/node",
       "root": "/common/temp/default/node_modules/.pnpm/@types+node@14.18.63/node_modules/@types/node",
     },
     Object {
-      "deps": Object {},
       "name": "@types/node",
       "root": "/common/temp/default/node_modules/.pnpm/@types+node@17.0.41/node_modules/@types/node",
     },
     Object {
-      "deps": Object {},
       "name": "@types/node",
       "root": "/common/temp/default/node_modules/.pnpm/@types+node@18.17.15/node_modules/@types/node",
     },
@@ -13833,17 +13566,14 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@types+node@20.12.12/node_modules/@types/node",
     },
     Object {
-      "deps": Object {},
       "name": "@types/normalize-package-data",
       "root": "/common/temp/default/node_modules/.pnpm/@types+normalize-package-data@2.4.4/node_modules/@types/normalize-package-data",
     },
     Object {
-      "deps": Object {},
       "name": "@types/npm-package-arg",
       "root": "/common/temp/default/node_modules/.pnpm/@types+npm-package-arg@6.1.0/node_modules/@types/npm-package-arg",
     },
     Object {
-      "deps": Object {},
       "name": "@types/npm-packlist",
       "root": "/common/temp/default/node_modules/.pnpm/@types+npm-packlist@1.1.2/node_modules/@types/npm-packlist",
     },
@@ -13855,42 +13585,34 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@types+npmlog@4.1.6/node_modules/@types/npmlog",
     },
     Object {
-      "deps": Object {},
       "name": "@types/overlayscrollbars",
       "root": "/common/temp/default/node_modules/.pnpm/@types+overlayscrollbars@1.12.5/node_modules/@types/overlayscrollbars",
     },
     Object {
-      "deps": Object {},
       "name": "@types/parse-json",
       "root": "/common/temp/default/node_modules/.pnpm/@types+parse-json@4.0.2/node_modules/@types/parse-json",
     },
     Object {
-      "deps": Object {},
       "name": "@types/parse5",
       "root": "/common/temp/default/node_modules/.pnpm/@types+parse5@5.0.3/node_modules/@types/parse5",
     },
     Object {
-      "deps": Object {},
       "name": "@types/prettier",
       "root": "/common/temp/default/node_modules/.pnpm/@types+prettier@2.7.3/node_modules/@types/prettier",
     },
     Object {
-      "deps": Object {},
       "name": "@types/pretty-hrtime",
       "root": "/common/temp/default/node_modules/.pnpm/@types+pretty-hrtime@1.0.3/node_modules/@types/pretty-hrtime",
     },
     Object {
-      "deps": Object {},
       "name": "@types/prop-types",
       "root": "/common/temp/default/node_modules/.pnpm/@types+prop-types@15.7.11/node_modules/@types/prop-types",
     },
     Object {
-      "deps": Object {},
       "name": "@types/qs",
       "root": "/common/temp/default/node_modules/.pnpm/@types+qs@6.9.13/node_modules/@types/qs",
     },
     Object {
-      "deps": Object {},
       "name": "@types/range-parser",
       "root": "/common/temp/default/node_modules/.pnpm/@types+range-parser@1.2.7/node_modules/@types/range-parser",
     },
@@ -13928,12 +13650,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@types+react@17.0.74/node_modules/@types/react",
     },
     Object {
-      "deps": Object {},
       "name": "@types/read-package-tree",
       "root": "/common/temp/default/node_modules/.pnpm/@types+read-package-tree@5.1.0/node_modules/@types/read-package-tree",
     },
     Object {
-      "deps": Object {},
       "name": "@types/resolve",
       "root": "/common/temp/default/node_modules/.pnpm/@types+resolve@1.20.2/node_modules/@types/resolve",
     },
@@ -13945,17 +13665,14 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@types+responselike@1.0.3/node_modules/@types/responselike",
     },
     Object {
-      "deps": Object {},
       "name": "@types/retry",
       "root": "/common/temp/default/node_modules/.pnpm/@types+retry@0.12.0/node_modules/@types/retry",
     },
     Object {
-      "deps": Object {},
       "name": "@types/scheduler",
       "root": "/common/temp/default/node_modules/.pnpm/@types+scheduler@0.16.8/node_modules/@types/scheduler",
     },
     Object {
-      "deps": Object {},
       "name": "@types/semver",
       "root": "/common/temp/default/node_modules/.pnpm/@types+semver@7.5.0/node_modules/@types/semver",
     },
@@ -13968,7 +13685,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@types+send@0.17.4/node_modules/@types/send",
     },
     Object {
-      "deps": Object {},
       "name": "@types/serialize-javascript",
       "root": "/common/temp/default/node_modules/.pnpm/@types+serialize-javascript@5.0.2/node_modules/@types/serialize-javascript",
     },
@@ -13996,7 +13712,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@types+sockjs@0.3.36/node_modules/@types/sockjs",
     },
     Object {
-      "deps": Object {},
       "name": "@types/source-list-map",
       "root": "/common/temp/default/node_modules/.pnpm/@types+source-list-map@0.1.6/node_modules/@types/source-list-map",
     },
@@ -14008,22 +13723,18 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@types+ssri@7.1.5/node_modules/@types/ssri",
     },
     Object {
-      "deps": Object {},
       "name": "@types/stack-utils",
       "root": "/common/temp/default/node_modules/.pnpm/@types+stack-utils@2.0.3/node_modules/@types/stack-utils",
     },
     Object {
-      "deps": Object {},
       "name": "@types/strict-uri-encode",
       "root": "/common/temp/default/node_modules/.pnpm/@types+strict-uri-encode@2.0.0/node_modules/@types/strict-uri-encode",
     },
     Object {
-      "deps": Object {},
       "name": "@types/supports-color",
       "root": "/common/temp/default/node_modules/.pnpm/@types+supports-color@8.1.3/node_modules/@types/supports-color",
     },
     Object {
-      "deps": Object {},
       "name": "@types/tapable",
       "root": "/common/temp/default/node_modules/.pnpm/@types+tapable@1.0.6/node_modules/@types/tapable",
     },
@@ -14043,7 +13754,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@types+through@0.0.33/node_modules/@types/through",
     },
     Object {
-      "deps": Object {},
       "name": "@types/tough-cookie",
       "root": "/common/temp/default/node_modules/.pnpm/@types+tough-cookie@4.0.5/node_modules/@types/tough-cookie",
     },
@@ -14062,7 +13772,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@types+uglify-js@3.17.5/node_modules/@types/uglify-js",
     },
     Object {
-      "deps": Object {},
       "name": "@types/unist",
       "root": "/common/temp/default/node_modules/.pnpm/@types+unist@2.0.10/node_modules/@types/unist",
     },
@@ -14075,17 +13784,14 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@types+update-notifier@6.0.8/node_modules/@types/update-notifier",
     },
     Object {
-      "deps": Object {},
       "name": "@types/use-sync-external-store",
       "root": "/common/temp/default/node_modules/.pnpm/@types+use-sync-external-store@0.0.3/node_modules/@types/use-sync-external-store",
     },
     Object {
-      "deps": Object {},
       "name": "@types/uuid",
       "root": "/common/temp/default/node_modules/.pnpm/@types+uuid@8.3.4/node_modules/@types/uuid",
     },
     Object {
-      "deps": Object {},
       "name": "@types/vscode",
       "root": "/common/temp/default/node_modules/.pnpm/@types+vscode@1.87.0/node_modules/@types/vscode",
     },
@@ -14098,7 +13804,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@types+watchpack@2.4.0/node_modules/@types/watchpack",
     },
     Object {
-      "deps": Object {},
       "name": "@types/webpack-env",
       "root": "/common/temp/default/node_modules/.pnpm/@types+webpack-env@1.18.0/node_modules/@types/webpack-env",
     },
@@ -14131,12 +13836,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@types+ws@8.5.5/node_modules/@types/ws",
     },
     Object {
-      "deps": Object {},
       "name": "@types/xmldoc",
       "root": "/common/temp/default/node_modules/.pnpm/@types+xmldoc@1.1.4/node_modules/@types/xmldoc",
     },
     Object {
-      "deps": Object {},
       "name": "@types/yargs-parser",
       "root": "/common/temp/default/node_modules/.pnpm/@types+yargs-parser@21.0.3/node_modules/@types/yargs-parser",
     },
@@ -14640,7 +14343,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@typescript-eslint+visitor-keys@8.1.0_typescript@5.4.2/node_modules/@typescript-eslint/visitor-keys",
     },
     Object {
-      "deps": Object {},
       "name": "@ungap/structured-clone",
       "root": "/common/temp/default/node_modules/.pnpm/@ungap+structured-clone@1.2.0/node_modules/@ungap/structured-clone",
     },
@@ -14697,7 +14399,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@vue+compiler-ssr@3.4.21/node_modules/@vue/compiler-ssr",
     },
     Object {
-      "deps": Object {},
       "name": "@vue/shared",
       "root": "/common/temp/default/node_modules/.pnpm/@vue+shared@3.4.21/node_modules/@vue/shared",
     },
@@ -14719,32 +14420,26 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@webassemblyjs+ast@1.9.0/node_modules/@webassemblyjs/ast",
     },
     Object {
-      "deps": Object {},
       "name": "@webassemblyjs/floating-point-hex-parser",
       "root": "/common/temp/default/node_modules/.pnpm/@webassemblyjs+floating-point-hex-parser@1.11.6/node_modules/@webassemblyjs/floating-point-hex-parser",
     },
     Object {
-      "deps": Object {},
       "name": "@webassemblyjs/floating-point-hex-parser",
       "root": "/common/temp/default/node_modules/.pnpm/@webassemblyjs+floating-point-hex-parser@1.9.0/node_modules/@webassemblyjs/floating-point-hex-parser",
     },
     Object {
-      "deps": Object {},
       "name": "@webassemblyjs/helper-api-error",
       "root": "/common/temp/default/node_modules/.pnpm/@webassemblyjs+helper-api-error@1.11.6/node_modules/@webassemblyjs/helper-api-error",
     },
     Object {
-      "deps": Object {},
       "name": "@webassemblyjs/helper-api-error",
       "root": "/common/temp/default/node_modules/.pnpm/@webassemblyjs+helper-api-error@1.9.0/node_modules/@webassemblyjs/helper-api-error",
     },
     Object {
-      "deps": Object {},
       "name": "@webassemblyjs/helper-buffer",
       "root": "/common/temp/default/node_modules/.pnpm/@webassemblyjs+helper-buffer@1.12.1/node_modules/@webassemblyjs/helper-buffer",
     },
     Object {
-      "deps": Object {},
       "name": "@webassemblyjs/helper-buffer",
       "root": "/common/temp/default/node_modules/.pnpm/@webassemblyjs+helper-buffer@1.9.0/node_modules/@webassemblyjs/helper-buffer",
     },
@@ -14756,7 +14451,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@webassemblyjs+helper-code-frame@1.9.0/node_modules/@webassemblyjs/helper-code-frame",
     },
     Object {
-      "deps": Object {},
       "name": "@webassemblyjs/helper-fsm",
       "root": "/common/temp/default/node_modules/.pnpm/@webassemblyjs+helper-fsm@1.9.0/node_modules/@webassemblyjs/helper-fsm",
     },
@@ -14777,12 +14471,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@webassemblyjs+helper-numbers@1.11.6/node_modules/@webassemblyjs/helper-numbers",
     },
     Object {
-      "deps": Object {},
       "name": "@webassemblyjs/helper-wasm-bytecode",
       "root": "/common/temp/default/node_modules/.pnpm/@webassemblyjs+helper-wasm-bytecode@1.11.6/node_modules/@webassemblyjs/helper-wasm-bytecode",
     },
     Object {
-      "deps": Object {},
       "name": "@webassemblyjs/helper-wasm-bytecode",
       "root": "/common/temp/default/node_modules/.pnpm/@webassemblyjs+helper-wasm-bytecode@1.9.0/node_modules/@webassemblyjs/helper-wasm-bytecode",
     },
@@ -14835,12 +14527,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@webassemblyjs+leb128@1.9.0/node_modules/@webassemblyjs/leb128",
     },
     Object {
-      "deps": Object {},
       "name": "@webassemblyjs/utf8",
       "root": "/common/temp/default/node_modules/.pnpm/@webassemblyjs+utf8@1.11.6/node_modules/@webassemblyjs/utf8",
     },
     Object {
-      "deps": Object {},
       "name": "@webassemblyjs/utf8",
       "root": "/common/temp/default/node_modules/.pnpm/@webassemblyjs+utf8@1.9.0/node_modules/@webassemblyjs/utf8",
     },
@@ -14968,17 +14658,14 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@webassemblyjs+wast-printer@1.9.0/node_modules/@webassemblyjs/wast-printer",
     },
     Object {
-      "deps": Object {},
       "name": "@xtuc/ieee754",
       "root": "/common/temp/default/node_modules/.pnpm/@xtuc+ieee754@1.2.0/node_modules/@xtuc/ieee754",
     },
     Object {
-      "deps": Object {},
       "name": "@xtuc/long",
       "root": "/common/temp/default/node_modules/.pnpm/@xtuc+long@4.2.2/node_modules/@xtuc/long",
     },
     Object {
-      "deps": Object {},
       "name": "@yarnpkg/lockfile",
       "root": "/common/temp/default/node_modules/.pnpm/@yarnpkg+lockfile@1.0.2/node_modules/@yarnpkg/lockfile",
     },
@@ -14992,17 +14679,14 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/@zkochan+cmd-shim@5.4.1/node_modules/@zkochan/cmd-shim",
     },
     Object {
-      "deps": Object {},
       "name": "abab",
       "root": "/common/temp/default/node_modules/.pnpm/abab@2.0.6/node_modules/abab",
     },
     Object {
-      "deps": Object {},
       "name": "abbrev",
       "root": "/common/temp/default/node_modules/.pnpm/abbrev@1.1.1/node_modules/abbrev",
     },
     Object {
-      "deps": Object {},
       "name": "abstract-logging",
       "root": "/common/temp/default/node_modules/.pnpm/abstract-logging@2.0.1/node_modules/abstract-logging",
     },
@@ -15044,37 +14728,30 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/acorn-jsx@5.3.2_acorn@8.11.3/node_modules/acorn-jsx",
     },
     Object {
-      "deps": Object {},
       "name": "acorn-walk",
       "root": "/common/temp/default/node_modules/.pnpm/acorn-walk@7.2.0/node_modules/acorn-walk",
     },
     Object {
-      "deps": Object {},
       "name": "acorn-walk",
       "root": "/common/temp/default/node_modules/.pnpm/acorn-walk@8.3.2/node_modules/acorn-walk",
     },
     Object {
-      "deps": Object {},
       "name": "acorn",
       "root": "/common/temp/default/node_modules/.pnpm/acorn@6.4.2/node_modules/acorn",
     },
     Object {
-      "deps": Object {},
       "name": "acorn",
       "root": "/common/temp/default/node_modules/.pnpm/acorn@7.4.1/node_modules/acorn",
     },
     Object {
-      "deps": Object {},
       "name": "acorn",
       "root": "/common/temp/default/node_modules/.pnpm/acorn@8.11.3/node_modules/acorn",
     },
     Object {
-      "deps": Object {},
       "name": "address",
       "root": "/common/temp/default/node_modules/.pnpm/address@1.2.2/node_modules/address",
     },
     Object {
-      "deps": Object {},
       "name": "agent-base",
       "root": "/common/temp/default/node_modules/.pnpm/agent-base@5.1.1/node_modules/agent-base",
     },
@@ -15211,17 +14888,14 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/ansi-align@3.0.1/node_modules/ansi-align",
     },
     Object {
-      "deps": Object {},
       "name": "ansi-colors",
       "root": "/common/temp/default/node_modules/.pnpm/ansi-colors@3.2.4/node_modules/ansi-colors",
     },
     Object {
-      "deps": Object {},
       "name": "ansi-colors",
       "root": "/common/temp/default/node_modules/.pnpm/ansi-colors@4.1.1/node_modules/ansi-colors",
     },
     Object {
-      "deps": Object {},
       "name": "ansi-colors",
       "root": "/common/temp/default/node_modules/.pnpm/ansi-colors@4.1.3/node_modules/ansi-colors",
     },
@@ -15233,27 +14907,22 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/ansi-escapes@4.3.2/node_modules/ansi-escapes",
     },
     Object {
-      "deps": Object {},
       "name": "ansi-html-community",
       "root": "/common/temp/default/node_modules/.pnpm/ansi-html-community@0.0.8/node_modules/ansi-html-community",
     },
     Object {
-      "deps": Object {},
       "name": "ansi-regex",
       "root": "/common/temp/default/node_modules/.pnpm/ansi-regex@2.1.1/node_modules/ansi-regex",
     },
     Object {
-      "deps": Object {},
       "name": "ansi-regex",
       "root": "/common/temp/default/node_modules/.pnpm/ansi-regex@4.1.1/node_modules/ansi-regex",
     },
     Object {
-      "deps": Object {},
       "name": "ansi-regex",
       "root": "/common/temp/default/node_modules/.pnpm/ansi-regex@5.0.1/node_modules/ansi-regex",
     },
     Object {
-      "deps": Object {},
       "name": "ansi-regex",
       "root": "/common/temp/default/node_modules/.pnpm/ansi-regex@6.0.1/node_modules/ansi-regex",
     },
@@ -15272,12 +14941,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/ansi-styles@4.3.0/node_modules/ansi-styles",
     },
     Object {
-      "deps": Object {},
       "name": "ansi-styles",
       "root": "/common/temp/default/node_modules/.pnpm/ansi-styles@5.2.0/node_modules/ansi-styles",
     },
     Object {
-      "deps": Object {},
       "name": "ansi-styles",
       "root": "/common/temp/default/node_modules/.pnpm/ansi-styles@6.2.1/node_modules/ansi-styles",
     },
@@ -15289,7 +14956,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/ansi-to-html@0.6.15/node_modules/ansi-to-html",
     },
     Object {
-      "deps": Object {},
       "name": "any-promise",
       "root": "/common/temp/default/node_modules/.pnpm/any-promise@1.3.0/node_modules/any-promise",
     },
@@ -15310,17 +14976,14 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/anymatch@3.1.3/node_modules/anymatch",
     },
     Object {
-      "deps": Object {},
       "name": "app-root-dir",
       "root": "/common/temp/default/node_modules/.pnpm/app-root-dir@1.0.2/node_modules/app-root-dir",
     },
     Object {
-      "deps": Object {},
       "name": "aproba",
       "root": "/common/temp/default/node_modules/.pnpm/aproba@1.2.0/node_modules/aproba",
     },
     Object {
-      "deps": Object {},
       "name": "aproba",
       "root": "/common/temp/default/node_modules/.pnpm/aproba@2.0.0/node_modules/aproba",
     },
@@ -15370,7 +15033,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/archiver@5.3.2/node_modules/archiver",
     },
     Object {
-      "deps": Object {},
       "name": "archy",
       "root": "/common/temp/default/node_modules/.pnpm/archy@1.0.0/node_modules/archy",
     },
@@ -15398,22 +15060,18 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/argparse@1.0.10/node_modules/argparse",
     },
     Object {
-      "deps": Object {},
       "name": "argparse",
       "root": "/common/temp/default/node_modules/.pnpm/argparse@2.0.1/node_modules/argparse",
     },
     Object {
-      "deps": Object {},
       "name": "arr-diff",
       "root": "/common/temp/default/node_modules/.pnpm/arr-diff@4.0.0/node_modules/arr-diff",
     },
     Object {
-      "deps": Object {},
       "name": "arr-flatten",
       "root": "/common/temp/default/node_modules/.pnpm/arr-flatten@1.1.0/node_modules/arr-flatten",
     },
     Object {
-      "deps": Object {},
       "name": "arr-union",
       "root": "/common/temp/default/node_modules/.pnpm/arr-union@3.1.0/node_modules/arr-union",
     },
@@ -15426,12 +15084,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/array-buffer-byte-length@1.0.1/node_modules/array-buffer-byte-length",
     },
     Object {
-      "deps": Object {},
       "name": "array-differ",
       "root": "/common/temp/default/node_modules/.pnpm/array-differ@3.0.0/node_modules/array-differ",
     },
     Object {
-      "deps": Object {},
       "name": "array-flatten",
       "root": "/common/temp/default/node_modules/.pnpm/array-flatten@1.1.1/node_modules/array-flatten",
     },
@@ -15454,17 +15110,14 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/array-union@1.0.2/node_modules/array-union",
     },
     Object {
-      "deps": Object {},
       "name": "array-union",
       "root": "/common/temp/default/node_modules/.pnpm/array-union@2.1.0/node_modules/array-union",
     },
     Object {
-      "deps": Object {},
       "name": "array-uniq",
       "root": "/common/temp/default/node_modules/.pnpm/array-uniq@1.0.3/node_modules/array-uniq",
     },
     Object {
-      "deps": Object {},
       "name": "array-unique",
       "root": "/common/temp/default/node_modules/.pnpm/array-unique@0.3.2/node_modules/array-unique",
     },
@@ -15537,17 +15190,14 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/arraybuffer.prototype.slice@1.0.3/node_modules/arraybuffer.prototype.slice",
     },
     Object {
-      "deps": Object {},
       "name": "arrify",
       "root": "/common/temp/default/node_modules/.pnpm/arrify@1.0.1/node_modules/arrify",
     },
     Object {
-      "deps": Object {},
       "name": "arrify",
       "root": "/common/temp/default/node_modules/.pnpm/arrify@2.0.1/node_modules/arrify",
     },
     Object {
-      "deps": Object {},
       "name": "asap",
       "root": "/common/temp/default/node_modules/.pnpm/asap@2.0.6/node_modules/asap",
     },
@@ -15569,12 +15219,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/assert@1.5.1/node_modules/assert",
     },
     Object {
-      "deps": Object {},
       "name": "assign-symbols",
       "root": "/common/temp/default/node_modules/.pnpm/assign-symbols@1.0.0/node_modules/assign-symbols",
     },
     Object {
-      "deps": Object {},
       "name": "ast-types",
       "root": "/common/temp/default/node_modules/.pnpm/ast-types@0.13.3/node_modules/ast-types",
     },
@@ -15586,22 +15234,18 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/ast-types@0.14.2/node_modules/ast-types",
     },
     Object {
-      "deps": Object {},
       "name": "astral-regex",
       "root": "/common/temp/default/node_modules/.pnpm/astral-regex@1.0.0/node_modules/astral-regex",
     },
     Object {
-      "deps": Object {},
       "name": "astral-regex",
       "root": "/common/temp/default/node_modules/.pnpm/astral-regex@2.0.0/node_modules/astral-regex",
     },
     Object {
-      "deps": Object {},
       "name": "async-each",
       "root": "/common/temp/default/node_modules/.pnpm/async-each@1.0.6/node_modules/async-each",
     },
     Object {
-      "deps": Object {},
       "name": "async-limiter",
       "root": "/common/temp/default/node_modules/.pnpm/async-limiter@1.0.1/node_modules/async-limiter",
     },
@@ -15613,37 +15257,30 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/async-retry@1.3.3/node_modules/async-retry",
     },
     Object {
-      "deps": Object {},
       "name": "async",
       "root": "/common/temp/default/node_modules/.pnpm/async@1.5.2/node_modules/async",
     },
     Object {
-      "deps": Object {},
       "name": "async",
       "root": "/common/temp/default/node_modules/.pnpm/async@3.2.5/node_modules/async",
     },
     Object {
-      "deps": Object {},
       "name": "asynckit",
       "root": "/common/temp/default/node_modules/.pnpm/asynckit@0.4.0/node_modules/asynckit",
     },
     Object {
-      "deps": Object {},
       "name": "at-least-node",
       "root": "/common/temp/default/node_modules/.pnpm/at-least-node@1.0.0/node_modules/at-least-node",
     },
     Object {
-      "deps": Object {},
       "name": "atob",
       "root": "/common/temp/default/node_modules/.pnpm/atob@2.1.2/node_modules/atob",
     },
     Object {
-      "deps": Object {},
       "name": "atomic-sleep",
       "root": "/common/temp/default/node_modules/.pnpm/atomic-sleep@1.0.0/node_modules/atomic-sleep",
     },
     Object {
-      "deps": Object {},
       "name": "atomically",
       "root": "/common/temp/default/node_modules/.pnpm/atomically@1.7.0/node_modules/atomically",
     },
@@ -15727,7 +15364,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/aws-cdk-lib@2.80.0_constructs@10.0.130/node_modules/aws-cdk-lib",
     },
     Object {
-      "deps": Object {},
       "name": "aws-cdk",
       "root": "/common/temp/default/node_modules/.pnpm/aws-cdk@2.50.0/node_modules/aws-cdk",
     },
@@ -15789,7 +15425,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/babel-loader@8.2.5_@babel+core@7.20.12_webpack@4.47.0/node_modules/babel-loader",
     },
     Object {
-      "deps": Object {},
       "name": "babel-plugin-add-react-displayname",
       "root": "/common/temp/default/node_modules/.pnpm/babel-plugin-add-react-displayname@0.0.5/node_modules/babel-plugin-add-react-displayname",
     },
@@ -15917,7 +15552,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/babel-plugin-react-docgen@4.2.1/node_modules/babel-plugin-react-docgen",
     },
     Object {
-      "deps": Object {},
       "name": "babel-plugin-syntax-jsx",
       "root": "/common/temp/default/node_modules/.pnpm/babel-plugin-syntax-jsx@6.18.0/node_modules/babel-plugin-syntax-jsx",
     },
@@ -15950,17 +15584,14 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/babel-preset-jest@29.6.3_@babel+core@7.20.12/node_modules/babel-preset-jest",
     },
     Object {
-      "deps": Object {},
       "name": "bail",
       "root": "/common/temp/default/node_modules/.pnpm/bail@1.0.5/node_modules/bail",
     },
     Object {
-      "deps": Object {},
       "name": "balanced-match",
       "root": "/common/temp/default/node_modules/.pnpm/balanced-match@1.0.2/node_modules/balanced-match",
     },
     Object {
-      "deps": Object {},
       "name": "base64-js",
       "root": "/common/temp/default/node_modules/.pnpm/base64-js@1.5.1/node_modules/base64-js",
     },
@@ -15978,12 +15609,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/base@0.11.2/node_modules/base",
     },
     Object {
-      "deps": Object {},
       "name": "batch-processor",
       "root": "/common/temp/default/node_modules/.pnpm/batch-processor@1.0.0/node_modules/batch-processor",
     },
     Object {
-      "deps": Object {},
       "name": "batch",
       "root": "/common/temp/default/node_modules/.pnpm/batch@0.6.1/node_modules/batch",
     },
@@ -16002,22 +15631,18 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/better-path-resolve@1.0.0/node_modules/better-path-resolve",
     },
     Object {
-      "deps": Object {},
       "name": "big-integer",
       "root": "/common/temp/default/node_modules/.pnpm/big-integer@1.6.52/node_modules/big-integer",
     },
     Object {
-      "deps": Object {},
       "name": "big.js",
       "root": "/common/temp/default/node_modules/.pnpm/big.js@5.2.2/node_modules/big.js",
     },
     Object {
-      "deps": Object {},
       "name": "binary-extensions",
       "root": "/common/temp/default/node_modules/.pnpm/binary-extensions@1.13.1/node_modules/binary-extensions",
     },
     Object {
-      "deps": Object {},
       "name": "binary-extensions",
       "root": "/common/temp/default/node_modules/.pnpm/binary-extensions@2.3.0/node_modules/binary-extensions",
     },
@@ -16046,22 +15671,18 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/bl@4.1.0/node_modules/bl",
     },
     Object {
-      "deps": Object {},
       "name": "bluebird",
       "root": "/common/temp/default/node_modules/.pnpm/bluebird@3.4.7/node_modules/bluebird",
     },
     Object {
-      "deps": Object {},
       "name": "bluebird",
       "root": "/common/temp/default/node_modules/.pnpm/bluebird@3.7.2/node_modules/bluebird",
     },
     Object {
-      "deps": Object {},
       "name": "bn.js",
       "root": "/common/temp/default/node_modules/.pnpm/bn.js@4.12.0/node_modules/bn.js",
     },
     Object {
-      "deps": Object {},
       "name": "bn.js",
       "root": "/common/temp/default/node_modules/.pnpm/bn.js@5.2.1/node_modules/bn.js",
     },
@@ -16100,12 +15721,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/bonjour-service@1.2.1/node_modules/bonjour-service",
     },
     Object {
-      "deps": Object {},
       "name": "boolbase",
       "root": "/common/temp/default/node_modules/.pnpm/boolbase@1.0.0/node_modules/boolbase",
     },
     Object {
-      "deps": Object {},
       "name": "bowser",
       "root": "/common/temp/default/node_modules/.pnpm/bowser@2.11.0/node_modules/bowser",
     },
@@ -16176,12 +15795,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/braces@3.0.2/node_modules/braces",
     },
     Object {
-      "deps": Object {},
       "name": "brorand",
       "root": "/common/temp/default/node_modules/.pnpm/brorand@1.1.0/node_modules/brorand",
     },
     Object {
-      "deps": Object {},
       "name": "browser-stdout",
       "root": "/common/temp/default/node_modules/.pnpm/browser-stdout@1.3.1/node_modules/browser-stdout",
     },
@@ -16265,32 +15882,26 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/bser@2.1.1/node_modules/bser",
     },
     Object {
-      "deps": Object {},
       "name": "buffer-builder",
       "root": "/common/temp/default/node_modules/.pnpm/buffer-builder@0.2.0/node_modules/buffer-builder",
     },
     Object {
-      "deps": Object {},
       "name": "buffer-crc32",
       "root": "/common/temp/default/node_modules/.pnpm/buffer-crc32@0.2.13/node_modules/buffer-crc32",
     },
     Object {
-      "deps": Object {},
       "name": "buffer-equal-constant-time",
       "root": "/common/temp/default/node_modules/.pnpm/buffer-equal-constant-time@1.0.1/node_modules/buffer-equal-constant-time",
     },
     Object {
-      "deps": Object {},
       "name": "buffer-from",
       "root": "/common/temp/default/node_modules/.pnpm/buffer-from@1.1.2/node_modules/buffer-from",
     },
     Object {
-      "deps": Object {},
       "name": "buffer-indexof-polyfill",
       "root": "/common/temp/default/node_modules/.pnpm/buffer-indexof-polyfill@1.0.2/node_modules/buffer-indexof-polyfill",
     },
     Object {
-      "deps": Object {},
       "name": "buffer-xor",
       "root": "/common/temp/default/node_modules/.pnpm/buffer-xor@1.0.3/node_modules/buffer-xor",
     },
@@ -16312,42 +15923,34 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/buffer@5.7.1/node_modules/buffer",
     },
     Object {
-      "deps": Object {},
       "name": "buffers",
       "root": "/common/temp/default/node_modules/.pnpm/buffers@0.1.1/node_modules/buffers",
     },
     Object {
-      "deps": Object {},
       "name": "builtin-modules",
       "root": "/common/temp/default/node_modules/.pnpm/builtin-modules@1.1.1/node_modules/builtin-modules",
     },
     Object {
-      "deps": Object {},
       "name": "builtin-modules",
       "root": "/common/temp/default/node_modules/.pnpm/builtin-modules@3.1.0/node_modules/builtin-modules",
     },
     Object {
-      "deps": Object {},
       "name": "builtin-status-codes",
       "root": "/common/temp/default/node_modules/.pnpm/builtin-status-codes@3.0.0/node_modules/builtin-status-codes",
     },
     Object {
-      "deps": Object {},
       "name": "builtins",
       "root": "/common/temp/default/node_modules/.pnpm/builtins@1.0.3/node_modules/builtins",
     },
     Object {
-      "deps": Object {},
       "name": "buttono",
       "root": "/common/temp/default/node_modules/.pnpm/buttono@1.0.4/node_modules/buttono",
     },
     Object {
-      "deps": Object {},
       "name": "bytes",
       "root": "/common/temp/default/node_modules/.pnpm/bytes@3.0.0/node_modules/bytes",
     },
     Object {
-      "deps": Object {},
       "name": "bytes",
       "root": "/common/temp/default/node_modules/.pnpm/bytes@3.1.2/node_modules/bytes",
     },
@@ -16430,7 +16033,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/cache-base@1.0.1/node_modules/cache-base",
     },
     Object {
-      "deps": Object {},
       "name": "cacheable-lookup",
       "root": "/common/temp/default/node_modules/.pnpm/cacheable-lookup@5.0.4/node_modules/cacheable-lookup",
     },
@@ -16459,7 +16061,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/call-bind@1.0.7/node_modules/call-bind",
     },
     Object {
-      "deps": Object {},
       "name": "call-me-maybe",
       "root": "/common/temp/default/node_modules/.pnpm/call-me-maybe@1.0.2/node_modules/call-me-maybe",
     },
@@ -16477,12 +16078,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/callsite-record@4.1.5/node_modules/callsite-record",
     },
     Object {
-      "deps": Object {},
       "name": "callsite",
       "root": "/common/temp/default/node_modules/.pnpm/callsite@1.0.0/node_modules/callsite",
     },
     Object {
-      "deps": Object {},
       "name": "callsites",
       "root": "/common/temp/default/node_modules/.pnpm/callsites@3.1.0/node_modules/callsites",
     },
@@ -16495,7 +16094,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/camel-case@4.1.2/node_modules/camel-case",
     },
     Object {
-      "deps": Object {},
       "name": "camelcase-css",
       "root": "/common/temp/default/node_modules/.pnpm/camelcase-css@2.0.1/node_modules/camelcase-css",
     },
@@ -16509,17 +16107,14 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/camelcase-keys@6.2.2/node_modules/camelcase-keys",
     },
     Object {
-      "deps": Object {},
       "name": "camelcase",
       "root": "/common/temp/default/node_modules/.pnpm/camelcase@5.3.1/node_modules/camelcase",
     },
     Object {
-      "deps": Object {},
       "name": "camelcase",
       "root": "/common/temp/default/node_modules/.pnpm/camelcase@6.3.0/node_modules/camelcase",
     },
     Object {
-      "deps": Object {},
       "name": "camelcase",
       "root": "/common/temp/default/node_modules/.pnpm/camelcase@7.0.1/node_modules/camelcase",
     },
@@ -16534,7 +16129,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/caniuse-api@3.0.0/node_modules/caniuse-api",
     },
     Object {
-      "deps": Object {},
       "name": "caniuse-lite",
       "root": "/common/temp/default/node_modules/.pnpm/caniuse-lite@1.0.30001599/node_modules/caniuse-lite",
     },
@@ -16546,17 +16140,14 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/capture-exit@2.0.0/node_modules/capture-exit",
     },
     Object {
-      "deps": Object {},
       "name": "case-sensitive-paths-webpack-plugin",
       "root": "/common/temp/default/node_modules/.pnpm/case-sensitive-paths-webpack-plugin@2.4.0/node_modules/case-sensitive-paths-webpack-plugin",
     },
     Object {
-      "deps": Object {},
       "name": "case",
       "root": "/common/temp/default/node_modules/.pnpm/case@1.6.3/node_modules/case",
     },
     Object {
-      "deps": Object {},
       "name": "ccount",
       "root": "/common/temp/default/node_modules/.pnpm/ccount@1.1.0/node_modules/ccount",
     },
@@ -16593,32 +16184,26 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/chalk@4.1.2/node_modules/chalk",
     },
     Object {
-      "deps": Object {},
       "name": "chalk",
       "root": "/common/temp/default/node_modules/.pnpm/chalk@5.3.0/node_modules/chalk",
     },
     Object {
-      "deps": Object {},
       "name": "char-regex",
       "root": "/common/temp/default/node_modules/.pnpm/char-regex@1.0.2/node_modules/char-regex",
     },
     Object {
-      "deps": Object {},
       "name": "character-entities-legacy",
       "root": "/common/temp/default/node_modules/.pnpm/character-entities-legacy@1.1.4/node_modules/character-entities-legacy",
     },
     Object {
-      "deps": Object {},
       "name": "character-entities",
       "root": "/common/temp/default/node_modules/.pnpm/character-entities@1.2.4/node_modules/character-entities",
     },
     Object {
-      "deps": Object {},
       "name": "character-reference-invalid",
       "root": "/common/temp/default/node_modules/.pnpm/character-reference-invalid@1.1.4/node_modules/character-reference-invalid",
     },
     Object {
-      "deps": Object {},
       "name": "chardet",
       "root": "/common/temp/default/node_modules/.pnpm/chardet@0.7.0/node_modules/chardet",
     },
@@ -16704,27 +16289,22 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/chokidar@3.6.0/node_modules/chokidar",
     },
     Object {
-      "deps": Object {},
       "name": "chownr",
       "root": "/common/temp/default/node_modules/.pnpm/chownr@1.1.4/node_modules/chownr",
     },
     Object {
-      "deps": Object {},
       "name": "chownr",
       "root": "/common/temp/default/node_modules/.pnpm/chownr@2.0.0/node_modules/chownr",
     },
     Object {
-      "deps": Object {},
       "name": "chrome-trace-event",
       "root": "/common/temp/default/node_modules/.pnpm/chrome-trace-event@1.0.3/node_modules/chrome-trace-event",
     },
     Object {
-      "deps": Object {},
       "name": "ci-info",
       "root": "/common/temp/default/node_modules/.pnpm/ci-info@2.0.0/node_modules/ci-info",
     },
     Object {
-      "deps": Object {},
       "name": "ci-info",
       "root": "/common/temp/default/node_modules/.pnpm/ci-info@3.9.0/node_modules/ci-info",
     },
@@ -16737,7 +16317,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/cipher-base@1.0.4/node_modules/cipher-base",
     },
     Object {
-      "deps": Object {},
       "name": "cjs-module-lexer",
       "root": "/common/temp/default/node_modules/.pnpm/cjs-module-lexer@1.2.3/node_modules/cjs-module-lexer",
     },
@@ -16766,17 +16345,14 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/clean-css@5.3.3/node_modules/clean-css",
     },
     Object {
-      "deps": Object {},
       "name": "clean-stack",
       "root": "/common/temp/default/node_modules/.pnpm/clean-stack@2.2.0/node_modules/clean-stack",
     },
     Object {
-      "deps": Object {},
       "name": "cli-boxes",
       "root": "/common/temp/default/node_modules/.pnpm/cli-boxes@2.2.1/node_modules/cli-boxes",
     },
     Object {
-      "deps": Object {},
       "name": "cli-boxes",
       "root": "/common/temp/default/node_modules/.pnpm/cli-boxes@3.0.0/node_modules/cli-boxes",
     },
@@ -16788,7 +16364,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/cli-cursor@3.1.0/node_modules/cli-cursor",
     },
     Object {
-      "deps": Object {},
       "name": "cli-spinners",
       "root": "/common/temp/default/node_modules/.pnpm/cli-spinners@2.9.2/node_modules/cli-spinners",
     },
@@ -16808,7 +16383,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/cli-table@0.3.11/node_modules/cli-table",
     },
     Object {
-      "deps": Object {},
       "name": "cli-width",
       "root": "/common/temp/default/node_modules/.pnpm/cli-width@3.0.0/node_modules/cli-width",
     },
@@ -16865,37 +16439,30 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/clone-response@1.0.3/node_modules/clone-response",
     },
     Object {
-      "deps": Object {},
       "name": "clone",
       "root": "/common/temp/default/node_modules/.pnpm/clone@1.0.4/node_modules/clone",
     },
     Object {
-      "deps": Object {},
       "name": "clsx",
       "root": "/common/temp/default/node_modules/.pnpm/clsx@1.2.1/node_modules/clsx",
     },
     Object {
-      "deps": Object {},
       "name": "cluster-key-slot",
       "root": "/common/temp/default/node_modules/.pnpm/cluster-key-slot@1.1.2/node_modules/cluster-key-slot",
     },
     Object {
-      "deps": Object {},
       "name": "cmd-extension",
       "root": "/common/temp/default/node_modules/.pnpm/cmd-extension@1.0.2/node_modules/cmd-extension",
     },
     Object {
-      "deps": Object {},
       "name": "co",
       "root": "/common/temp/default/node_modules/.pnpm/co@4.6.0/node_modules/co",
     },
     Object {
-      "deps": Object {},
       "name": "code-point-at",
       "root": "/common/temp/default/node_modules/.pnpm/code-point-at@1.1.0/node_modules/code-point-at",
     },
     Object {
-      "deps": Object {},
       "name": "collapse-white-space",
       "root": "/common/temp/default/node_modules/.pnpm/collapse-white-space@1.0.6/node_modules/collapse-white-space",
     },
@@ -16943,37 +16510,30 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/color-convert@2.0.1/node_modules/color-convert",
     },
     Object {
-      "deps": Object {},
       "name": "color-name",
       "root": "/common/temp/default/node_modules/.pnpm/color-name@1.1.3/node_modules/color-name",
     },
     Object {
-      "deps": Object {},
       "name": "color-name",
       "root": "/common/temp/default/node_modules/.pnpm/color-name@1.1.4/node_modules/color-name",
     },
     Object {
-      "deps": Object {},
       "name": "color-support",
       "root": "/common/temp/default/node_modules/.pnpm/color-support@1.1.3/node_modules/color-support",
     },
     Object {
-      "deps": Object {},
       "name": "colord",
       "root": "/common/temp/default/node_modules/.pnpm/colord@2.9.3/node_modules/colord",
     },
     Object {
-      "deps": Object {},
       "name": "colorette",
       "root": "/common/temp/default/node_modules/.pnpm/colorette@2.0.20/node_modules/colorette",
     },
     Object {
-      "deps": Object {},
       "name": "colors",
       "root": "/common/temp/default/node_modules/.pnpm/colors@1.0.3/node_modules/colors",
     },
     Object {
-      "deps": Object {},
       "name": "colors",
       "root": "/common/temp/default/node_modules/.pnpm/colors@1.2.5/node_modules/colors",
     },
@@ -16985,62 +16545,50 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/combined-stream@1.0.8/node_modules/combined-stream",
     },
     Object {
-      "deps": Object {},
       "name": "comma-separated-tokens",
       "root": "/common/temp/default/node_modules/.pnpm/comma-separated-tokens@1.0.8/node_modules/comma-separated-tokens",
     },
     Object {
-      "deps": Object {},
       "name": "commander",
       "root": "/common/temp/default/node_modules/.pnpm/commander@10.0.1/node_modules/commander",
     },
     Object {
-      "deps": Object {},
       "name": "commander",
       "root": "/common/temp/default/node_modules/.pnpm/commander@12.0.0/node_modules/commander",
     },
     Object {
-      "deps": Object {},
       "name": "commander",
       "root": "/common/temp/default/node_modules/.pnpm/commander@2.20.3/node_modules/commander",
     },
     Object {
-      "deps": Object {},
       "name": "commander",
       "root": "/common/temp/default/node_modules/.pnpm/commander@4.1.1/node_modules/commander",
     },
     Object {
-      "deps": Object {},
       "name": "commander",
       "root": "/common/temp/default/node_modules/.pnpm/commander@6.2.1/node_modules/commander",
     },
     Object {
-      "deps": Object {},
       "name": "commander",
       "root": "/common/temp/default/node_modules/.pnpm/commander@7.2.0/node_modules/commander",
     },
     Object {
-      "deps": Object {},
       "name": "commander",
       "root": "/common/temp/default/node_modules/.pnpm/commander@8.3.0/node_modules/commander",
     },
     Object {
-      "deps": Object {},
       "name": "comment-parser",
       "root": "/common/temp/default/node_modules/.pnpm/comment-parser@1.3.0/node_modules/comment-parser",
     },
     Object {
-      "deps": Object {},
       "name": "common-path-prefix",
       "root": "/common/temp/default/node_modules/.pnpm/common-path-prefix@3.0.0/node_modules/common-path-prefix",
     },
     Object {
-      "deps": Object {},
       "name": "commondir",
       "root": "/common/temp/default/node_modules/.pnpm/commondir@1.0.1/node_modules/commondir",
     },
     Object {
-      "deps": Object {},
       "name": "component-emitter",
       "root": "/common/temp/default/node_modules/.pnpm/component-emitter@1.3.1/node_modules/component-emitter",
     },
@@ -17075,12 +16623,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/compression@1.7.4/node_modules/compression",
     },
     Object {
-      "deps": Object {},
       "name": "compute-scroll-into-view",
       "root": "/common/temp/default/node_modules/.pnpm/compute-scroll-into-view@1.0.20/node_modules/compute-scroll-into-view",
     },
     Object {
-      "deps": Object {},
       "name": "concat-map",
       "root": "/common/temp/default/node_modules/.pnpm/concat-map@0.0.1/node_modules/concat-map",
     },
@@ -17123,27 +16669,22 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/configstore@5.0.1/node_modules/configstore",
     },
     Object {
-      "deps": Object {},
       "name": "connect-history-api-fallback",
       "root": "/common/temp/default/node_modules/.pnpm/connect-history-api-fallback@2.0.0/node_modules/connect-history-api-fallback",
     },
     Object {
-      "deps": Object {},
       "name": "console-browserify",
       "root": "/common/temp/default/node_modules/.pnpm/console-browserify@1.2.0/node_modules/console-browserify",
     },
     Object {
-      "deps": Object {},
       "name": "console-control-strings",
       "root": "/common/temp/default/node_modules/.pnpm/console-control-strings@1.1.0/node_modules/console-control-strings",
     },
     Object {
-      "deps": Object {},
       "name": "constants-browserify",
       "root": "/common/temp/default/node_modules/.pnpm/constants-browserify@1.0.0/node_modules/constants-browserify",
     },
     Object {
-      "deps": Object {},
       "name": "constructs",
       "root": "/common/temp/default/node_modules/.pnpm/constructs@10.0.130/node_modules/constructs",
     },
@@ -17155,32 +16696,26 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/content-disposition@0.5.4/node_modules/content-disposition",
     },
     Object {
-      "deps": Object {},
       "name": "content-type",
       "root": "/common/temp/default/node_modules/.pnpm/content-type@1.0.5/node_modules/content-type",
     },
     Object {
-      "deps": Object {},
       "name": "convert-source-map",
       "root": "/common/temp/default/node_modules/.pnpm/convert-source-map@1.9.0/node_modules/convert-source-map",
     },
     Object {
-      "deps": Object {},
       "name": "convert-source-map",
       "root": "/common/temp/default/node_modules/.pnpm/convert-source-map@2.0.0/node_modules/convert-source-map",
     },
     Object {
-      "deps": Object {},
       "name": "cookie-signature",
       "root": "/common/temp/default/node_modules/.pnpm/cookie-signature@1.0.6/node_modules/cookie-signature",
     },
     Object {
-      "deps": Object {},
       "name": "cookie",
       "root": "/common/temp/default/node_modules/.pnpm/cookie@0.5.0/node_modules/cookie",
     },
     Object {
-      "deps": Object {},
       "name": "cookie",
       "root": "/common/temp/default/node_modules/.pnpm/cookie@0.6.0/node_modules/cookie",
     },
@@ -17197,7 +16732,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/copy-concurrently@1.0.5/node_modules/copy-concurrently",
     },
     Object {
-      "deps": Object {},
       "name": "copy-descriptor",
       "root": "/common/temp/default/node_modules/.pnpm/copy-descriptor@0.1.1/node_modules/copy-descriptor",
     },
@@ -17216,17 +16750,14 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/core-js-compat@3.36.0/node_modules/core-js-compat",
     },
     Object {
-      "deps": Object {},
       "name": "core-js-pure",
       "root": "/common/temp/default/node_modules/.pnpm/core-js-pure@3.36.0/node_modules/core-js-pure",
     },
     Object {
-      "deps": Object {},
       "name": "core-js",
       "root": "/common/temp/default/node_modules/.pnpm/core-js@3.36.0/node_modules/core-js",
     },
     Object {
-      "deps": Object {},
       "name": "core-util-is",
       "root": "/common/temp/default/node_modules/.pnpm/core-util-is@1.0.3/node_modules/core-util-is",
     },
@@ -17286,7 +16817,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/cpy@8.1.2/node_modules/cpy",
     },
     Object {
-      "deps": Object {},
       "name": "crc-32",
       "root": "/common/temp/default/node_modules/.pnpm/crc-32@1.2.2/node_modules/crc-32",
     },
@@ -17380,7 +16910,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/crypto-browserify@3.12.0/node_modules/crypto-browserify",
     },
     Object {
-      "deps": Object {},
       "name": "crypto-random-string",
       "root": "/common/temp/default/node_modules/.pnpm/crypto-random-string@2.0.0/node_modules/crypto-random-string",
     },
@@ -17487,12 +17016,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/css-tree@1.1.3/node_modules/css-tree",
     },
     Object {
-      "deps": Object {},
       "name": "css-what",
       "root": "/common/temp/default/node_modules/.pnpm/css-what@6.1.0/node_modules/css-what",
     },
     Object {
-      "deps": Object {},
       "name": "cssesc",
       "root": "/common/temp/default/node_modules/.pnpm/cssesc@3.0.0/node_modules/cssesc",
     },
@@ -17557,12 +17084,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/csso@4.2.0/node_modules/csso",
     },
     Object {
-      "deps": Object {},
       "name": "cssom",
       "root": "/common/temp/default/node_modules/.pnpm/cssom@0.3.8/node_modules/cssom",
     },
     Object {
-      "deps": Object {},
       "name": "cssom",
       "root": "/common/temp/default/node_modules/.pnpm/cssom@0.5.0/node_modules/cssom",
     },
@@ -17574,17 +17099,14 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/cssstyle@2.3.0/node_modules/cssstyle",
     },
     Object {
-      "deps": Object {},
       "name": "csstype",
       "root": "/common/temp/default/node_modules/.pnpm/csstype@2.6.21/node_modules/csstype",
     },
     Object {
-      "deps": Object {},
       "name": "csstype",
       "root": "/common/temp/default/node_modules/.pnpm/csstype@3.1.3/node_modules/csstype",
     },
     Object {
-      "deps": Object {},
       "name": "cyclist",
       "root": "/common/temp/default/node_modules/.pnpm/cyclist@1.0.2/node_modules/cyclist",
     },
@@ -17625,7 +17147,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/data-view-byte-offset@1.0.0/node_modules/data-view-byte-offset",
     },
     Object {
-      "deps": Object {},
       "name": "date-format",
       "root": "/common/temp/default/node_modules/.pnpm/date-format@4.0.14/node_modules/date-format",
     },
@@ -17659,7 +17180,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/debug@4.3.4_supports-color@8.1.1/node_modules/debug",
     },
     Object {
-      "deps": Object {},
       "name": "debuglog",
       "root": "/common/temp/default/node_modules/.pnpm/debuglog@1.0.1/node_modules/debuglog",
     },
@@ -17672,22 +17192,18 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/decamelize-keys@1.1.1/node_modules/decamelize-keys",
     },
     Object {
-      "deps": Object {},
       "name": "decamelize",
       "root": "/common/temp/default/node_modules/.pnpm/decamelize@1.2.0/node_modules/decamelize",
     },
     Object {
-      "deps": Object {},
       "name": "decamelize",
       "root": "/common/temp/default/node_modules/.pnpm/decamelize@4.0.0/node_modules/decamelize",
     },
     Object {
-      "deps": Object {},
       "name": "decimal.js",
       "root": "/common/temp/default/node_modules/.pnpm/decimal.js@10.4.3/node_modules/decimal.js",
     },
     Object {
-      "deps": Object {},
       "name": "decode-uri-component",
       "root": "/common/temp/default/node_modules/.pnpm/decode-uri-component@0.2.2/node_modules/decode-uri-component",
     },
@@ -17699,32 +17215,26 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/decompress-response@6.0.0/node_modules/decompress-response",
     },
     Object {
-      "deps": Object {},
       "name": "dedent",
       "root": "/common/temp/default/node_modules/.pnpm/dedent@0.7.0/node_modules/dedent",
     },
     Object {
-      "deps": Object {},
       "name": "dedent",
       "root": "/common/temp/default/node_modules/.pnpm/dedent@1.5.1/node_modules/dedent",
     },
     Object {
-      "deps": Object {},
       "name": "deep-extend",
       "root": "/common/temp/default/node_modules/.pnpm/deep-extend@0.6.0/node_modules/deep-extend",
     },
     Object {
-      "deps": Object {},
       "name": "deep-is",
       "root": "/common/temp/default/node_modules/.pnpm/deep-is@0.1.4/node_modules/deep-is",
     },
     Object {
-      "deps": Object {},
       "name": "deep-object-diff",
       "root": "/common/temp/default/node_modules/.pnpm/deep-object-diff@1.1.9/node_modules/deep-object-diff",
     },
     Object {
-      "deps": Object {},
       "name": "deepmerge",
       "root": "/common/temp/default/node_modules/.pnpm/deepmerge@4.3.1/node_modules/deepmerge",
     },
@@ -17743,7 +17253,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/defaults@1.0.4/node_modules/defaults",
     },
     Object {
-      "deps": Object {},
       "name": "defer-to-connect",
       "root": "/common/temp/default/node_modules/.pnpm/defer-to-connect@2.0.1/node_modules/defer-to-connect",
     },
@@ -17757,7 +17266,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/define-data-property@1.1.4/node_modules/define-data-property",
     },
     Object {
-      "deps": Object {},
       "name": "define-lazy-prop",
       "root": "/common/temp/default/node_modules/.pnpm/define-lazy-prop@2.0.0/node_modules/define-lazy-prop",
     },
@@ -17793,12 +17301,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/define-property@2.0.2/node_modules/define-property",
     },
     Object {
-      "deps": Object {},
       "name": "delayed-stream",
       "root": "/common/temp/default/node_modules/.pnpm/delayed-stream@1.0.0/node_modules/delayed-stream",
     },
     Object {
-      "deps": Object {},
       "name": "delegates",
       "root": "/common/temp/default/node_modules/.pnpm/delegates@1.0.0/node_modules/delegates",
     },
@@ -17839,12 +17345,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/depcheck@1.4.7/node_modules/depcheck",
     },
     Object {
-      "deps": Object {},
       "name": "depd",
       "root": "/common/temp/default/node_modules/.pnpm/depd@1.1.2/node_modules/depd",
     },
     Object {
-      "deps": Object {},
       "name": "depd",
       "root": "/common/temp/default/node_modules/.pnpm/depd@2.0.0/node_modules/depd",
     },
@@ -17859,7 +17363,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/dependency-path@9.2.8/node_modules/dependency-path",
     },
     Object {
-      "deps": Object {},
       "name": "deps-regex",
       "root": "/common/temp/default/node_modules/.pnpm/deps-regex@0.2.0/node_modules/deps-regex",
     },
@@ -17872,12 +17375,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/des.js@1.1.0/node_modules/des.js",
     },
     Object {
-      "deps": Object {},
       "name": "destroy",
       "root": "/common/temp/default/node_modules/.pnpm/destroy@1.0.4/node_modules/destroy",
     },
     Object {
-      "deps": Object {},
       "name": "destroy",
       "root": "/common/temp/default/node_modules/.pnpm/destroy@1.2.0/node_modules/destroy",
     },
@@ -17889,27 +17390,22 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/detab@2.0.4/node_modules/detab",
     },
     Object {
-      "deps": Object {},
       "name": "detect-file",
       "root": "/common/temp/default/node_modules/.pnpm/detect-file@1.0.0/node_modules/detect-file",
     },
     Object {
-      "deps": Object {},
       "name": "detect-indent",
       "root": "/common/temp/default/node_modules/.pnpm/detect-indent@6.1.0/node_modules/detect-indent",
     },
     Object {
-      "deps": Object {},
       "name": "detect-libc",
       "root": "/common/temp/default/node_modules/.pnpm/detect-libc@2.0.2/node_modules/detect-libc",
     },
     Object {
-      "deps": Object {},
       "name": "detect-newline",
       "root": "/common/temp/default/node_modules/.pnpm/detect-newline@3.1.0/node_modules/detect-newline",
     },
     Object {
-      "deps": Object {},
       "name": "detect-node",
       "root": "/common/temp/default/node_modules/.pnpm/detect-node@2.1.0/node_modules/detect-node",
     },
@@ -17938,22 +17434,18 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/dezalgo@1.0.4/node_modules/dezalgo",
     },
     Object {
-      "deps": Object {},
       "name": "diff-sequences",
       "root": "/common/temp/default/node_modules/.pnpm/diff-sequences@27.5.1/node_modules/diff-sequences",
     },
     Object {
-      "deps": Object {},
       "name": "diff-sequences",
       "root": "/common/temp/default/node_modules/.pnpm/diff-sequences@29.6.3/node_modules/diff-sequences",
     },
     Object {
-      "deps": Object {},
       "name": "diff",
       "root": "/common/temp/default/node_modules/.pnpm/diff@4.0.2/node_modules/diff",
     },
     Object {
-      "deps": Object {},
       "name": "diff",
       "root": "/common/temp/default/node_modules/.pnpm/diff@5.0.0/node_modules/diff",
     },
@@ -18035,17 +17527,14 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/dom-serializer@2.0.0/node_modules/dom-serializer",
     },
     Object {
-      "deps": Object {},
       "name": "dom-walk",
       "root": "/common/temp/default/node_modules/.pnpm/dom-walk@0.1.2/node_modules/dom-walk",
     },
     Object {
-      "deps": Object {},
       "name": "domain-browser",
       "root": "/common/temp/default/node_modules/.pnpm/domain-browser@1.2.0/node_modules/domain-browser",
     },
     Object {
-      "deps": Object {},
       "name": "domelementtype",
       "root": "/common/temp/default/node_modules/.pnpm/domelementtype@2.3.0/node_modules/domelementtype",
     },
@@ -18111,22 +17600,18 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/dot-prop@6.0.1/node_modules/dot-prop",
     },
     Object {
-      "deps": Object {},
       "name": "dotenv-expand",
       "root": "/common/temp/default/node_modules/.pnpm/dotenv-expand@5.1.0/node_modules/dotenv-expand",
     },
     Object {
-      "deps": Object {},
       "name": "dotenv",
       "root": "/common/temp/default/node_modules/.pnpm/dotenv@10.0.0/node_modules/dotenv",
     },
     Object {
-      "deps": Object {},
       "name": "dotenv",
       "root": "/common/temp/default/node_modules/.pnpm/dotenv@16.4.5/node_modules/dotenv",
     },
     Object {
-      "deps": Object {},
       "name": "dotenv",
       "root": "/common/temp/default/node_modules/.pnpm/dotenv@8.6.0/node_modules/dotenv",
     },
@@ -18150,7 +17635,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/duplexer2@0.1.4/node_modules/duplexer2",
     },
     Object {
-      "deps": Object {},
       "name": "duplexer",
       "root": "/common/temp/default/node_modules/.pnpm/duplexer@0.1.2/node_modules/duplexer",
     },
@@ -18165,7 +17649,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/duplexify@3.7.1/node_modules/duplexify",
     },
     Object {
-      "deps": Object {},
       "name": "eastasianwidth",
       "root": "/common/temp/default/node_modules/.pnpm/eastasianwidth@0.2.0/node_modules/eastasianwidth",
     },
@@ -18177,12 +17660,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/ecdsa-sig-formatter@1.0.11/node_modules/ecdsa-sig-formatter",
     },
     Object {
-      "deps": Object {},
       "name": "ee-first",
       "root": "/common/temp/default/node_modules/.pnpm/ee-first@1.1.1/node_modules/ee-first",
     },
     Object {
-      "deps": Object {},
       "name": "electron-to-chromium",
       "root": "/common/temp/default/node_modules/.pnpm/electron-to-chromium@1.4.709/node_modules/electron-to-chromium",
     },
@@ -18207,27 +17688,22 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/elliptic@6.5.5/node_modules/elliptic",
     },
     Object {
-      "deps": Object {},
       "name": "emittery",
       "root": "/common/temp/default/node_modules/.pnpm/emittery@0.13.1/node_modules/emittery",
     },
     Object {
-      "deps": Object {},
       "name": "emoji-regex",
       "root": "/common/temp/default/node_modules/.pnpm/emoji-regex@7.0.3/node_modules/emoji-regex",
     },
     Object {
-      "deps": Object {},
       "name": "emoji-regex",
       "root": "/common/temp/default/node_modules/.pnpm/emoji-regex@8.0.0/node_modules/emoji-regex",
     },
     Object {
-      "deps": Object {},
       "name": "emoji-regex",
       "root": "/common/temp/default/node_modules/.pnpm/emoji-regex@9.2.2/node_modules/emoji-regex",
     },
     Object {
-      "deps": Object {},
       "name": "emojis-list",
       "root": "/common/temp/default/node_modules/.pnpm/emojis-list@3.0.0/node_modules/emojis-list",
     },
@@ -18251,7 +17727,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/encode-registry@3.0.1/node_modules/encode-registry",
     },
     Object {
-      "deps": Object {},
       "name": "encodeurl",
       "root": "/common/temp/default/node_modules/.pnpm/encodeurl@1.0.2/node_modules/encodeurl",
     },
@@ -18304,32 +17779,26 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/enquirer@2.4.1/node_modules/enquirer",
     },
     Object {
-      "deps": Object {},
       "name": "entities",
       "root": "/common/temp/default/node_modules/.pnpm/entities@2.1.0/node_modules/entities",
     },
     Object {
-      "deps": Object {},
       "name": "entities",
       "root": "/common/temp/default/node_modules/.pnpm/entities@2.2.0/node_modules/entities",
     },
     Object {
-      "deps": Object {},
       "name": "entities",
       "root": "/common/temp/default/node_modules/.pnpm/entities@4.5.0/node_modules/entities",
     },
     Object {
-      "deps": Object {},
       "name": "env-paths",
       "root": "/common/temp/default/node_modules/.pnpm/env-paths@2.2.1/node_modules/env-paths",
     },
     Object {
-      "deps": Object {},
       "name": "envinfo",
       "root": "/common/temp/default/node_modules/.pnpm/envinfo@7.11.1/node_modules/envinfo",
     },
     Object {
-      "deps": Object {},
       "name": "err-code",
       "root": "/common/temp/default/node_modules/.pnpm/err-code@2.0.3/node_modules/err-code",
     },
@@ -18407,7 +17876,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/es-abstract@1.23.2/node_modules/es-abstract",
     },
     Object {
-      "deps": Object {},
       "name": "es-array-method-boxes-properly",
       "root": "/common/temp/default/node_modules/.pnpm/es-array-method-boxes-properly@1.0.0/node_modules/es-array-method-boxes-properly",
     },
@@ -18419,7 +17887,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/es-define-property@1.0.0/node_modules/es-define-property",
     },
     Object {
-      "deps": Object {},
       "name": "es-errors",
       "root": "/common/temp/default/node_modules/.pnpm/es-errors@1.3.0/node_modules/es-errors",
     },
@@ -18459,7 +17926,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/es-iterator-helpers@1.0.18/node_modules/es-iterator-helpers",
     },
     Object {
-      "deps": Object {},
       "name": "es-module-lexer",
       "root": "/common/temp/default/node_modules/.pnpm/es-module-lexer@1.4.1/node_modules/es-module-lexer",
     },
@@ -18496,17 +17962,14 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/es-to-primitive@1.2.1/node_modules/es-to-primitive",
     },
     Object {
-      "deps": Object {},
       "name": "es5-shim",
       "root": "/common/temp/default/node_modules/.pnpm/es5-shim@4.6.7/node_modules/es5-shim",
     },
     Object {
-      "deps": Object {},
       "name": "es6-shim",
       "root": "/common/temp/default/node_modules/.pnpm/es6-shim@0.35.8/node_modules/es6-shim",
     },
     Object {
-      "deps": Object {},
       "name": "esbuild-linux-64",
       "root": "/common/temp/default/node_modules/.pnpm/esbuild-linux-64@0.14.54/node_modules/esbuild-linux-64",
     },
@@ -18534,32 +17997,26 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/esbuild@0.20.2/node_modules/esbuild",
     },
     Object {
-      "deps": Object {},
       "name": "escalade",
       "root": "/common/temp/default/node_modules/.pnpm/escalade@3.1.2/node_modules/escalade",
     },
     Object {
-      "deps": Object {},
       "name": "escape-goat",
       "root": "/common/temp/default/node_modules/.pnpm/escape-goat@2.1.1/node_modules/escape-goat",
     },
     Object {
-      "deps": Object {},
       "name": "escape-html",
       "root": "/common/temp/default/node_modules/.pnpm/escape-html@1.0.3/node_modules/escape-html",
     },
     Object {
-      "deps": Object {},
       "name": "escape-string-regexp",
       "root": "/common/temp/default/node_modules/.pnpm/escape-string-regexp@1.0.5/node_modules/escape-string-regexp",
     },
     Object {
-      "deps": Object {},
       "name": "escape-string-regexp",
       "root": "/common/temp/default/node_modules/.pnpm/escape-string-regexp@2.0.0/node_modules/escape-string-regexp",
     },
     Object {
-      "deps": Object {},
       "name": "escape-string-regexp",
       "root": "/common/temp/default/node_modules/.pnpm/escape-string-regexp@4.0.0/node_modules/escape-string-regexp",
     },
@@ -18818,22 +18275,18 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/eslint-utils@3.0.0_eslint@8.57.0/node_modules/eslint-utils",
     },
     Object {
-      "deps": Object {},
       "name": "eslint-visitor-keys",
       "root": "/common/temp/default/node_modules/.pnpm/eslint-visitor-keys@1.3.0/node_modules/eslint-visitor-keys",
     },
     Object {
-      "deps": Object {},
       "name": "eslint-visitor-keys",
       "root": "/common/temp/default/node_modules/.pnpm/eslint-visitor-keys@2.1.0/node_modules/eslint-visitor-keys",
     },
     Object {
-      "deps": Object {},
       "name": "eslint-visitor-keys",
       "root": "/common/temp/default/node_modules/.pnpm/eslint-visitor-keys@3.4.3/node_modules/eslint-visitor-keys",
     },
     Object {
-      "deps": Object {},
       "name": "eslint-visitor-keys",
       "root": "/common/temp/default/node_modules/.pnpm/eslint-visitor-keys@4.0.0/node_modules/eslint-visitor-keys",
     },
@@ -19129,7 +18582,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/espree@9.6.1/node_modules/espree",
     },
     Object {
-      "deps": Object {},
       "name": "esprima",
       "root": "/common/temp/default/node_modules/.pnpm/esprima@4.0.1/node_modules/esprima",
     },
@@ -19148,12 +18600,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/esrecurse@4.3.0/node_modules/esrecurse",
     },
     Object {
-      "deps": Object {},
       "name": "estraverse",
       "root": "/common/temp/default/node_modules/.pnpm/estraverse@4.3.0/node_modules/estraverse",
     },
     Object {
-      "deps": Object {},
       "name": "estraverse",
       "root": "/common/temp/default/node_modules/.pnpm/estraverse@5.3.0/node_modules/estraverse",
     },
@@ -19167,32 +18617,26 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/estree-to-babel@3.2.1/node_modules/estree-to-babel",
     },
     Object {
-      "deps": Object {},
       "name": "estree-walker",
       "root": "/common/temp/default/node_modules/.pnpm/estree-walker@2.0.2/node_modules/estree-walker",
     },
     Object {
-      "deps": Object {},
       "name": "esutils",
       "root": "/common/temp/default/node_modules/.pnpm/esutils@2.0.3/node_modules/esutils",
     },
     Object {
-      "deps": Object {},
       "name": "etag",
       "root": "/common/temp/default/node_modules/.pnpm/etag@1.8.1/node_modules/etag",
     },
     Object {
-      "deps": Object {},
       "name": "eventemitter3",
       "root": "/common/temp/default/node_modules/.pnpm/eventemitter3@4.0.7/node_modules/eventemitter3",
     },
     Object {
-      "deps": Object {},
       "name": "events",
       "root": "/common/temp/default/node_modules/.pnpm/events@1.1.1/node_modules/events",
     },
     Object {
-      "deps": Object {},
       "name": "events",
       "root": "/common/temp/default/node_modules/.pnpm/events@3.3.0/node_modules/events",
     },
@@ -19205,7 +18649,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/evp_bytestokey@1.0.3/node_modules/evp_bytestokey",
     },
     Object {
-      "deps": Object {},
       "name": "exec-sh",
       "root": "/common/temp/default/node_modules/.pnpm/exec-sh@0.3.6/node_modules/exec-sh",
     },
@@ -19238,7 +18681,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/execa@5.1.1/node_modules/execa",
     },
     Object {
-      "deps": Object {},
       "name": "exit",
       "root": "/common/temp/default/node_modules/.pnpm/exit@0.1.2/node_modules/exit",
     },
@@ -19256,7 +18698,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/expand-brackets@2.1.4/node_modules/expand-brackets",
     },
     Object {
-      "deps": Object {},
       "name": "expand-template",
       "root": "/common/temp/default/node_modules/.pnpm/expand-template@2.0.3/node_modules/expand-template",
     },
@@ -19331,7 +18772,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/extend-shallow@3.0.2/node_modules/extend-shallow",
     },
     Object {
-      "deps": Object {},
       "name": "extend",
       "root": "/common/temp/default/node_modules/.pnpm/extend@3.0.2/node_modules/extend",
     },
@@ -19369,12 +18809,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/extract-zip@1.7.0/node_modules/extract-zip",
     },
     Object {
-      "deps": Object {},
       "name": "fast-decode-uri-component",
       "root": "/common/temp/default/node_modules/.pnpm/fast-decode-uri-component@1.0.1/node_modules/fast-decode-uri-component",
     },
     Object {
-      "deps": Object {},
       "name": "fast-deep-equal",
       "root": "/common/temp/default/node_modules/.pnpm/fast-deep-equal@3.1.3/node_modules/fast-deep-equal",
     },
@@ -19402,12 +18840,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/fast-glob@3.3.2/node_modules/fast-glob",
     },
     Object {
-      "deps": Object {},
       "name": "fast-json-parse",
       "root": "/common/temp/default/node_modules/.pnpm/fast-json-parse@1.0.3/node_modules/fast-json-parse",
     },
     Object {
-      "deps": Object {},
       "name": "fast-json-stable-stringify",
       "root": "/common/temp/default/node_modules/.pnpm/fast-json-stable-stringify@2.1.0/node_modules/fast-json-stable-stringify",
     },
@@ -19422,17 +18858,14 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/fast-json-stringify@2.7.13/node_modules/fast-json-stringify",
     },
     Object {
-      "deps": Object {},
       "name": "fast-levenshtein",
       "root": "/common/temp/default/node_modules/.pnpm/fast-levenshtein@2.0.6/node_modules/fast-levenshtein",
     },
     Object {
-      "deps": Object {},
       "name": "fast-redact",
       "root": "/common/temp/default/node_modules/.pnpm/fast-redact@3.4.0/node_modules/fast-redact",
     },
     Object {
-      "deps": Object {},
       "name": "fast-safe-stringify",
       "root": "/common/temp/default/node_modules/.pnpm/fast-safe-stringify@2.1.1/node_modules/fast-safe-stringify",
     },
@@ -19444,12 +18877,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/fast-xml-parser@4.2.5/node_modules/fast-xml-parser",
     },
     Object {
-      "deps": Object {},
       "name": "fastify-error",
       "root": "/common/temp/default/node_modules/.pnpm/fastify-error@0.3.1/node_modules/fastify-error",
     },
     Object {
-      "deps": Object {},
       "name": "fastify-warning",
       "root": "/common/temp/default/node_modules/.pnpm/fastify-warning@0.2.0/node_modules/fastify-warning",
     },
@@ -19511,7 +18942,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/fd-slicer@1.1.0/node_modules/fd-slicer",
     },
     Object {
-      "deps": Object {},
       "name": "figgy-pudding",
       "root": "/common/temp/default/node_modules/.pnpm/figgy-pudding@3.5.2/node_modules/figgy-pudding",
     },
@@ -19563,7 +18993,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/file-system-cache@1.1.0/node_modules/file-system-cache",
     },
     Object {
-      "deps": Object {},
       "name": "file-uri-to-path",
       "root": "/common/temp/default/node_modules/.pnpm/file-uri-to-path@1.0.0/node_modules/file-uri-to-path",
     },
@@ -19626,7 +19055,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/find-my-way@4.5.1/node_modules/find-my-way",
     },
     Object {
-      "deps": Object {},
       "name": "find-root",
       "root": "/common/temp/default/node_modules/.pnpm/find-root@1.1.0/node_modules/find-root",
     },
@@ -19700,27 +19128,22 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/flat-cache@3.2.0/node_modules/flat-cache",
     },
     Object {
-      "deps": Object {},
       "name": "flat",
       "root": "/common/temp/default/node_modules/.pnpm/flat@5.0.2/node_modules/flat",
     },
     Object {
-      "deps": Object {},
       "name": "flatstr",
       "root": "/common/temp/default/node_modules/.pnpm/flatstr@1.0.12/node_modules/flatstr",
     },
     Object {
-      "deps": Object {},
       "name": "flatted",
       "root": "/common/temp/default/node_modules/.pnpm/flatted@2.0.2/node_modules/flatted",
     },
     Object {
-      "deps": Object {},
       "name": "flatted",
       "root": "/common/temp/default/node_modules/.pnpm/flatted@3.3.1/node_modules/flatted",
     },
     Object {
-      "deps": Object {},
       "name": "flow-parser",
       "root": "/common/temp/default/node_modules/.pnpm/flow-parser@0.231.0/node_modules/flow-parser",
     },
@@ -19733,7 +19156,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/flush-write-stream@1.1.1/node_modules/flush-write-stream",
     },
     Object {
-      "deps": Object {},
       "name": "follow-redirects",
       "root": "/common/temp/default/node_modules/.pnpm/follow-redirects@1.15.6/node_modules/follow-redirects",
     },
@@ -19745,7 +19167,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/for-each@0.3.3/node_modules/for-each",
     },
     Object {
-      "deps": Object {},
       "name": "for-in",
       "root": "/common/temp/default/node_modules/.pnpm/for-in@1.0.2/node_modules/for-in",
     },
@@ -19811,17 +19232,14 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/form-data@4.0.0/node_modules/form-data",
     },
     Object {
-      "deps": Object {},
       "name": "format",
       "root": "/common/temp/default/node_modules/.pnpm/format@0.2.2/node_modules/format",
     },
     Object {
-      "deps": Object {},
       "name": "forwarded",
       "root": "/common/temp/default/node_modules/.pnpm/forwarded@0.2.0/node_modules/forwarded",
     },
     Object {
-      "deps": Object {},
       "name": "fraction.js",
       "root": "/common/temp/default/node_modules/.pnpm/fraction.js@4.3.7/node_modules/fraction.js",
     },
@@ -19833,7 +19251,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/fragment-cache@0.2.1/node_modules/fragment-cache",
     },
     Object {
-      "deps": Object {},
       "name": "fresh",
       "root": "/common/temp/default/node_modules/.pnpm/fresh@0.5.2/node_modules/fresh",
     },
@@ -19846,7 +19263,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/from2@2.3.0/node_modules/from2",
     },
     Object {
-      "deps": Object {},
       "name": "fs-constants",
       "root": "/common/temp/default/node_modules/.pnpm/fs-constants@1.0.0/node_modules/fs-constants",
     },
@@ -19904,7 +19320,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/fs-minipass@2.1.0/node_modules/fs-minipass",
     },
     Object {
-      "deps": Object {},
       "name": "fs-monkey",
       "root": "/common/temp/default/node_modules/.pnpm/fs-monkey@1.0.3/node_modules/fs-monkey",
     },
@@ -19919,7 +19334,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/fs-write-stream-atomic@1.0.10/node_modules/fs-write-stream-atomic",
     },
     Object {
-      "deps": Object {},
       "name": "fs.realpath",
       "root": "/common/temp/default/node_modules/.pnpm/fs.realpath@1.0.0/node_modules/fs.realpath",
     },
@@ -19934,7 +19348,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/fstream@1.0.12/node_modules/fstream",
     },
     Object {
-      "deps": Object {},
       "name": "function-bind",
       "root": "/common/temp/default/node_modules/.pnpm/function-bind@1.1.2/node_modules/function-bind",
     },
@@ -19949,17 +19362,14 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/function.prototype.name@1.1.6/node_modules/function.prototype.name",
     },
     Object {
-      "deps": Object {},
       "name": "functional-red-black-tree",
       "root": "/common/temp/default/node_modules/.pnpm/functional-red-black-tree@1.0.1/node_modules/functional-red-black-tree",
     },
     Object {
-      "deps": Object {},
       "name": "functions-have-names",
       "root": "/common/temp/default/node_modules/.pnpm/functions-have-names@1.2.3/node_modules/functions-have-names",
     },
     Object {
-      "deps": Object {},
       "name": "fuse.js",
       "root": "/common/temp/default/node_modules/.pnpm/fuse.js@3.6.1/node_modules/fuse.js",
     },
@@ -20000,17 +19410,14 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/generic-names@4.0.0/node_modules/generic-names",
     },
     Object {
-      "deps": Object {},
       "name": "generic-pool",
       "root": "/common/temp/default/node_modules/.pnpm/generic-pool@3.9.0/node_modules/generic-pool",
     },
     Object {
-      "deps": Object {},
       "name": "gensync",
       "root": "/common/temp/default/node_modules/.pnpm/gensync@1.0.0-beta.2/node_modules/gensync",
     },
     Object {
-      "deps": Object {},
       "name": "get-caller-file",
       "root": "/common/temp/default/node_modules/.pnpm/get-caller-file@2.0.5/node_modules/get-caller-file",
     },
@@ -20026,12 +19433,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/get-intrinsic@1.2.4/node_modules/get-intrinsic",
     },
     Object {
-      "deps": Object {},
       "name": "get-package-type",
       "root": "/common/temp/default/node_modules/.pnpm/get-package-type@0.1.0/node_modules/get-package-type",
     },
     Object {
-      "deps": Object {},
       "name": "get-port",
       "root": "/common/temp/default/node_modules/.pnpm/get-port@5.1.1/node_modules/get-port",
     },
@@ -20050,7 +19455,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/get-stream@5.2.0/node_modules/get-stream",
     },
     Object {
-      "deps": Object {},
       "name": "get-stream",
       "root": "/common/temp/default/node_modules/.pnpm/get-stream@6.0.1/node_modules/get-stream",
     },
@@ -20064,32 +19468,26 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/get-symbol-description@1.0.2/node_modules/get-symbol-description",
     },
     Object {
-      "deps": Object {},
       "name": "get-value",
       "root": "/common/temp/default/node_modules/.pnpm/get-value@2.0.6/node_modules/get-value",
     },
     Object {
-      "deps": Object {},
       "name": "git-repo-info",
       "root": "/common/temp/default/node_modules/.pnpm/git-repo-info@2.1.1/node_modules/git-repo-info",
     },
     Object {
-      "deps": Object {},
       "name": "github-from-package",
       "root": "/common/temp/default/node_modules/.pnpm/github-from-package@0.0.0/node_modules/github-from-package",
     },
     Object {
-      "deps": Object {},
       "name": "github-slugger",
       "root": "/common/temp/default/node_modules/.pnpm/github-slugger@1.5.0/node_modules/github-slugger",
     },
     Object {
-      "deps": Object {},
       "name": "giturl",
       "root": "/common/temp/default/node_modules/.pnpm/giturl@1.0.3/node_modules/giturl",
     },
     Object {
-      "deps": Object {},
       "name": "glob-escape",
       "root": "/common/temp/default/node_modules/.pnpm/glob-escape@0.0.2/node_modules/glob-escape",
     },
@@ -20124,12 +19522,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/glob-promise@3.4.0_glob@7.2.3/node_modules/glob-promise",
     },
     Object {
-      "deps": Object {},
       "name": "glob-to-regexp",
       "root": "/common/temp/default/node_modules/.pnpm/glob-to-regexp@0.3.0/node_modules/glob-to-regexp",
     },
     Object {
-      "deps": Object {},
       "name": "glob-to-regexp",
       "root": "/common/temp/default/node_modules/.pnpm/glob-to-regexp@0.4.1/node_modules/glob-to-regexp",
     },
@@ -20220,7 +19616,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/global@4.4.0/node_modules/global",
     },
     Object {
-      "deps": Object {},
       "name": "globals",
       "root": "/common/temp/default/node_modules/.pnpm/globals@11.12.0/node_modules/globals",
     },
@@ -20239,7 +19634,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/globals@13.24.0/node_modules/globals",
     },
     Object {
-      "deps": Object {},
       "name": "globals",
       "root": "/common/temp/default/node_modules/.pnpm/globals@14.0.0/node_modules/globals",
     },
@@ -20301,27 +19695,22 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/got@11.8.6/node_modules/got",
     },
     Object {
-      "deps": Object {},
       "name": "graceful-fs",
       "root": "/common/temp/default/node_modules/.pnpm/graceful-fs@4.2.11/node_modules/graceful-fs",
     },
     Object {
-      "deps": Object {},
       "name": "graceful-fs",
       "root": "/common/temp/default/node_modules/.pnpm/graceful-fs@4.2.4/node_modules/graceful-fs",
     },
     Object {
-      "deps": Object {},
       "name": "grapheme-splitter",
       "root": "/common/temp/default/node_modules/.pnpm/grapheme-splitter@1.0.4/node_modules/grapheme-splitter",
     },
     Object {
-      "deps": Object {},
       "name": "graphemer",
       "root": "/common/temp/default/node_modules/.pnpm/graphemer@1.4.0/node_modules/graphemer",
     },
     Object {
-      "deps": Object {},
       "name": "graphql",
       "root": "/common/temp/default/node_modules/.pnpm/graphql@16.8.1/node_modules/graphql",
     },
@@ -20333,7 +19722,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/gzip-size@6.0.0/node_modules/gzip-size",
     },
     Object {
-      "deps": Object {},
       "name": "handle-thing",
       "root": "/common/temp/default/node_modules/.pnpm/handle-thing@2.0.1/node_modules/handle-thing",
     },
@@ -20349,22 +19737,18 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/handlebars@4.7.8/node_modules/handlebars",
     },
     Object {
-      "deps": Object {},
       "name": "hard-rejection",
       "root": "/common/temp/default/node_modules/.pnpm/hard-rejection@2.1.0/node_modules/hard-rejection",
     },
     Object {
-      "deps": Object {},
       "name": "has-bigints",
       "root": "/common/temp/default/node_modules/.pnpm/has-bigints@1.0.2/node_modules/has-bigints",
     },
     Object {
-      "deps": Object {},
       "name": "has-flag",
       "root": "/common/temp/default/node_modules/.pnpm/has-flag@3.0.0/node_modules/has-flag",
     },
     Object {
-      "deps": Object {},
       "name": "has-flag",
       "root": "/common/temp/default/node_modules/.pnpm/has-flag@4.0.0/node_modules/has-flag",
     },
@@ -20383,12 +19767,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/has-property-descriptors@1.0.2/node_modules/has-property-descriptors",
     },
     Object {
-      "deps": Object {},
       "name": "has-proto",
       "root": "/common/temp/default/node_modules/.pnpm/has-proto@1.0.3/node_modules/has-proto",
     },
     Object {
-      "deps": Object {},
       "name": "has-symbols",
       "root": "/common/temp/default/node_modules/.pnpm/has-symbols@1.0.3/node_modules/has-symbols",
     },
@@ -20400,7 +19782,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/has-tostringtag@1.0.2/node_modules/has-tostringtag",
     },
     Object {
-      "deps": Object {},
       "name": "has-unicode",
       "root": "/common/temp/default/node_modules/.pnpm/has-unicode@2.0.1/node_modules/has-unicode",
     },
@@ -20423,7 +19804,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/has-value@1.0.0/node_modules/has-value",
     },
     Object {
-      "deps": Object {},
       "name": "has-values",
       "root": "/common/temp/default/node_modules/.pnpm/has-values@0.1.4/node_modules/has-values",
     },
@@ -20436,12 +19816,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/has-values@1.0.0/node_modules/has-values",
     },
     Object {
-      "deps": Object {},
       "name": "has-yarn",
       "root": "/common/temp/default/node_modules/.pnpm/has-yarn@2.1.0/node_modules/has-yarn",
     },
     Object {
-      "deps": Object {},
       "name": "has",
       "root": "/common/temp/default/node_modules/.pnpm/has@1.0.4/node_modules/has",
     },
@@ -20503,7 +19881,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/hast-util-from-parse5@6.0.1/node_modules/hast-util-from-parse5",
     },
     Object {
-      "deps": Object {},
       "name": "hast-util-parse-selector",
       "root": "/common/temp/default/node_modules/.pnpm/hast-util-parse-selector@2.2.5/node_modules/hast-util-parse-selector",
     },
@@ -20546,7 +19923,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/hastscript@6.0.0/node_modules/hastscript",
     },
     Object {
-      "deps": Object {},
       "name": "he",
       "root": "/common/temp/default/node_modules/.pnpm/he@1.2.0/node_modules/he",
     },
@@ -20560,7 +19936,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/highlight-es@1.0.3/node_modules/highlight-es",
     },
     Object {
-      "deps": Object {},
       "name": "highlight.js",
       "root": "/common/temp/default/node_modules/.pnpm/highlight.js@10.7.3/node_modules/highlight.js",
     },
@@ -20595,7 +19970,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/homedir-polyfill@1.0.3/node_modules/homedir-polyfill",
     },
     Object {
-      "deps": Object {},
       "name": "hosted-git-info",
       "root": "/common/temp/default/node_modules/.pnpm/hosted-git-info@2.8.9/node_modules/hosted-git-info",
     },
@@ -20624,12 +19998,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/html-encoding-sniffer@3.0.0/node_modules/html-encoding-sniffer",
     },
     Object {
-      "deps": Object {},
       "name": "html-entities",
       "root": "/common/temp/default/node_modules/.pnpm/html-entities@2.5.2/node_modules/html-entities",
     },
     Object {
-      "deps": Object {},
       "name": "html-escaper",
       "root": "/common/temp/default/node_modules/.pnpm/html-escaper@2.0.2/node_modules/html-escaper",
     },
@@ -20660,12 +20032,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/html-minifier-terser@6.1.0/node_modules/html-minifier-terser",
     },
     Object {
-      "deps": Object {},
       "name": "html-tags",
       "root": "/common/temp/default/node_modules/.pnpm/html-tags@3.3.1/node_modules/html-tags",
     },
     Object {
-      "deps": Object {},
       "name": "html-void-elements",
       "root": "/common/temp/default/node_modules/.pnpm/html-void-elements@1.0.5/node_modules/html-void-elements",
     },
@@ -20718,12 +20088,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/htmlparser2@8.0.2/node_modules/htmlparser2",
     },
     Object {
-      "deps": Object {},
       "name": "http-cache-semantics",
       "root": "/common/temp/default/node_modules/.pnpm/http-cache-semantics@4.1.1/node_modules/http-cache-semantics",
     },
     Object {
-      "deps": Object {},
       "name": "http-deceiver",
       "root": "/common/temp/default/node_modules/.pnpm/http-deceiver@1.2.7/node_modules/http-deceiver",
     },
@@ -20760,7 +20128,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/http-errors@2.0.0/node_modules/http-errors",
     },
     Object {
-      "deps": Object {},
       "name": "http-parser-js",
       "root": "/common/temp/default/node_modules/.pnpm/http-parser-js@0.5.8/node_modules/http-parser-js",
     },
@@ -20830,7 +20197,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/http2-wrapper@1.0.3/node_modules/http2-wrapper",
     },
     Object {
-      "deps": Object {},
       "name": "https-browserify",
       "root": "/common/temp/default/node_modules/.pnpm/https-browserify@1.0.0/node_modules/https-browserify",
     },
@@ -20859,7 +20225,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/https-proxy-agent@7.0.4/node_modules/https-proxy-agent",
     },
     Object {
-      "deps": Object {},
       "name": "human-signals",
       "root": "/common/temp/default/node_modules/.pnpm/human-signals@2.1.0/node_modules/human-signals",
     },
@@ -20899,17 +20264,14 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/icss-utils@5.1.0_postcss@8.4.36/node_modules/icss-utils",
     },
     Object {
-      "deps": Object {},
       "name": "ieee754",
       "root": "/common/temp/default/node_modules/.pnpm/ieee754@1.1.13/node_modules/ieee754",
     },
     Object {
-      "deps": Object {},
       "name": "ieee754",
       "root": "/common/temp/default/node_modules/.pnpm/ieee754@1.2.1/node_modules/ieee754",
     },
     Object {
-      "deps": Object {},
       "name": "iferr",
       "root": "/common/temp/default/node_modules/.pnpm/iferr@0.1.5/node_modules/iferr",
     },
@@ -20921,32 +20283,26 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/ignore-walk@3.0.4/node_modules/ignore-walk",
     },
     Object {
-      "deps": Object {},
       "name": "ignore",
       "root": "/common/temp/default/node_modules/.pnpm/ignore@4.0.6/node_modules/ignore",
     },
     Object {
-      "deps": Object {},
       "name": "ignore",
       "root": "/common/temp/default/node_modules/.pnpm/ignore@5.1.9/node_modules/ignore",
     },
     Object {
-      "deps": Object {},
       "name": "ignore",
       "root": "/common/temp/default/node_modules/.pnpm/ignore@5.3.1/node_modules/ignore",
     },
     Object {
-      "deps": Object {},
       "name": "immediate",
       "root": "/common/temp/default/node_modules/.pnpm/immediate@3.0.6/node_modules/immediate",
     },
     Object {
-      "deps": Object {},
       "name": "immer",
       "root": "/common/temp/default/node_modules/.pnpm/immer@9.0.21/node_modules/immer",
     },
     Object {
-      "deps": Object {},
       "name": "immutable",
       "root": "/common/temp/default/node_modules/.pnpm/immutable@4.3.5/node_modules/immutable",
     },
@@ -20959,12 +20315,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/import-fresh@3.3.0/node_modules/import-fresh",
     },
     Object {
-      "deps": Object {},
       "name": "import-lazy",
       "root": "/common/temp/default/node_modules/.pnpm/import-lazy@2.1.0/node_modules/import-lazy",
     },
     Object {
-      "deps": Object {},
       "name": "import-lazy",
       "root": "/common/temp/default/node_modules/.pnpm/import-lazy@4.0.0/node_modules/import-lazy",
     },
@@ -20985,27 +20339,22 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/import-local@3.1.0/node_modules/import-local",
     },
     Object {
-      "deps": Object {},
       "name": "imurmurhash",
       "root": "/common/temp/default/node_modules/.pnpm/imurmurhash@0.1.4/node_modules/imurmurhash",
     },
     Object {
-      "deps": Object {},
       "name": "indent-string",
       "root": "/common/temp/default/node_modules/.pnpm/indent-string@4.0.0/node_modules/indent-string",
     },
     Object {
-      "deps": Object {},
       "name": "indent-string",
       "root": "/common/temp/default/node_modules/.pnpm/indent-string@5.0.0/node_modules/indent-string",
     },
     Object {
-      "deps": Object {},
       "name": "individual",
       "root": "/common/temp/default/node_modules/.pnpm/individual@3.0.0/node_modules/individual",
     },
     Object {
-      "deps": Object {},
       "name": "infer-owner",
       "root": "/common/temp/default/node_modules/.pnpm/infer-owner@1.0.4/node_modules/infer-owner",
     },
@@ -21018,32 +20367,26 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/inflight@1.0.6/node_modules/inflight",
     },
     Object {
-      "deps": Object {},
       "name": "inherits",
       "root": "/common/temp/default/node_modules/.pnpm/inherits@2.0.3/node_modules/inherits",
     },
     Object {
-      "deps": Object {},
       "name": "inherits",
       "root": "/common/temp/default/node_modules/.pnpm/inherits@2.0.4/node_modules/inherits",
     },
     Object {
-      "deps": Object {},
       "name": "ini",
       "root": "/common/temp/default/node_modules/.pnpm/ini@1.3.8/node_modules/ini",
     },
     Object {
-      "deps": Object {},
       "name": "ini",
       "root": "/common/temp/default/node_modules/.pnpm/ini@2.0.0/node_modules/ini",
     },
     Object {
-      "deps": Object {},
       "name": "inline-style-parser",
       "root": "/common/temp/default/node_modules/.pnpm/inline-style-parser@0.1.1/node_modules/inline-style-parser",
     },
     Object {
-      "deps": Object {},
       "name": "inpath",
       "root": "/common/temp/default/node_modules/.pnpm/inpath@1.0.2/node_modules/inpath",
     },
@@ -21076,12 +20419,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/internal-slot@1.0.7/node_modules/internal-slot",
     },
     Object {
-      "deps": Object {},
       "name": "interpret",
       "root": "/common/temp/default/node_modules/.pnpm/interpret@1.4.0/node_modules/interpret",
     },
     Object {
-      "deps": Object {},
       "name": "interpret",
       "root": "/common/temp/default/node_modules/.pnpm/interpret@2.2.0/node_modules/interpret",
     },
@@ -21101,22 +20442,18 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/ip-address@9.0.5/node_modules/ip-address",
     },
     Object {
-      "deps": Object {},
       "name": "ip",
       "root": "/common/temp/default/node_modules/.pnpm/ip@1.1.9/node_modules/ip",
     },
     Object {
-      "deps": Object {},
       "name": "ipaddr.js",
       "root": "/common/temp/default/node_modules/.pnpm/ipaddr.js@1.9.1/node_modules/ipaddr.js",
     },
     Object {
-      "deps": Object {},
       "name": "ipaddr.js",
       "root": "/common/temp/default/node_modules/.pnpm/ipaddr.js@2.1.0/node_modules/ipaddr.js",
     },
     Object {
-      "deps": Object {},
       "name": "is-absolute-url",
       "root": "/common/temp/default/node_modules/.pnpm/is-absolute-url@3.0.3/node_modules/is-absolute-url",
     },
@@ -21128,7 +20465,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/is-accessor-descriptor@1.0.1/node_modules/is-accessor-descriptor",
     },
     Object {
-      "deps": Object {},
       "name": "is-alphabetical",
       "root": "/common/temp/default/node_modules/.pnpm/is-alphabetical@1.0.4/node_modules/is-alphabetical",
     },
@@ -21157,7 +20493,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/is-array-buffer@3.0.4/node_modules/is-array-buffer",
     },
     Object {
-      "deps": Object {},
       "name": "is-arrayish",
       "root": "/common/temp/default/node_modules/.pnpm/is-arrayish@0.2.1/node_modules/is-arrayish",
     },
@@ -21198,17 +20533,14 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/is-boolean-object@1.1.2/node_modules/is-boolean-object",
     },
     Object {
-      "deps": Object {},
       "name": "is-buffer",
       "root": "/common/temp/default/node_modules/.pnpm/is-buffer@1.1.6/node_modules/is-buffer",
     },
     Object {
-      "deps": Object {},
       "name": "is-buffer",
       "root": "/common/temp/default/node_modules/.pnpm/is-buffer@2.0.5/node_modules/is-buffer",
     },
     Object {
-      "deps": Object {},
       "name": "is-callable",
       "root": "/common/temp/default/node_modules/.pnpm/is-callable@1.2.7/node_modules/is-callable",
     },
@@ -21248,7 +20580,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/is-date-object@1.0.5/node_modules/is-date-object",
     },
     Object {
-      "deps": Object {},
       "name": "is-decimal",
       "root": "/common/temp/default/node_modules/.pnpm/is-decimal@1.0.4/node_modules/is-decimal",
     },
@@ -21269,7 +20600,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/is-descriptor@1.0.3/node_modules/is-descriptor",
     },
     Object {
-      "deps": Object {},
       "name": "is-docker",
       "root": "/common/temp/default/node_modules/.pnpm/is-docker@2.2.1/node_modules/is-docker",
     },
@@ -21282,12 +20612,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/is-dom@1.1.0/node_modules/is-dom",
     },
     Object {
-      "deps": Object {},
       "name": "is-es2016-keyword",
       "root": "/common/temp/default/node_modules/.pnpm/is-es2016-keyword@1.0.0/node_modules/is-es2016-keyword",
     },
     Object {
-      "deps": Object {},
       "name": "is-extendable",
       "root": "/common/temp/default/node_modules/.pnpm/is-extendable@0.1.1/node_modules/is-extendable",
     },
@@ -21299,7 +20627,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/is-extendable@1.0.1/node_modules/is-extendable",
     },
     Object {
-      "deps": Object {},
       "name": "is-extglob",
       "root": "/common/temp/default/node_modules/.pnpm/is-extglob@2.1.1/node_modules/is-extglob",
     },
@@ -21318,22 +20645,18 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/is-fullwidth-code-point@1.0.0/node_modules/is-fullwidth-code-point",
     },
     Object {
-      "deps": Object {},
       "name": "is-fullwidth-code-point",
       "root": "/common/temp/default/node_modules/.pnpm/is-fullwidth-code-point@2.0.0/node_modules/is-fullwidth-code-point",
     },
     Object {
-      "deps": Object {},
       "name": "is-fullwidth-code-point",
       "root": "/common/temp/default/node_modules/.pnpm/is-fullwidth-code-point@3.0.0/node_modules/is-fullwidth-code-point",
     },
     Object {
-      "deps": Object {},
       "name": "is-function",
       "root": "/common/temp/default/node_modules/.pnpm/is-function@1.0.2/node_modules/is-function",
     },
     Object {
-      "deps": Object {},
       "name": "is-generator-fn",
       "root": "/common/temp/default/node_modules/.pnpm/is-generator-fn@2.1.0/node_modules/is-generator-fn",
     },
@@ -21359,7 +20682,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/is-glob@4.0.3/node_modules/is-glob",
     },
     Object {
-      "deps": Object {},
       "name": "is-hexadecimal",
       "root": "/common/temp/default/node_modules/.pnpm/is-hexadecimal@1.0.4/node_modules/is-hexadecimal",
     },
@@ -21372,27 +20694,22 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/is-installed-globally@0.4.0/node_modules/is-installed-globally",
     },
     Object {
-      "deps": Object {},
       "name": "is-interactive",
       "root": "/common/temp/default/node_modules/.pnpm/is-interactive@1.0.0/node_modules/is-interactive",
     },
     Object {
-      "deps": Object {},
       "name": "is-lambda",
       "root": "/common/temp/default/node_modules/.pnpm/is-lambda@1.0.1/node_modules/is-lambda",
     },
     Object {
-      "deps": Object {},
       "name": "is-map",
       "root": "/common/temp/default/node_modules/.pnpm/is-map@2.0.3/node_modules/is-map",
     },
     Object {
-      "deps": Object {},
       "name": "is-negative-zero",
       "root": "/common/temp/default/node_modules/.pnpm/is-negative-zero@2.0.3/node_modules/is-negative-zero",
     },
     Object {
-      "deps": Object {},
       "name": "is-npm",
       "root": "/common/temp/default/node_modules/.pnpm/is-npm@5.0.0/node_modules/is-npm",
     },
@@ -21411,37 +20728,30 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/is-number@3.0.0/node_modules/is-number",
     },
     Object {
-      "deps": Object {},
       "name": "is-number",
       "root": "/common/temp/default/node_modules/.pnpm/is-number@7.0.0/node_modules/is-number",
     },
     Object {
-      "deps": Object {},
       "name": "is-obj",
       "root": "/common/temp/default/node_modules/.pnpm/is-obj@2.0.0/node_modules/is-obj",
     },
     Object {
-      "deps": Object {},
       "name": "is-object",
       "root": "/common/temp/default/node_modules/.pnpm/is-object@1.0.2/node_modules/is-object",
     },
     Object {
-      "deps": Object {},
       "name": "is-path-inside",
       "root": "/common/temp/default/node_modules/.pnpm/is-path-inside@3.0.3/node_modules/is-path-inside",
     },
     Object {
-      "deps": Object {},
       "name": "is-plain-obj",
       "root": "/common/temp/default/node_modules/.pnpm/is-plain-obj@1.1.0/node_modules/is-plain-obj",
     },
     Object {
-      "deps": Object {},
       "name": "is-plain-obj",
       "root": "/common/temp/default/node_modules/.pnpm/is-plain-obj@2.1.0/node_modules/is-plain-obj",
     },
     Object {
-      "deps": Object {},
       "name": "is-plain-obj",
       "root": "/common/temp/default/node_modules/.pnpm/is-plain-obj@3.0.0/node_modules/is-plain-obj",
     },
@@ -21453,12 +20763,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/is-plain-object@2.0.4/node_modules/is-plain-object",
     },
     Object {
-      "deps": Object {},
       "name": "is-plain-object",
       "root": "/common/temp/default/node_modules/.pnpm/is-plain-object@5.0.0/node_modules/is-plain-object",
     },
     Object {
-      "deps": Object {},
       "name": "is-potential-custom-element-name",
       "root": "/common/temp/default/node_modules/.pnpm/is-potential-custom-element-name@1.0.1/node_modules/is-potential-custom-element-name",
     },
@@ -21471,7 +20779,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/is-regex@1.1.4/node_modules/is-regex",
     },
     Object {
-      "deps": Object {},
       "name": "is-set",
       "root": "/common/temp/default/node_modules/.pnpm/is-set@2.0.3/node_modules/is-set",
     },
@@ -21483,12 +20790,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/is-shared-array-buffer@1.0.3/node_modules/is-shared-array-buffer",
     },
     Object {
-      "deps": Object {},
       "name": "is-stream",
       "root": "/common/temp/default/node_modules/.pnpm/is-stream@1.1.0/node_modules/is-stream",
     },
     Object {
-      "deps": Object {},
       "name": "is-stream",
       "root": "/common/temp/default/node_modules/.pnpm/is-stream@2.0.1/node_modules/is-stream",
     },
@@ -21521,17 +20826,14 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/is-typed-array@1.1.13/node_modules/is-typed-array",
     },
     Object {
-      "deps": Object {},
       "name": "is-typedarray",
       "root": "/common/temp/default/node_modules/.pnpm/is-typedarray@1.0.0/node_modules/is-typedarray",
     },
     Object {
-      "deps": Object {},
       "name": "is-unicode-supported",
       "root": "/common/temp/default/node_modules/.pnpm/is-unicode-supported@0.1.0/node_modules/is-unicode-supported",
     },
     Object {
-      "deps": Object {},
       "name": "is-weakmap",
       "root": "/common/temp/default/node_modules/.pnpm/is-weakmap@2.0.2/node_modules/is-weakmap",
     },
@@ -21551,27 +20853,22 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/is-weakset@2.0.3/node_modules/is-weakset",
     },
     Object {
-      "deps": Object {},
       "name": "is-whitespace-character",
       "root": "/common/temp/default/node_modules/.pnpm/is-whitespace-character@1.0.4/node_modules/is-whitespace-character",
     },
     Object {
-      "deps": Object {},
       "name": "is-window",
       "root": "/common/temp/default/node_modules/.pnpm/is-window@1.0.2/node_modules/is-window",
     },
     Object {
-      "deps": Object {},
       "name": "is-windows",
       "root": "/common/temp/default/node_modules/.pnpm/is-windows@1.0.2/node_modules/is-windows",
     },
     Object {
-      "deps": Object {},
       "name": "is-word-character",
       "root": "/common/temp/default/node_modules/.pnpm/is-word-character@1.0.4/node_modules/is-word-character",
     },
     Object {
-      "deps": Object {},
       "name": "is-wsl",
       "root": "/common/temp/default/node_modules/.pnpm/is-wsl@1.1.0/node_modules/is-wsl",
     },
@@ -21583,22 +20880,18 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/is-wsl@2.2.0/node_modules/is-wsl",
     },
     Object {
-      "deps": Object {},
       "name": "is-yarn-global",
       "root": "/common/temp/default/node_modules/.pnpm/is-yarn-global@0.3.0/node_modules/is-yarn-global",
     },
     Object {
-      "deps": Object {},
       "name": "isarray",
       "root": "/common/temp/default/node_modules/.pnpm/isarray@1.0.0/node_modules/isarray",
     },
     Object {
-      "deps": Object {},
       "name": "isarray",
       "root": "/common/temp/default/node_modules/.pnpm/isarray@2.0.5/node_modules/isarray",
     },
     Object {
-      "deps": Object {},
       "name": "isexe",
       "root": "/common/temp/default/node_modules/.pnpm/isexe@2.0.0/node_modules/isexe",
     },
@@ -21610,17 +20903,14 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/isobject@2.1.0/node_modules/isobject",
     },
     Object {
-      "deps": Object {},
       "name": "isobject",
       "root": "/common/temp/default/node_modules/.pnpm/isobject@3.0.1/node_modules/isobject",
     },
     Object {
-      "deps": Object {},
       "name": "isobject",
       "root": "/common/temp/default/node_modules/.pnpm/isobject@4.0.0/node_modules/isobject",
     },
     Object {
-      "deps": Object {},
       "name": "istanbul-lib-coverage",
       "root": "/common/temp/default/node_modules/.pnpm/istanbul-lib-coverage@3.2.2/node_modules/istanbul-lib-coverage",
     },
@@ -21673,7 +20963,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/istanbul-reports@3.1.7/node_modules/istanbul-reports",
     },
     Object {
-      "deps": Object {},
       "name": "iterate-iterator",
       "root": "/common/temp/default/node_modules/.pnpm/iterate-iterator@1.0.2/node_modules/iterate-iterator",
     },
@@ -21941,12 +21230,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/jest-environment-node@29.7.0/node_modules/jest-environment-node",
     },
     Object {
-      "deps": Object {},
       "name": "jest-get-type",
       "root": "/common/temp/default/node_modules/.pnpm/jest-get-type@27.5.1/node_modules/jest-get-type",
     },
     Object {
-      "deps": Object {},
       "name": "jest-get-type",
       "root": "/common/temp/default/node_modules/.pnpm/jest-get-type@29.6.3/node_modules/jest-get-type",
     },
@@ -22063,12 +21350,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/jest-pnp-resolver@1.2.3_jest-resolve@29.7.0/node_modules/jest-pnp-resolver",
     },
     Object {
-      "deps": Object {},
       "name": "jest-regex-util",
       "root": "/common/temp/default/node_modules/.pnpm/jest-regex-util@26.0.0/node_modules/jest-regex-util",
     },
     Object {
-      "deps": Object {},
       "name": "jest-regex-util",
       "root": "/common/temp/default/node_modules/.pnpm/jest-regex-util@29.6.3/node_modules/jest-regex-util",
     },
@@ -22326,32 +21611,26 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/jest@29.3.1_@types+node@18.17.15/node_modules/jest",
     },
     Object {
-      "deps": Object {},
       "name": "jju",
       "root": "/common/temp/default/node_modules/.pnpm/jju@1.4.0/node_modules/jju",
     },
     Object {
-      "deps": Object {},
       "name": "jmespath",
       "root": "/common/temp/default/node_modules/.pnpm/jmespath@0.16.0/node_modules/jmespath",
     },
     Object {
-      "deps": Object {},
       "name": "js-sdsl",
       "root": "/common/temp/default/node_modules/.pnpm/js-sdsl@4.4.2/node_modules/js-sdsl",
     },
     Object {
-      "deps": Object {},
       "name": "js-string-escape",
       "root": "/common/temp/default/node_modules/.pnpm/js-string-escape@1.0.1/node_modules/js-string-escape",
     },
     Object {
-      "deps": Object {},
       "name": "js-tokens",
       "root": "/common/temp/default/node_modules/.pnpm/js-tokens@3.0.2/node_modules/js-tokens",
     },
     Object {
-      "deps": Object {},
       "name": "js-tokens",
       "root": "/common/temp/default/node_modules/.pnpm/js-tokens@4.0.0/node_modules/js-tokens",
     },
@@ -22379,7 +21658,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/js-yaml@4.1.0/node_modules/js-yaml",
     },
     Object {
-      "deps": Object {},
       "name": "jsbn",
       "root": "/common/temp/default/node_modules/.pnpm/jsbn@1.1.0/node_modules/jsbn",
     },
@@ -22410,7 +21688,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/jscodeshift@0.13.1_@babel+preset-env@7.24.0/node_modules/jscodeshift",
     },
     Object {
-      "deps": Object {},
       "name": "jsdoc-type-pratt-parser",
       "root": "/common/temp/default/node_modules/.pnpm/jsdoc-type-pratt-parser@2.2.5/node_modules/jsdoc-type-pratt-parser",
     },
@@ -22447,52 +21724,42 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/jsdom@20.0.3/node_modules/jsdom",
     },
     Object {
-      "deps": Object {},
       "name": "jsesc",
       "root": "/common/temp/default/node_modules/.pnpm/jsesc@0.5.0/node_modules/jsesc",
     },
     Object {
-      "deps": Object {},
       "name": "jsesc",
       "root": "/common/temp/default/node_modules/.pnpm/jsesc@2.5.2/node_modules/jsesc",
     },
     Object {
-      "deps": Object {},
       "name": "json-buffer",
       "root": "/common/temp/default/node_modules/.pnpm/json-buffer@3.0.1/node_modules/json-buffer",
     },
     Object {
-      "deps": Object {},
       "name": "json-parse-better-errors",
       "root": "/common/temp/default/node_modules/.pnpm/json-parse-better-errors@1.0.2/node_modules/json-parse-better-errors",
     },
     Object {
-      "deps": Object {},
       "name": "json-parse-even-better-errors",
       "root": "/common/temp/default/node_modules/.pnpm/json-parse-even-better-errors@2.3.1/node_modules/json-parse-even-better-errors",
     },
     Object {
-      "deps": Object {},
       "name": "json-schema-traverse",
       "root": "/common/temp/default/node_modules/.pnpm/json-schema-traverse@0.4.1/node_modules/json-schema-traverse",
     },
     Object {
-      "deps": Object {},
       "name": "json-schema-traverse",
       "root": "/common/temp/default/node_modules/.pnpm/json-schema-traverse@1.0.0/node_modules/json-schema-traverse",
     },
     Object {
-      "deps": Object {},
       "name": "json-schema-typed",
       "root": "/common/temp/default/node_modules/.pnpm/json-schema-typed@7.0.3/node_modules/json-schema-typed",
     },
     Object {
-      "deps": Object {},
       "name": "json-stable-stringify-without-jsonify",
       "root": "/common/temp/default/node_modules/.pnpm/json-stable-stringify-without-jsonify@1.0.1/node_modules/json-stable-stringify-without-jsonify",
     },
     Object {
-      "deps": Object {},
       "name": "json-stringify-safe",
       "root": "/common/temp/default/node_modules/.pnpm/json-stringify-safe@5.0.1/node_modules/json-stringify-safe",
     },
@@ -22504,7 +21771,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/json5@1.0.2/node_modules/json5",
     },
     Object {
-      "deps": Object {},
       "name": "json5",
       "root": "/common/temp/default/node_modules/.pnpm/json5@2.2.3/node_modules/json5",
     },
@@ -22524,12 +21790,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/jsonfile@6.1.0/node_modules/jsonfile",
     },
     Object {
-      "deps": Object {},
       "name": "jsonpath-plus",
       "root": "/common/temp/default/node_modules/.pnpm/jsonpath-plus@4.0.0/node_modules/jsonpath-plus",
     },
     Object {
-      "deps": Object {},
       "name": "jsonschema",
       "root": "/common/temp/default/node_modules/.pnpm/jsonschema@1.4.1/node_modules/jsonschema",
     },
@@ -22577,7 +21841,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/jszip@3.8.0/node_modules/jszip",
     },
     Object {
-      "deps": Object {},
       "name": "junk",
       "root": "/common/temp/default/node_modules/.pnpm/junk@3.1.0/node_modules/junk",
     },
@@ -22616,7 +21879,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/jws@4.0.0/node_modules/jws",
     },
     Object {
-      "deps": Object {},
       "name": "keyborg",
       "root": "/common/temp/default/node_modules/.pnpm/keyborg@2.5.0/node_modules/keyborg",
     },
@@ -22650,17 +21912,14 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/kind-of@4.0.0/node_modules/kind-of",
     },
     Object {
-      "deps": Object {},
       "name": "kind-of",
       "root": "/common/temp/default/node_modules/.pnpm/kind-of@6.0.3/node_modules/kind-of",
     },
     Object {
-      "deps": Object {},
       "name": "kleur",
       "root": "/common/temp/default/node_modules/.pnpm/kleur@3.0.3/node_modules/kleur",
     },
     Object {
-      "deps": Object {},
       "name": "klona",
       "root": "/common/temp/default/node_modules/.pnpm/klona@2.0.6/node_modules/klona",
     },
@@ -22684,7 +21943,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/kysely-data-api@0.1.4_aws-sdk@2.1580.0_kysely@0.21.6/node_modules/kysely-data-api",
     },
     Object {
-      "deps": Object {},
       "name": "kysely",
       "root": "/common/temp/default/node_modules/.pnpm/kysely@0.21.6/node_modules/kysely",
     },
@@ -22714,7 +21972,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/lazystream@1.0.1/node_modules/lazystream",
     },
     Object {
-      "deps": Object {},
       "name": "leven",
       "root": "/common/temp/default/node_modules/.pnpm/leven@3.1.0/node_modules/leven",
     },
@@ -22744,12 +22001,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/light-my-request@4.12.0/node_modules/light-my-request",
     },
     Object {
-      "deps": Object {},
       "name": "lilconfig",
       "root": "/common/temp/default/node_modules/.pnpm/lilconfig@2.1.0/node_modules/lilconfig",
     },
     Object {
-      "deps": Object {},
       "name": "lines-and-columns",
       "root": "/common/temp/default/node_modules/.pnpm/lines-and-columns@1.2.4/node_modules/lines-and-columns",
     },
@@ -22761,7 +22016,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/linkify-it@3.0.3/node_modules/linkify-it",
     },
     Object {
-      "deps": Object {},
       "name": "listenercount",
       "root": "/common/temp/default/node_modules/.pnpm/listenercount@1.0.1/node_modules/listenercount",
     },
@@ -22786,12 +22040,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/load-yaml-file@0.2.0/node_modules/load-yaml-file",
     },
     Object {
-      "deps": Object {},
       "name": "loader-runner",
       "root": "/common/temp/default/node_modules/.pnpm/loader-runner@2.4.0/node_modules/loader-runner",
     },
     Object {
-      "deps": Object {},
       "name": "loader-runner",
       "root": "/common/temp/default/node_modules/.pnpm/loader-runner@4.3.0/node_modules/loader-runner",
     },
@@ -22823,7 +22075,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/loader-utils@2.0.4/node_modules/loader-utils",
     },
     Object {
-      "deps": Object {},
       "name": "loader-utils",
       "root": "/common/temp/default/node_modules/.pnpm/loader-utils@3.2.1/node_modules/loader-utils",
     },
@@ -22850,102 +22101,82 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/locate-path@6.0.0/node_modules/locate-path",
     },
     Object {
-      "deps": Object {},
       "name": "lodash.camelcase",
       "root": "/common/temp/default/node_modules/.pnpm/lodash.camelcase@4.3.0/node_modules/lodash.camelcase",
     },
     Object {
-      "deps": Object {},
       "name": "lodash.debounce",
       "root": "/common/temp/default/node_modules/.pnpm/lodash.debounce@4.0.8/node_modules/lodash.debounce",
     },
     Object {
-      "deps": Object {},
       "name": "lodash.defaults",
       "root": "/common/temp/default/node_modules/.pnpm/lodash.defaults@4.2.0/node_modules/lodash.defaults",
     },
     Object {
-      "deps": Object {},
       "name": "lodash.difference",
       "root": "/common/temp/default/node_modules/.pnpm/lodash.difference@4.5.0/node_modules/lodash.difference",
     },
     Object {
-      "deps": Object {},
       "name": "lodash.flatten",
       "root": "/common/temp/default/node_modules/.pnpm/lodash.flatten@4.4.0/node_modules/lodash.flatten",
     },
     Object {
-      "deps": Object {},
       "name": "lodash.get",
       "root": "/common/temp/default/node_modules/.pnpm/lodash.get@4.4.2/node_modules/lodash.get",
     },
     Object {
-      "deps": Object {},
       "name": "lodash.includes",
       "root": "/common/temp/default/node_modules/.pnpm/lodash.includes@4.3.0/node_modules/lodash.includes",
     },
     Object {
-      "deps": Object {},
       "name": "lodash.isboolean",
       "root": "/common/temp/default/node_modules/.pnpm/lodash.isboolean@3.0.3/node_modules/lodash.isboolean",
     },
     Object {
-      "deps": Object {},
       "name": "lodash.isequal",
       "root": "/common/temp/default/node_modules/.pnpm/lodash.isequal@4.5.0/node_modules/lodash.isequal",
     },
     Object {
-      "deps": Object {},
       "name": "lodash.isinteger",
       "root": "/common/temp/default/node_modules/.pnpm/lodash.isinteger@4.0.4/node_modules/lodash.isinteger",
     },
     Object {
-      "deps": Object {},
       "name": "lodash.isnumber",
       "root": "/common/temp/default/node_modules/.pnpm/lodash.isnumber@3.0.3/node_modules/lodash.isnumber",
     },
     Object {
-      "deps": Object {},
       "name": "lodash.isplainobject",
       "root": "/common/temp/default/node_modules/.pnpm/lodash.isplainobject@4.0.6/node_modules/lodash.isplainobject",
     },
     Object {
-      "deps": Object {},
       "name": "lodash.isstring",
       "root": "/common/temp/default/node_modules/.pnpm/lodash.isstring@4.0.1/node_modules/lodash.isstring",
     },
     Object {
-      "deps": Object {},
       "name": "lodash.memoize",
       "root": "/common/temp/default/node_modules/.pnpm/lodash.memoize@4.1.2/node_modules/lodash.memoize",
     },
     Object {
-      "deps": Object {},
       "name": "lodash.merge",
       "root": "/common/temp/default/node_modules/.pnpm/lodash.merge@4.6.2/node_modules/lodash.merge",
     },
     Object {
-      "deps": Object {},
       "name": "lodash.once",
       "root": "/common/temp/default/node_modules/.pnpm/lodash.once@4.1.1/node_modules/lodash.once",
     },
     Object {
-      "deps": Object {},
       "name": "lodash.truncate",
       "root": "/common/temp/default/node_modules/.pnpm/lodash.truncate@4.4.2/node_modules/lodash.truncate",
     },
     Object {
-      "deps": Object {},
       "name": "lodash.union",
       "root": "/common/temp/default/node_modules/.pnpm/lodash.union@4.6.0/node_modules/lodash.union",
     },
     Object {
-      "deps": Object {},
       "name": "lodash.uniq",
       "root": "/common/temp/default/node_modules/.pnpm/lodash.uniq@4.5.0/node_modules/lodash.uniq",
     },
     Object {
-      "deps": Object {},
       "name": "lodash",
       "root": "/common/temp/default/node_modules/.pnpm/lodash@4.17.21/node_modules/lodash",
     },
@@ -22969,7 +22200,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/log4js@6.9.1/node_modules/log4js",
     },
     Object {
-      "deps": Object {},
       "name": "long",
       "root": "/common/temp/default/node_modules/.pnpm/long@4.0.0/node_modules/long",
     },
@@ -22988,7 +22218,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/lower-case@2.0.2/node_modules/lower-case",
     },
     Object {
-      "deps": Object {},
       "name": "lowercase-keys",
       "root": "/common/temp/default/node_modules/.pnpm/lowercase-keys@2.0.0/node_modules/lowercase-keys",
     },
@@ -23079,22 +22308,18 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/map-age-cleaner@0.1.3/node_modules/map-age-cleaner",
     },
     Object {
-      "deps": Object {},
       "name": "map-cache",
       "root": "/common/temp/default/node_modules/.pnpm/map-cache@0.2.2/node_modules/map-cache",
     },
     Object {
-      "deps": Object {},
       "name": "map-obj",
       "root": "/common/temp/default/node_modules/.pnpm/map-obj@1.0.1/node_modules/map-obj",
     },
     Object {
-      "deps": Object {},
       "name": "map-obj",
       "root": "/common/temp/default/node_modules/.pnpm/map-obj@4.3.0/node_modules/map-obj",
     },
     Object {
-      "deps": Object {},
       "name": "map-or-similar",
       "root": "/common/temp/default/node_modules/.pnpm/map-or-similar@1.5.0/node_modules/map-or-similar",
     },
@@ -23106,7 +22331,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/map-visit@1.0.0/node_modules/map-visit",
     },
     Object {
-      "deps": Object {},
       "name": "markdown-escapes",
       "root": "/common/temp/default/node_modules/.pnpm/markdown-escapes@1.0.4/node_modules/markdown-escapes",
     },
@@ -23166,22 +22390,18 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/mdast-util-to-hast@10.0.1/node_modules/mdast-util-to-hast",
     },
     Object {
-      "deps": Object {},
       "name": "mdast-util-to-string",
       "root": "/common/temp/default/node_modules/.pnpm/mdast-util-to-string@1.1.0/node_modules/mdast-util-to-string",
     },
     Object {
-      "deps": Object {},
       "name": "mdn-data",
       "root": "/common/temp/default/node_modules/.pnpm/mdn-data@2.0.14/node_modules/mdn-data",
     },
     Object {
-      "deps": Object {},
       "name": "mdurl",
       "root": "/common/temp/default/node_modules/.pnpm/mdurl@1.0.1/node_modules/mdurl",
     },
     Object {
-      "deps": Object {},
       "name": "media-typer",
       "root": "/common/temp/default/node_modules/.pnpm/media-typer@0.3.0/node_modules/media-typer",
     },
@@ -23242,32 +22462,26 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/meow@9.0.0/node_modules/meow",
     },
     Object {
-      "deps": Object {},
       "name": "merge-descriptors",
       "root": "/common/temp/default/node_modules/.pnpm/merge-descriptors@1.0.1/node_modules/merge-descriptors",
     },
     Object {
-      "deps": Object {},
       "name": "merge-descriptors",
       "root": "/common/temp/default/node_modules/.pnpm/merge-descriptors@1.0.3/node_modules/merge-descriptors",
     },
     Object {
-      "deps": Object {},
       "name": "merge-stream",
       "root": "/common/temp/default/node_modules/.pnpm/merge-stream@2.0.0/node_modules/merge-stream",
     },
     Object {
-      "deps": Object {},
       "name": "merge2",
       "root": "/common/temp/default/node_modules/.pnpm/merge2@1.4.1/node_modules/merge2",
     },
     Object {
-      "deps": Object {},
       "name": "methods",
       "root": "/common/temp/default/node_modules/.pnpm/methods@1.1.2/node_modules/methods",
     },
     Object {
-      "deps": Object {},
       "name": "microevent.ts",
       "root": "/common/temp/default/node_modules/.pnpm/microevent.ts@0.1.1/node_modules/microevent.ts",
     },
@@ -23307,7 +22521,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/miller-rabin@4.0.1/node_modules/miller-rabin",
     },
     Object {
-      "deps": Object {},
       "name": "mime-db",
       "root": "/common/temp/default/node_modules/.pnpm/mime-db@1.52.0/node_modules/mime-db",
     },
@@ -23319,32 +22532,26 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/mime-types@2.1.35/node_modules/mime-types",
     },
     Object {
-      "deps": Object {},
       "name": "mime",
       "root": "/common/temp/default/node_modules/.pnpm/mime@1.6.0/node_modules/mime",
     },
     Object {
-      "deps": Object {},
       "name": "mime",
       "root": "/common/temp/default/node_modules/.pnpm/mime@2.6.0/node_modules/mime",
     },
     Object {
-      "deps": Object {},
       "name": "mimic-fn",
       "root": "/common/temp/default/node_modules/.pnpm/mimic-fn@2.1.0/node_modules/mimic-fn",
     },
     Object {
-      "deps": Object {},
       "name": "mimic-fn",
       "root": "/common/temp/default/node_modules/.pnpm/mimic-fn@3.1.0/node_modules/mimic-fn",
     },
     Object {
-      "deps": Object {},
       "name": "mimic-response",
       "root": "/common/temp/default/node_modules/.pnpm/mimic-response@1.0.1/node_modules/mimic-response",
     },
     Object {
-      "deps": Object {},
       "name": "mimic-response",
       "root": "/common/temp/default/node_modules/.pnpm/mimic-response@3.1.0/node_modules/mimic-response",
     },
@@ -23356,7 +22563,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/min-document@2.19.0/node_modules/min-document",
     },
     Object {
-      "deps": Object {},
       "name": "min-indent",
       "root": "/common/temp/default/node_modules/.pnpm/min-indent@1.0.1/node_modules/min-indent",
     },
@@ -23369,12 +22575,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/mini-css-extract-plugin@2.5.3_webpack@5.82.1/node_modules/mini-css-extract-plugin",
     },
     Object {
-      "deps": Object {},
       "name": "minimalistic-assert",
       "root": "/common/temp/default/node_modules/.pnpm/minimalistic-assert@1.0.1/node_modules/minimalistic-assert",
     },
     Object {
-      "deps": Object {},
       "name": "minimalistic-crypto-utils",
       "root": "/common/temp/default/node_modules/.pnpm/minimalistic-crypto-utils@1.0.1/node_modules/minimalistic-crypto-utils",
     },
@@ -23437,7 +22641,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/minimist-options@4.1.0/node_modules/minimist-options",
     },
     Object {
-      "deps": Object {},
       "name": "minimist",
       "root": "/common/temp/default/node_modules/.pnpm/minimist@1.2.8/node_modules/minimist",
     },
@@ -23487,12 +22690,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/minipass@3.3.6/node_modules/minipass",
     },
     Object {
-      "deps": Object {},
       "name": "minipass",
       "root": "/common/temp/default/node_modules/.pnpm/minipass@4.2.8/node_modules/minipass",
     },
     Object {
-      "deps": Object {},
       "name": "minipass",
       "root": "/common/temp/default/node_modules/.pnpm/minipass@5.0.0/node_modules/minipass",
     },
@@ -23529,7 +22730,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/mixin-deep@1.3.2/node_modules/mixin-deep",
     },
     Object {
-      "deps": Object {},
       "name": "mkdirp-classic",
       "root": "/common/temp/default/node_modules/.pnpm/mkdirp-classic@0.5.3/node_modules/mkdirp-classic",
     },
@@ -23541,7 +22741,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/mkdirp@0.5.6/node_modules/mkdirp",
     },
     Object {
-      "deps": Object {},
       "name": "mkdirp",
       "root": "/common/temp/default/node_modules/.pnpm/mkdirp@1.0.4/node_modules/mkdirp",
     },
@@ -23584,27 +22783,22 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/move-concurrently@1.0.1/node_modules/move-concurrently",
     },
     Object {
-      "deps": Object {},
       "name": "mrmime",
       "root": "/common/temp/default/node_modules/.pnpm/mrmime@1.0.1/node_modules/mrmime",
     },
     Object {
-      "deps": Object {},
       "name": "ms",
       "root": "/common/temp/default/node_modules/.pnpm/ms@2.0.0/node_modules/ms",
     },
     Object {
-      "deps": Object {},
       "name": "ms",
       "root": "/common/temp/default/node_modules/.pnpm/ms@2.1.1/node_modules/ms",
     },
     Object {
-      "deps": Object {},
       "name": "ms",
       "root": "/common/temp/default/node_modules/.pnpm/ms@2.1.2/node_modules/ms",
     },
     Object {
-      "deps": Object {},
       "name": "ms",
       "root": "/common/temp/default/node_modules/.pnpm/ms@2.1.3/node_modules/ms",
     },
@@ -23628,7 +22822,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/multimatch@5.0.0/node_modules/multimatch",
     },
     Object {
-      "deps": Object {},
       "name": "mute-stream",
       "root": "/common/temp/default/node_modules/.pnpm/mute-stream@0.0.8/node_modules/mute-stream",
     },
@@ -23642,12 +22835,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/mz@2.7.0/node_modules/mz",
     },
     Object {
-      "deps": Object {},
       "name": "nan",
       "root": "/common/temp/default/node_modules/.pnpm/nan@2.19.0/node_modules/nan",
     },
     Object {
-      "deps": Object {},
       "name": "nanoid",
       "root": "/common/temp/default/node_modules/.pnpm/nanoid@3.3.7/node_modules/nanoid",
     },
@@ -23669,12 +22860,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/nanomatch@1.2.13/node_modules/nanomatch",
     },
     Object {
-      "deps": Object {},
       "name": "napi-build-utils",
       "root": "/common/temp/default/node_modules/.pnpm/napi-build-utils@1.0.2/node_modules/napi-build-utils",
     },
     Object {
-      "deps": Object {},
       "name": "natural-compare",
       "root": "/common/temp/default/node_modules/.pnpm/natural-compare@1.4.0/node_modules/natural-compare",
     },
@@ -23690,22 +22879,18 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/ndjson@2.0.0/node_modules/ndjson",
     },
     Object {
-      "deps": Object {},
       "name": "negotiator",
       "root": "/common/temp/default/node_modules/.pnpm/negotiator@0.6.3/node_modules/negotiator",
     },
     Object {
-      "deps": Object {},
       "name": "neo-async",
       "root": "/common/temp/default/node_modules/.pnpm/neo-async@2.6.2/node_modules/neo-async",
     },
     Object {
-      "deps": Object {},
       "name": "nested-error-stacks",
       "root": "/common/temp/default/node_modules/.pnpm/nested-error-stacks@2.1.1/node_modules/nested-error-stacks",
     },
     Object {
-      "deps": Object {},
       "name": "nice-try",
       "root": "/common/temp/default/node_modules/.pnpm/nice-try@1.0.5/node_modules/nice-try",
     },
@@ -23725,12 +22910,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/node-abi@3.56.0/node_modules/node-abi",
     },
     Object {
-      "deps": Object {},
       "name": "node-addon-api",
       "root": "/common/temp/default/node_modules/.pnpm/node-addon-api@3.2.1/node_modules/node-addon-api",
     },
     Object {
-      "deps": Object {},
       "name": "node-addon-api",
       "root": "/common/temp/default/node_modules/.pnpm/node-addon-api@4.3.0/node_modules/node-addon-api",
     },
@@ -23756,7 +22939,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/node-fetch@2.6.7/node_modules/node-fetch",
     },
     Object {
-      "deps": Object {},
       "name": "node-forge",
       "root": "/common/temp/default/node_modules/.pnpm/node-forge@1.3.1/node_modules/node-forge",
     },
@@ -23777,7 +22959,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/node-gyp@8.1.0/node_modules/node-gyp",
     },
     Object {
-      "deps": Object {},
       "name": "node-int64",
       "root": "/common/temp/default/node_modules/.pnpm/node-int64@0.4.0/node_modules/node-int64",
     },
@@ -23811,7 +22992,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/node-libs-browser@2.2.1/node_modules/node-libs-browser",
     },
     Object {
-      "deps": Object {},
       "name": "node-releases",
       "root": "/common/temp/default/node_modules/.pnpm/node-releases@2.0.14/node_modules/node-releases",
     },
@@ -23850,17 +23030,14 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/normalize-path@2.1.1/node_modules/normalize-path",
     },
     Object {
-      "deps": Object {},
       "name": "normalize-path",
       "root": "/common/temp/default/node_modules/.pnpm/normalize-path@3.0.0/node_modules/normalize-path",
     },
     Object {
-      "deps": Object {},
       "name": "normalize-range",
       "root": "/common/temp/default/node_modules/.pnpm/normalize-range@0.1.2/node_modules/normalize-range",
     },
     Object {
-      "deps": Object {},
       "name": "normalize-url",
       "root": "/common/temp/default/node_modules/.pnpm/normalize-url@6.1.0/node_modules/normalize-url",
     },
@@ -23905,7 +23082,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/npm-check@6.0.1/node_modules/npm-check",
     },
     Object {
-      "deps": Object {},
       "name": "npm-normalize-package-bin",
       "root": "/common/temp/default/node_modules/.pnpm/npm-normalize-package-bin@1.0.1/node_modules/npm-normalize-package-bin",
     },
@@ -23971,22 +23147,18 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/nth-check@2.1.1/node_modules/nth-check",
     },
     Object {
-      "deps": Object {},
       "name": "num2fraction",
       "root": "/common/temp/default/node_modules/.pnpm/num2fraction@1.2.2/node_modules/num2fraction",
     },
     Object {
-      "deps": Object {},
       "name": "number-is-nan",
       "root": "/common/temp/default/node_modules/.pnpm/number-is-nan@1.0.1/node_modules/number-is-nan",
     },
     Object {
-      "deps": Object {},
       "name": "nwsapi",
       "root": "/common/temp/default/node_modules/.pnpm/nwsapi@2.2.7/node_modules/nwsapi",
     },
     Object {
-      "deps": Object {},
       "name": "object-assign",
       "root": "/common/temp/default/node_modules/.pnpm/object-assign@4.1.1/node_modules/object-assign",
     },
@@ -24000,12 +23172,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/object-copy@0.1.0/node_modules/object-copy",
     },
     Object {
-      "deps": Object {},
       "name": "object-inspect",
       "root": "/common/temp/default/node_modules/.pnpm/object-inspect@1.13.1/node_modules/object-inspect",
     },
     Object {
-      "deps": Object {},
       "name": "object-keys",
       "root": "/common/temp/default/node_modules/.pnpm/object-keys@1.1.1/node_modules/object-keys",
     },
@@ -24080,12 +23250,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/object.values@1.2.0/node_modules/object.values",
     },
     Object {
-      "deps": Object {},
       "name": "objectorarray",
       "root": "/common/temp/default/node_modules/.pnpm/objectorarray@1.0.5/node_modules/objectorarray",
     },
     Object {
-      "deps": Object {},
       "name": "obuf",
       "root": "/common/temp/default/node_modules/.pnpm/obuf@1.1.2/node_modules/obuf",
     },
@@ -24104,7 +23272,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/on-finished@2.4.1/node_modules/on-finished",
     },
     Object {
-      "deps": Object {},
       "name": "on-headers",
       "root": "/common/temp/default/node_modules/.pnpm/on-headers@1.0.2/node_modules/on-headers",
     },
@@ -24140,7 +23307,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/open@8.4.2/node_modules/open",
     },
     Object {
-      "deps": Object {},
       "name": "opener",
       "root": "/common/temp/default/node_modules/.pnpm/opener@1.5.2/node_modules/opener",
     },
@@ -24172,17 +23338,14 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/ora@5.4.1/node_modules/ora",
     },
     Object {
-      "deps": Object {},
       "name": "os-browserify",
       "root": "/common/temp/default/node_modules/.pnpm/os-browserify@0.3.0/node_modules/os-browserify",
     },
     Object {
-      "deps": Object {},
       "name": "os-homedir",
       "root": "/common/temp/default/node_modules/.pnpm/os-homedir@1.0.2/node_modules/os-homedir",
     },
     Object {
-      "deps": Object {},
       "name": "os-tmpdir",
       "root": "/common/temp/default/node_modules/.pnpm/os-tmpdir@1.0.2/node_modules/os-tmpdir",
     },
@@ -24195,7 +23358,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/osenv@0.1.5/node_modules/osenv",
     },
     Object {
-      "deps": Object {},
       "name": "overlayscrollbars",
       "root": "/common/temp/default/node_modules/.pnpm/overlayscrollbars@1.13.3/node_modules/overlayscrollbars",
     },
@@ -24207,12 +23369,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/p-all@2.1.0/node_modules/p-all",
     },
     Object {
-      "deps": Object {},
       "name": "p-cancelable",
       "root": "/common/temp/default/node_modules/.pnpm/p-cancelable@2.1.1/node_modules/p-cancelable",
     },
     Object {
-      "deps": Object {},
       "name": "p-defer",
       "root": "/common/temp/default/node_modules/.pnpm/p-defer@1.0.0/node_modules/p-defer",
     },
@@ -24231,7 +23391,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/p-filter@2.1.0/node_modules/p-filter",
     },
     Object {
-      "deps": Object {},
       "name": "p-finally",
       "root": "/common/temp/default/node_modules/.pnpm/p-finally@1.0.0/node_modules/p-finally",
     },
@@ -24271,7 +23430,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/p-locate@5.0.0/node_modules/p-locate",
     },
     Object {
-      "deps": Object {},
       "name": "p-map",
       "root": "/common/temp/default/node_modules/.pnpm/p-map@2.1.0/node_modules/p-map",
     },
@@ -24290,7 +23448,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/p-map@4.0.0/node_modules/p-map",
     },
     Object {
-      "deps": Object {},
       "name": "p-reflect",
       "root": "/common/temp/default/node_modules/.pnpm/p-reflect@2.1.0/node_modules/p-reflect",
     },
@@ -24318,7 +23475,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/p-timeout@3.2.0/node_modules/p-timeout",
     },
     Object {
-      "deps": Object {},
       "name": "p-try",
       "root": "/common/temp/default/node_modules/.pnpm/p-try@2.2.0/node_modules/p-try",
     },
@@ -24333,7 +23489,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/package-json@7.0.0/node_modules/package-json",
     },
     Object {
-      "deps": Object {},
       "name": "pako",
       "root": "/common/temp/default/node_modules/.pnpm/pako@1.0.11/node_modules/pako",
     },
@@ -24396,7 +23551,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/parse-json@5.2.0/node_modules/parse-json",
     },
     Object {
-      "deps": Object {},
       "name": "parse-passwd",
       "root": "/common/temp/default/node_modules/.pnpm/parse-passwd@1.0.0/node_modules/parse-passwd",
     },
@@ -24416,7 +23570,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/parse5-htmlparser2-tree-adapter@7.0.0/node_modules/parse5-htmlparser2-tree-adapter",
     },
     Object {
-      "deps": Object {},
       "name": "parse5",
       "root": "/common/temp/default/node_modules/.pnpm/parse5@6.0.1/node_modules/parse5",
     },
@@ -24428,7 +23581,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/parse5@7.1.2/node_modules/parse5",
     },
     Object {
-      "deps": Object {},
       "name": "parseurl",
       "root": "/common/temp/default/node_modules/.pnpm/parseurl@1.3.3/node_modules/parseurl",
     },
@@ -24441,52 +23593,42 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/pascal-case@3.1.2/node_modules/pascal-case",
     },
     Object {
-      "deps": Object {},
       "name": "pascalcase",
       "root": "/common/temp/default/node_modules/.pnpm/pascalcase@0.1.1/node_modules/pascalcase",
     },
     Object {
-      "deps": Object {},
       "name": "path-browserify",
       "root": "/common/temp/default/node_modules/.pnpm/path-browserify@0.0.1/node_modules/path-browserify",
     },
     Object {
-      "deps": Object {},
       "name": "path-dirname",
       "root": "/common/temp/default/node_modules/.pnpm/path-dirname@1.0.2/node_modules/path-dirname",
     },
     Object {
-      "deps": Object {},
       "name": "path-exists",
       "root": "/common/temp/default/node_modules/.pnpm/path-exists@3.0.0/node_modules/path-exists",
     },
     Object {
-      "deps": Object {},
       "name": "path-exists",
       "root": "/common/temp/default/node_modules/.pnpm/path-exists@4.0.0/node_modules/path-exists",
     },
     Object {
-      "deps": Object {},
       "name": "path-is-absolute",
       "root": "/common/temp/default/node_modules/.pnpm/path-is-absolute@1.0.1/node_modules/path-is-absolute",
     },
     Object {
-      "deps": Object {},
       "name": "path-key",
       "root": "/common/temp/default/node_modules/.pnpm/path-key@2.0.1/node_modules/path-key",
     },
     Object {
-      "deps": Object {},
       "name": "path-key",
       "root": "/common/temp/default/node_modules/.pnpm/path-key@3.1.1/node_modules/path-key",
     },
     Object {
-      "deps": Object {},
       "name": "path-parse",
       "root": "/common/temp/default/node_modules/.pnpm/path-parse@1.0.7/node_modules/path-parse",
     },
     Object {
-      "deps": Object {},
       "name": "path-to-regexp",
       "root": "/common/temp/default/node_modules/.pnpm/path-to-regexp@0.1.7/node_modules/path-to-regexp",
     },
@@ -24498,7 +23640,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/path-type@3.0.0/node_modules/path-type",
     },
     Object {
-      "deps": Object {},
       "name": "path-type",
       "root": "/common/temp/default/node_modules/.pnpm/path-type@4.0.0/node_modules/path-type",
     },
@@ -24514,37 +23655,30 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/pbkdf2@3.1.2/node_modules/pbkdf2",
     },
     Object {
-      "deps": Object {},
       "name": "pend",
       "root": "/common/temp/default/node_modules/.pnpm/pend@1.2.0/node_modules/pend",
     },
     Object {
-      "deps": Object {},
       "name": "picocolors",
       "root": "/common/temp/default/node_modules/.pnpm/picocolors@0.2.1/node_modules/picocolors",
     },
     Object {
-      "deps": Object {},
       "name": "picocolors",
       "root": "/common/temp/default/node_modules/.pnpm/picocolors@1.0.0/node_modules/picocolors",
     },
     Object {
-      "deps": Object {},
       "name": "picomatch",
       "root": "/common/temp/default/node_modules/.pnpm/picomatch@2.3.1/node_modules/picomatch",
     },
     Object {
-      "deps": Object {},
       "name": "pidof",
       "root": "/common/temp/default/node_modules/.pnpm/pidof@1.0.2/node_modules/pidof",
     },
     Object {
-      "deps": Object {},
       "name": "pify",
       "root": "/common/temp/default/node_modules/.pnpm/pify@3.0.0/node_modules/pify",
     },
     Object {
-      "deps": Object {},
       "name": "pify",
       "root": "/common/temp/default/node_modules/.pnpm/pify@4.0.1/node_modules/pify",
     },
@@ -24556,12 +23690,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/pinkie-promise@2.0.1/node_modules/pinkie-promise",
     },
     Object {
-      "deps": Object {},
       "name": "pinkie",
       "root": "/common/temp/default/node_modules/.pnpm/pinkie@2.0.4/node_modules/pinkie",
     },
     Object {
-      "deps": Object {},
       "name": "pino-std-serializers",
       "root": "/common/temp/default/node_modules/.pnpm/pino-std-serializers@3.2.0/node_modules/pino-std-serializers",
     },
@@ -24579,7 +23711,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/pino@6.14.0/node_modules/pino",
     },
     Object {
-      "deps": Object {},
       "name": "pirates",
       "root": "/common/temp/default/node_modules/.pnpm/pirates@4.0.6/node_modules/pirates",
     },
@@ -24641,12 +23772,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/polished@4.3.1/node_modules/polished",
     },
     Object {
-      "deps": Object {},
       "name": "posix-character-classes",
       "root": "/common/temp/default/node_modules/.pnpm/posix-character-classes@0.1.1/node_modules/posix-character-classes",
     },
     Object {
-      "deps": Object {},
       "name": "possible-typed-array-names",
       "root": "/common/temp/default/node_modules/.pnpm/possible-typed-array-names@1.0.0/node_modules/possible-typed-array-names",
     },
@@ -25013,7 +24142,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/postcss-unique-selectors@5.1.1_postcss@8.4.36/node_modules/postcss-unique-selectors",
     },
     Object {
-      "deps": Object {},
       "name": "postcss-value-parser",
       "root": "/common/temp/default/node_modules/.pnpm/postcss-value-parser@4.2.0/node_modules/postcss-value-parser",
     },
@@ -25063,12 +24191,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/preferred-pm@3.1.3/node_modules/preferred-pm",
     },
     Object {
-      "deps": Object {},
       "name": "prelude-ls",
       "root": "/common/temp/default/node_modules/.pnpm/prelude-ls@1.2.1/node_modules/prelude-ls",
     },
     Object {
-      "deps": Object {},
       "name": "prettier",
       "root": "/common/temp/default/node_modules/.pnpm/prettier@2.3.0/node_modules/prettier",
     },
@@ -25107,47 +24233,38 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/pretty-format@29.7.0/node_modules/pretty-format",
     },
     Object {
-      "deps": Object {},
       "name": "pretty-hrtime",
       "root": "/common/temp/default/node_modules/.pnpm/pretty-hrtime@1.0.3/node_modules/pretty-hrtime",
     },
     Object {
-      "deps": Object {},
       "name": "prismjs",
       "root": "/common/temp/default/node_modules/.pnpm/prismjs@1.27.0/node_modules/prismjs",
     },
     Object {
-      "deps": Object {},
       "name": "prismjs",
       "root": "/common/temp/default/node_modules/.pnpm/prismjs@1.29.0/node_modules/prismjs",
     },
     Object {
-      "deps": Object {},
       "name": "private",
       "root": "/common/temp/default/node_modules/.pnpm/private@0.1.8/node_modules/private",
     },
     Object {
-      "deps": Object {},
       "name": "process-nextick-args",
       "root": "/common/temp/default/node_modules/.pnpm/process-nextick-args@2.0.1/node_modules/process-nextick-args",
     },
     Object {
-      "deps": Object {},
       "name": "process-warning",
       "root": "/common/temp/default/node_modules/.pnpm/process-warning@1.0.0/node_modules/process-warning",
     },
     Object {
-      "deps": Object {},
       "name": "process",
       "root": "/common/temp/default/node_modules/.pnpm/process@0.11.10/node_modules/process",
     },
     Object {
-      "deps": Object {},
       "name": "progress",
       "root": "/common/temp/default/node_modules/.pnpm/progress@2.0.3/node_modules/progress",
     },
     Object {
-      "deps": Object {},
       "name": "promise-inflight",
       "root": "/common/temp/default/node_modules/.pnpm/promise-inflight@1.0.1/node_modules/promise-inflight",
     },
@@ -25215,12 +24332,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/proxy-addr@2.0.7/node_modules/proxy-addr",
     },
     Object {
-      "deps": Object {},
       "name": "proxy-from-env",
       "root": "/common/temp/default/node_modules/.pnpm/proxy-from-env@1.1.0/node_modules/proxy-from-env",
     },
     Object {
-      "deps": Object {},
       "name": "prr",
       "root": "/common/temp/default/node_modules/.pnpm/prr@1.0.1/node_modules/prr",
     },
@@ -25232,7 +24347,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/pseudolocale@1.1.0/node_modules/pseudolocale",
     },
     Object {
-      "deps": Object {},
       "name": "psl",
       "root": "/common/temp/default/node_modules/.pnpm/psl@1.9.0/node_modules/psl",
     },
@@ -25274,17 +24388,14 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/pumpify@1.5.1/node_modules/pumpify",
     },
     Object {
-      "deps": Object {},
       "name": "punycode",
       "root": "/common/temp/default/node_modules/.pnpm/punycode@1.3.2/node_modules/punycode",
     },
     Object {
-      "deps": Object {},
       "name": "punycode",
       "root": "/common/temp/default/node_modules/.pnpm/punycode@1.4.1/node_modules/punycode",
     },
     Object {
-      "deps": Object {},
       "name": "punycode",
       "root": "/common/temp/default/node_modules/.pnpm/punycode@2.3.1/node_modules/punycode",
     },
@@ -25312,12 +24423,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/puppeteer-core@2.1.1/node_modules/puppeteer-core",
     },
     Object {
-      "deps": Object {},
       "name": "pure-rand",
       "root": "/common/temp/default/node_modules/.pnpm/pure-rand@6.0.4/node_modules/pure-rand",
     },
     Object {
-      "deps": Object {},
       "name": "q",
       "root": "/common/temp/default/node_modules/.pnpm/q@1.5.1/node_modules/q",
     },
@@ -25336,47 +24445,38 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/qs@6.12.0/node_modules/qs",
     },
     Object {
-      "deps": Object {},
       "name": "querystring-es3",
       "root": "/common/temp/default/node_modules/.pnpm/querystring-es3@0.2.1/node_modules/querystring-es3",
     },
     Object {
-      "deps": Object {},
       "name": "querystring",
       "root": "/common/temp/default/node_modules/.pnpm/querystring@0.2.0/node_modules/querystring",
     },
     Object {
-      "deps": Object {},
       "name": "querystringify",
       "root": "/common/temp/default/node_modules/.pnpm/querystringify@2.2.0/node_modules/querystringify",
     },
     Object {
-      "deps": Object {},
       "name": "queue-microtask",
       "root": "/common/temp/default/node_modules/.pnpm/queue-microtask@1.2.3/node_modules/queue-microtask",
     },
     Object {
-      "deps": Object {},
       "name": "quick-format-unescaped",
       "root": "/common/temp/default/node_modules/.pnpm/quick-format-unescaped@4.0.4/node_modules/quick-format-unescaped",
     },
     Object {
-      "deps": Object {},
       "name": "quick-lru",
       "root": "/common/temp/default/node_modules/.pnpm/quick-lru@4.0.1/node_modules/quick-lru",
     },
     Object {
-      "deps": Object {},
       "name": "quick-lru",
       "root": "/common/temp/default/node_modules/.pnpm/quick-lru@5.1.1/node_modules/quick-lru",
     },
     Object {
-      "deps": Object {},
       "name": "ramda",
       "root": "/common/temp/default/node_modules/.pnpm/ramda@0.27.2/node_modules/ramda",
     },
     Object {
-      "deps": Object {},
       "name": "ramda",
       "root": "/common/temp/default/node_modules/.pnpm/ramda@0.28.0/node_modules/ramda",
     },
@@ -25396,7 +24496,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/randomfill@1.0.4/node_modules/randomfill",
     },
     Object {
-      "deps": Object {},
       "name": "range-parser",
       "root": "/common/temp/default/node_modules/.pnpm/range-parser@1.2.1/node_modules/range-parser",
     },
@@ -25502,7 +24601,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/react-element-to-jsx-string@14.3.4_react-dom@17.0.2_react@17.0.2/node_modules/react-element-to-jsx-string",
     },
     Object {
-      "deps": Object {},
       "name": "react-fast-compare",
       "root": "/common/temp/default/node_modules/.pnpm/react-fast-compare@3.2.2/node_modules/react-fast-compare",
     },
@@ -25537,17 +24635,14 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/react-inspector@5.1.1_react@17.0.2/node_modules/react-inspector",
     },
     Object {
-      "deps": Object {},
       "name": "react-is",
       "root": "/common/temp/default/node_modules/.pnpm/react-is@16.13.1/node_modules/react-is",
     },
     Object {
-      "deps": Object {},
       "name": "react-is",
       "root": "/common/temp/default/node_modules/.pnpm/react-is@17.0.2/node_modules/react-is",
     },
     Object {
-      "deps": Object {},
       "name": "react-is",
       "root": "/common/temp/default/node_modules/.pnpm/react-is@18.2.0/node_modules/react-is",
     },
@@ -25592,7 +24687,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/react-redux@8.0.7_@reduxjs+toolkit@1.8.6_@types+react-dom@17.0.25_@types+react@17.0.74_react-_fxbgebfgcimhtvtdsot4e7klsa/node_modules/react-redux",
     },
     Object {
-      "deps": Object {},
       "name": "react-refresh",
       "root": "/common/temp/default/node_modules/.pnpm/react-refresh@0.11.0/node_modules/react-refresh",
     },
@@ -25864,17 +24958,14 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/regenerate-unicode-properties@10.1.1/node_modules/regenerate-unicode-properties",
     },
     Object {
-      "deps": Object {},
       "name": "regenerate",
       "root": "/common/temp/default/node_modules/.pnpm/regenerate@1.4.2/node_modules/regenerate",
     },
     Object {
-      "deps": Object {},
       "name": "regenerator-runtime",
       "root": "/common/temp/default/node_modules/.pnpm/regenerator-runtime@0.13.11/node_modules/regenerator-runtime",
     },
     Object {
-      "deps": Object {},
       "name": "regenerator-runtime",
       "root": "/common/temp/default/node_modules/.pnpm/regenerator-runtime@0.14.1/node_modules/regenerator-runtime",
     },
@@ -25904,7 +24995,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/regexp.prototype.flags@1.5.2/node_modules/regexp.prototype.flags",
     },
     Object {
-      "deps": Object {},
       "name": "regexpp",
       "root": "/common/temp/default/node_modules/.pnpm/regexpp@3.2.0/node_modules/regexpp",
     },
@@ -25921,7 +25011,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/regexpu-core@5.3.2/node_modules/regexpu-core",
     },
     Object {
-      "deps": Object {},
       "name": "regextras",
       "root": "/common/temp/default/node_modules/.pnpm/regextras@0.8.0/node_modules/regextras",
     },
@@ -25947,7 +25036,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/regjsparser@0.9.1/node_modules/regjsparser",
     },
     Object {
-      "deps": Object {},
       "name": "relateurl",
       "root": "/common/temp/default/node_modules/.pnpm/relateurl@0.2.7/node_modules/relateurl",
     },
@@ -25963,7 +25051,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/remark-external-links@8.0.0/node_modules/remark-external-links",
     },
     Object {
-      "deps": Object {},
       "name": "remark-footnotes",
       "root": "/common/temp/default/node_modules/.pnpm/remark-footnotes@2.0.0/node_modules/remark-footnotes",
     },
@@ -26020,12 +25107,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/remark-squeeze-paragraphs@4.0.0/node_modules/remark-squeeze-paragraphs",
     },
     Object {
-      "deps": Object {},
       "name": "remeda",
       "root": "/common/temp/default/node_modules/.pnpm/remeda@0.0.32/node_modules/remeda",
     },
     Object {
-      "deps": Object {},
       "name": "remove-trailing-separator",
       "root": "/common/temp/default/node_modules/.pnpm/remove-trailing-separator@1.1.0/node_modules/remove-trailing-separator",
     },
@@ -26052,47 +25137,38 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/renderkid@3.0.0/node_modules/renderkid",
     },
     Object {
-      "deps": Object {},
       "name": "repeat-element",
       "root": "/common/temp/default/node_modules/.pnpm/repeat-element@1.1.4/node_modules/repeat-element",
     },
     Object {
-      "deps": Object {},
       "name": "repeat-string",
       "root": "/common/temp/default/node_modules/.pnpm/repeat-string@1.6.1/node_modules/repeat-string",
     },
     Object {
-      "deps": Object {},
       "name": "require-directory",
       "root": "/common/temp/default/node_modules/.pnpm/require-directory@2.1.1/node_modules/require-directory",
     },
     Object {
-      "deps": Object {},
       "name": "require-from-string",
       "root": "/common/temp/default/node_modules/.pnpm/require-from-string@2.0.2/node_modules/require-from-string",
     },
     Object {
-      "deps": Object {},
       "name": "require-main-filename",
       "root": "/common/temp/default/node_modules/.pnpm/require-main-filename@2.0.0/node_modules/require-main-filename",
     },
     Object {
-      "deps": Object {},
       "name": "require-package-name",
       "root": "/common/temp/default/node_modules/.pnpm/require-package-name@2.0.1/node_modules/require-package-name",
     },
     Object {
-      "deps": Object {},
       "name": "requires-port",
       "root": "/common/temp/default/node_modules/.pnpm/requires-port@1.0.0/node_modules/requires-port",
     },
     Object {
-      "deps": Object {},
       "name": "reselect",
       "root": "/common/temp/default/node_modules/.pnpm/reselect@4.1.8/node_modules/reselect",
     },
     Object {
-      "deps": Object {},
       "name": "resolve-alpn",
       "root": "/common/temp/default/node_modules/.pnpm/resolve-alpn@1.2.1/node_modules/resolve-alpn",
     },
@@ -26119,27 +25195,22 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/resolve-dir@1.0.1/node_modules/resolve-dir",
     },
     Object {
-      "deps": Object {},
       "name": "resolve-from",
       "root": "/common/temp/default/node_modules/.pnpm/resolve-from@3.0.0/node_modules/resolve-from",
     },
     Object {
-      "deps": Object {},
       "name": "resolve-from",
       "root": "/common/temp/default/node_modules/.pnpm/resolve-from@4.0.0/node_modules/resolve-from",
     },
     Object {
-      "deps": Object {},
       "name": "resolve-from",
       "root": "/common/temp/default/node_modules/.pnpm/resolve-from@5.0.0/node_modules/resolve-from",
     },
     Object {
-      "deps": Object {},
       "name": "resolve-url",
       "root": "/common/temp/default/node_modules/.pnpm/resolve-url@0.2.1/node_modules/resolve-url",
     },
     Object {
-      "deps": Object {},
       "name": "resolve.exports",
       "root": "/common/temp/default/node_modules/.pnpm/resolve.exports@2.0.2/node_modules/resolve.exports",
     },
@@ -26177,37 +25248,30 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/restore-cursor@3.1.0/node_modules/restore-cursor",
     },
     Object {
-      "deps": Object {},
       "name": "ret",
       "root": "/common/temp/default/node_modules/.pnpm/ret@0.1.15/node_modules/ret",
     },
     Object {
-      "deps": Object {},
       "name": "ret",
       "root": "/common/temp/default/node_modules/.pnpm/ret@0.2.2/node_modules/ret",
     },
     Object {
-      "deps": Object {},
       "name": "retry",
       "root": "/common/temp/default/node_modules/.pnpm/retry@0.12.0/node_modules/retry",
     },
     Object {
-      "deps": Object {},
       "name": "retry",
       "root": "/common/temp/default/node_modules/.pnpm/retry@0.13.1/node_modules/retry",
     },
     Object {
-      "deps": Object {},
       "name": "reusify",
       "root": "/common/temp/default/node_modules/.pnpm/reusify@1.0.4/node_modules/reusify",
     },
     Object {
-      "deps": Object {},
       "name": "rfc4648",
       "root": "/common/temp/default/node_modules/.pnpm/rfc4648@1.5.3/node_modules/rfc4648",
     },
     Object {
-      "deps": Object {},
       "name": "rfdc",
       "root": "/common/temp/default/node_modules/.pnpm/rfdc@1.3.1/node_modules/rfdc",
     },
@@ -26241,7 +25305,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/ripemd160@2.0.2/node_modules/ripemd160",
     },
     Object {
-      "deps": Object {},
       "name": "rsvp",
       "root": "/common/temp/default/node_modules/.pnpm/rsvp@4.8.5/node_modules/rsvp",
     },
@@ -26253,7 +25316,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/rtl-css-js@1.16.1/node_modules/rtl-css-js",
     },
     Object {
-      "deps": Object {},
       "name": "run-async",
       "root": "/common/temp/default/node_modules/.pnpm/run-async@2.4.1/node_modules/run-async",
     },
@@ -26296,17 +25358,14 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/safe-array-concat@1.1.2/node_modules/safe-array-concat",
     },
     Object {
-      "deps": Object {},
       "name": "safe-buffer",
       "root": "/common/temp/default/node_modules/.pnpm/safe-buffer@5.1.1/node_modules/safe-buffer",
     },
     Object {
-      "deps": Object {},
       "name": "safe-buffer",
       "root": "/common/temp/default/node_modules/.pnpm/safe-buffer@5.1.2/node_modules/safe-buffer",
     },
     Object {
-      "deps": Object {},
       "name": "safe-buffer",
       "root": "/common/temp/default/node_modules/.pnpm/safe-buffer@5.2.1/node_modules/safe-buffer",
     },
@@ -26334,7 +25393,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/safe-regex@1.1.0/node_modules/safe-regex",
     },
     Object {
-      "deps": Object {},
       "name": "safer-buffer",
       "root": "/common/temp/default/node_modules/.pnpm/safer-buffer@2.1.2/node_modules/safer-buffer",
     },
@@ -26354,12 +25412,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/sane@4.1.0/node_modules/sane",
     },
     Object {
-      "deps": Object {},
       "name": "sass-embedded-linux-musl-x64",
       "root": "/common/temp/default/node_modules/.pnpm/sass-embedded-linux-musl-x64@1.77.2/node_modules/sass-embedded-linux-musl-x64",
     },
     Object {
-      "deps": Object {},
       "name": "sass-embedded-linux-x64",
       "root": "/common/temp/default/node_modules/.pnpm/sass-embedded-linux-x64@1.77.2/node_modules/sass-embedded-linux-x64",
     },
@@ -26401,7 +25457,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/sass-loader@12.4.0_sass@1.49.11_webpack@5.82.1/node_modules/sass-loader",
     },
     Object {
-      "deps": Object {},
       "name": "sass",
       "root": "/common/temp/default/node_modules/.pnpm/sass@1.3.2/node_modules/sass",
     },
@@ -26415,12 +25470,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/sass@1.49.11/node_modules/sass",
     },
     Object {
-      "deps": Object {},
       "name": "sax",
       "root": "/common/temp/default/node_modules/.pnpm/sax@1.2.1/node_modules/sax",
     },
     Object {
-      "deps": Object {},
       "name": "sax",
       "root": "/common/temp/default/node_modules/.pnpm/sax@1.3.0/node_modules/sax",
     },
@@ -26494,12 +25547,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/schema-utils@4.2.0/node_modules/schema-utils",
     },
     Object {
-      "deps": Object {},
       "name": "secure-json-parse",
       "root": "/common/temp/default/node_modules/.pnpm/secure-json-parse@2.7.0/node_modules/secure-json-parse",
     },
     Object {
-      "deps": Object {},
       "name": "select-hose",
       "root": "/common/temp/default/node_modules/.pnpm/select-hose@2.0.0/node_modules/select-hose",
     },
@@ -26512,7 +25563,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/selfsigned@2.4.1/node_modules/selfsigned",
     },
     Object {
-      "deps": Object {},
       "name": "semver-compare",
       "root": "/common/temp/default/node_modules/.pnpm/semver-compare@1.0.0/node_modules/semver-compare",
     },
@@ -26524,17 +25574,14 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/semver-diff@3.1.1/node_modules/semver-diff",
     },
     Object {
-      "deps": Object {},
       "name": "semver-store",
       "root": "/common/temp/default/node_modules/.pnpm/semver-store@0.3.0/node_modules/semver-store",
     },
     Object {
-      "deps": Object {},
       "name": "semver",
       "root": "/common/temp/default/node_modules/.pnpm/semver@5.7.2/node_modules/semver",
     },
     Object {
-      "deps": Object {},
       "name": "semver",
       "root": "/common/temp/default/node_modules/.pnpm/semver@6.3.1/node_modules/semver",
     },
@@ -26546,7 +25593,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/semver@7.5.4/node_modules/semver",
     },
     Object {
-      "deps": Object {},
       "name": "semver",
       "root": "/common/temp/default/node_modules/.pnpm/semver@7.6.3/node_modules/semver",
     },
@@ -26651,12 +25697,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/serve-static@1.15.0/node_modules/serve-static",
     },
     Object {
-      "deps": Object {},
       "name": "set-blocking",
       "root": "/common/temp/default/node_modules/.pnpm/set-blocking@2.0.0/node_modules/set-blocking",
     },
     Object {
-      "deps": Object {},
       "name": "set-cookie-parser",
       "root": "/common/temp/default/node_modules/.pnpm/set-cookie-parser@2.6.0/node_modules/set-cookie-parser",
     },
@@ -26683,7 +25727,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/set-function-name@2.0.2/node_modules/set-function-name",
     },
     Object {
-      "deps": Object {},
       "name": "set-immediate-shim",
       "root": "/common/temp/default/node_modules/.pnpm/set-immediate-shim@1.0.1/node_modules/set-immediate-shim",
     },
@@ -26698,17 +25741,14 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/set-value@2.0.1/node_modules/set-value",
     },
     Object {
-      "deps": Object {},
       "name": "setimmediate",
       "root": "/common/temp/default/node_modules/.pnpm/setimmediate@1.0.5/node_modules/setimmediate",
     },
     Object {
-      "deps": Object {},
       "name": "setprototypeof",
       "root": "/common/temp/default/node_modules/.pnpm/setprototypeof@1.1.0/node_modules/setprototypeof",
     },
     Object {
-      "deps": Object {},
       "name": "setprototypeof",
       "root": "/common/temp/default/node_modules/.pnpm/setprototypeof@1.2.0/node_modules/setprototypeof",
     },
@@ -26728,7 +25768,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/shallow-clone@3.0.1/node_modules/shallow-clone",
     },
     Object {
-      "deps": Object {},
       "name": "shallowequal",
       "root": "/common/temp/default/node_modules/.pnpm/shallowequal@1.1.0/node_modules/shallowequal",
     },
@@ -26747,12 +25786,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/shebang-command@2.0.0/node_modules/shebang-command",
     },
     Object {
-      "deps": Object {},
       "name": "shebang-regex",
       "root": "/common/temp/default/node_modules/.pnpm/shebang-regex@1.0.0/node_modules/shebang-regex",
     },
     Object {
-      "deps": Object {},
       "name": "shebang-regex",
       "root": "/common/temp/default/node_modules/.pnpm/shebang-regex@3.0.0/node_modules/shebang-regex",
     },
@@ -26776,12 +25813,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/side-channel@1.0.6/node_modules/side-channel",
     },
     Object {
-      "deps": Object {},
       "name": "signal-exit",
       "root": "/common/temp/default/node_modules/.pnpm/signal-exit@3.0.7/node_modules/signal-exit",
     },
     Object {
-      "deps": Object {},
       "name": "simple-concat",
       "root": "/common/temp/default/node_modules/.pnpm/simple-concat@1.0.1/node_modules/simple-concat",
     },
@@ -26804,17 +25839,14 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/sirv@1.0.19/node_modules/sirv",
     },
     Object {
-      "deps": Object {},
       "name": "sisteransi",
       "root": "/common/temp/default/node_modules/.pnpm/sisteransi@1.0.5/node_modules/sisteransi",
     },
     Object {
-      "deps": Object {},
       "name": "slash",
       "root": "/common/temp/default/node_modules/.pnpm/slash@2.0.0/node_modules/slash",
     },
     Object {
-      "deps": Object {},
       "name": "slash",
       "root": "/common/temp/default/node_modules/.pnpm/slash@3.0.0/node_modules/slash",
     },
@@ -26837,7 +25869,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/slice-ansi@4.0.0/node_modules/slice-ansi",
     },
     Object {
-      "deps": Object {},
       "name": "smart-buffer",
       "root": "/common/temp/default/node_modules/.pnpm/smart-buffer@4.2.0/node_modules/smart-buffer",
     },
@@ -26913,12 +25944,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/sort-keys@4.2.0/node_modules/sort-keys",
     },
     Object {
-      "deps": Object {},
       "name": "source-list-map",
       "root": "/common/temp/default/node_modules/.pnpm/source-list-map@2.0.1/node_modules/source-list-map",
     },
     Object {
-      "deps": Object {},
       "name": "source-map-js",
       "root": "/common/temp/default/node_modules/.pnpm/source-map-js@1.1.0/node_modules/source-map-js",
     },
@@ -26973,27 +26002,22 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/source-map-support@0.5.21/node_modules/source-map-support",
     },
     Object {
-      "deps": Object {},
       "name": "source-map-url",
       "root": "/common/temp/default/node_modules/.pnpm/source-map-url@0.4.1/node_modules/source-map-url",
     },
     Object {
-      "deps": Object {},
       "name": "source-map",
       "root": "/common/temp/default/node_modules/.pnpm/source-map@0.5.7/node_modules/source-map",
     },
     Object {
-      "deps": Object {},
       "name": "source-map",
       "root": "/common/temp/default/node_modules/.pnpm/source-map@0.6.1/node_modules/source-map",
     },
     Object {
-      "deps": Object {},
       "name": "source-map",
       "root": "/common/temp/default/node_modules/.pnpm/source-map@0.7.4/node_modules/source-map",
     },
     Object {
-      "deps": Object {},
       "name": "space-separated-tokens",
       "root": "/common/temp/default/node_modules/.pnpm/space-separated-tokens@1.1.5/node_modules/space-separated-tokens",
     },
@@ -27006,7 +26030,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/spdx-correct@3.2.0/node_modules/spdx-correct",
     },
     Object {
-      "deps": Object {},
       "name": "spdx-exceptions",
       "root": "/common/temp/default/node_modules/.pnpm/spdx-exceptions@2.5.0/node_modules/spdx-exceptions",
     },
@@ -27019,7 +26042,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/spdx-expression-parse@3.0.1/node_modules/spdx-expression-parse",
     },
     Object {
-      "deps": Object {},
       "name": "spdx-license-ids",
       "root": "/common/temp/default/node_modules/.pnpm/spdx-license-ids@3.0.17/node_modules/spdx-license-ids",
     },
@@ -27061,12 +26083,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/split2@3.2.2/node_modules/split2",
     },
     Object {
-      "deps": Object {},
       "name": "sprintf-js",
       "root": "/common/temp/default/node_modules/.pnpm/sprintf-js@1.0.3/node_modules/sprintf-js",
     },
     Object {
-      "deps": Object {},
       "name": "sprintf-js",
       "root": "/common/temp/default/node_modules/.pnpm/sprintf-js@1.1.3/node_modules/sprintf-js",
     },
@@ -27085,7 +26105,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/ssri@8.0.1/node_modules/ssri",
     },
     Object {
-      "deps": Object {},
       "name": "stable",
       "root": "/common/temp/default/node_modules/.pnpm/stable@0.1.8/node_modules/stable",
     },
@@ -27097,12 +26116,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/stack-utils@2.0.6/node_modules/stack-utils",
     },
     Object {
-      "deps": Object {},
       "name": "stackframe",
       "root": "/common/temp/default/node_modules/.pnpm/stackframe@1.3.4/node_modules/stackframe",
     },
     Object {
-      "deps": Object {},
       "name": "state-toggle",
       "root": "/common/temp/default/node_modules/.pnpm/state-toggle@1.0.3/node_modules/state-toggle",
     },
@@ -27115,12 +26132,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/static-extend@0.1.2/node_modules/static-extend",
     },
     Object {
-      "deps": Object {},
       "name": "statuses",
       "root": "/common/temp/default/node_modules/.pnpm/statuses@1.5.0/node_modules/statuses",
     },
     Object {
-      "deps": Object {},
       "name": "statuses",
       "root": "/common/temp/default/node_modules/.pnpm/statuses@2.0.1/node_modules/statuses",
     },
@@ -27132,12 +26147,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/stop-iteration-iterator@1.0.0/node_modules/stop-iteration-iterator",
     },
     Object {
-      "deps": Object {},
       "name": "stoppable",
       "root": "/common/temp/default/node_modules/.pnpm/stoppable@1.1.0/node_modules/stoppable",
     },
     Object {
-      "deps": Object {},
       "name": "store2",
       "root": "/common/temp/default/node_modules/.pnpm/store2@2.14.3/node_modules/store2",
     },
@@ -27169,7 +26182,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/stream-http@2.8.3/node_modules/stream-http",
     },
     Object {
-      "deps": Object {},
       "name": "stream-shift",
       "root": "/common/temp/default/node_modules/.pnpm/stream-shift@1.0.3/node_modules/stream-shift",
     },
@@ -27183,17 +26195,14 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/streamroller@3.1.5/node_modules/streamroller",
     },
     Object {
-      "deps": Object {},
       "name": "strict-uri-encode",
       "root": "/common/temp/default/node_modules/.pnpm/strict-uri-encode@2.0.0/node_modules/strict-uri-encode",
     },
     Object {
-      "deps": Object {},
       "name": "string-argv",
       "root": "/common/temp/default/node_modules/.pnpm/string-argv@0.3.2/node_modules/string-argv",
     },
     Object {
-      "deps": Object {},
       "name": "string-hash",
       "root": "/common/temp/default/node_modules/.pnpm/string-hash@1.1.3/node_modules/string-hash",
     },
@@ -27206,7 +26215,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/string-length@4.0.2/node_modules/string-length",
     },
     Object {
-      "deps": Object {},
       "name": "string-similarity",
       "root": "/common/temp/default/node_modules/.pnpm/string-similarity@4.0.4/node_modules/string-similarity",
     },
@@ -27351,22 +26359,18 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/strip-ansi@7.1.0/node_modules/strip-ansi",
     },
     Object {
-      "deps": Object {},
       "name": "strip-bom",
       "root": "/common/temp/default/node_modules/.pnpm/strip-bom@3.0.0/node_modules/strip-bom",
     },
     Object {
-      "deps": Object {},
       "name": "strip-bom",
       "root": "/common/temp/default/node_modules/.pnpm/strip-bom@4.0.0/node_modules/strip-bom",
     },
     Object {
-      "deps": Object {},
       "name": "strip-eof",
       "root": "/common/temp/default/node_modules/.pnpm/strip-eof@1.0.0/node_modules/strip-eof",
     },
     Object {
-      "deps": Object {},
       "name": "strip-final-newline",
       "root": "/common/temp/default/node_modules/.pnpm/strip-final-newline@2.0.0/node_modules/strip-final-newline",
     },
@@ -27378,17 +26382,14 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/strip-indent@3.0.0/node_modules/strip-indent",
     },
     Object {
-      "deps": Object {},
       "name": "strip-json-comments",
       "root": "/common/temp/default/node_modules/.pnpm/strip-json-comments@2.0.1/node_modules/strip-json-comments",
     },
     Object {
-      "deps": Object {},
       "name": "strip-json-comments",
       "root": "/common/temp/default/node_modules/.pnpm/strip-json-comments@3.1.1/node_modules/strip-json-comments",
     },
     Object {
-      "deps": Object {},
       "name": "strnum",
       "root": "/common/temp/default/node_modules/.pnpm/strnum@1.0.5/node_modules/strnum",
     },
@@ -27434,7 +26435,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/stylehacks@5.1.1_postcss@8.4.36/node_modules/stylehacks",
     },
     Object {
-      "deps": Object {},
       "name": "stylis",
       "root": "/common/temp/default/node_modules/.pnpm/stylis@4.3.1/node_modules/stylis",
     },
@@ -27476,7 +26476,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/supports-color@8.1.1/node_modules/supports-color",
     },
     Object {
-      "deps": Object {},
       "name": "supports-preserve-symlinks-flag",
       "root": "/common/temp/default/node_modules/.pnpm/supports-preserve-symlinks-flag@1.0.0/node_modules/supports-preserve-symlinks-flag",
     },
@@ -27494,7 +26493,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/svgo@2.8.0/node_modules/svgo",
     },
     Object {
-      "deps": Object {},
       "name": "symbol-tree",
       "root": "/common/temp/default/node_modules/.pnpm/symbol-tree@3.2.4/node_modules/symbol-tree",
     },
@@ -27510,7 +26508,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/symbol.prototype.description@1.0.6/node_modules/symbol.prototype.description",
     },
     Object {
-      "deps": Object {},
       "name": "synchronous-promise",
       "root": "/common/temp/default/node_modules/.pnpm/synchronous-promise@2.0.17/node_modules/synchronous-promise",
     },
@@ -27544,12 +26541,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/tabster@6.1.0/node_modules/tabster",
     },
     Object {
-      "deps": Object {},
       "name": "tapable",
       "root": "/common/temp/default/node_modules/.pnpm/tapable@1.1.3/node_modules/tapable",
     },
     Object {
-      "deps": Object {},
       "name": "tapable",
       "root": "/common/temp/default/node_modules/.pnpm/tapable@2.2.1/node_modules/tapable",
     },
@@ -27696,7 +26691,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/test-exclude@6.0.0/node_modules/test-exclude",
     },
     Object {
-      "deps": Object {},
       "name": "text-table",
       "root": "/common/temp/default/node_modules/.pnpm/text-table@0.2.0/node_modules/text-table",
     },
@@ -27715,12 +26709,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/thenify@3.3.1/node_modules/thenify",
     },
     Object {
-      "deps": Object {},
       "name": "throat",
       "root": "/common/temp/default/node_modules/.pnpm/throat@6.0.2/node_modules/throat",
     },
     Object {
-      "deps": Object {},
       "name": "throttle-debounce",
       "root": "/common/temp/default/node_modules/.pnpm/throttle-debounce@3.0.1/node_modules/throttle-debounce",
     },
@@ -27740,12 +26732,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/through2@4.0.2/node_modules/through2",
     },
     Object {
-      "deps": Object {},
       "name": "through",
       "root": "/common/temp/default/node_modules/.pnpm/through@2.3.8/node_modules/through",
     },
     Object {
-      "deps": Object {},
       "name": "thunky",
       "root": "/common/temp/default/node_modules/.pnpm/thunky@1.1.0/node_modules/thunky",
     },
@@ -27757,7 +26747,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/timers-browserify@2.0.12/node_modules/timers-browserify",
     },
     Object {
-      "deps": Object {},
       "name": "tiny-lru",
       "root": "/common/temp/default/node_modules/.pnpm/tiny-lru@7.0.6/node_modules/tiny-lru",
     },
@@ -27769,22 +26758,18 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/tmp@0.0.33/node_modules/tmp",
     },
     Object {
-      "deps": Object {},
       "name": "tmp",
       "root": "/common/temp/default/node_modules/.pnpm/tmp@0.2.3/node_modules/tmp",
     },
     Object {
-      "deps": Object {},
       "name": "tmpl",
       "root": "/common/temp/default/node_modules/.pnpm/tmpl@1.0.5/node_modules/tmpl",
     },
     Object {
-      "deps": Object {},
       "name": "to-arraybuffer",
       "root": "/common/temp/default/node_modules/.pnpm/to-arraybuffer@1.0.1/node_modules/to-arraybuffer",
     },
     Object {
-      "deps": Object {},
       "name": "to-fast-properties",
       "root": "/common/temp/default/node_modules/.pnpm/to-fast-properties@2.0.0/node_modules/to-fast-properties",
     },
@@ -27821,17 +26806,14 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/to-regex@3.0.2/node_modules/to-regex",
     },
     Object {
-      "deps": Object {},
       "name": "toggle-selection",
       "root": "/common/temp/default/node_modules/.pnpm/toggle-selection@1.0.6/node_modules/toggle-selection",
     },
     Object {
-      "deps": Object {},
       "name": "toidentifier",
       "root": "/common/temp/default/node_modules/.pnpm/toidentifier@1.0.1/node_modules/toidentifier",
     },
     Object {
-      "deps": Object {},
       "name": "totalist",
       "root": "/common/temp/default/node_modules/.pnpm/totalist@1.1.0/node_modules/totalist",
     },
@@ -27846,7 +26828,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/tough-cookie@4.1.3/node_modules/tough-cookie",
     },
     Object {
-      "deps": Object {},
       "name": "tr46",
       "root": "/common/temp/default/node_modules/.pnpm/tr46@0.0.3/node_modules/tr46",
     },
@@ -27858,32 +26839,26 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/tr46@3.0.0/node_modules/tr46",
     },
     Object {
-      "deps": Object {},
       "name": "traverse",
       "root": "/common/temp/default/node_modules/.pnpm/traverse@0.3.9/node_modules/traverse",
     },
     Object {
-      "deps": Object {},
       "name": "trim-newlines",
       "root": "/common/temp/default/node_modules/.pnpm/trim-newlines@3.0.1/node_modules/trim-newlines",
     },
     Object {
-      "deps": Object {},
       "name": "trim-trailing-lines",
       "root": "/common/temp/default/node_modules/.pnpm/trim-trailing-lines@1.1.4/node_modules/trim-trailing-lines",
     },
     Object {
-      "deps": Object {},
       "name": "trim",
       "root": "/common/temp/default/node_modules/.pnpm/trim@0.0.1/node_modules/trim",
     },
     Object {
-      "deps": Object {},
       "name": "trough",
       "root": "/common/temp/default/node_modules/.pnpm/trough@1.0.5/node_modules/trough",
     },
     Object {
-      "deps": Object {},
       "name": "true-case-path",
       "root": "/common/temp/default/node_modules/.pnpm/true-case-path@2.2.1/node_modules/true-case-path",
     },
@@ -27902,7 +26877,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/ts-api-utils@1.3.0_typescript@5.4.2/node_modules/ts-api-utils",
     },
     Object {
-      "deps": Object {},
       "name": "ts-dedent",
       "root": "/common/temp/default/node_modules/.pnpm/ts-dedent@2.2.0/node_modules/ts-dedent",
     },
@@ -27936,22 +26910,18 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/tsconfig-paths@3.15.0/node_modules/tsconfig-paths",
     },
     Object {
-      "deps": Object {},
       "name": "tslib",
       "root": "/common/temp/default/node_modules/.pnpm/tslib@1.14.1/node_modules/tslib",
     },
     Object {
-      "deps": Object {},
       "name": "tslib",
       "root": "/common/temp/default/node_modules/.pnpm/tslib@2.3.1/node_modules/tslib",
     },
     Object {
-      "deps": Object {},
       "name": "tslib",
       "root": "/common/temp/default/node_modules/.pnpm/tslib@2.4.0/node_modules/tslib",
     },
     Object {
-      "deps": Object {},
       "name": "tslib",
       "root": "/common/temp/default/node_modules/.pnpm/tslib@2.6.2/node_modules/tslib",
     },
@@ -28076,7 +27046,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/tsutils@3.21.0_typescript@5.4.2/node_modules/tsutils",
     },
     Object {
-      "deps": Object {},
       "name": "tty-browserify",
       "root": "/common/temp/default/node_modules/.pnpm/tty-browserify@0.0.0/node_modules/tty-browserify",
     },
@@ -28088,7 +27057,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/tunnel-agent@0.6.0/node_modules/tunnel-agent",
     },
     Object {
-      "deps": Object {},
       "name": "tunnel",
       "root": "/common/temp/default/node_modules/.pnpm/tunnel@0.0.6/node_modules/tunnel",
     },
@@ -28100,37 +27068,30 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/type-check@0.4.0/node_modules/type-check",
     },
     Object {
-      "deps": Object {},
       "name": "type-detect",
       "root": "/common/temp/default/node_modules/.pnpm/type-detect@4.0.8/node_modules/type-detect",
     },
     Object {
-      "deps": Object {},
       "name": "type-fest",
       "root": "/common/temp/default/node_modules/.pnpm/type-fest@0.18.1/node_modules/type-fest",
     },
     Object {
-      "deps": Object {},
       "name": "type-fest",
       "root": "/common/temp/default/node_modules/.pnpm/type-fest@0.20.2/node_modules/type-fest",
     },
     Object {
-      "deps": Object {},
       "name": "type-fest",
       "root": "/common/temp/default/node_modules/.pnpm/type-fest@0.21.3/node_modules/type-fest",
     },
     Object {
-      "deps": Object {},
       "name": "type-fest",
       "root": "/common/temp/default/node_modules/.pnpm/type-fest@0.6.0/node_modules/type-fest",
     },
     Object {
-      "deps": Object {},
       "name": "type-fest",
       "root": "/common/temp/default/node_modules/.pnpm/type-fest@0.8.1/node_modules/type-fest",
     },
     Object {
-      "deps": Object {},
       "name": "type-fest",
       "root": "/common/temp/default/node_modules/.pnpm/type-fest@2.19.0/node_modules/type-fest",
     },
@@ -28203,37 +27164,30 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/typedarray-to-buffer@3.1.5/node_modules/typedarray-to-buffer",
     },
     Object {
-      "deps": Object {},
       "name": "typedarray",
       "root": "/common/temp/default/node_modules/.pnpm/typedarray@0.0.6/node_modules/typedarray",
     },
     Object {
-      "deps": Object {},
       "name": "typescript",
       "root": "/common/temp/default/node_modules/.pnpm/typescript@2.9.2/node_modules/typescript",
     },
     Object {
-      "deps": Object {},
       "name": "typescript",
       "root": "/common/temp/default/node_modules/.pnpm/typescript@3.9.10/node_modules/typescript",
     },
     Object {
-      "deps": Object {},
       "name": "typescript",
       "root": "/common/temp/default/node_modules/.pnpm/typescript@4.9.5/node_modules/typescript",
     },
     Object {
-      "deps": Object {},
       "name": "typescript",
       "root": "/common/temp/default/node_modules/.pnpm/typescript@5.4.2/node_modules/typescript",
     },
     Object {
-      "deps": Object {},
       "name": "uc.micro",
       "root": "/common/temp/default/node_modules/.pnpm/uc.micro@1.0.6/node_modules/uc.micro",
     },
     Object {
-      "deps": Object {},
       "name": "uglify-js",
       "root": "/common/temp/default/node_modules/.pnpm/uglify-js@3.17.4/node_modules/uglify-js",
     },
@@ -28248,17 +27202,14 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/unbox-primitive@1.0.2/node_modules/unbox-primitive",
     },
     Object {
-      "deps": Object {},
       "name": "underscore",
       "root": "/common/temp/default/node_modules/.pnpm/underscore@1.13.6/node_modules/underscore",
     },
     Object {
-      "deps": Object {},
       "name": "undici-types",
       "root": "/common/temp/default/node_modules/.pnpm/undici-types@5.26.5/node_modules/undici-types",
     },
     Object {
-      "deps": Object {},
       "name": "unfetch",
       "root": "/common/temp/default/node_modules/.pnpm/unfetch@4.2.0/node_modules/unfetch",
     },
@@ -28271,7 +27222,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/unherit@1.1.3/node_modules/unherit",
     },
     Object {
-      "deps": Object {},
       "name": "unicode-canonical-property-names-ecmascript",
       "root": "/common/temp/default/node_modules/.pnpm/unicode-canonical-property-names-ecmascript@2.0.0/node_modules/unicode-canonical-property-names-ecmascript",
     },
@@ -28284,12 +27234,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/unicode-match-property-ecmascript@2.0.0/node_modules/unicode-match-property-ecmascript",
     },
     Object {
-      "deps": Object {},
       "name": "unicode-match-property-value-ecmascript",
       "root": "/common/temp/default/node_modules/.pnpm/unicode-match-property-value-ecmascript@2.1.0/node_modules/unicode-match-property-value-ecmascript",
     },
     Object {
-      "deps": Object {},
       "name": "unicode-property-aliases-ecmascript",
       "root": "/common/temp/default/node_modules/.pnpm/unicode-property-aliases-ecmascript@2.1.0/node_modules/unicode-property-aliases-ecmascript",
     },
@@ -28337,22 +27285,18 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/unique-string@2.0.0/node_modules/unique-string",
     },
     Object {
-      "deps": Object {},
       "name": "unist-builder",
       "root": "/common/temp/default/node_modules/.pnpm/unist-builder@2.0.3/node_modules/unist-builder",
     },
     Object {
-      "deps": Object {},
       "name": "unist-util-generated",
       "root": "/common/temp/default/node_modules/.pnpm/unist-util-generated@1.1.6/node_modules/unist-util-generated",
     },
     Object {
-      "deps": Object {},
       "name": "unist-util-is",
       "root": "/common/temp/default/node_modules/.pnpm/unist-util-is@4.1.0/node_modules/unist-util-is",
     },
     Object {
-      "deps": Object {},
       "name": "unist-util-position",
       "root": "/common/temp/default/node_modules/.pnpm/unist-util-position@3.1.0/node_modules/unist-util-position",
     },
@@ -28395,22 +27339,18 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/unist-util-visit@2.0.3/node_modules/unist-util-visit",
     },
     Object {
-      "deps": Object {},
       "name": "universalify",
       "root": "/common/temp/default/node_modules/.pnpm/universalify@0.1.2/node_modules/universalify",
     },
     Object {
-      "deps": Object {},
       "name": "universalify",
       "root": "/common/temp/default/node_modules/.pnpm/universalify@0.2.0/node_modules/universalify",
     },
     Object {
-      "deps": Object {},
       "name": "universalify",
       "root": "/common/temp/default/node_modules/.pnpm/universalify@2.0.1/node_modules/universalify",
     },
     Object {
-      "deps": Object {},
       "name": "unpipe",
       "root": "/common/temp/default/node_modules/.pnpm/unpipe@1.0.0/node_modules/unpipe",
     },
@@ -28439,7 +27379,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/unzipper@0.10.14/node_modules/unzipper",
     },
     Object {
-      "deps": Object {},
       "name": "upath",
       "root": "/common/temp/default/node_modules/.pnpm/upath@1.2.0/node_modules/upath",
     },
@@ -28480,12 +27419,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/uri-js@4.4.1/node_modules/uri-js",
     },
     Object {
-      "deps": Object {},
       "name": "urix",
       "root": "/common/temp/default/node_modules/.pnpm/urix@0.1.0/node_modules/urix",
     },
     Object {
-      "deps": Object {},
       "name": "url-join",
       "root": "/common/temp/default/node_modules/.pnpm/url-join@4.0.1/node_modules/url-join",
     },
@@ -28576,12 +27513,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/use-sync-external-store@1.2.0_react@17.0.2/node_modules/use-sync-external-store",
     },
     Object {
-      "deps": Object {},
       "name": "use",
       "root": "/common/temp/default/node_modules/.pnpm/use@3.1.1/node_modules/use",
     },
     Object {
-      "deps": Object {},
       "name": "util-deprecate",
       "root": "/common/temp/default/node_modules/.pnpm/util-deprecate@1.0.2/node_modules/util-deprecate",
     },
@@ -28619,42 +27554,34 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/util@0.12.5/node_modules/util",
     },
     Object {
-      "deps": Object {},
       "name": "utila",
       "root": "/common/temp/default/node_modules/.pnpm/utila@0.4.0/node_modules/utila",
     },
     Object {
-      "deps": Object {},
       "name": "utils-merge",
       "root": "/common/temp/default/node_modules/.pnpm/utils-merge@1.0.1/node_modules/utils-merge",
     },
     Object {
-      "deps": Object {},
       "name": "uuid-browser",
       "root": "/common/temp/default/node_modules/.pnpm/uuid-browser@3.1.0/node_modules/uuid-browser",
     },
     Object {
-      "deps": Object {},
       "name": "uuid",
       "root": "/common/temp/default/node_modules/.pnpm/uuid@3.4.0/node_modules/uuid",
     },
     Object {
-      "deps": Object {},
       "name": "uuid",
       "root": "/common/temp/default/node_modules/.pnpm/uuid@8.0.0/node_modules/uuid",
     },
     Object {
-      "deps": Object {},
       "name": "uuid",
       "root": "/common/temp/default/node_modules/.pnpm/uuid@8.3.2/node_modules/uuid",
     },
     Object {
-      "deps": Object {},
       "name": "uuid",
       "root": "/common/temp/default/node_modules/.pnpm/uuid@9.0.1/node_modules/uuid",
     },
     Object {
-      "deps": Object {},
       "name": "v8-compile-cache",
       "root": "/common/temp/default/node_modules/.pnpm/v8-compile-cache@2.4.0/node_modules/v8-compile-cache",
     },
@@ -28683,22 +27610,18 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/validate-npm-package-name@3.0.0/node_modules/validate-npm-package-name",
     },
     Object {
-      "deps": Object {},
       "name": "validator",
       "root": "/common/temp/default/node_modules/.pnpm/validator@13.11.0/node_modules/validator",
     },
     Object {
-      "deps": Object {},
       "name": "varint",
       "root": "/common/temp/default/node_modules/.pnpm/varint@6.0.0/node_modules/varint",
     },
     Object {
-      "deps": Object {},
       "name": "vary",
       "root": "/common/temp/default/node_modules/.pnpm/vary@1.1.2/node_modules/vary",
     },
     Object {
-      "deps": Object {},
       "name": "vfile-location",
       "root": "/common/temp/default/node_modules/.pnpm/vfile-location@3.2.0/node_modules/vfile-location",
     },
@@ -28721,7 +27644,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/vfile@4.2.1/node_modules/vfile",
     },
     Object {
-      "deps": Object {},
       "name": "vm-browserify",
       "root": "/common/temp/default/node_modules/.pnpm/vm-browserify@1.1.2/node_modules/vm-browserify",
     },
@@ -28812,17 +27734,14 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/wcwidth@1.0.1/node_modules/wcwidth",
     },
     Object {
-      "deps": Object {},
       "name": "web-namespaces",
       "root": "/common/temp/default/node_modules/.pnpm/web-namespaces@1.1.4/node_modules/web-namespaces",
     },
     Object {
-      "deps": Object {},
       "name": "webidl-conversions",
       "root": "/common/temp/default/node_modules/.pnpm/webidl-conversions@3.0.1/node_modules/webidl-conversions",
     },
     Object {
-      "deps": Object {},
       "name": "webidl-conversions",
       "root": "/common/temp/default/node_modules/.pnpm/webidl-conversions@7.0.0/node_modules/webidl-conversions",
     },
@@ -29054,7 +27973,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/webpack-sources@1.4.3/node_modules/webpack-sources",
     },
     Object {
-      "deps": Object {},
       "name": "webpack-sources",
       "root": "/common/temp/default/node_modules/.pnpm/webpack-sources@3.2.3/node_modules/webpack-sources",
     },
@@ -29135,7 +28053,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/websocket-driver@0.7.4/node_modules/websocket-driver",
     },
     Object {
-      "deps": Object {},
       "name": "websocket-extensions",
       "root": "/common/temp/default/node_modules/.pnpm/websocket-extensions@0.1.4/node_modules/websocket-extensions",
     },
@@ -29147,12 +28064,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/whatwg-encoding@2.0.0/node_modules/whatwg-encoding",
     },
     Object {
-      "deps": Object {},
       "name": "whatwg-mimetype",
       "root": "/common/temp/default/node_modules/.pnpm/whatwg-mimetype@2.3.0/node_modules/whatwg-mimetype",
     },
     Object {
-      "deps": Object {},
       "name": "whatwg-mimetype",
       "root": "/common/temp/default/node_modules/.pnpm/whatwg-mimetype@3.0.0/node_modules/whatwg-mimetype",
     },
@@ -29212,7 +28127,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/which-collection@1.0.2/node_modules/which-collection",
     },
     Object {
-      "deps": Object {},
       "name": "which-module",
       "root": "/common/temp/default/node_modules/.pnpm/which-module@2.0.1/node_modules/which-module",
     },
@@ -29271,12 +28185,10 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/widest-line@4.0.1/node_modules/widest-line",
     },
     Object {
-      "deps": Object {},
       "name": "wildcard",
       "root": "/common/temp/default/node_modules/.pnpm/wildcard@2.0.1/node_modules/wildcard",
     },
     Object {
-      "deps": Object {},
       "name": "wordwrap",
       "root": "/common/temp/default/node_modules/.pnpm/wordwrap@1.0.0/node_modules/wordwrap",
     },
@@ -29295,7 +28207,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/worker-rpc@0.1.1/node_modules/worker-rpc",
     },
     Object {
-      "deps": Object {},
       "name": "workerpool",
       "root": "/common/temp/default/node_modules/.pnpm/workerpool@6.2.1/node_modules/workerpool",
     },
@@ -29336,7 +28247,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/wrap-ansi@8.1.0/node_modules/wrap-ansi",
     },
     Object {
-      "deps": Object {},
       "name": "wrappy",
       "root": "/common/temp/default/node_modules/.pnpm/wrappy@1.0.2/node_modules/wrappy",
     },
@@ -29390,22 +28300,18 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/ws@6.2.2/node_modules/ws",
     },
     Object {
-      "deps": Object {},
       "name": "ws",
       "root": "/common/temp/default/node_modules/.pnpm/ws@7.5.9/node_modules/ws",
     },
     Object {
-      "deps": Object {},
       "name": "ws",
       "root": "/common/temp/default/node_modules/.pnpm/ws@8.14.2/node_modules/ws",
     },
     Object {
-      "deps": Object {},
       "name": "xdg-basedir",
       "root": "/common/temp/default/node_modules/.pnpm/xdg-basedir@4.0.0/node_modules/xdg-basedir",
     },
     Object {
-      "deps": Object {},
       "name": "xml-name-validator",
       "root": "/common/temp/default/node_modules/.pnpm/xml-name-validator@4.0.0/node_modules/xml-name-validator",
     },
@@ -29434,17 +28340,14 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/xml2js@0.6.2/node_modules/xml2js",
     },
     Object {
-      "deps": Object {},
       "name": "xml",
       "root": "/common/temp/default/node_modules/.pnpm/xml@1.0.1/node_modules/xml",
     },
     Object {
-      "deps": Object {},
       "name": "xmlbuilder",
       "root": "/common/temp/default/node_modules/.pnpm/xmlbuilder@11.0.1/node_modules/xmlbuilder",
     },
     Object {
-      "deps": Object {},
       "name": "xmlchars",
       "root": "/common/temp/default/node_modules/.pnpm/xmlchars@2.2.0/node_modules/xmlchars",
     },
@@ -29456,42 +28359,34 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/xmldoc@1.1.4/node_modules/xmldoc",
     },
     Object {
-      "deps": Object {},
       "name": "xstate",
       "root": "/common/temp/default/node_modules/.pnpm/xstate@4.26.1/node_modules/xstate",
     },
     Object {
-      "deps": Object {},
       "name": "xtend",
       "root": "/common/temp/default/node_modules/.pnpm/xtend@4.0.2/node_modules/xtend",
     },
     Object {
-      "deps": Object {},
       "name": "y18n",
       "root": "/common/temp/default/node_modules/.pnpm/y18n@4.0.3/node_modules/y18n",
     },
     Object {
-      "deps": Object {},
       "name": "y18n",
       "root": "/common/temp/default/node_modules/.pnpm/y18n@5.0.8/node_modules/y18n",
     },
     Object {
-      "deps": Object {},
       "name": "yallist",
       "root": "/common/temp/default/node_modules/.pnpm/yallist@3.1.1/node_modules/yallist",
     },
     Object {
-      "deps": Object {},
       "name": "yallist",
       "root": "/common/temp/default/node_modules/.pnpm/yallist@4.0.0/node_modules/yallist",
     },
     Object {
-      "deps": Object {},
       "name": "yaml",
       "root": "/common/temp/default/node_modules/.pnpm/yaml@1.10.2/node_modules/yaml",
     },
     Object {
-      "deps": Object {},
       "name": "yaml",
       "root": "/common/temp/default/node_modules/.pnpm/yaml@2.4.1/node_modules/yaml",
     },
@@ -29512,17 +28407,14 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/yargs-parser@18.1.3/node_modules/yargs-parser",
     },
     Object {
-      "deps": Object {},
       "name": "yargs-parser",
       "root": "/common/temp/default/node_modules/.pnpm/yargs-parser@20.2.4/node_modules/yargs-parser",
     },
     Object {
-      "deps": Object {},
       "name": "yargs-parser",
       "root": "/common/temp/default/node_modules/.pnpm/yargs-parser@20.2.9/node_modules/yargs-parser",
     },
     Object {
-      "deps": Object {},
       "name": "yargs-parser",
       "root": "/common/temp/default/node_modules/.pnpm/yargs-parser@21.1.1/node_modules/yargs-parser",
     },
@@ -29611,7 +28503,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/yazl@2.5.1/node_modules/yazl",
     },
     Object {
-      "deps": Object {},
       "name": "yocto-queue",
       "root": "/common/temp/default/node_modules/.pnpm/yocto-queue@0.1.0/node_modules/yocto-queue",
     },
@@ -29645,7 +28536,6 @@ Object {
       "root": "/common/temp/default/node_modules/.pnpm/zip-stream@4.1.1/node_modules/zip-stream",
     },
     Object {
-      "deps": Object {},
       "name": "zwitch",
       "root": "/common/temp/default/node_modules/.pnpm/zwitch@1.0.5/node_modules/zwitch",
     },

--- a/rush-plugins/rush-resolver-cache-plugin/src/types.ts
+++ b/rush-plugins/rush-resolver-cache-plugin/src/types.ts
@@ -8,8 +8,9 @@ export interface IResolverContext {
   deps: Map<string, string>;
   isProject: boolean;
   ordinal: number;
+  parent?: IResolverContext | undefined;
   optional?: boolean;
-  files?: string[];
+  nestedPackageDirs?: string[];
 }
 
 export type IDependencyEntry =

--- a/rush-plugins/rush-resolver-cache-plugin/test-collateral/bundled-dependencies.yaml
+++ b/rush-plugins/rush-resolver-cache-plugin/test-collateral/bundled-dependencies.yaml
@@ -1,0 +1,17 @@
+lockfileVersion: '6.0'
+
+settings:
+  autoInstallPeers: false
+  excludeLinksFromLockfile: false
+
+importers:
+  .:
+    dependencies:
+      foo:
+        specifier: 1.0.0
+        version: 1.0.0
+
+packages:
+  /foo@1.0.0:
+    bundledDependencies:
+      - '@learningclient/common'

--- a/webpack/webpack-workspace-resolve-plugin/src/KnownDescriptionFilePlugin.ts
+++ b/webpack/webpack-workspace-resolve-plugin/src/KnownDescriptionFilePlugin.ts
@@ -92,7 +92,7 @@ export class KnownDescriptionFilePlugin {
 
           resolveContext.fileDependencies?.add(descriptionFilePath);
           // Store the resolver context since a WeakMap lookup is cheaper than walking the tree again
-          contextForPackage.set(descriptionFileData, match.value);
+          contextForPackage.set(descriptionFileData, match);
 
           const obj: ResolveRequest = {
             ...request,

--- a/webpack/webpack-workspace-resolve-plugin/src/test/KnownPackageDependenciesPlugin.test.ts
+++ b/webpack/webpack-workspace-resolve-plugin/src/test/KnownPackageDependenciesPlugin.test.ts
@@ -108,6 +108,68 @@ describe(KnownPackageDependenciesPlugin.name, () => {
     });
   });
 
+  it('should find a parent (/)', () => {
+    const resolver: WrappedResolve = createResolve('/');
+
+    const descriptionFilePath: string = '/workspace/b/node_modules/c/package.json';
+    const descriptionFileData: object = parsedJson[descriptionFilePath];
+    const descriptionFileRoot: string = '/workspace/b/node_modules/c';
+
+    const [err1, result1] = resolver(
+      {
+        path: '/workspace/b/node_modules/c/lib/foo.js',
+        request: 'b/lib/index.js',
+        descriptionFileRoot,
+        descriptionFileData,
+        descriptionFilePath,
+        relativePath: './lib/foo.js'
+      },
+      {}
+    );
+
+    expect(err1).toBeFalsy();
+    expect(result1).toEqual({
+      path: '/workspace/b',
+      request: './lib/index.js',
+      descriptionFileRoot: '/workspace/b',
+      descriptionFilePath: '/workspace/b/package.json',
+      relativePath: './lib/index.js',
+      fullySpecified: undefined,
+      module: false
+    });
+  });
+
+  it('should resolve through a parent (/)', () => {
+    const resolver: WrappedResolve = createResolve('/');
+
+    const descriptionFilePath: string = '/workspace/b/node_modules/c/package.json';
+    const descriptionFileData: object = parsedJson[descriptionFilePath];
+    const descriptionFileRoot: string = '/workspace/b/node_modules/c';
+
+    const [err1, result1] = resolver(
+      {
+        path: '/workspace/b/node_modules/c/lib/foo.js',
+        request: 'a/lib/index.js',
+        descriptionFileRoot,
+        descriptionFileData,
+        descriptionFilePath,
+        relativePath: './lib/foo.js'
+      },
+      {}
+    );
+
+    expect(err1).toBeFalsy();
+    expect(result1).toEqual({
+      path: '/workspace/a',
+      request: './lib/index.js',
+      descriptionFileRoot: '/workspace/a',
+      descriptionFilePath: '/workspace/a/package.json',
+      relativePath: './lib/index.js',
+      fullySpecified: undefined,
+      module: false
+    });
+  });
+
   it('should defer to other plugins if not in a context', () => {
     const resolver: WrappedResolve = createResolve('/');
 


### PR DESCRIPTION
## Summary
Updates `@rushstack/lookup-by-path` to return a linked list of matches from `findLongestPrefixMatch`, where the head of the list is the longest match and each link is a successively shorter match.
Updates `@rushstack/rush-resolver-cache-plugin` to parse `bundledDependencies` and include that data in the resolver cache file.
Updates `@rushstack/webpack-workspace-resolve-plugin` to handle hierarchical `node_modules` if the cache indicates such.

## Details
Cache file now allows a context to have a pointer to the parent context.
Cache file now allows the `deps` field to be omitted.

## How it was tested
Added unit tests.

## Impacted documentation
Docs for the plugins.
