### PR TITLE
[rush] move sharded operation config to its own block

### DIFF
--- a/apps/rush/UPGRADING.md
+++ b/apps/rush/UPGRADING.md
@@ -1,5 +1,47 @@
 # Upgrade notes for @microsoft/rush
 
+### Rush 5.135.0
+
+This release of Rush deprecates the `rush-project.json`'s `operationSettings.sharding.shardOperationSettings`
+option in favor of defining a separate operation with a `:shard` suffix. This will only affect projects that
+have opted into sharding and have custom sharded operation settings.
+
+To migrate,
+**`rush-project.json`** (OLD)
+```json
+{
+  "operationSettings": [
+    {
+      "operationName": "_phase:build",
+      "sharding": {
+        "count": 4,
+        "shardOperationSettings": {
+          "weight": 4
+        }
+      },
+    }
+  ]
+}
+```
+
+**`rush-project.json`** (NEW)
+```json
+{
+  "operationSettings": [
+    {
+      "operationName": "_phase:build",
+      "sharding": {
+        "count": 4,
+      },
+    },
+    {
+      "operationName": "_phase:build:shard", // note the suffix here
+      "weight": 4
+    }
+  ]
+}
+```
+
 ### Rush 5.60.0
 
 This release of Rush includes a breaking change for the experiment build cache feature. It only affects

--- a/build-tests/rush-redis-cobuild-plugin-integration-test/sandbox/sharded-repo/projects/a/config/rush-project.json
+++ b/build-tests/rush-redis-cobuild-plugin-integration-test/sandbox/sharded-repo/projects/a/config/rush-project.json
@@ -6,12 +6,12 @@
       "outputFolderNames": ["dist"],
       "sharding": {
         "count": 4,
-        "outputFolderArgumentFormat": "--output-directory=.rush/{phaseName}/shards/{shardIndex}",
-
-        "shardOperationSettings": {
-          "weight": 4
-        }
+        "outputFolderArgumentFormat": "--output-directory=.rush/{phaseName}/shards/{shardIndex}"
       }
+    },
+    {
+      "operationName": "_phase:build:shard",
+      "weight": 4
     }
   ]
 }

--- a/build-tests/rush-redis-cobuild-plugin-integration-test/sandbox/sharded-repo/projects/b/config/rush-project.json
+++ b/build-tests/rush-redis-cobuild-plugin-integration-test/sandbox/sharded-repo/projects/b/config/rush-project.json
@@ -5,11 +5,12 @@
       "outputFolderNames": ["dist"],
       "sharding": {
         "count": 5,
-        "outputFolderArgumentFormat": "--output-directory=.rush/{phaseName}/shards/{shardIndex}",
-        "shardOperationSettings": {
-          "weight": 10
-        }
+        "outputFolderArgumentFormat": "--output-directory=.rush/{phaseName}/shards/{shardIndex}"
       }
+    },
+    {
+      "operationName": "_phase:build:shard",
+      "weight": 10
     }
   ]
 }

--- a/build-tests/rush-redis-cobuild-plugin-integration-test/sandbox/sharded-repo/projects/e/config/rush-project.json
+++ b/build-tests/rush-redis-cobuild-plugin-integration-test/sandbox/sharded-repo/projects/e/config/rush-project.json
@@ -4,8 +4,15 @@
       "operationName": "_phase:build",
       "outputFolderNames": ["dist"],
       "sharding": {
-        "count": 75
+        "count": 75,
+        "shardOperationSettings": {
+          "weight": 10
+        }
       }
+    },
+    {
+      "operationName": "_phase:build:shard",
+      "weight": 1
     }
   ]
 }

--- a/common/changes/@microsoft/rush/sennyeya-shard-schema-updates_2024-09-13-22-46.json
+++ b/common/changes/@microsoft/rush/sennyeya-shard-schema-updates_2024-09-13-22-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Remove sharding.shardOperationSettings. Use a new operationSettings object with a name of ':shard'",
+      "type": "none",
+      "packageName": "@microsoft/rush"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "aramissennyeydd@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush/sennyeya-shard-schema-updates_2024-09-13-22-46.json
+++ b/common/changes/@microsoft/rush/sennyeya-shard-schema-updates_2024-09-13-22-46.json
@@ -1,7 +1,7 @@
 {
   "changes": [
     {
-      "comment": "Remove sharding.shardOperationSettings. Use a new operationSettings object with a name of ':shard'",
+      "comment": "(DEPRECATED) Deprecated the `sharding.shardOperationSettings` property in the project `config/rush-project.json` in favor of an `operationSettings` entry for an operation with a suffix of `:shard`.",
       "type": "none",
       "packageName": "@microsoft/rush"
     }

--- a/common/changes/@microsoft/rush/sennyeya-shard-schema-updates_2024-09-13-22-46.json
+++ b/common/changes/@microsoft/rush/sennyeya-shard-schema-updates_2024-09-13-22-46.json
@@ -1,7 +1,7 @@
 {
   "changes": [
     {
-      "comment": "(DEPRECATED) Deprecated the `sharding.shardOperationSettings` property in the project `config/rush-project.json` in favor of an `operationSettings` entry for an operation with a suffix of `:shard`.",
+      "comment": "Deprecate the `sharding.shardOperationSettings` property in the project `config/rush-project.json` in favor of an `operationSettings` entry for an operation with a suffix of `:shard`.",
       "type": "none",
       "packageName": "@microsoft/rush"
     }

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -785,9 +785,6 @@ export interface IRushPhaseSharding {
     count: number;
     outputFolderArgumentFormat?: string;
     shardArgumentFormat?: string;
-    shardOperationSettings?: {
-        weight?: number;
-    };
 }
 
 // @beta (undocumented)

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -785,6 +785,8 @@ export interface IRushPhaseSharding {
     count: number;
     outputFolderArgumentFormat?: string;
     shardArgumentFormat?: string;
+    // @deprecated (undocumented)
+    shardOperationSettings?: unknown;
 }
 
 // @beta (undocumented)

--- a/libraries/rush-lib/src/api/RushProjectConfiguration.ts
+++ b/libraries/rush-lib/src/api/RushProjectConfiguration.ts
@@ -63,17 +63,6 @@ export interface IRushPhaseSharding {
    * @defaultValue `--shard-output-folder=.rush/operations/{phaseName}/shards/{shardIndex}`.
    */
   outputFolderArgumentFormat?: string;
-
-  /**
-   * Configuration for the shard operation. All other configuration applies to the collator operation.
-   */
-  shardOperationSettings?: {
-    /**
-     * How many concurrency units this operation should take up during execution. The maximum concurrent units is
-     *  determined by the -p flag.
-     */
-    weight?: number;
-  };
 }
 
 /**

--- a/libraries/rush-lib/src/api/RushProjectConfiguration.ts
+++ b/libraries/rush-lib/src/api/RushProjectConfiguration.ts
@@ -2,7 +2,7 @@
 // See LICENSE in the project root for license information.
 
 import { AlreadyReportedError, Async, Path } from '@rushstack/node-core-library';
-import { type ITerminal } from '@rushstack/terminal';
+import type { ITerminal } from '@rushstack/terminal';
 import { ConfigurationFile, InheritanceType } from '@rushstack/heft-config-file';
 import { RigConfig } from '@rushstack/rig-package';
 

--- a/libraries/rush-lib/src/api/RushProjectConfiguration.ts
+++ b/libraries/rush-lib/src/api/RushProjectConfiguration.ts
@@ -2,7 +2,7 @@
 // See LICENSE in the project root for license information.
 
 import { AlreadyReportedError, Async, Path } from '@rushstack/node-core-library';
-import type { ITerminal } from '@rushstack/terminal';
+import { Colorize, type ITerminal } from '@rushstack/terminal';
 import { ConfigurationFile, InheritanceType } from '@rushstack/heft-config-file';
 import { RigConfig } from '@rushstack/rig-package';
 
@@ -63,6 +63,11 @@ export interface IRushPhaseSharding {
    * @defaultValue `--shard-output-folder=.rush/operations/{phaseName}/shards/{shardIndex}`.
    */
   outputFolderArgumentFormat?: string;
+
+  /**
+   * @deprecated Create a separate operation settings object for the shard operation settings with the name `{operationName}:shard`.
+   */
+  shardOperationSettings?: unknown;
 }
 
 /**
@@ -572,6 +577,17 @@ export class RushProjectConfiguration {
           terminal.writeErrorLine(errorMessage);
         } else {
           operationSettingsByOperationName.set(operationName, operationSettings);
+        }
+      }
+
+      for (const [operationName, operationSettings] of operationSettingsByOperationName) {
+        if (operationSettings.sharding?.shardOperationSettings) {
+          // eslint-disable-next-line no-console
+          console.log(
+            Colorize.yellow(
+              `DEPRECATED: The "sharding.shardOperationSettings" field is deprecated. Please create a new operation, '${operationName}:shard' to track shard operation settings.`
+            )
+          );
         }
       }
     }

--- a/libraries/rush-lib/src/api/RushProjectConfiguration.ts
+++ b/libraries/rush-lib/src/api/RushProjectConfiguration.ts
@@ -2,7 +2,7 @@
 // See LICENSE in the project root for license information.
 
 import { AlreadyReportedError, Async, Path } from '@rushstack/node-core-library';
-import { Colorize, type ITerminal } from '@rushstack/terminal';
+import { type ITerminal } from '@rushstack/terminal';
 import { ConfigurationFile, InheritanceType } from '@rushstack/heft-config-file';
 import { RigConfig } from '@rushstack/rig-package';
 

--- a/libraries/rush-lib/src/api/RushProjectConfiguration.ts
+++ b/libraries/rush-lib/src/api/RushProjectConfiguration.ts
@@ -582,11 +582,8 @@ export class RushProjectConfiguration {
 
       for (const [operationName, operationSettings] of operationSettingsByOperationName) {
         if (operationSettings.sharding?.shardOperationSettings) {
-          // eslint-disable-next-line no-console
-          console.log(
-            Colorize.yellow(
-              `DEPRECATED: The "sharding.shardOperationSettings" field is deprecated. Please create a new operation, '${operationName}:shard' to track shard operation settings.`
-            )
+          terminal.writeWarningLine(
+            `DEPRECATED: The "sharding.shardOperationSettings" field is deprecated. Please create a new operation, '${operationName}:shard' to track shard operation settings.`
           );
         }
       }

--- a/libraries/rush-lib/src/logic/operations/ShardedPhaseOperationPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/ShardedPhaseOperationPlugin.ts
@@ -2,7 +2,7 @@
 // See LICENSE in the project root for license information.
 
 import type { IPhase } from '../../api/CommandLineConfiguration';
-import type { RushProjectConfiguration } from '../../api/RushProjectConfiguration';
+import type { IOperationSettings, RushProjectConfiguration } from '../../api/RushProjectConfiguration';
 import type {
   ICreateOperationsContext,
   IPhasedCommandPlugin,
@@ -173,11 +173,15 @@ function spliceShards(existingOperations: Set<Operation>, context: ICreateOperat
           shard.toString()
         );
 
+        const shardOperationSettings: IOperationSettings =
+          projectConfiguration?.operationSettingsByOperationName.get(shardOperationName) ??
+          (operationSettings.sharding.shardOperationSettings as IOperationSettings);
+
         const shardOperation: Operation = new Operation({
           project,
           phase,
           settings: {
-            ...projectConfiguration?.operationSettingsByOperationName.get(shardOperationName),
+            ...shardOperationSettings,
             operationName: shardOperationName,
             outputFolderNames: [outputDirectory]
           },

--- a/libraries/rush-lib/src/schemas/rush-project.schema.json
+++ b/libraries/rush-lib/src/schemas/rush-project.schema.json
@@ -90,17 +90,6 @@
               "outputFolderArgumentFormat": {
                 "type": "string",
                 "description": "The command-line argument to pass to the operation to specify the output folder. The string may contain the following placeholders: {phaseName} {shardIndex}. Must end with {shardIndex}. Defaults to --shard-output-folder=\".rush/operations/{phaseName}/shards/{shardIndex}\""
-              },
-              "shardOperationSettings": {
-                "type": "object",
-                "additionalProperties": false,
-                "properties": {
-                  "weight": {
-                    "description": "The number of concurrency units that this operation should take up. The maximum concurrency units is determined by the -p flag.",
-                    "type": "integer",
-                    "minimum": 0
-                  }
-                }
               }
             }
           },

--- a/libraries/rush-lib/src/schemas/rush-project.schema.json
+++ b/libraries/rush-lib/src/schemas/rush-project.schema.json
@@ -90,6 +90,11 @@
               "outputFolderArgumentFormat": {
                 "type": "string",
                 "description": "The command-line argument to pass to the operation to specify the output folder. The string may contain the following placeholders: {phaseName} {shardIndex}. Must end with {shardIndex}. Defaults to --shard-output-folder=\".rush/operations/{phaseName}/shards/{shardIndex}\""
+              },
+              "shardOperationSettings": {
+                "type": "object",
+                "description": "DEPRECATED. Use a separate operationSettings entry with {this operation's name}:shard as the name, ex _phase:build would have a separate operation _phase:build:shard to manage per-shard settings.",
+                "additionalProperties": true
               }
             }
           },


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

Followup to @iclanton's comments in https://github.com/microsoft/rushstack/pull/4871. Moving the config for shards to its own object instead of piggybacking onto the collate operation.

As-is this is a breaking change, open to thoughts on how to roll this out safely.

## How it was tested

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

Tested locally against the rush-redis-cobuild-plugin-integration-tests.

## Impacted documentation

<!--------------------------------------------------------------------------
👉 STEP 7: Does your PR affect anything that is discussed in the website docs?
     If so, please paste the URL of each affected web page, so we will
     remember to update the documentation after your PR is merged.
     (Updating the website is appreciated but not required.)
     If no docs are impacted, delete the "Impacted documentation" section.

     If you modified a JSON schema, remember to update init templates such as:
     rush-lib/assets/rush-init/*.json
     api-extractor/src/schemas/api-extractor-template.json
--------------------------------------------------------------------------->

Schema definitions will need to be updated.

<!--------------------------------------------------------------------------
👉 STEP 8: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
