### PR TITLE
[rush] Pass the credentials cache into _getCredentialFromTokenAsync.

### DIFF
--- a/common/changes/@microsoft/rush/pass-credential-cache_2024-09-12-23-22.json
+++ b/common/changes/@microsoft/rush/pass-credential-cache_2024-09-12-23-22.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Pass the initialized credentials cache to `AzureAuthenticationBase._getCredentialFromTokenAsync` in `@rushstack/rush-azure-storage-build-cache-plugin`.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/reviews/api/rush-azure-storage-build-cache-plugin.api.md
+++ b/common/reviews/api/rush-azure-storage-build-cache-plugin.api.md
@@ -5,6 +5,7 @@
 ```ts
 
 import { AzureAuthorityHosts } from '@azure/identity';
+import { CredentialCache } from '@rushstack/rush-sdk';
 import { DeviceCodeCredentialOptions } from '@azure/identity';
 import type { ICredentialCacheEntry } from '@rushstack/rush-sdk';
 import { InteractiveBrowserCredentialNodeOptions } from '@azure/identity';
@@ -37,7 +38,7 @@ export abstract class AzureAuthenticationBase {
     protected readonly _failoverOrder: Record<LoginFlowType, LoginFlowType | undefined>;
     protected abstract _getCacheIdParts(): string[];
     // (undocumented)
-    protected abstract _getCredentialFromTokenAsync(terminal: ITerminal, tokenCredential: TokenCredential): Promise<ICredentialResult>;
+    protected abstract _getCredentialFromTokenAsync(terminal: ITerminal, tokenCredential: TokenCredential, credentialsCache: CredentialCache): Promise<ICredentialResult>;
     // (undocumented)
     protected readonly _loginFlow: LoginFlowType;
     // (undocumented)


### PR DESCRIPTION
## Summary

Pass the initialized credentials cache to `AzureAuthenticationBase._getCredentialFromTokenAsync` in `@rushstack/rush-azure-storage-build-cache-plugin`.

## How it was tested

N/A

## Impacted documentation

API