### PR TITLE
[rush] Expose AzureAuthenticationBase._credentialCacheId.

### DIFF
--- a/common/changes/@microsoft/rush/expose_credentialCacheId_2024-09-06-23-00.json
+++ b/common/changes/@microsoft/rush/expose_credentialCacheId_2024-09-06-23-00.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Mark `AzureAuthenticationBase._credentialCacheId` as protected in `@rushstack/rush-azure-storage-build-cache-plugin`.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/reviews/api/rush-azure-storage-build-cache-plugin.api.md
+++ b/common/reviews/api/rush-azure-storage-build-cache-plugin.api.md
@@ -24,6 +24,8 @@ export abstract class AzureAuthenticationBase {
     // (undocumented)
     protected readonly _azureEnvironment: AzureEnvironmentName;
     // (undocumented)
+    protected get _credentialCacheId(): string;
+    // (undocumented)
     protected abstract readonly _credentialKindForLogging: string;
     // (undocumented)
     protected abstract readonly _credentialNameForCache: string;

--- a/rush-plugins/rush-azure-storage-build-cache-plugin/src/AzureAuthenticationBase.ts
+++ b/rush-plugins/rush-azure-storage-build-cache-plugin/src/AzureAuthenticationBase.ts
@@ -131,7 +131,7 @@ export abstract class AzureAuthenticationBase {
   protected readonly _failoverOrder: Record<LoginFlowType, LoginFlowType | undefined>;
 
   private __credentialCacheId: string | undefined;
-  private get _credentialCacheId(): string {
+  protected get _credentialCacheId(): string {
     if (!this.__credentialCacheId) {
       const cacheIdParts: string[] = [
         this._credentialNameForCache,


### PR DESCRIPTION
## Summary

Marks `AzureAuthenticationBase._credentialCacheId` as protected to allow subclasses to read it.

## How it was tested

N/A

## Impacted documentation

None.