### PR TITLE
Add custom formats to JsonSchema

### DIFF
--- a/common/changes/@rushstack/node-core-library/rf-jsonschema-add-custom-formats_2024-09-10-03-15.json
+++ b/common/changes/@rushstack/node-core-library/rf-jsonschema-add-custom-formats_2024-09-10-03-15.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/node-core-library",
+      "comment": "Add a `customFormats` option to `JsonSchema`.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/node-core-library"
+}

--- a/common/reviews/api/node-core-library.api.md
+++ b/common/reviews/api/node-core-library.api.md
@@ -424,6 +424,12 @@ export interface IJsonFileStringifyOptions extends IJsonFileParseOptions {
 }
 
 // @public
+export interface IJsonSchemaCustomFormat<T extends string | number> {
+    type: T extends string ? "string" : T extends number ? "number" : never;
+    validate: (data: T) => boolean;
+}
+
+// @public
 export interface IJsonSchemaErrorInfo {
     details: string;
 }
@@ -436,6 +442,7 @@ export type IJsonSchemaFromObjectOptions = IJsonSchemaLoadOptions;
 
 // @public
 export interface IJsonSchemaLoadOptions {
+    customFormats?: Record<string, IJsonSchemaCustomFormat<string> | IJsonSchemaCustomFormat<number>>;
     dependentSchemas?: JsonSchema[];
     schemaVersion?: JsonSchemaVersion;
 }

--- a/common/reviews/api/node-core-library.api.md
+++ b/common/reviews/api/node-core-library.api.md
@@ -425,7 +425,7 @@ export interface IJsonFileStringifyOptions extends IJsonFileParseOptions {
 
 // @public
 export interface IJsonSchemaCustomFormat<T extends string | number> {
-    type: T extends string ? "string" : T extends number ? "number" : never;
+    type: T extends string ? 'string' : T extends number ? 'number' : never;
     validate: (data: T) => boolean;
 }
 

--- a/libraries/node-core-library/src/JsonSchema.ts
+++ b/libraries/node-core-library/src/JsonSchema.ts
@@ -26,6 +26,23 @@ interface ISchemaWithId {
 export type JsonSchemaVersion = 'draft-04' | 'draft-07';
 
 /**
+ * A definition for a custom format to consider during validation.
+ * @public
+ */
+export interface IJsonSchemaCustomFormat<T extends string | number> {
+  /**
+   * The base JSON type.
+   */
+  type: T extends string ? 'string' : T extends number ? 'number' : never;
+  /**
+   * A validation function for the format.
+   * @param data - The raw field data to validate.
+   * @returns whether the data is valid according to the format.
+   */
+  validate: (data: T) => boolean;
+}
+
+/**
  * Callback function arguments for {@link JsonSchema.validateObjectWithCallback}
  * @public
  */
@@ -94,6 +111,11 @@ export interface IJsonSchemaLoadOptions {
    * or does not match an expected URL, the default version will be used.
    */
   schemaVersion?: JsonSchemaVersion;
+
+  /**
+   * Any custom formats to consider during validation.
+   */
+  customFormats?: Record<string, IJsonSchemaCustomFormat<string> | IJsonSchemaCustomFormat<number>>;
 }
 
 /**
@@ -141,6 +163,9 @@ export class JsonSchema {
   private _validator: ValidateFunction | undefined = undefined;
   private _schemaObject: JsonObject | undefined = undefined;
   private _schemaVersion: JsonSchemaVersion | undefined = undefined;
+  private _customFormats:
+    | Record<string, IJsonSchemaCustomFormat<string> | IJsonSchemaCustomFormat<number>>
+    | undefined = undefined;
 
   private constructor() {}
 
@@ -163,6 +188,7 @@ export class JsonSchema {
     if (options) {
       schema._dependentSchemas = options.dependentSchemas || [];
       schema._schemaVersion = options.schemaVersion;
+      schema._customFormats = options.customFormats;
     }
 
     return schema;
@@ -181,6 +207,7 @@ export class JsonSchema {
     if (options) {
       schema._dependentSchemas = options.dependentSchemas || [];
       schema._schemaVersion = options.schemaVersion;
+      schema._customFormats = options.customFormats;
     }
 
     return schema;
@@ -308,6 +335,11 @@ export class JsonSchema {
       // Enable json-schema format validation
       // https://ajv.js.org/packages/ajv-formats.html
       addFormats(validator);
+      if (this._customFormats) {
+        Object.entries(this._customFormats).forEach(([name, format]) => {
+          validator.addFormat(name, { ...format, async: false });
+        });
+      }
 
       const collectedSchemas: JsonSchema[] = [];
       const seenObjects: Set<JsonSchema> = new Set<JsonSchema>();

--- a/libraries/node-core-library/src/JsonSchema.ts
+++ b/libraries/node-core-library/src/JsonSchema.ts
@@ -114,7 +114,9 @@ export interface IJsonSchemaLoadOptions {
   schemaVersion?: JsonSchemaVersion;
 
   /**
-   * Any custom formats to consider during validation.
+   * Any custom formats to consider during validation. Some standard formats are supported
+   * out-of-the-box (e.g. emails, uris), but additional formats can be defined here. You could
+   * for example define generic numeric formats (e.g. uint8) or domain-specific formats.
    */
   customFormats?: Record<string, IJsonSchemaCustomFormat<string> | IJsonSchemaCustomFormat<number>>;
 }
@@ -339,7 +341,7 @@ export class JsonSchema {
       if (this._customFormats) {
         for (const [name, format] of Object.entries(this._customFormats)) {
           validator.addFormat(name, { ...format, async: false });
-        });
+        }
       }
 
       const collectedSchemas: JsonSchema[] = [];

--- a/libraries/node-core-library/src/JsonSchema.ts
+++ b/libraries/node-core-library/src/JsonSchema.ts
@@ -34,6 +34,7 @@ export interface IJsonSchemaCustomFormat<T extends string | number> {
    * The base JSON type.
    */
   type: T extends string ? 'string' : T extends number ? 'number' : never;
+
   /**
    * A validation function for the format.
    * @param data - The raw field data to validate.

--- a/libraries/node-core-library/src/JsonSchema.ts
+++ b/libraries/node-core-library/src/JsonSchema.ts
@@ -336,7 +336,7 @@ export class JsonSchema {
       // https://ajv.js.org/packages/ajv-formats.html
       addFormats(validator);
       if (this._customFormats) {
-        Object.entries(this._customFormats).forEach(([name, format]) => {
+        for (const [name, format] of Object.entries(this._customFormats)) {
           validator.addFormat(name, { ...format, async: false });
         });
       }

--- a/libraries/node-core-library/src/index.ts
+++ b/libraries/node-core-library/src/index.ts
@@ -65,6 +65,7 @@ export {
 } from './JsonFile';
 export {
   type IJsonSchemaErrorInfo,
+  type IJsonSchemaCustomFormat,
   type IJsonSchemaFromFileOptions,
   type IJsonSchemaFromObjectOptions,
   type IJsonSchemaLoadOptions,

--- a/libraries/node-core-library/src/test/JsonSchema.test.ts
+++ b/libraries/node-core-library/src/test/JsonSchema.test.ts
@@ -119,4 +119,32 @@ describe(JsonSchema.name, () => {
       expect(errorDetails).toMatchSnapshot();
     });
   });
+
+  test('successfully applies custom formats', () => {
+    const schemaWithCustomFormat = JsonSchema.fromLoadedObject(
+      {
+        title: 'Test Custom Format',
+        type: 'object',
+        properties: {
+          exampleNumber: {
+            type: 'number',
+            format: 'uint8'
+          }
+        },
+        additionalProperties: false,
+        required: ['exampleNumber']
+      },
+      {
+        schemaVersion: 'draft-07',
+        customFormats: {
+          uint8: {
+            type: 'number',
+            validate: (data) => data >= 0 && data <= 255
+          }
+        }
+      }
+    );
+    expect(() => schemaWithCustomFormat.validateObject({ exampleNumber: 10 }, '')).not.toThrow();
+    expect(() => schemaWithCustomFormat.validateObject({ exampleNumber: 1000 }, '')).toThrow();
+  });
 });


### PR DESCRIPTION
Was putting up a [PR to Relay](https://github.com/facebook/relay/pull/4780) to load configuration files and was running into issues using `JsonSchema` because Relay's configuration JSON schema has formats like `uint8` coming from [schemars](https://github.com/GREsau/schemars).  Rather than dropping down to raw AJV was just hoping to expose some minimal/reasonable API surface here to support validating custom formats