### PR TITLE
[rush] fix: ignore flags when doing install with resolution only

### DIFF
--- a/common/changes/@microsoft/rush/sennyeya-ignore-flags-when-resolution-only_2024-08-28-17-54.json
+++ b/common/changes/@microsoft/rush/sennyeya-ignore-flags-when-resolution-only_2024-08-28-17-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix an issue where running `rush install --resolution-only` followed by `rush install` would not actually install modules.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
+++ b/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
@@ -776,7 +776,6 @@ ${gitLfsHookHandling}
         'The "--resolution-only" parameter is only supported when using the PNPM package manager.'
       );
     }
-    console.log(resolutionOnly);
     if (this.rushConfiguration.packageManager === 'npm') {
       if (semver.lt(this.rushConfiguration.packageManagerToolVersion, '5.0.0')) {
         // NOTE:

--- a/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
+++ b/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
@@ -114,7 +114,8 @@ export abstract class BaseInstallManager {
   }
 
   public async doInstallAsync(): Promise<void> {
-    const { allowShrinkwrapUpdates, selectedProjects, pnpmFilterArgumentValues } = this.options;
+    const { allowShrinkwrapUpdates, selectedProjects, pnpmFilterArgumentValues, resolutionOnly } =
+      this.options;
     const isFilteredInstall: boolean = pnpmFilterArgumentValues.length > 0;
     const useWorkspaces: boolean =
       this.rushConfiguration.pnpmOptions && this.rushConfiguration.pnpmOptions.useWorkspaces;
@@ -202,7 +203,13 @@ export abstract class BaseInstallManager {
       return this.canSkipInstall(outputStats.mtime, subspace);
     };
 
-    if (cleanInstall || !shrinkwrapIsUpToDate || !canSkipInstall() || !projectImpactGraphIsUpToDate) {
+    if (
+      resolutionOnly ||
+      cleanInstall ||
+      !shrinkwrapIsUpToDate ||
+      !canSkipInstall() ||
+      !projectImpactGraphIsUpToDate
+    ) {
       // eslint-disable-next-line no-console
       console.log();
       await this.validateNpmSetupAsync();
@@ -224,12 +231,14 @@ export abstract class BaseInstallManager {
         }
       }
 
-      // Delete the successful install file to indicate the install transaction has started
-      await commonTempInstallFlag.clearAsync();
+      if (!resolutionOnly) {
+        // Delete the successful install file to indicate the install transaction has started
+        await commonTempInstallFlag.clearAsync();
 
-      // Since we're going to be tampering with common/node_modules, delete the "rush link" flag file if it exists;
-      // this ensures that a full "rush link" is required next time
-      await this._commonTempLinkFlag.clearAsync();
+        // Since we're going to be tampering with common/node_modules, delete the "rush link" flag file if it exists;
+        // this ensures that a full "rush link" is required next time
+        await this._commonTempLinkFlag.clearAsync();
+      }
 
       // Give plugins an opportunity to act before invoking the installation process
       if (this.options.beforeInstallAsync !== undefined) {
@@ -347,8 +356,10 @@ export abstract class BaseInstallManager {
     // Perform any post-install work the install manager requires
     await this.postInstallAsync(subspace);
 
-    // Create the marker file to indicate a successful install
-    await commonTempInstallFlag.createAsync();
+    if (!resolutionOnly) {
+      // Create the marker file to indicate a successful install
+      await commonTempInstallFlag.createAsync();
+    }
 
     // Give plugins an opportunity to act after a successful install
     if (this.options.afterInstallAsync !== undefined) {
@@ -765,6 +776,7 @@ ${gitLfsHookHandling}
         'The "--resolution-only" parameter is only supported when using the PNPM package manager.'
       );
     }
+    console.log(resolutionOnly);
     if (this.rushConfiguration.packageManager === 'npm') {
       if (semver.lt(this.rushConfiguration.packageManagerToolVersion, '5.0.0')) {
         // NOTE:


### PR DESCRIPTION
## Summary

Fixes an issue with #4893 where running `rush install --resolution-only` would write the LastInstall flag but wouldn't install any packages, so subsequent `rush install`'s would pass without doing anything, causing a broken module state. This PR skips the LastInstall check when using `--resolution-only` and runs pnpm every time.


## How it was tested


I set the `usePnpmFrozenLockfileForRushInstall` experiment to false in both our monorepo and the rush monorepo, 
1. ran `rush purge`
1. ran `node ./apps/rush/lib/start-dev install --resolution-only` 
2. ran `node ./apps/rush/lib/start-dev install` - ensured that the install actually finished
3. ran `node ./apps/rush/lib/start-dev install --resolution-only` to ensure that the resolution check happens again
2. ran `node ./apps/rush/lib/start-dev install` to ensure that the cache flag is still used for regular installs
