### PR TITLE
[rush-resolver-cache] Fix projectFolder on Windows

### DIFF
--- a/common/changes/@microsoft/rush/fix-project-folder_2024-09-20-00-10.json
+++ b/common/changes/@microsoft/rush/fix-project-folder_2024-09-20-00-10.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix a bug that caused rush-resolver-cache-plugin to crash on Windows.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/rush-plugins/rush-resolver-cache-plugin/src/test/computeResolverCacheFromLockfileAsync.test.ts
+++ b/rush-plugins/rush-resolver-cache-plugin/src/test/computeResolverCacheFromLockfileAsync.test.ts
@@ -107,7 +107,8 @@ describe(computeResolverCacheFromLockfileAsync.name, () => {
       for (const importerPath of lockfile.importers.keys()) {
         const remainder: string = importerPath.slice(importerPath.lastIndexOf('../') + 3);
         projectByImporterPath.setItem(importerPath, {
-          projectFolder: `${commonPrefixToTrim.replace(/\\/g, '/')}${remainder}`,
+          // Normalization is the responsibility of the implementation
+          projectFolder: `${commonPrefixToTrim}${remainder}`,
           packageJson: {
             name: `@local/${remainder.replace(/\//g, '+')}`
           }


### PR DESCRIPTION
## Summary
Fixes forward vs back slashes in the `projectFolder` value for Rush projects on Windows in the `rush-resolver-cache-plugin`.

## Details
Normalizes to forward slashes inside of the processor.

## How it was tested
Updated unit tests.
Ran an install with it on Windows.

## Impacted documentation
None.