### PR TITLE
[rush] Logging enhancements

### DIFF
--- a/common/changes/@microsoft/rush/logging-enhancement_2024-09-19-00-28.json
+++ b/common/changes/@microsoft/rush/logging-enhancement_2024-09-19-00-28.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Make individual Rush log files available via the rush-serve-plugin server at the relative URL specified by \"logServePath\" option. Annotate operations sent over the WebSocket with the URLs of their log files.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -525,11 +525,11 @@ export interface ILaunchOptions {
 
 // @alpha
 export interface ILogFilePaths {
-    errorLogPath: string;
-    jsonlFolderPath: string;
-    jsonlPath: string;
-    logFolderPath: string;
-    logPath: string;
+    error: string;
+    jsonl: string;
+    jsonlFolder: string;
+    text: string;
+    textFolder: string;
 }
 
 // @beta (undocumented)

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -523,6 +523,15 @@ export interface ILaunchOptions {
     terminalProvider?: ITerminalProvider;
 }
 
+// @alpha
+export interface ILogFilePaths {
+    errorLogPath: string;
+    jsonlFolderPath: string;
+    jsonlPath: string;
+    logFolderPath: string;
+    logPath: string;
+}
+
 // @beta (undocumented)
 export interface ILogger {
     emitError(error: Error): void;
@@ -553,6 +562,7 @@ export interface _INpmOptionsJson extends IPackageManagerOptionsJsonBase {
 export interface IOperationExecutionResult {
     readonly cobuildRunnerId: string | undefined;
     readonly error: Error | undefined;
+    readonly logFilePaths: ILogFilePaths | undefined;
     readonly nonCachedDurationMs: number | undefined;
     readonly operation: Operation;
     readonly status: OperationStatus;

--- a/libraries/rush-lib/src/index.ts
+++ b/libraries/rush-lib/src/index.ts
@@ -134,6 +134,7 @@ export type {
 } from './logic/operations/IOperationExecutionResult';
 export { type IOperationOptions, Operation } from './logic/operations/Operation';
 export { OperationStatus } from './logic/operations/OperationStatus';
+export type { ILogFilePaths } from './logic/operations/ProjectLogWritable';
 
 export {
   RushSession,

--- a/libraries/rush-lib/src/logic/operations/CacheableOperationPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/CacheableOperationPlugin.ts
@@ -239,7 +239,7 @@ export class CacheableOperationPlugin implements IPhasedCommandPlugin {
             !buildCacheContext.buildCacheTerminal ||
             buildCacheContext.buildCacheTerminalWritable?.isOpen === false
           ) {
-            // The writable is does not exist or is closed, re-create one
+            // The writable does not exist or has been closed, re-create one
             // eslint-disable-next-line require-atomic-updates
             buildCacheContext.buildCacheTerminal = await this._createBuildCacheTerminalAsync({
               record,
@@ -321,7 +321,7 @@ export class CacheableOperationPlugin implements IPhasedCommandPlugin {
           //     has changed happens inside the hashing logic.
           //
 
-          const { errorLogPath } = getProjectLogFilePaths({
+          const { error: errorLogPath } = getProjectLogFilePaths({
             project,
             logFilenameIdentifier: operationMetadataManager.logFilenameIdentifier
           });
@@ -443,9 +443,9 @@ export class CacheableOperationPlugin implements IPhasedCommandPlugin {
             const { logFilenameIdentifier } = operationMetadataManager;
             const { duration: durationInSeconds } = stopwatch;
             const {
-              logPath,
-              errorLogPath,
-              jsonlPath: logChunksPath
+              text: logPath,
+              error: errorLogPath,
+              jsonl: logChunksPath
             } = getProjectLogFilePaths({
               project,
               logFilenameIdentifier

--- a/libraries/rush-lib/src/logic/operations/IOperationExecutionResult.ts
+++ b/libraries/rush-lib/src/logic/operations/IOperationExecutionResult.ts
@@ -5,6 +5,7 @@ import type { StdioSummarizer } from '@rushstack/terminal';
 import type { OperationStatus } from './OperationStatus';
 import type { Operation } from './Operation';
 import type { IStopwatchResult } from '../../utilities/Stopwatch';
+import type { ILogFilePaths } from './ProjectLogWritable';
 
 /**
  * The `IOperationExecutionResult` interface represents the results of executing an {@link Operation}.
@@ -43,6 +44,10 @@ export interface IOperationExecutionResult {
    * The id of the runner which actually runs the building process in cobuild mode.
    */
   readonly cobuildRunnerId: string | undefined;
+  /**
+   * The paths to the log files, if applicable.
+   */
+  readonly logFilePaths: ILogFilePaths | undefined;
 }
 
 /**

--- a/libraries/rush-lib/src/logic/operations/ProjectLogWritable.ts
+++ b/libraries/rush-lib/src/logic/operations/ProjectLogWritable.ts
@@ -1,165 +1,153 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import { FileSystem, FileWriter, InternalError } from '@rushstack/node-core-library';
-import { TerminalChunkKind, TerminalWritable, type ITerminalChunk } from '@rushstack/terminal';
-import type { CollatedTerminal } from '@rushstack/stream-collator';
+import { FileSystem, FileWriter, InternalError, NewlineKind } from '@rushstack/node-core-library';
+import {
+  SplitterTransform,
+  TerminalChunkKind,
+  TerminalWritable,
+  TextRewriterTransform,
+  type ITerminalChunk
+} from '@rushstack/terminal';
 
 import type { RushConfigurationProject } from '../../api/RushConfigurationProject';
 import { PackageNameParsers } from '../../api/PackageNameParsers';
 import { RushConstants } from '../RushConstants';
 
 export interface IProjectLogWritableOptions {
-  project: RushConfigurationProject;
-  terminal: CollatedTerminal;
-  logFilenameIdentifier: string;
+  logFilePaths: ILogFilePaths;
   enableChunkedOutput?: boolean;
 }
 
-export interface ILogFilePaths {
-  logFolderPath: string;
-  logChunksFolderPath: string;
+export interface ILogFileNames {
+  mergedFileName: string;
+  jsonlFileName: string;
+  errorFileName: string;
+}
 
+/**
+ * Information about the log files for an operation.
+ *
+ * @alpha
+ */
+export interface ILogFilePaths {
+  /**
+   * The absolute path to the folder containing the text log files.
+   */
+  logFolderPath: string;
+  /**
+   * The absolute path to the folder containing the JSONL log files.
+   */
+  jsonlFolderPath: string;
+
+  /**
+   * The absolute path to the merged (interleaved stdout and stderr) text log.
+   * ANSI escape codes have been stripped.
+   */
   logPath: string;
-  logChunksPath: string;
+  /**
+   * The absolute path to the stderr text log.
+   * ANSI escape codes have been stripped.
+   */
   errorLogPath: string;
-  relativeLogPath: string;
-  relativeErrorLogPath: string;
-  relativeLogChunksPath: string;
+  /**
+   * The absolute path to the JSONL log. ANSI escape codes are left intact to be able to reproduce the console output.
+   */
+  jsonlPath: string;
 }
 
 export interface IGetLogFilePathsOptions {
-  project: RushConfigurationProject;
+  project: Pick<RushConfigurationProject, 'projectFolder' | 'packageName'>;
   logFilenameIdentifier: string;
 }
 
 const LOG_CHUNKS_FOLDER_RELATIVE_PATH: string = `${RushConstants.projectRushFolderName}/${RushConstants.rushTempFolderName}/chunked-rush-logs`;
 
-export class ProjectLogWritable extends TerminalWritable {
-  private readonly _terminal: CollatedTerminal;
+/**
+ * A new terminal stream that writes all log chunks to a JSONL format so they can be faithfully reconstructed
+ *  during build cache restores. This is used for adding warning + error messages in cobuilds where the original
+ *  logs cannot be completely restored from the existing `all.log` and `error.log` files.
+ *
+ * Example output:
+ * libraries/rush-lib/.rush/temp/operations/rush-lib._phase_build.chunks.jsonl
+ * ```
+ * {"kind":"O","text":"Invoking: heft run --only build -- --clean \n"}
+ * {"kind":"O","text":" ---- build started ---- \n"}
+ * {"kind":"O","text":"[build:clean] Deleted 0 files and 5 folders\n"}
+ * {"kind":"O","text":"[build:typescript] Using TypeScript version 5.4.2\n"}
+ * {"kind":"O","text":"[build:lint] Using ESLint version 8.57.0\n"}
+ * {"kind":"E","text":"[build:lint] Warning: libraries/rush-lib/src/logic/operations/LogChunksWritable.ts:15:7 - (@typescript-eslint/typedef) Expected test to have a type annotation.\n"}
+ * {"kind":"E","text":"[build:lint] Warning: libraries/rush-lib/src/logic/operations/LogChunksWritable.ts:15:7 - (@typescript-eslint/no-unused-vars) 'test' is assigned a value but never used.\n"}
+ * {"kind":"O","text":"[build:typescript] Copied 1138 folders or files and linked 0 files\n"}
+ * {"kind":"O","text":"[build:webpack] Using Webpack version 5.82.1\n"}
+ * {"kind":"O","text":"[build:webpack] Running Webpack compilation\n"}
+ * {"kind":"O","text":"[build:api-extractor] Using API Extractor version 7.43.1\n"}
+ * {"kind":"O","text":"[build:api-extractor] Analysis will use the bundled TypeScript version 5.4.2\n"}
+ * {"kind":"O","text":"[build:copy-mock-flush-telemetry-plugin] Copied 1260 folders or files and linked 5 files\n"}
+ * {"kind":"O","text":" ---- build finished (6.856s) ---- \n"}
+ * {"kind":"O","text":"-------------------- Finished (6.858s) --------------------\n"}
+ * ```
+ */
+export class JsonLFileWritable extends TerminalWritable {
+  public readonly logPath: string;
 
+  private _writer: FileWriter | undefined;
+
+  public constructor(logPath: string) {
+    super();
+
+    this.logPath = logPath;
+
+    this._writer = FileWriter.open(logPath);
+  }
+
+  // Override writeChunk function to throw custom error
+  public writeChunk(chunk: ITerminalChunk): void {
+    if (!this._writer) {
+      throw new InternalError(`Log writer was closed for ${this.logPath}`);
+    }
+    // Stderr can always get written to a error log writer
+    super.writeChunk(chunk);
+  }
+
+  protected onWriteChunk(chunk: ITerminalChunk): void {
+    if (!this._writer) {
+      throw new InternalError(`Log writer was closed for ${this.logPath}`);
+    }
+    this._writer.write(JSON.stringify(chunk) + '\n');
+  }
+
+  protected onClose(): void {
+    if (this._writer) {
+      try {
+        this._writer.close();
+      } catch (error) {
+        throw new InternalError('Failed to close file handle for ' + this._writer.filePath);
+      }
+      this._writer = undefined;
+    }
+  }
+}
+
+/**
+ * A terminal stream that writes a merged log file and an error log file.
+ * The merged log file contains intermingled stdout and stderr.
+ */
+export class SplitLogFileWritable extends TerminalWritable {
   public readonly logPath: string;
   public readonly errorLogPath: string;
-  public readonly logChunksPath: string;
-  public readonly relativeLogPath: string;
-  public readonly relativeErrorLogPath: string;
-  public readonly relativeLogChunksPath: string;
 
   private _logWriter: FileWriter | undefined = undefined;
   private _errorLogWriter: FileWriter | undefined = undefined;
 
-  /**
-   * A new terminal stream that writes all log chunks to a JSON format so they can be faithfully reconstructed
-   *  during build cache restores. This is used for adding warning + error messages in cobuilds where the original
-   *  logs cannot be completely restored from the existing `all.log` and `error.log` files.
-   *
-   * Example output:
-   * libraries/rush-lib/.rush/temp/operations/rush-lib._phase_build.chunks.jsonl
-   * ```
-   * {"kind":"O","text":"Invoking: heft run --only build -- --clean \n"}
-   * {"kind":"O","text":" ---- build started ---- \n"}
-   * {"kind":"O","text":"[build:clean] Deleted 0 files and 5 folders\n"}
-   * {"kind":"O","text":"[build:typescript] Using TypeScript version 5.4.2\n"}
-   * {"kind":"O","text":"[build:lint] Using ESLint version 8.57.0\n"}
-   * {"kind":"E","text":"[build:lint] Warning: libraries/rush-lib/src/logic/operations/LogChunksWritable.ts:15:7 - (@typescript-eslint/typedef) Expected test to have a type annotation.\n"}
-   * {"kind":"E","text":"[build:lint] Warning: libraries/rush-lib/src/logic/operations/LogChunksWritable.ts:15:7 - (@typescript-eslint/no-unused-vars) 'test' is assigned a value but never used.\n"}
-   * {"kind":"O","text":"[build:typescript] Copied 1138 folders or files and linked 0 files\n"}
-   * {"kind":"O","text":"[build:webpack] Using Webpack version 5.82.1\n"}
-   * {"kind":"O","text":"[build:webpack] Running Webpack compilation\n"}
-   * {"kind":"O","text":"[build:api-extractor] Using API Extractor version 7.43.1\n"}
-   * {"kind":"O","text":"[build:api-extractor] Analysis will use the bundled TypeScript version 5.4.2\n"}
-   * {"kind":"O","text":"[build:copy-mock-flush-telemetry-plugin] Copied 1260 folders or files and linked 5 files\n"}
-   * {"kind":"O","text":" ---- build finished (6.856s) ---- \n"}
-   * {"kind":"O","text":"-------------------- Finished (6.858s) --------------------\n"}
-   * ```
-   */
-  private _chunkWriter: FileWriter | undefined;
-
-  private _enableChunkedOutput: boolean;
-
-  private constructor(
-    terminal: CollatedTerminal,
-    enableChunkedOutput: boolean,
-    {
-      logPath,
-      errorLogPath,
-      logChunksPath,
-      relativeLogPath,
-      relativeErrorLogPath,
-      relativeLogChunksPath
-    }: ILogFilePaths
-  ) {
+  public constructor(logPath: string, errorLogPath: string) {
     super();
-    this._terminal = terminal;
-    this._enableChunkedOutput = enableChunkedOutput;
 
     this.logPath = logPath;
     this.errorLogPath = errorLogPath;
-    this.logChunksPath = logChunksPath;
-    this.relativeLogPath = relativeLogPath;
-    this.relativeErrorLogPath = relativeErrorLogPath;
-    this.relativeLogChunksPath = relativeLogChunksPath;
 
     this._logWriter = FileWriter.open(logPath);
-    this._chunkWriter = FileWriter.open(logChunksPath);
-  }
-
-  public static async initializeAsync({
-    project,
-    terminal,
-    logFilenameIdentifier,
-    enableChunkedOutput = false
-  }: IProjectLogWritableOptions): Promise<ProjectLogWritable> {
-    const logFilePaths: ILogFilePaths = ProjectLogWritable.getLogFilePaths({
-      project,
-      logFilenameIdentifier
-    });
-
-    const { logFolderPath, logChunksFolderPath, logPath, errorLogPath, logChunksPath } = logFilePaths;
-    await Promise.all([
-      FileSystem.ensureFolderAsync(logFolderPath),
-      FileSystem.ensureFolderAsync(logChunksFolderPath),
-      FileSystem.deleteFileAsync(logPath),
-      FileSystem.deleteFileAsync(errorLogPath),
-      FileSystem.deleteFileAsync(logChunksPath)
-    ]);
-
-    return new ProjectLogWritable(terminal, enableChunkedOutput, logFilePaths);
-  }
-
-  public static getLogFilePaths({
-    project: { projectFolder, packageName },
-    logFilenameIdentifier
-  }: IGetLogFilePathsOptions): ILogFilePaths {
-    const unscopedProjectName: string = PackageNameParsers.permissive.getUnscopedName(packageName);
-    const logFileBaseName: string = `${unscopedProjectName}.${logFilenameIdentifier}`;
-
-    const logFolderPath: string = `${projectFolder}/${RushConstants.rushLogsFolderName}`;
-    const logChunksFolderPath: string = `${projectFolder}/${LOG_CHUNKS_FOLDER_RELATIVE_PATH}`;
-
-    const logFileBasePath: string = `${RushConstants.rushLogsFolderName}/${logFileBaseName}`;
-    const chunkLogFileBasePath: string = `${LOG_CHUNKS_FOLDER_RELATIVE_PATH}/${logFileBaseName}`;
-
-    const relativeLogPath: string = `${logFileBasePath}.log`;
-    const relativeErrorLogPath: string = `${logFileBasePath}.error.log`;
-    const relativeLogChunksPath: string = `${chunkLogFileBasePath}.chunks.jsonl`;
-
-    const logPath: string = `${projectFolder}/${relativeLogPath}`;
-    const errorLogPath: string = `${projectFolder}/${relativeErrorLogPath}`;
-    const logChunksPath: string = `${projectFolder}/${relativeLogChunksPath}`;
-
-    return {
-      logFolderPath,
-      logChunksFolderPath,
-
-      logPath,
-      errorLogPath,
-      logChunksPath,
-
-      relativeLogChunksPath,
-      relativeLogPath,
-      relativeErrorLogPath
-    };
+    this._errorLogWriter = FileWriter.open(errorLogPath);
   }
 
   // Override writeChunk function to throw custom error
@@ -178,13 +166,6 @@ export class ProjectLogWritable extends TerminalWritable {
     // Both stderr and stdout get written to *.<phaseName>.log
     this._logWriter.write(chunk.text);
 
-    if (this._enableChunkedOutput) {
-      if (!this._chunkWriter) {
-        throw new InternalError('Chunked output file was closed');
-      }
-      this._chunkWriter.write(JSON.stringify(chunk) + '\n');
-    }
-
     if (chunk.kind === TerminalChunkKind.Stderr) {
       // Only stderr gets written to *.<phaseName>.error.log
       if (!this._errorLogWriter) {
@@ -199,7 +180,7 @@ export class ProjectLogWritable extends TerminalWritable {
       try {
         this._logWriter.close();
       } catch (error) {
-        this._terminal.writeStderrLine('Failed to close file handle for ' + this._logWriter.filePath);
+        throw new InternalError('Failed to close file handle for ' + this._logWriter.filePath);
       }
       this._logWriter = undefined;
     }
@@ -208,18 +189,112 @@ export class ProjectLogWritable extends TerminalWritable {
       try {
         this._errorLogWriter.close();
       } catch (error) {
-        this._terminal.writeStderrLine('Failed to close file handle for ' + this._errorLogWriter.filePath);
+        throw new InternalError('Failed to close file handle for ' + this._errorLogWriter.filePath);
       }
       this._errorLogWriter = undefined;
     }
-
-    if (this._chunkWriter) {
-      try {
-        this._chunkWriter.close();
-      } catch (error) {
-        this._terminal.writeStderrLine('Failed to close file handle for ' + this._chunkWriter.filePath);
-      }
-      this._chunkWriter = undefined;
-    }
   }
+}
+
+/**
+ * Initializes the project log files for a project. Produces a combined log file, an error log file, and optionally a
+ * chunks file that can be used to reconstrct the original console output.
+ * @param options - The options to initialize the project log files.
+ * @returns The terminal writable stream that will write to the log files.
+ */
+export async function initializeProjectLogFilesAsync(
+  options: IProjectLogWritableOptions
+): Promise<TerminalWritable> {
+  const { logFilePaths, enableChunkedOutput = false } = options;
+
+  const { logFolderPath, jsonlFolderPath, logPath, errorLogPath, jsonlPath } = logFilePaths;
+  await Promise.all([
+    FileSystem.ensureFolderAsync(logFolderPath),
+    enableChunkedOutput && FileSystem.ensureFolderAsync(jsonlFolderPath),
+    FileSystem.deleteFileAsync(logPath),
+    FileSystem.deleteFileAsync(errorLogPath),
+    FileSystem.deleteFileAsync(jsonlPath)
+  ]);
+
+  const splitLog: TerminalWritable = new TextRewriterTransform({
+    destination: new SplitLogFileWritable(logPath, errorLogPath),
+    removeColors: true,
+    normalizeNewlines: NewlineKind.OsDefault
+  });
+
+  if (enableChunkedOutput) {
+    const chunksFile: JsonLFileWritable = new JsonLFileWritable(jsonlPath);
+    const splitter: SplitterTransform = new SplitterTransform({
+      destinations: [splitLog, chunksFile]
+    });
+    return splitter;
+  }
+
+  return splitLog;
+}
+
+/**
+ * @internal
+ *
+ * @param packageName - The raw package name
+ * @param logFilenameIdentifier - The identifier to append to the log file name (typically the phase name)
+ * @returns The base names of the log files
+ */
+export function getLogfileBaseNames(packageName: string, logFilenameIdentifier: string): ILogFileNames {
+  const unscopedProjectName: string = PackageNameParsers.permissive.getUnscopedName(packageName);
+  const logFileBaseName: string = `${unscopedProjectName}.${logFilenameIdentifier}`;
+
+  return {
+    mergedFileName: `${logFileBaseName}.log`,
+    jsonlFileName: `${logFileBaseName}.chunks.jsonl`,
+    errorFileName: `${logFileBaseName}.error.log`
+  };
+}
+
+/**
+ * @internal
+ *
+ * @param projectFolder - The absolute path of the project folder
+ * @returns The absolute paths of the log folders for regular and chunked logs
+ */
+export function getProjectLogFolders(
+  projectFolder: string
+): Pick<ILogFilePaths, 'logFolderPath' | 'jsonlFolderPath'> {
+  const logFolderPath: string = `${projectFolder}/${RushConstants.rushLogsFolderName}`;
+  const jsonlFolderPath: string = `${projectFolder}/${LOG_CHUNKS_FOLDER_RELATIVE_PATH}`;
+
+  return { logFolderPath, jsonlFolderPath };
+}
+
+/**
+ * @internal
+ *
+ * @param options - The options to get the log file paths
+ * @returns All information about log file paths for the project and log identifier
+ */
+export function getProjectLogFilePaths(options: IGetLogFilePathsOptions): ILogFilePaths {
+  const {
+    project: { projectFolder, packageName },
+    logFilenameIdentifier
+  } = options;
+
+  const { logFolderPath, jsonlFolderPath } = getProjectLogFolders(projectFolder);
+  const {
+    mergedFileName: log,
+    jsonlFileName: logChunks,
+    errorFileName: errorLog
+  } = getLogfileBaseNames(packageName, logFilenameIdentifier);
+
+  const logPath: string = `${logFolderPath}/${log}`;
+  const errorLogPath: string = `${logFolderPath}/${errorLog}`;
+  const jsonlPath: string = `${jsonlFolderPath}/${logChunks}`;
+
+  return {
+    logFolderPath,
+    jsonlFolderPath,
+
+    logPath,
+    errorLogPath,
+    jsonlPath
+  };
 }

--- a/rush-plugins/rush-serve-plugin/src/RushProjectServeConfigFile.ts
+++ b/rush-plugins/rush-serve-plugin/src/RushProjectServeConfigFile.ts
@@ -57,7 +57,7 @@ export class RushServeConfiguration {
     projects: Iterable<RushConfigurationProject>,
     terminal: ITerminal,
     workspaceRoutingRules: Iterable<IRoutingRule>
-  ): Promise<Iterable<IRoutingRule>> {
+  ): Promise<IRoutingRule[]> {
     const rules: IRoutingRule[] = Array.from(workspaceRoutingRules);
 
     await Async.forEachAsync(

--- a/rush-plugins/rush-serve-plugin/src/RushServePlugin.ts
+++ b/rush-plugins/rush-serve-plugin/src/RushServePlugin.ts
@@ -38,6 +38,11 @@ export interface IRushServePluginOptions {
   portParameterLongName?: string | undefined;
 
   /**
+   * The URL path at which to host Rush log files. If not specified, log files will not be served.
+   */
+  logServePath?: string | undefined;
+
+  /**
    * Routing rules for files that are associated with the entire workspace, rather than a single project (e.g. files output by Rush plugins).
    */
   globalRouting?: IGlobalRoutingRuleJson[];
@@ -52,12 +57,14 @@ export class RushServePlugin implements IRushPlugin {
   private readonly _phasedCommands: Set<string>;
   private readonly _portParameterLongName: string | undefined;
   private readonly _globalRoutingRules: IGlobalRoutingRuleJson[];
+  private readonly _logServePath: string | undefined;
   private readonly _buildStatusWebSocketPath: string | undefined;
 
   public constructor(options: IRushServePluginOptions) {
     this._phasedCommands = new Set(options.phasedCommands);
     this._portParameterLongName = options.portParameterLongName;
     this._globalRoutingRules = options.globalRouting ?? [];
+    this._logServePath = options.logServePath;
     this._buildStatusWebSocketPath = options.buildStatusWebSocketPath;
   }
 
@@ -84,6 +91,7 @@ export class RushServePlugin implements IRushPlugin {
         rushConfiguration,
         command,
         portParameterLongName: this._portParameterLongName,
+        logServePath: this._logServePath,
         globalRoutingRules,
         buildStatusWebSocketPath: this._buildStatusWebSocketPath
       });

--- a/rush-plugins/rush-serve-plugin/src/api.types.ts
+++ b/rush-plugins/rush-serve-plugin/src/api.types.ts
@@ -10,17 +10,17 @@ export type ReadableOperationStatus = keyof typeof OperationStatus;
 
 export interface ILogFileURLs {
   /**
-   * The URL to the merged log file.
+   * The relative URL to the merged (interleaved stdout and stderr) text log.
    */
-  log: string;
+  text: string;
 
   /**
-   * The URL to the stderr log file.
+   * The relative URL to the stderr log file.
    */
   error: string;
 
   /**
-   * The URL to the JSONL log file.
+   * The relative URL to the JSONL log file.
    */
   jsonl: string;
 }

--- a/rush-plugins/rush-serve-plugin/src/api.types.ts
+++ b/rush-plugins/rush-serve-plugin/src/api.types.ts
@@ -8,6 +8,23 @@ import type { OperationStatus } from '@rushstack/rush-sdk';
  */
 export type ReadableOperationStatus = keyof typeof OperationStatus;
 
+export interface ILogFileURLs {
+  /**
+   * The URL to the merged log file.
+   */
+  log: string;
+
+  /**
+   * The URL to the stderr log file.
+   */
+  error: string;
+
+  /**
+   * The URL to the JSONL log file.
+   */
+  jsonl: string;
+}
+
 /**
  * Information about an operation in the graph.
  */
@@ -40,6 +57,11 @@ export interface IOperationInfo {
    * The current status of the operation. This value is in PascalCase and is the key of the corresponding `OperationStatus` constant.
    */
   status: ReadableOperationStatus;
+
+  /**
+   * The URLs to the log files, if applicable.
+   */
+  logFileURLs: ILogFileURLs | undefined;
 
   /**
    * The start time of the operation, if it has started, in milliseconds. Not wall clock time.
@@ -80,6 +102,7 @@ export interface IWebSocketBeforeExecuteEventMessage {
  */
 export interface IWebSocketAfterExecuteEventMessage {
   event: 'after-execute';
+  operations: IOperationInfo[];
   status: ReadableOperationStatus;
 }
 

--- a/rush-plugins/rush-serve-plugin/src/phasedCommandHandler.ts
+++ b/rush-plugins/rush-serve-plugin/src/phasedCommandHandler.ts
@@ -488,6 +488,6 @@ function getRepositoryIdentifier(rushConfiguration: RushConfiguration): string {
   return `${os.hostname()} - ${rushConfiguration.rushJsonFolder}`;
 }
 
-function getLogServePathForProject(logServePath: string, packageName: string) {
+function getLogServePathForProject(logServePath: string, packageName: string): string {
   return `${logServePath}/${packageName}`;
 }

--- a/rush-plugins/rush-serve-plugin/src/phasedCommandHandler.ts
+++ b/rush-plugins/rush-serve-plugin/src/phasedCommandHandler.ts
@@ -166,7 +166,7 @@ export async function phasedCommandHandler(options: IPhasedCommandHandlerOptions
       const { logServePath } = options;
       if (logServePath) {
         for (const project of selectedProjects) {
-          const projectLogServePath: string = `${logServePath}/${project.packageName}`;
+          const projectLogServePath: string = getLogServePathForProject(logServePath, project.packageName);
 
           routingRules.push({
             type: 'folder',
@@ -309,7 +309,7 @@ function tryEnableBuildStatusWebSocketServer(
       return;
     }
 
-    const projectLogServePath: string = `${logServePath}/${packageName}`;
+    const projectLogServePath: string = getLogServePathForProject(logServePath, packageName);
 
     const logFileUrls: ILogFileURLs = {
       text: `${projectLogServePath}${logFilePaths.text.slice(logFilePaths.textFolder.length)}`,
@@ -486,4 +486,8 @@ function getRepositoryIdentifier(rushConfiguration: RushConfiguration): string {
   }
 
   return `${os.hostname()} - ${rushConfiguration.rushJsonFolder}`;
+}
+
+function getLogServePathForProject(logServePath: string, packageName: string) {
+  return `${logServePath}/${packageName}`;
 }

--- a/rush-plugins/rush-serve-plugin/src/schemas/rush-serve-plugin-options.schema.json
+++ b/rush-plugins/rush-serve-plugin/src/schemas/rush-serve-plugin-options.schema.json
@@ -33,6 +33,12 @@
       "pattern": "^/(?:[a-zA-Z0-9_$-]+(?:/[a-zA-Z0-9_$-]+)*)?$"
     },
 
+    "logServePath": {
+      "type": "string",
+      "description": "The URL path at which to host Rush log files. If not specified, log files will not be served.",
+      "pattern": "^/(?:[a-zA-Z0-9_$-]+(?:/[a-zA-Z0-9_$-]+)*)?$"
+    },
+
     "globalRouting": {
       "type": "array",
       "description": "Routing rules for files that are associated with the entire workspace, rather than a single project (e.g. files output by Rush plugins).",


### PR DESCRIPTION
## Summary
Leaves ANSI escape codes present in the JSONL log files, so that color information will be preserved when replaying from cache.

Adds a property `logFilePaths` to `IOperationExecutionResult` so that they are available to plugins that may wish to interact with them.

Adds a property `logServePath` to the options for `rush-serve-plugin` that specifies a base path under which all log files will be made available via the local server.

## Details
The `logFilePaths` property will only be defined for operations that created log files.

Served files are all in a single flat directory. This may cause collisions if two projects in the same repository have the same unscoped package name, since the naming convention for log files uses the unscoped package name, rather than the full package name.

Refactors logging-related code to have ProjectLogWritable construct the splitter and text rewriter internally, rather than it being the responsibility of the caller. This facilitates routing the raw log directly to the JSONL output and separately performing the newline rewriting and ANSI escape code trimming only for text logs.

## How it was tested
Built with `FORCE_COLOR=1` and verified that the jsonl logs contained the ANSI escape codes from Heft formatting.

Wired up `rush-serve-plugin` in the repository temporarily and validated that WebSocket messages contained information about log files. Also checked that the referenced log files could be fetched.

## Impacted documentation
Documentation for rush-serve-plugin, mainly regarding the schema. The examples for use of websocket will be extended in a future PR when we have a fully functional dashboard to submit.