### PR TITLE
[workspace-resolve] Fix cross-package import

### DIFF
--- a/common/changes/@rushstack/webpack-workspace-resolve-plugin/fix-workspace-resolve_2024-08-28-22-55.json
+++ b/common/changes/@rushstack/webpack-workspace-resolve-plugin/fix-workspace-resolve_2024-08-28-22-55.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/webpack-workspace-resolve-plugin",
+      "comment": "Fix description file resolution after cross-package import.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/webpack-workspace-resolve-plugin"
+}

--- a/webpack/webpack-workspace-resolve-plugin/src/WorkspaceResolvePlugin.ts
+++ b/webpack/webpack-workspace-resolve-plugin/src/WorkspaceResolvePlugin.ts
@@ -52,7 +52,9 @@ export class WorkspaceResolvePlugin implements WebpackPluginInstance {
           new KnownDescriptionFilePlugin(cache, 'parsed-resolve', 'described-resolve'),
           // Optimize locating the installed dependencies of the current package
           new KnownPackageDependenciesPlugin(cache, 'raw-module', 'resolve-as-module'),
-          // Optimize loading the package.json file for the destination package
+          // Optimize loading the package.json file for the destination package (bare specifier)
+          new KnownDescriptionFilePlugin(cache, 'resolve-as-module', 'resolve-in-package'),
+          // Optimize loading the package.json file for the destination package (relative path)
           new KnownDescriptionFilePlugin(cache, 'relative', 'described-relative'),
           // Optimize locating and loading nested package.json for a directory
           new KnownDescriptionFilePlugin(cache, 'undescribed-existing-directory', 'existing-directory', true),


### PR DESCRIPTION
## Summary
Fixes a bug in `@rushstack/webpack-workspace-resolve-plugin` wherein cross-package imports didn't use `@rushstack/webpack-workspace-resolve-plugin` to lookup the `package.json` for the destination package.

## Details
Added a missing instance of `KnownDescriptionFilePlugin` after `KnownPackageDependenciesPlugin`.

## How it was tested
Ran the modified version against a real production repository and verified successful build (using `@rushstack/rush-resolver-cache-plugin`.

## Impacted documentation
None.