### PR TITLE
[rush-lib] fix: update shrinkwrap when globalPackageExtensions has been changed

### DIFF
--- a/common/changes/@microsoft/rush/kenrick-fix-update-shrinkwrap-packageExtensions_2024-09-06-03-55.json
+++ b/common/changes/@microsoft/rush/kenrick-fix-update-shrinkwrap-packageExtensions_2024-09-06-03-55.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Always update shrinkwrap when globalPackageExtensions has been changed",
+      "comment": "Always update shrinkwrap when `globalPackageExtensions` in `common/config/rush/pnpm-config.json` has been changed.",
       "type": "none"
     }
   ],

--- a/common/changes/@microsoft/rush/kenrick-fix-update-shrinkwrap-packageExtensions_2024-09-06-03-55.json
+++ b/common/changes/@microsoft/rush/kenrick-fix-update-shrinkwrap-packageExtensions_2024-09-06-03-55.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Always update shrinkwrap when globalPackageExtensions has been changed",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@rushstack/node-core-library/kenrick-fix-update-shrinkwrap-packageExtensions_2024-09-06-03-55.json
+++ b/common/changes/@rushstack/node-core-library/kenrick-fix-update-shrinkwrap-packageExtensions_2024-09-06-03-55.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/node-core-library",
+      "comment": "Add Sort.sortKeys for sorting keys in an object",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/node-core-library"
+}

--- a/common/changes/@rushstack/node-core-library/kenrick-fix-update-shrinkwrap-packageExtensions_2024-09-06-03-55.json
+++ b/common/changes/@rushstack/node-core-library/kenrick-fix-update-shrinkwrap-packageExtensions_2024-09-06-03-55.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@rushstack/node-core-library",
-      "comment": "Add Sort.sortKeys for sorting keys in an object",
+      "comment": "Add a `Sort.sortKeys` function for sorting keys in an object",
       "type": "minor"
     }
   ],

--- a/common/reviews/api/node-core-library.api.md
+++ b/common/reviews/api/node-core-library.api.md
@@ -831,6 +831,10 @@ export class Sort {
     static isSorted<T>(collection: Iterable<T>, comparer?: (x: any, y: any) => number): boolean;
     static isSortedBy<T>(collection: Iterable<T>, keySelector: (element: T) => any, comparer?: (x: any, y: any) => number): boolean;
     static sortBy<T>(array: T[], keySelector: (element: T) => any, comparer?: (x: any, y: any) => number): void;
+    static sortKeys<T extends Partial<Record<string, unknown>> | unknown[]>(object: T, { deep, compare }?: {
+        deep?: boolean;
+        compare?: (x: string, y: string) => number;
+    }): T;
     static sortMapKeys<K, V>(map: Map<K, V>, keyComparer?: (x: K, y: K) => number): void;
     static sortSet<T>(set: Set<T>, comparer?: (x: T, y: T) => number): void;
     static sortSetBy<T>(set: Set<T>, keySelector: (element: T) => any, keyComparer?: (x: T, y: T) => number): void;

--- a/common/reviews/api/node-core-library.api.md
+++ b/common/reviews/api/node-core-library.api.md
@@ -609,12 +609,6 @@ export interface IRunWithRetriesOptions<TResult> {
 }
 
 // @public
-export interface ISortKeysOptions {
-    compare?: (x: string, y: string) => number;
-    deep?: boolean;
-}
-
-// @public
 export interface IStringBuilder {
     append(text: string): void;
     toString(): string;
@@ -837,7 +831,7 @@ export class Sort {
     static isSorted<T>(collection: Iterable<T>, comparer?: (x: any, y: any) => number): boolean;
     static isSortedBy<T>(collection: Iterable<T>, keySelector: (element: T) => any, comparer?: (x: any, y: any) => number): boolean;
     static sortBy<T>(array: T[], keySelector: (element: T) => any, comparer?: (x: any, y: any) => number): void;
-    static sortKeys<T extends Partial<Record<string, unknown>> | unknown[]>(object: T, options?: ISortKeysOptions): T;
+    static sortKeys<T extends Partial<Record<string, unknown>> | unknown[]>(object: T): T;
     static sortMapKeys<K, V>(map: Map<K, V>, keyComparer?: (x: K, y: K) => number): void;
     static sortSet<T>(set: Set<T>, comparer?: (x: T, y: T) => number): void;
     static sortSetBy<T>(set: Set<T>, keySelector: (element: T) => any, keyComparer?: (x: T, y: T) => number): void;

--- a/common/reviews/api/node-core-library.api.md
+++ b/common/reviews/api/node-core-library.api.md
@@ -609,6 +609,12 @@ export interface IRunWithRetriesOptions<TResult> {
 }
 
 // @public
+export interface ISortKeysOptions {
+    compare?: (x: string, y: string) => number;
+    deep?: boolean;
+}
+
+// @public
 export interface IStringBuilder {
     append(text: string): void;
     toString(): string;
@@ -831,10 +837,7 @@ export class Sort {
     static isSorted<T>(collection: Iterable<T>, comparer?: (x: any, y: any) => number): boolean;
     static isSortedBy<T>(collection: Iterable<T>, keySelector: (element: T) => any, comparer?: (x: any, y: any) => number): boolean;
     static sortBy<T>(array: T[], keySelector: (element: T) => any, comparer?: (x: any, y: any) => number): void;
-    static sortKeys<T extends Partial<Record<string, unknown>> | unknown[]>(object: T, { deep, compare }?: {
-        deep?: boolean;
-        compare?: (x: string, y: string) => number;
-    }): T;
+    static sortKeys<T extends Partial<Record<string, unknown>> | unknown[]>(object: T, options?: ISortKeysOptions): T;
     static sortMapKeys<K, V>(map: Map<K, V>, keyComparer?: (x: K, y: K) => number): void;
     static sortSet<T>(set: Set<T>, comparer?: (x: T, y: T) => number): void;
     static sortSetBy<T>(set: Set<T>, keySelector: (element: T) => any, keyComparer?: (x: T, y: T) => number): void;

--- a/libraries/node-core-library/src/Sort.ts
+++ b/libraries/node-core-library/src/Sort.ts
@@ -12,6 +12,7 @@ export interface ISortKeysOptions {
    * @defaultValue false
    */
   deep?: boolean;
+
   /**
    * Custom compare function when sorting the keys
    *
@@ -297,6 +298,7 @@ export class Sort {
       : (innerSortKeys(object, context) as T);
   }
 }
+
 function isPlainObject(obj: unknown): obj is object {
   return obj !== null && typeof obj === 'object';
 }
@@ -309,22 +311,24 @@ function innerSortArray(arr: unknown[], context: ISortKeysContext): unknown[] {
   const result: unknown[] = [];
   context.cache.set(arr, result);
   if (context.options.deep) {
-    result.push(
-      ...arr.map((entry) => {
-        if (Array.isArray(entry)) {
-          return innerSortArray(entry, context);
-        } else if (isPlainObject(entry)) {
-          return innerSortKeys(entry, context);
-        }
-        return entry;
-      })
-    );
+    for (const entry of arr) {
+      if (Array.isArray(entry)) {
+        result.push(innerSortArray(entry, context));
+      } else if (isPlainObject(entry)) {
+        result.push(innerSortKeys(entry, context));
+      } else {
+        result.push(entry);
+      }
+    }
   } else {
-    result.push(...arr);
+    for (const entry of arr) {
+      result.push(entry);
+    }
   }
 
   return result;
 }
+
 function innerSortKeys(
   obj: Partial<Record<string, unknown>>,
   context: ISortKeysContext

--- a/libraries/node-core-library/src/index.ts
+++ b/libraries/node-core-library/src/index.ts
@@ -93,7 +93,7 @@ export {
   type IPathFormatConciselyOptions
 } from './Path';
 export { Encoding, Text, NewlineKind, type IReadLinesFromIterableOptions } from './Text';
-export { Sort, type ISortKeysOptions } from './Sort';
+export { Sort } from './Sort';
 export {
   AlreadyExistsBehavior,
   FileSystem,

--- a/libraries/node-core-library/src/index.ts
+++ b/libraries/node-core-library/src/index.ts
@@ -93,7 +93,7 @@ export {
   type IPathFormatConciselyOptions
 } from './Path';
 export { Encoding, Text, NewlineKind, type IReadLinesFromIterableOptions } from './Text';
-export { Sort } from './Sort';
+export { Sort, type ISortKeysOptions } from './Sort';
 export {
   AlreadyExistsBehavior,
   FileSystem,

--- a/libraries/node-core-library/src/test/Sort.test.ts
+++ b/libraries/node-core-library/src/test/Sort.test.ts
@@ -69,3 +69,182 @@ test('Sort.sortSet', () => {
   Sort.sortSet(set);
   expect(Array.from(set)).toEqual(['aardvark', 'goose', 'zebra']);
 });
+
+describe('Sort.sortKeys', () => {
+  // Test cases from https://github.com/sindresorhus/sort-keys/blob/v4.2.0/test.js
+  function deepEqualInOrder(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    actual: Partial<Record<string, any>>,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expected: Partial<Record<string, any>>
+  ): void {
+    expect(actual).toEqual(expected);
+
+    const seen = new Set();
+
+    function assertSameKeysInOrder(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      object1: Partial<Record<string, any>>,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      object2: Partial<Record<string, any>>
+    ): void {
+      // This function assumes the objects given are already deep equal.
+
+      if (seen.has(object1) && seen.has(object2)) {
+        return;
+      }
+
+      seen.add(object1);
+      seen.add(object2);
+
+      if (Array.isArray(object1)) {
+        for (const index of object1.keys()) {
+          assertSameKeysInOrder(object1[index], object2[index]);
+        }
+      } else if (typeof object1 === 'object') {
+        const keys1 = Object.keys(object1);
+        const keys2 = Object.keys(object2);
+        expect(keys1).toEqual(keys2);
+        for (const index of keys1.keys()) {
+          assertSameKeysInOrder(object1[keys1[index]], object2[keys2[index]]);
+        }
+      }
+    }
+
+    assertSameKeysInOrder(actual, expected);
+  }
+
+  test('sort the keys of an object', () => {
+    deepEqualInOrder(Sort.sortKeys({ c: 0, a: 0, b: 0 }), { a: 0, b: 0, c: 0 });
+  });
+
+  test('custom compare function', () => {
+    const compare: (a: string, b: string) => number = (a: string, b: string) => b.localeCompare(a);
+    deepEqualInOrder(Sort.sortKeys({ c: 0, a: 0, b: 0 }, { compare }), { c: 0, b: 0, a: 0 });
+  });
+
+  test('deep option', () => {
+    deepEqualInOrder(Sort.sortKeys({ c: { c: 0, a: 0, b: 0 }, a: 0, b: 0 }, { deep: true }), {
+      a: 0,
+      b: 0,
+      c: { a: 0, b: 0, c: 0 }
+    });
+
+    expect(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const object: Partial<Record<string, any>> = { a: 0 };
+      object.circular = object;
+      Sort.sortKeys(object, { deep: true });
+    }).not.toThrow();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const object: Partial<Record<string, any>> = { z: 0 };
+    object.circular = object;
+    const sortedObject = Sort.sortKeys(object, { deep: true });
+
+    expect(sortedObject).toBe(sortedObject.circular);
+    expect(Object.keys(sortedObject)).toEqual(['circular', 'z']);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const object1: Partial<Record<string, any>> = { b: 0 };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const object2: Partial<Record<string, any>> = { d: 0 };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const object3: Partial<Record<string, any>> = { a: [{ b: 0 }] };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const object4: Partial<Record<string, any>> = { a: [{ d: 0 }] };
+
+    object1.a = object2;
+    object2.c = object1;
+    object3.a[0].a = object4.a[0];
+    object4.a[0].c = object3.a[0];
+
+    expect(() => {
+      Sort.sortKeys(object1, { deep: true });
+      Sort.sortKeys(object2, { deep: true });
+      Sort.sortKeys(object3, { deep: true });
+      Sort.sortKeys(object4, { deep: true });
+    }).not.toThrow();
+
+    const sorted = Sort.sortKeys(object1, { deep: true });
+    const deepSorted = Sort.sortKeys(object3, { deep: true });
+
+    expect(sorted).toBe(sorted.a.c);
+    deepEqualInOrder(deepSorted.a[0], deepSorted.a[0].a.c);
+    expect(Object.keys(sorted)).toStrictEqual(['a', 'b']);
+    expect(Object.keys(deepSorted.a[0])).toStrictEqual(['a', 'b']);
+    deepEqualInOrder(
+      Sort.sortKeys({ c: { c: 0, a: 0, b: 0 }, a: 0, b: 0, z: [9, 8, 7, 6, 5] }, { deep: true }),
+      { a: 0, b: 0, c: { a: 0, b: 0, c: 0 }, z: [9, 8, 7, 6, 5] }
+    );
+    expect(Object.keys(Sort.sortKeys({ a: [{ b: 0, a: 0 }] }, { deep: true }).a[0])).toEqual(['a', 'b']);
+  });
+
+  test('deep arrays', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const object: Partial<Record<string, any>> = {
+      b: 0,
+      a: [{ b: 0, a: 0 }, [{ b: 0, a: 0 }]]
+    };
+    object.a.push(object);
+    object.a[1].push(object.a[1]);
+
+    expect(() => {
+      Sort.sortKeys(object, { deep: true });
+    }).not.toThrow();
+
+    const sorted = Sort.sortKeys(object, { deep: true });
+    // Cannot use .toBe() as Jest will encounter https://github.com/jestjs/jest/issues/10577
+    expect(sorted.a[2] === sorted).toBeTruthy();
+    expect(sorted.a[1][1] === sorted.a[1]).toBeTruthy();
+    expect(Object.keys(sorted)).toEqual(['a', 'b']);
+    expect(Object.keys(sorted.a[0])).toEqual(['a', 'b']);
+    expect(Object.keys(sorted.a[1][0])).toEqual(['a', 'b']);
+  });
+
+  test('top-level array', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const array: Array<any> = [
+      { b: 0, a: 0 },
+      { c: 0, d: 0 }
+    ];
+    const sorted = Sort.sortKeys(array);
+    expect(sorted).not.toBe(array);
+    expect(sorted[0]).toBe(array[0]);
+    expect(sorted[1]).toBe(array[1]);
+
+    const deepSorted = Sort.sortKeys(array, { deep: true });
+    expect(deepSorted).not.toBe(array);
+    expect(deepSorted[0]).not.toBe(array[0]);
+    expect(deepSorted[1]).not.toBe(array[1]);
+    expect(Object.keys(deepSorted[0])).toEqual(['a', 'b']);
+    expect(Object.keys(deepSorted[1])).toEqual(['c', 'd']);
+  });
+
+  test('keeps property descriptors intact', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const descriptors: Partial<Record<string, any>> = {
+      b: {
+        value: 1,
+        configurable: true,
+        enumerable: true,
+        writable: false
+      },
+      a: {
+        value: 2,
+        configurable: false,
+        enumerable: true,
+        writable: true
+      }
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const object: Partial<Record<string, any>> = {};
+    Object.defineProperties(object, descriptors);
+
+    const sorted = Sort.sortKeys(object);
+
+    deepEqualInOrder(sorted, { a: 2, b: 1 });
+    expect(Object.getOwnPropertyDescriptors(sorted)).toEqual(descriptors);
+  });
+});

--- a/libraries/node-core-library/src/test/Sort.test.ts
+++ b/libraries/node-core-library/src/test/Sort.test.ts
@@ -71,170 +71,48 @@ test('Sort.sortSet', () => {
 });
 
 describe('Sort.sortKeys', () => {
-  // Test cases from https://github.com/sindresorhus/sort-keys/blob/v4.2.0/test.js
-  function deepEqualInOrder(
-    actual: Partial<Record<string, unknown>>,
-    expected: Partial<Record<string, unknown>>
-  ): void {
-    expect(actual).toEqual(expected);
-
-    const seen: Set<unknown> = new Set();
-
-    function assertSameKeysInOrder(object1: unknown, object2: unknown): void {
-      // This function assumes the objects given are already deep equal.
-
-      if (seen.has(object1) && seen.has(object2)) {
-        return;
-      }
-
-      seen.add(object1);
-      seen.add(object2);
-
-      if (Array.isArray(object1) && Array.isArray(object2)) {
-        for (const index of object1.keys()) {
-          assertSameKeysInOrder(object1[index], object2[index]);
-        }
-      } else if (
-        typeof object1 === 'object' &&
-        typeof object2 === 'object' &&
-        object1 != null &&
-        object2 != null
-      ) {
-        const keys1 = Object.keys(object1);
-        const keys2 = Object.keys(object2);
-        expect(keys1).toEqual(keys2);
-        for (const index of keys1.keys()) {
-          assertSameKeysInOrder(
-            (object1 as Partial<Record<string, unknown>>)[keys1[index]],
-            (object2 as Partial<Record<string, unknown>>)[keys2[index]]
-          );
-        }
-      }
-    }
-
-    assertSameKeysInOrder(actual, expected);
-  }
-
-  test('sort the keys of an object', () => {
-    const unsortedObj = { c: 0, a: 0, b: 0 };
+  test('Simple object', () => {
+    const unsortedObj = { q: 0, p: 0, r: 0 };
     const sortedObj = Sort.sortKeys(unsortedObj);
+
     // Assert that it's not sorted in-place
     expect(sortedObj).not.toBe(unsortedObj);
-    deepEqualInOrder(unsortedObj, { c: 0, a: 0, b: 0 });
-    deepEqualInOrder(sortedObj, { a: 0, b: 0, c: 0 });
+
+    expect(Object.keys(unsortedObj)).toEqual(['q', 'p', 'r']);
+    expect(Object.keys(sortedObj)).toEqual(['p', 'q', 'r']);
   });
-
-  test('custom compare function', () => {
-    const compare: (a: string, b: string) => number = (a: string, b: string) => b.localeCompare(a);
-    deepEqualInOrder(Sort.sortKeys({ c: 0, a: 0, b: 0 }, { compare }), { c: 0, b: 0, a: 0 });
-  });
-
-  test('deep option', () => {
-    deepEqualInOrder(Sort.sortKeys({ c: { c: 0, a: 0, b: 0 }, a: 0, b: 0 }, { deep: true }), {
-      a: 0,
-      b: 0,
-      c: { a: 0, b: 0, c: 0 }
-    });
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const object: Partial<Record<string, any>> = { z: 0 };
-    object.circular = object;
-    const sortedObject = Sort.sortKeys(object, { deep: true });
+  test('Simple array with objects', () => {
+    const unsortedArr = [
+      { b: 1, a: 0 },
+      { y: 0, z: 1, x: 2 }
+    ];
+    const sortedArr = Sort.sortKeys(unsortedArr);
 
     // Assert that it's not sorted in-place
-    expect(sortedObject).not.toBe(object);
-    expect(Object.keys(object)).toEqual(['z', 'circular']);
+    expect(sortedArr).not.toBe(unsortedArr);
 
-    // Assert that circular value references the same thing
-    expect(sortedObject).toBe(sortedObject.circular);
-    expect(Object.keys(sortedObject)).toEqual(['circular', 'z']);
+    expect(Object.keys(unsortedArr[0])).toEqual(['b', 'a']);
+    expect(Object.keys(sortedArr[0])).toEqual(['a', 'b']);
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const object1: Partial<Record<string, any>> = { b: 0 };
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const object2: Partial<Record<string, any>> = { d: 0 };
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const object3: Partial<Record<string, any>> = { a: [{ b: 0 }] };
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const object4: Partial<Record<string, any>> = { a: [{ d: 0 }] };
-
-    object1.a = object2;
-    object2.c = object1;
-    object3.a[0].a = object4.a[0];
-    object4.a[0].c = object3.a[0];
-
-    const sortedObject1 = Sort.sortKeys(object1, { deep: true });
-    const sortedObject3 = Sort.sortKeys(object3, { deep: true });
-
-    expect(sortedObject1).toBe(sortedObject1.a.c);
-    deepEqualInOrder(sortedObject3.a[0], sortedObject3.a[0].a.c);
-    expect(Object.keys(sortedObject1)).toStrictEqual(['a', 'b']);
-    expect(Object.keys(sortedObject3.a[0])).toStrictEqual(['a', 'b']);
-    deepEqualInOrder(
-      Sort.sortKeys({ c: { c: 0, a: 0, b: 0 }, a: 0, b: 0, z: [9, 8, 7, 6, 5] }, { deep: true }),
-      { a: 0, b: 0, c: { a: 0, b: 0, c: 0 }, z: [9, 8, 7, 6, 5] }
-    );
-    expect(Object.keys(Sort.sortKeys({ a: [{ b: 0, a: 0 }] }, { deep: true }).a[0])).toEqual(['a', 'b']);
+    expect(Object.keys(unsortedArr[1])).toEqual(['y', 'z', 'x']);
+    expect(Object.keys(sortedArr[1])).toEqual(['x', 'y', 'z']);
   });
+  test('Nested objects', () => {
+    const unsortedDeepObj = { c: { q: 0, r: { a: 42 }, p: 2 }, b: { y: 0, z: 1, x: 2 }, a: 2 };
+    const sortedDeepObj = Sort.sortKeys(unsortedDeepObj);
 
-  test('deep arrays', () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const object: Partial<Record<string, any>> = {
-      b: 0,
-      a: [{ b: 0, a: 0 }, [{ b: 0, a: 0 }]]
-    };
-    object.a.push(object);
-    object.a[1].push(object.a[1]);
+    expect(sortedDeepObj).not.toBe(unsortedDeepObj);
 
-    const sorted = Sort.sortKeys(object, { deep: true });
-    // Cannot use .toBe() as Jest will encounter https://github.com/jestjs/jest/issues/10577
-    expect(sorted.a[2] === sorted).toBeTruthy();
-    expect(sorted.a[1][1] === sorted.a[1]).toBeTruthy();
-    expect(Object.keys(sorted)).toEqual(['a', 'b']);
-    expect(Object.keys(sorted.a[0])).toEqual(['a', 'b']);
-    expect(Object.keys(sorted.a[1][0])).toEqual(['a', 'b']);
-  });
+    expect(Object.keys(unsortedDeepObj)).toEqual(['c', 'b', 'a']);
+    expect(Object.keys(sortedDeepObj)).toEqual(['a', 'b', 'c']);
 
-  test('top-level array', () => {
-    const array: Array<Partial<Record<string, number>>> = [
-      { b: 0, a: 0 },
-      { c: 0, d: 0 }
-    ];
-    const sorted = Sort.sortKeys(array);
-    expect(sorted).not.toBe(array);
-    expect(sorted[0]).toBe(array[0]);
-    expect(sorted[1]).toBe(array[1]);
+    expect(Object.keys(unsortedDeepObj.b)).toEqual(['y', 'z', 'x']);
+    expect(Object.keys(sortedDeepObj.b)).toEqual(['x', 'y', 'z']);
 
-    const deepSorted = Sort.sortKeys(array, { deep: true });
-    expect(deepSorted).not.toBe(array);
-    expect(deepSorted[0]).not.toBe(array[0]);
-    expect(deepSorted[1]).not.toBe(array[1]);
-    expect(Object.keys(deepSorted[0])).toEqual(['a', 'b']);
-    expect(Object.keys(deepSorted[1])).toEqual(['c', 'd']);
-  });
+    expect(Object.keys(unsortedDeepObj.c)).toEqual(['q', 'r', 'p']);
+    expect(Object.keys(sortedDeepObj.c)).toEqual(['p', 'q', 'r']);
 
-  test('keeps property descriptors intact', () => {
-    const descriptors: PropertyDescriptorMap = {
-      b: {
-        value: 1,
-        configurable: true,
-        enumerable: true,
-        writable: false
-      },
-      a: {
-        value: 2,
-        configurable: false,
-        enumerable: true,
-        writable: true
-      }
-    };
-
-    const object: Partial<Record<string, unknown>> = {};
-    Object.defineProperties(object, descriptors);
-
-    const sorted = Sort.sortKeys(object);
-
-    deepEqualInOrder(sorted, { a: 2, b: 1 });
-    expect(Object.getOwnPropertyDescriptors(sorted)).toEqual(descriptors);
+    expect(Object.keys(unsortedDeepObj.c.r)).toEqual(['a']);
+    expect(Object.keys(sortedDeepObj.c.r)).toEqual(['a']);
   });
 });

--- a/libraries/node-core-library/src/test/Sort.test.ts
+++ b/libraries/node-core-library/src/test/Sort.test.ts
@@ -115,7 +115,12 @@ describe('Sort.sortKeys', () => {
   }
 
   test('sort the keys of an object', () => {
-    deepEqualInOrder(Sort.sortKeys({ c: 0, a: 0, b: 0 }), { a: 0, b: 0, c: 0 });
+    const unsortedObj = { c: 0, a: 0, b: 0 };
+    const sortedObj = Sort.sortKeys(unsortedObj);
+    // Assert that it's not sorted in-place
+    expect(sortedObj).not.toBe(unsortedObj);
+    deepEqualInOrder(unsortedObj, { c: 0, a: 0, b: 0 });
+    deepEqualInOrder(sortedObj, { a: 0, b: 0, c: 0 });
   });
 
   test('custom compare function', () => {
@@ -142,6 +147,11 @@ describe('Sort.sortKeys', () => {
     object.circular = object;
     const sortedObject = Sort.sortKeys(object, { deep: true });
 
+    // Assert that it's not sorted in-place
+    expect(sortedObject).not.toBe(object);
+    expect(Object.keys(object)).toEqual(['z', 'circular']);
+
+    // Assert that circular value references the same thing
     expect(sortedObject).toBe(sortedObject.circular);
     expect(Object.keys(sortedObject)).toEqual(['circular', 'z']);
 

--- a/libraries/node-core-library/src/test/Sort.test.ts
+++ b/libraries/node-core-library/src/test/Sort.test.ts
@@ -73,21 +73,14 @@ test('Sort.sortSet', () => {
 describe('Sort.sortKeys', () => {
   // Test cases from https://github.com/sindresorhus/sort-keys/blob/v4.2.0/test.js
   function deepEqualInOrder(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    actual: Partial<Record<string, any>>,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    expected: Partial<Record<string, any>>
+    actual: Partial<Record<string, unknown>>,
+    expected: Partial<Record<string, unknown>>
   ): void {
     expect(actual).toEqual(expected);
 
-    const seen = new Set();
+    const seen: Set<unknown> = new Set();
 
-    function assertSameKeysInOrder(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      object1: Partial<Record<string, any>>,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      object2: Partial<Record<string, any>>
-    ): void {
+    function assertSameKeysInOrder(object1: unknown, object2: unknown): void {
       // This function assumes the objects given are already deep equal.
 
       if (seen.has(object1) && seen.has(object2)) {
@@ -97,16 +90,24 @@ describe('Sort.sortKeys', () => {
       seen.add(object1);
       seen.add(object2);
 
-      if (Array.isArray(object1)) {
+      if (Array.isArray(object1) && Array.isArray(object2)) {
         for (const index of object1.keys()) {
           assertSameKeysInOrder(object1[index], object2[index]);
         }
-      } else if (typeof object1 === 'object') {
+      } else if (
+        typeof object1 === 'object' &&
+        typeof object2 === 'object' &&
+        object1 != null &&
+        object2 != null
+      ) {
         const keys1 = Object.keys(object1);
         const keys2 = Object.keys(object2);
         expect(keys1).toEqual(keys2);
         for (const index of keys1.keys()) {
-          assertSameKeysInOrder(object1[keys1[index]], object2[keys2[index]]);
+          assertSameKeysInOrder(
+            (object1 as Partial<Record<string, unknown>>)[keys1[index]],
+            (object2 as Partial<Record<string, unknown>>)[keys2[index]]
+          );
         }
       }
     }
@@ -135,13 +136,6 @@ describe('Sort.sortKeys', () => {
       c: { a: 0, b: 0, c: 0 }
     });
 
-    expect(() => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const object: Partial<Record<string, any>> = { a: 0 };
-      object.circular = object;
-      Sort.sortKeys(object, { deep: true });
-    }).not.toThrow();
-
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const object: Partial<Record<string, any>> = { z: 0 };
     object.circular = object;
@@ -169,20 +163,13 @@ describe('Sort.sortKeys', () => {
     object3.a[0].a = object4.a[0];
     object4.a[0].c = object3.a[0];
 
-    expect(() => {
-      Sort.sortKeys(object1, { deep: true });
-      Sort.sortKeys(object2, { deep: true });
-      Sort.sortKeys(object3, { deep: true });
-      Sort.sortKeys(object4, { deep: true });
-    }).not.toThrow();
+    const sortedObject1 = Sort.sortKeys(object1, { deep: true });
+    const sortedObject3 = Sort.sortKeys(object3, { deep: true });
 
-    const sorted = Sort.sortKeys(object1, { deep: true });
-    const deepSorted = Sort.sortKeys(object3, { deep: true });
-
-    expect(sorted).toBe(sorted.a.c);
-    deepEqualInOrder(deepSorted.a[0], deepSorted.a[0].a.c);
-    expect(Object.keys(sorted)).toStrictEqual(['a', 'b']);
-    expect(Object.keys(deepSorted.a[0])).toStrictEqual(['a', 'b']);
+    expect(sortedObject1).toBe(sortedObject1.a.c);
+    deepEqualInOrder(sortedObject3.a[0], sortedObject3.a[0].a.c);
+    expect(Object.keys(sortedObject1)).toStrictEqual(['a', 'b']);
+    expect(Object.keys(sortedObject3.a[0])).toStrictEqual(['a', 'b']);
     deepEqualInOrder(
       Sort.sortKeys({ c: { c: 0, a: 0, b: 0 }, a: 0, b: 0, z: [9, 8, 7, 6, 5] }, { deep: true }),
       { a: 0, b: 0, c: { a: 0, b: 0, c: 0 }, z: [9, 8, 7, 6, 5] }
@@ -199,10 +186,6 @@ describe('Sort.sortKeys', () => {
     object.a.push(object);
     object.a[1].push(object.a[1]);
 
-    expect(() => {
-      Sort.sortKeys(object, { deep: true });
-    }).not.toThrow();
-
     const sorted = Sort.sortKeys(object, { deep: true });
     // Cannot use .toBe() as Jest will encounter https://github.com/jestjs/jest/issues/10577
     expect(sorted.a[2] === sorted).toBeTruthy();
@@ -213,8 +196,7 @@ describe('Sort.sortKeys', () => {
   });
 
   test('top-level array', () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const array: Array<any> = [
+    const array: Array<Partial<Record<string, number>>> = [
       { b: 0, a: 0 },
       { c: 0, d: 0 }
     ];
@@ -232,8 +214,7 @@ describe('Sort.sortKeys', () => {
   });
 
   test('keeps property descriptors intact', () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const descriptors: Partial<Record<string, any>> = {
+    const descriptors: PropertyDescriptorMap = {
       b: {
         value: 1,
         configurable: true,
@@ -248,8 +229,7 @@ describe('Sort.sortKeys', () => {
       }
     };
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const object: Partial<Record<string, any>> = {};
+    const object: Partial<Record<string, unknown>> = {};
     Object.defineProperties(object, descriptors);
 
     const sorted = Sort.sortKeys(object);

--- a/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
+++ b/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
@@ -10,8 +10,10 @@ import {
   AlreadyReportedError,
   Async,
   type IDependenciesMetaTable,
-  Path
+  Path,
+  Sort
 } from '@rushstack/node-core-library';
+import { createHash } from 'crypto';
 
 import { BaseInstallManager } from '../base/BaseInstallManager';
 import type { IInstallManagerOptions } from '../base/BaseInstallManagerTypes';
@@ -378,6 +380,18 @@ export class WorkspaceInstallManager extends BaseInstallManager {
       shrinkwrapIsUpToDate = false;
     }
 
+    // Check if packageExtensionsChecksum matches globalPackageExtension's hash
+    const packageExtensionsChecksum: string | undefined = this._getPackageExtensionChecksum(
+      this.rushConfiguration.pnpmOptions.globalPackageExtensions
+    );
+    const packageExtensionsChecksumAreEqual: boolean =
+      packageExtensionsChecksum === shrinkwrapFile?.packageExtensionsChecksum;
+
+    if (!packageExtensionsChecksumAreEqual) {
+      shrinkwrapWarnings.push("The package extension hash doesn't match the current shrinkwrap.");
+      shrinkwrapIsUpToDate = false;
+    }
+
     // Write the common package.json
     InstallHelpers.generateCommonPackageJson(this.rushConfiguration, subspace, undefined);
 
@@ -386,6 +400,22 @@ export class WorkspaceInstallManager extends BaseInstallManager {
     workspaceFile.save(workspaceFile.workspaceFilename, { onlyIfChanged: true });
 
     return { shrinkwrapIsUpToDate, shrinkwrapWarnings };
+  }
+
+  private _getPackageExtensionChecksum(
+    packageExtensions: Record<string, unknown> | undefined
+  ): string | undefined {
+    const packageExtensionsChecksum: string | undefined =
+      Object.keys(packageExtensions ?? {}).length === 0
+        ? undefined
+        : createObjectChecksum(packageExtensions!);
+
+    function createObjectChecksum(obj: Record<string, unknown>): string {
+      const s: string = JSON.stringify(Sort.sortKeys(obj, { deep: true }));
+      return createHash('md5').update(s).digest('hex');
+    }
+
+    return packageExtensionsChecksum;
   }
 
   protected canSkipInstall(lastModifiedDate: Date, subspace: Subspace): boolean {

--- a/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
+++ b/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
@@ -405,15 +405,11 @@ export class WorkspaceInstallManager extends BaseInstallManager {
   private _getPackageExtensionChecksum(
     packageExtensions: Record<string, unknown> | undefined
   ): string | undefined {
+    // https://github.com/pnpm/pnpm/blob/ba9409ffcef0c36dc1b167d770a023c87444822d/pkg-manager/core/src/install/index.ts#L331
     const packageExtensionsChecksum: string | undefined =
       Object.keys(packageExtensions ?? {}).length === 0
         ? undefined
         : createObjectChecksum(packageExtensions!);
-
-    function createObjectChecksum(obj: Record<string, unknown>): string {
-      const s: string = JSON.stringify(Sort.sortKeys(obj, { deep: true }));
-      return createHash('md5').update(s).digest('hex');
-    }
 
     return packageExtensionsChecksum;
   }
@@ -773,4 +769,14 @@ export class WorkspaceInstallManager extends BaseInstallManager {
       }
     }
   }
+}
+
+/**
+ * Source: https://github.com/pnpm/pnpm/blob/ba9409ffcef0c36dc1b167d770a023c87444822d/pkg-manager/core/src/install/index.ts#L821-L824
+ * @param obj
+ * @returns
+ */
+function createObjectChecksum(obj: Record<string, unknown>): string {
+  const s: string = JSON.stringify(Sort.sortKeys(obj, { deep: true }));
+  return createHash('md5').update(s).digest('hex');
 }

--- a/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
+++ b/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
@@ -777,6 +777,6 @@ export class WorkspaceInstallManager extends BaseInstallManager {
  * @returns
  */
 function createObjectChecksum(obj: Record<string, unknown>): string {
-  const s: string = JSON.stringify(Sort.sortKeys(obj, { deep: true }));
+  const s: string = JSON.stringify(Sort.sortKeys(obj));
   return createHash('md5').update(s).digest('hex');
 }

--- a/libraries/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
+++ b/libraries/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
@@ -148,6 +148,8 @@ export interface IPnpmShrinkwrapYaml {
   specifiers: Record<string, string>;
   /** The list of override version number for dependencies */
   overrides?: { [dependency: string]: string };
+  /** The checksum of package extensions fields for extending dependencies */
+  packageExtensionsChecksum?: string;
 }
 
 export interface ILoadFromFileOptions {
@@ -275,6 +277,7 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
   public readonly specifiers: ReadonlyMap<string, string>;
   public readonly packages: ReadonlyMap<string, IPnpmShrinkwrapDependencyYaml>;
   public readonly overrides: ReadonlyMap<string, string>;
+  public readonly packageExtensionsChecksum: undefined | string;
 
   private readonly _shrinkwrapJson: IPnpmShrinkwrapYaml;
   private readonly _integrities: Map<string, Map<string, string>>;
@@ -304,6 +307,7 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
     this.specifiers = new Map(Object.entries(shrinkwrapJson.specifiers || {}));
     this.packages = new Map(Object.entries(shrinkwrapJson.packages || {}));
     this.overrides = new Map(Object.entries(shrinkwrapJson.overrides || {}));
+    this.packageExtensionsChecksum = shrinkwrapJson.packageExtensionsChecksum;
 
     // Importers only exist in workspaces
     this.isWorkspaceCompatible = this.importers.size > 0;


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

Fixes #4901

## Details

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

Add one more condition in WorkspaceInstallManager to compare the values of:

- pnpm-config.json's `globalPackageExtensions` checksum
- shrinkwrap's `packageExtensionsChecksum`

To calculate the checksum, I added the same implementation as per what's used in pnpm ([ref](https://github.com/pnpm/pnpm/blob/ba9409ffcef0c36dc1b167d770a023c87444822d/pkg-manager/core/src/install/index.ts#L821-L824)). The code snippet used in pnpm is as such:

```ts
const packageExtensionsChecksum = isEmpty(opts.packageExtensions ?? {}) ? undefined : createObjectChecksum(opts.packageExtensions!)


export function createObjectChecksum (obj: Record<string, unknown>) {
  const s = JSON.stringify(sortKeys(obj, { deep: true }))
  return crypto.createHash('md5').update(s).digest('hex')
}
```

Since it depends on `sortKeys` (which pnpm uses [sort-keys@4.2.0](https://github.com/sindresorhus/sort-keys/tree/v4.2.0) npm package), I asked in [zulip](https://rushstack.zulipchat.com/#narrow/stream/279883-contributor-helpline/topic/Adding.20external.20dependencies.20or.20vendoring.20them.3F) if it's okay to add a new external dependency or not. The reply I received is to implement it in `node-core-library`, so I added: `Sort.sortKeys` with the tests imported and modified from [sort-keys@4.2.0](https://github.com/sindresorhus/sort-keys/blob/v4.2.0/test.js). 


## How it was tested

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->


1. Run `testrush update` in a Rush repo
2. Change `globalPackageExtensions`
3. Run `testrush update` and expect that it updates the lockfile

```
> testrush update

Rush Multi-Project Build Tool 5.133.3 (unmanaged) - https://rushjs.io
Node.js version is 18.20.4 (LTS)


Starting "rush update"

Checking Git policy for this repository.


Found files in the "common/git-hooks" folder.
Successfully installed these Git hook scripts: commit-msg, owners.json, post-checkout, pre-commit, pre-push

Trying to acquire lock for pnpm-8.15.8
Acquired lock for pnpm-8.15.8
Found pnpm version 8.15.8 in /path/to/user/.rush/node-v18.20.4/pnpm-8.15.8

Symlinking "/path/to/repo/common/temp/pnpm-local"
  --> "/path/to/user/.rush/node-v18.20.4/pnpm-8.15.8"
Transforming /path/to/repo/common/config/rush/.npmrc
  --> "/path/to/repo/common/temp/.npmrc"

Updating workspace files in /path/to/repo/common/temp
Copying "/path/to/repo/common/config/rush/pnpm-lock.yaml"
  --> "/path/to/repo/common/temp/pnpm-lock.yaml"
Copying "/path/to/repo/common/config/rush/pnpm-lock.yaml"
  --> "/path/to/repo/common/temp/pnpm-lock-preinstall.yaml"

The shrinkwrap file (pnpm-lock.yaml) contains the following issues:
  The package extension hash doesn't match the current shrinkwrap.


Checking installation in "/path/to/repo/common/temp"

Running "pnpm install" in /path/to/repo/common/temp
```

## Impacted documentation

<!--------------------------------------------------------------------------
👉 STEP 7: Does your PR affect anything that is discussed in the website docs?
     If so, please paste the URL of each affected web page, so we will
     remember to update the documentation after your PR is merged.
     (Updating the website is appreciated but not required.)
     If no docs are impacted, delete the "Impacted documentation" section.

     If you modified a JSON schema, remember to update init templates such as:
     rush-lib/assets/rush-init/*.json
     api-extractor/src/schemas/api-extractor-template.json
--------------------------------------------------------------------------->

Updated the JSON schema of `node-core-library`

<!--------------------------------------------------------------------------
👉 STEP 8: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
