### PR TITLE
[rush-resolver-cache] Fix Windows compatibility

### DIFF
--- a/common/changes/@microsoft/rush/resolver-cache-windows_2024-08-29-18-03.json
+++ b/common/changes/@microsoft/rush/resolver-cache-windows_2024-08-29-18-03.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix Windows compatibility for `@rushstack/rush-resolver-cache-plugin`.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/rush-plugins/rush-resolver-cache-plugin/src/computeResolverCacheFromLockfileAsync.ts
+++ b/rush-plugins/rush-resolver-cache-plugin/src/computeResolverCacheFromLockfileAsync.ts
@@ -144,14 +144,12 @@ export interface IComputeResolverCacheFromLockfileOptions {
 export async function computeResolverCacheFromLockfileAsync(
   params: IComputeResolverCacheFromLockfileOptions
 ): Promise<IResolverCacheFile> {
-  const {
-    workspaceRoot,
-    commonPrefixToTrim,
-    platformInfo,
-    projectByImporterPath,
-    lockfile,
-    afterExternalPackagesAsync
-  } = params;
+  const { platformInfo, projectByImporterPath, lockfile, afterExternalPackagesAsync } = params;
+  // Needs to be normalized to `/` for path.posix.join to work correctly
+  const workspaceRoot: string = params.workspaceRoot.replace(/\\/g, '/');
+  // Needs to be normalized to `/` for path.posix.join to work correctly
+  const commonPrefixToTrim: string = params.commonPrefixToTrim.replace(/\\/g, '/');
+
   const contexts: Map<string, IResolverContext> = new Map();
   const missingOptionalDependencies: Set<string> = new Set();
 

--- a/rush-plugins/rush-resolver-cache-plugin/src/test/computeResolverCacheFromLockfileAsync.test.ts
+++ b/rush-plugins/rush-resolver-cache-plugin/src/test/computeResolverCacheFromLockfileAsync.test.ts
@@ -23,13 +23,15 @@ interface ITestCase {
 
 const TEST_CASES: readonly ITestCase[] = [
   {
+    // Validate with POSIX-style path inputs
     workspaceRoot: '/$root/common/temp/build-tests',
     commonPrefixToTrim: '/$root/',
     lockfileName: 'build-tests-subspace.yaml'
   },
   {
-    workspaceRoot: '/$root/common/temp/default',
-    commonPrefixToTrim: '/$root/',
+    // Validate that it works with Windows-style path inputs
+    workspaceRoot: '\\$root\\common\\temp\\default',
+    commonPrefixToTrim: '\\$root\\',
     lockfileName: 'default-subspace.yaml'
   },
   {
@@ -105,7 +107,7 @@ describe(computeResolverCacheFromLockfileAsync.name, () => {
       for (const importerPath of lockfile.importers.keys()) {
         const remainder: string = importerPath.slice(importerPath.lastIndexOf('../') + 3);
         projectByImporterPath.setItem(importerPath, {
-          projectFolder: `${commonPrefixToTrim}${remainder}`,
+          projectFolder: `${commonPrefixToTrim.replace(/\\/g, '/')}${remainder}`,
           packageJson: {
             name: `@local/${remainder.replace(/\//g, '+')}`
           }


### PR DESCRIPTION
## Summary
Fixes compatibility of `@rushstack/rush-resolver-cache-plugin` with Windows.

## Details
Performs slash normalization on inputs so that `path.posix.join` calls work correctly.

## How it was tested
Updated unit tests to try passing in `\` delimited paths and verified that the output is unchanged.

## Impacted documentation
None.