### PR TITLE
[package-extractor] Allow for a custom link creation script path to be used for the create-links.js file

### DIFF
--- a/common/changes/@rushstack/package-extractor/user-danade-CustomLinkCreationScriptPath_2024-09-10-23-52.json
+++ b/common/changes/@rushstack/package-extractor/user-danade-CustomLinkCreationScriptPath_2024-09-10-23-52.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/package-extractor",
+      "comment": "Add the ability to change where the \"create-links.js\" file and the associated metadata file are generated when running in the \"script\" linkCreation mode",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/package-extractor"
+}

--- a/common/reviews/api/package-extractor.api.md
+++ b/common/reviews/api/package-extractor.api.md
@@ -31,6 +31,7 @@ export interface IExtractorOptions {
     includeDevDependencies?: boolean;
     includeNpmIgnoreFiles?: boolean;
     linkCreation?: 'default' | 'script' | 'none';
+    linkCreationScriptPath?: string;
     mainProjectName: string;
     overwriteExisting: boolean;
     pnpmInstallFolder?: string;

--- a/libraries/package-extractor/src/PackageExtractor.ts
+++ b/libraries/package-extractor/src/PackageExtractor.ts
@@ -433,10 +433,10 @@ export class PackageExtractor {
     switch (linkCreation) {
       case 'script': {
         terminal.writeLine(`Creating ${createLinksScriptFilename}`);
-        const createLinksSourceFilePath: string = path.join(scriptsFolderPath, createLinksScriptFilename);
+        const createLinksSourceFilePath: string = `${scriptsFolderPath}/${createLinksScriptFilename}`;
         const createLinksTargetFilePath: string = linkCreationScriptPath
           ? path.resolve(targetRootFolder, linkCreationScriptPath)
-          : path.join(targetRootFolder, createLinksScriptFilename);
+          : `${targetRootFolder}/${createLinksScriptFilename}`;
         let createLinksScriptContent: string = await FileSystem.readFileAsync(createLinksSourceFilePath);
         createLinksScriptContent = createLinksScriptContent.replace(
           TARGET_ROOT_SCRIPT_RELATIVE_PATH_TEMPLATE_STRING,

--- a/libraries/package-extractor/src/PackageExtractor.ts
+++ b/libraries/package-extractor/src/PackageExtractor.ts
@@ -448,8 +448,8 @@ export class PackageExtractor {
           });
         }
         await state.archiver?.addToArchiveAsync({
-          fileData: createLinksTargetFilePath,
-          archivePath: createLinksScriptFilename
+          fileData: createLinksScriptContent,
+          archivePath: path.relative(targetRootFolder, createLinksTargetFilePath)
         });
         break;
       }

--- a/libraries/package-extractor/src/scripts/create-links.ts
+++ b/libraries/package-extractor/src/scripts/create-links.ts
@@ -112,7 +112,7 @@ function main(): boolean {
     return false;
   }
 
-  const extractorMetadataPath: string = path.join(__dirname, 'extractor-metadata.json');
+  const extractorMetadataPath: string = `${__dirname}/extractor-metadata.json`;
   if (!fs.existsSync(extractorMetadataPath)) {
     throw new Error('Input file not found: ' + extractorMetadataPath);
   }

--- a/libraries/package-extractor/src/scripts/create-links.ts
+++ b/libraries/package-extractor/src/scripts/create-links.ts
@@ -7,8 +7,15 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import type { IExtractorMetadataJson } from '../PackageExtractor';
 import type { IFileSystemCreateLinkOptions } from '@rushstack/node-core-library';
+import type {
+  TARGET_ROOT_SCRIPT_RELATIVE_PATH_TEMPLATE_STRING as TargetRootScriptRelativePathTemplateString,
+  IExtractorMetadataJson
+} from '../PackageExtractor';
+
+const TARGET_ROOT_SCRIPT_RELATIVE_PATH: typeof TargetRootScriptRelativePathTemplateString =
+  '{TARGET_ROOT_SCRIPT_RELATIVE_PATH}';
+const TARGET_ROOT_FOLDER: string = path.resolve(__dirname, TARGET_ROOT_SCRIPT_RELATIVE_PATH);
 
 // API borrowed from @rushstack/node-core-library, since this script avoids using any
 // NPM dependencies.
@@ -105,9 +112,7 @@ function main(): boolean {
     return false;
   }
 
-  const targetRootFolder: string = __dirname;
-  const extractorMetadataPath: string = path.join(targetRootFolder, 'extractor-metadata.json');
-
+  const extractorMetadataPath: string = path.join(__dirname, 'extractor-metadata.json');
   if (!fs.existsSync(extractorMetadataPath)) {
     throw new Error('Input file not found: ' + extractorMetadataPath);
   }
@@ -116,12 +121,12 @@ function main(): boolean {
   const extractorMetadataObject: IExtractorMetadataJson = JSON.parse(extractorMetadataJson);
 
   if (args[0] === 'create') {
-    console.log(`\nCreating links for extraction at path "${targetRootFolder}"`);
-    removeLinks(targetRootFolder, extractorMetadataObject);
-    createLinks(targetRootFolder, extractorMetadataObject);
+    console.log(`\nCreating links for extraction at path "${TARGET_ROOT_FOLDER}"`);
+    removeLinks(TARGET_ROOT_FOLDER, extractorMetadataObject);
+    createLinks(TARGET_ROOT_FOLDER, extractorMetadataObject);
   } else {
-    console.log(`\nRemoving links for extraction at path "${targetRootFolder}"`);
-    removeLinks(targetRootFolder, extractorMetadataObject);
+    console.log(`\nRemoving links for extraction at path "${TARGET_ROOT_FOLDER}"`);
+    removeLinks(TARGET_ROOT_FOLDER, extractorMetadataObject);
   }
 
   console.log('The operation completed successfully.');

--- a/libraries/package-extractor/src/test/PackageExtractor.test.ts
+++ b/libraries/package-extractor/src/test/PackageExtractor.test.ts
@@ -2,8 +2,9 @@
 // See LICENSE in the project root for license information.
 
 import path from 'path';
+import type { ChildProcess } from 'child_process';
 
-import { FileSystem } from '@rushstack/node-core-library';
+import { Executable, FileSystem } from '@rushstack/node-core-library';
 import { Terminal, StringBufferTerminalProvider } from '@rushstack/terminal';
 import { PackageExtractor, type IExtractorProjectConfiguration } from '../PackageExtractor';
 
@@ -463,5 +464,137 @@ describe(PackageExtractor.name, () => {
     // Validate project 2 files
     await expect(FileSystem.existsAsync(path.join(targetFolder, 'package.json'))).resolves.toBe(true);
     await expect(FileSystem.existsAsync(path.join(targetFolder, 'src', 'index.js'))).resolves.toBe(true);
+  });
+
+  it('should extract project with script linkCreation', async () => {
+    const targetFolder: string = path.join(extractorTargetFolder, 'extractor-output-10');
+
+    await expect(
+      packageExtractor.extractAsync({
+        mainProjectName: project1PackageName,
+        sourceRootFolder: repoRoot,
+        targetRootFolder: targetFolder,
+        overwriteExisting: true,
+        projectConfigurations: getDefaultProjectConfigurations(),
+        terminal,
+        includeNpmIgnoreFiles: true,
+        linkCreation: 'script',
+        includeDevDependencies: true
+      })
+    ).resolves.not.toThrow();
+
+    // Validate project 1 files
+    await expect(
+      FileSystem.existsAsync(path.join(targetFolder, project1RelativePath, 'src', 'index.js'))
+    ).resolves.toBe(true);
+
+    // Validate project 2 is not linked through node_modules
+    const project1NodeModulesPath: string = path.join(targetFolder, project1RelativePath, 'node_modules');
+    await expect(
+      FileSystem.existsAsync(path.join(project1NodeModulesPath, project2PackageName, 'src', 'index.js'))
+    ).resolves.toEqual(false);
+
+    // Validate project 3 is not linked through node_modules
+    await expect(
+      FileSystem.existsAsync(path.join(project1NodeModulesPath, project3PackageName, 'src', 'index.js'))
+    ).resolves.toEqual(false);
+
+    // Run the linkCreation script
+    const createLinksProcess: ChildProcess = Executable.spawn(process.argv0, [
+      path.join(targetFolder, 'create-links.js'),
+      'create'
+    ]);
+    await expect(
+      Executable.waitForExitAsync(createLinksProcess, { throwOnNonZeroExitCode: true })
+    ).resolves.not.toThrow();
+
+    // Validate project 2 is linked through node_modules
+    await expect(
+      FileSystem.getRealPathAsync(path.join(project1NodeModulesPath, project2PackageName, 'src', 'index.js'))
+    ).resolves.toEqual(path.join(targetFolder, project2RelativePath, 'src', 'index.js'));
+
+    // Validate project 3 is linked through node_modules
+    await expect(
+      FileSystem.getRealPathAsync(path.join(project1NodeModulesPath, project3PackageName, 'src', 'index.js'))
+    ).resolves.toEqual(path.join(targetFolder, project3RelativePath, 'src', 'index.js'));
+    await expect(
+      FileSystem.getRealPathAsync(
+        path.join(
+          project1NodeModulesPath,
+          project2PackageName,
+          'node_modules',
+          project3PackageName,
+          'src',
+          'index.js'
+        )
+      )
+    ).resolves.toEqual(path.join(targetFolder, project3RelativePath, 'src', 'index.js'));
+  });
+
+  it('should extract project with script linkCreation and custom linkCreationScriptPath', async () => {
+    const targetFolder: string = path.join(extractorTargetFolder, 'extractor-output-11');
+    const linkCreationScriptPath: string = path.join(targetFolder, 'foo', 'bar', 'baz.js');
+
+    await expect(
+      packageExtractor.extractAsync({
+        mainProjectName: project1PackageName,
+        sourceRootFolder: repoRoot,
+        targetRootFolder: targetFolder,
+        overwriteExisting: true,
+        projectConfigurations: getDefaultProjectConfigurations(),
+        terminal,
+        includeNpmIgnoreFiles: true,
+        linkCreation: 'script',
+        linkCreationScriptPath,
+        includeDevDependencies: true
+      })
+    ).resolves.not.toThrow();
+
+    // Validate project 1 files
+    await expect(
+      FileSystem.existsAsync(path.join(targetFolder, project1RelativePath, 'src', 'index.js'))
+    ).resolves.toBe(true);
+
+    // Validate project 2 is not linked through node_modules
+    const project1NodeModulesPath: string = path.join(targetFolder, project1RelativePath, 'node_modules');
+    await expect(
+      FileSystem.existsAsync(path.join(project1NodeModulesPath, project2PackageName, 'src', 'index.js'))
+    ).resolves.toEqual(false);
+
+    // Validate project 3 is not linked through node_modules
+    await expect(
+      FileSystem.existsAsync(path.join(project1NodeModulesPath, project3PackageName, 'src', 'index.js'))
+    ).resolves.toEqual(false);
+
+    // Run the linkCreation script
+    const createLinksProcess: ChildProcess = Executable.spawn(process.argv0, [
+      linkCreationScriptPath,
+      'create'
+    ]);
+    await expect(
+      Executable.waitForExitAsync(createLinksProcess, { throwOnNonZeroExitCode: true })
+    ).resolves.not.toThrow();
+
+    // Validate project 2 is linked through node_modules
+    await expect(
+      FileSystem.getRealPathAsync(path.join(project1NodeModulesPath, project2PackageName, 'src', 'index.js'))
+    ).resolves.toEqual(path.join(targetFolder, project2RelativePath, 'src', 'index.js'));
+
+    // Validate project 3 is linked through node_modules
+    await expect(
+      FileSystem.getRealPathAsync(path.join(project1NodeModulesPath, project3PackageName, 'src', 'index.js'))
+    ).resolves.toEqual(path.join(targetFolder, project3RelativePath, 'src', 'index.js'));
+    await expect(
+      FileSystem.getRealPathAsync(
+        path.join(
+          project1NodeModulesPath,
+          project2PackageName,
+          'node_modules',
+          project3PackageName,
+          'src',
+          'index.js'
+        )
+      )
+    ).resolves.toEqual(path.join(targetFolder, project3RelativePath, 'src', 'index.js'));
   });
 });


### PR DESCRIPTION
## Summary

Allows for placing the "create-links.json" file and it's associated metadata file to be modified when operating in "script" mode.

## Details

Currently the "create-links.js" file gets created in the root of the extraction. This PR allows for changing where this file gets placed, which will allow for overlaying of multiple extractions from the same repository while allowing a custom location for all extraction scripts and metadatas.

## How it was tested

Added unit tests

## Impacted documentation

May require website document updates for new parameter