### PR TITLE
[webpack-localization-plugin] Fix circular reference in assetInfo.related

### DIFF
--- a/common/changes/@rushstack/webpack5-localization-plugin/webpack-loc-related-loop_2024-09-23-21-19.json
+++ b/common/changes/@rushstack/webpack5-localization-plugin/webpack-loc-related-loop_2024-09-23-21-19.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/webpack5-localization-plugin",
+      "comment": "Fix circular references between localized assets' \"related\" properties. This caused emitting of the webpack stats object to fail.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/webpack5-localization-plugin"
+}


### PR DESCRIPTION
## Summary
Fixes a bug that was causing emitting of webpack stats to encounter a stack overflow.

## Details
The `related` property on the webpack `AssetInfo` objects must not be cyclic for the current version of the webpack stats emitter.

## How it was tested
Used the modified version to emit webpack stats.

## Impacted documentation
None.