### PR TITLE
[heft] Update file copy layer to support incremental disk cache

### DIFF
--- a/apps/heft/src/operations/runners/TaskOperationRunner.ts
+++ b/apps/heft/src/operations/runners/TaskOperationRunner.ts
@@ -183,6 +183,7 @@ export class TaskOperationRunner implements IOperationRunner {
           ? copyFilesAsync(
               copyOperations,
               logger.terminal,
+              `${taskSession.tempFolderPath}/file-copy.json`,
               isWatchMode ? getWatchFileSystemAdapter() : undefined
             )
           : Promise.resolve(),

--- a/apps/heft/src/pluginFramework/IncrementalBuildInfo.ts
+++ b/apps/heft/src/pluginFramework/IncrementalBuildInfo.ts
@@ -1,0 +1,156 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import * as path from 'path';
+
+import { FileSystem, Path } from '@rushstack/node-core-library';
+
+/**
+ * Information about an incremental build. This information is used to determine which files need to be rebuilt.
+ * @beta
+ */
+export interface IIncrementalBuildInfo {
+  /**
+   * A string that represents the configuration inputs for the build.
+   * If the configuration changes, the old build info object should be discarded.
+   */
+  configHash: string;
+
+  /**
+   * A map of absolute input file paths to their version strings.
+   * The version string should change if the file changes.
+   */
+  inputFileVersions: Map<string, string>;
+
+  /**
+   * A map of absolute output file paths to the input files they were computed from.
+   */
+  fileDependencies?: Map<string, string[]>;
+}
+
+/**
+ * Serialized version of {@link IIncrementalBuildInfo}.
+ * @beta
+ */
+export interface ISerializedIncrementalBuildInfo {
+  /**
+   * A string that represents the configuration inputs for the build.
+   * If the configuration changes, the old build info object should be discarded.
+   */
+  configHash: string;
+
+  /**
+   * A map of input files to their version strings.
+   * File paths are specified relative to the folder containing the build info file.
+   */
+  inputFileVersions: [string, string][];
+
+  /**
+   * Map of output file names to the input file indices used to compute them.
+   * File paths are specified relative to the folder containing the build info file.
+   */
+  fileDependencies?: [string, number | number[]][];
+}
+
+/**
+ * Writes a build info object to disk.
+ * @param state - The build info to write
+ * @param filePath - The file path to write the build info to
+ * @beta
+ */
+export async function writeBuildInfoAsync(state: IIncrementalBuildInfo, filePath: string): Promise<void> {
+  const fileIndices: Map<string, number> = new Map();
+  const inputFileVersions: [string, string][] = [];
+  const directory: string = path.dirname(filePath);
+
+  for (const [absolutePath, version] of state.inputFileVersions) {
+    const relativePath: string = Path.convertToSlashes(path.relative(directory, absolutePath));
+    fileIndices.set(absolutePath, fileIndices.size);
+    inputFileVersions.push([relativePath, version]);
+  }
+
+  const { fileDependencies: newFileDependencies } = state;
+  let fileDependencies: [string, number | number[]][] | undefined;
+  if (newFileDependencies) {
+    fileDependencies = [];
+    for (const [absolutePath, dependencies] of newFileDependencies) {
+      const relativePath: string = Path.convertToSlashes(path.relative(directory, absolutePath));
+      const indices: number[] = [];
+      for (const dependency of dependencies) {
+        const index: number | undefined = fileIndices.get(dependency);
+        if (index === undefined) {
+          throw new Error(`Dependency not found: ${dependency}`);
+        }
+        indices.push(index);
+      }
+
+      fileDependencies.push([relativePath, indices.length === 1 ? indices[0] : indices]);
+    }
+  }
+
+  const serializedBuildInfo: ISerializedIncrementalBuildInfo = {
+    configHash: state.configHash,
+    inputFileVersions,
+    fileDependencies
+  };
+
+  // This file is meant only for machine reading, so don't pretty-print it.
+  const stringified: string = JSON.stringify(serializedBuildInfo);
+
+  await FileSystem.writeFileAsync(filePath, stringified, { ensureFolderExists: true });
+}
+
+/**
+ * Reads a build info object from disk.
+ * @param filePath - The file path to read the build info from
+ * @returns The build info object, or undefined if the file does not exist or cannot be parsed
+ * @beta
+ */
+export async function tryReadBuildInfoAsync(filePath: string): Promise<IIncrementalBuildInfo | undefined> {
+  let serializedBuildInfo: ISerializedIncrementalBuildInfo | undefined;
+  try {
+    const fileContents: string = await FileSystem.readFileAsync(filePath);
+    serializedBuildInfo = JSON.parse(fileContents) as ISerializedIncrementalBuildInfo;
+  } catch (error) {
+    if (FileSystem.isNotExistError(error)) {
+      return;
+    }
+    throw error;
+  }
+
+  const dirname: string = path.dirname(filePath);
+
+  const inputFileVersions: Map<string, string> = new Map();
+  const absolutePathByIndex: string[] = [];
+  for (const [relativePath, version] of serializedBuildInfo.inputFileVersions) {
+    const absolutePath: string = path.resolve(dirname, relativePath);
+    absolutePathByIndex.push(absolutePath);
+    inputFileVersions.set(absolutePath, version);
+  }
+
+  let fileDependencies: Map<string, string[]> | undefined;
+  const { fileDependencies: serializedFileDependencies } = serializedBuildInfo;
+  if (serializedFileDependencies) {
+    fileDependencies = new Map();
+    for (const [relativeOutputFile, indices] of serializedFileDependencies) {
+      const absoluteOutputFile: string = path.resolve(dirname, relativeOutputFile);
+      const dependencies: string[] = [];
+      for (const index of Array.isArray(indices) ? indices : [indices]) {
+        const dependencyAbsolutePath: string | undefined = absolutePathByIndex[index];
+        if (dependencyAbsolutePath === undefined) {
+          throw new Error(`Dependency index not found: ${index}`);
+        }
+        dependencies.push(dependencyAbsolutePath);
+      }
+      fileDependencies.set(absoluteOutputFile, dependencies);
+    }
+  }
+
+  const buildInfo: IIncrementalBuildInfo = {
+    configHash: serializedBuildInfo.configHash,
+    inputFileVersions,
+    fileDependencies
+  };
+
+  return buildInfo;
+}

--- a/apps/heft/src/pluginFramework/tests/IncrementalBuildInfo.test.ts
+++ b/apps/heft/src/pluginFramework/tests/IncrementalBuildInfo.test.ts
@@ -63,16 +63,9 @@ describe(serializeBuildInfo.name, () => {
   });
 
   it('Round trips correctly (Win32)', () => {
-    function makePathPortable(absolutePath: string): string {
-      return Path.convertToSlashes(path.win32.relative(win32BasePath, absolutePath));
-    }
-    function makePathAbsolute(portablePath: string): string {
-      return path.win32.resolve(win32BasePath, portablePath);
-    }
+    const serialized: ISerializedIncrementalBuildInfo = serializeBuildInfo(win32BuildInfo, win32ToPortable);
 
-    const serialized: ISerializedIncrementalBuildInfo = serializeBuildInfo(win32BuildInfo, makePathPortable);
-
-    const deserialized: IIncrementalBuildInfo = deserializeBuildInfo(serialized, makePathAbsolute);
+    const deserialized: IIncrementalBuildInfo = deserializeBuildInfo(serialized, portableToWin32);
 
     expect(deserialized).toEqual(win32BuildInfo);
   });

--- a/apps/heft/src/pluginFramework/tests/IncrementalBuildInfo.test.ts
+++ b/apps/heft/src/pluginFramework/tests/IncrementalBuildInfo.test.ts
@@ -1,0 +1,111 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import path from 'path';
+
+import { Path } from '@rushstack/node-core-library';
+
+import {
+  serializeBuildInfo,
+  deserializeBuildInfo,
+  type IIncrementalBuildInfo,
+  type ISerializedIncrementalBuildInfo
+} from '../IncrementalBuildInfo';
+
+const posixBuildInfo: IIncrementalBuildInfo = {
+  configHash: 'foobar',
+  inputFileVersions: new Map([
+    ['/a/b/c/file1', '1'],
+    ['/a/b/c/file2', '2']
+  ]),
+  fileDependencies: new Map([
+    ['/a/b/c/output1', ['/a/b/c/file1']],
+    ['/a/b/c/output2', ['/a/b/c/file1', '/a/b/c/file2']]
+  ])
+};
+
+const win32BuildInfo: IIncrementalBuildInfo = {
+  configHash: 'foobar',
+  inputFileVersions: new Map([
+    ['A:\\b\\c\\file1', '1'],
+    ['A:\\b\\c\\file2', '2']
+  ]),
+  fileDependencies: new Map([
+    ['A:\\b\\c\\output1', ['A:\\b\\c\\file1']],
+    ['A:\\b\\c\\output2', ['A:\\b\\c\\file1', 'A:\\b\\c\\file2']]
+  ])
+};
+
+const posixBasePath: string = '/a/b/temp';
+const win32BasePath: string = 'A:\\b\\temp';
+
+function posixToPortable(absolutePath: string): string {
+  return path.posix.relative(posixBasePath, absolutePath);
+}
+function portableToPosix(portablePath: string): string {
+  return path.posix.resolve(posixBasePath, portablePath);
+}
+
+function win32ToPortable(absolutePath: string): string {
+  return Path.convertToSlashes(path.win32.relative(win32BasePath, absolutePath));
+}
+function portableToWin32(portablePath: string): string {
+  return path.win32.resolve(win32BasePath, portablePath);
+}
+
+describe(serializeBuildInfo.name, () => {
+  it('Round trips correctly (POSIX)', () => {
+    const serialized: ISerializedIncrementalBuildInfo = serializeBuildInfo(posixBuildInfo, posixToPortable);
+
+    const deserialized: IIncrementalBuildInfo = deserializeBuildInfo(serialized, portableToPosix);
+
+    expect(deserialized).toEqual(posixBuildInfo);
+  });
+
+  it('Round trips correctly (Win32)', () => {
+    function makePathPortable(absolutePath: string): string {
+      return Path.convertToSlashes(path.win32.relative(win32BasePath, absolutePath));
+    }
+    function makePathAbsolute(portablePath: string): string {
+      return path.win32.resolve(win32BasePath, portablePath);
+    }
+
+    const serialized: ISerializedIncrementalBuildInfo = serializeBuildInfo(win32BuildInfo, makePathPortable);
+
+    const deserialized: IIncrementalBuildInfo = deserializeBuildInfo(serialized, makePathAbsolute);
+
+    expect(deserialized).toEqual(win32BuildInfo);
+  });
+
+  it('Converts (POSIX to Win32)', () => {
+    const serialized: ISerializedIncrementalBuildInfo = serializeBuildInfo(posixBuildInfo, posixToPortable);
+
+    const deserialized: IIncrementalBuildInfo = deserializeBuildInfo(serialized, portableToWin32);
+
+    expect(deserialized).toEqual(win32BuildInfo);
+  });
+
+  it('Converts (Win32 to POSIX)', () => {
+    const serialized: ISerializedIncrementalBuildInfo = serializeBuildInfo(win32BuildInfo, win32ToPortable);
+
+    const deserialized: IIncrementalBuildInfo = deserializeBuildInfo(serialized, portableToPosix);
+
+    expect(deserialized).toEqual(posixBuildInfo);
+  });
+
+  it('Has expected serialized format', () => {
+    const serializedPosix: ISerializedIncrementalBuildInfo = serializeBuildInfo(
+      posixBuildInfo,
+      posixToPortable
+    );
+    const serializedWin32: ISerializedIncrementalBuildInfo = serializeBuildInfo(
+      win32BuildInfo,
+      win32ToPortable
+    );
+
+    expect(serializedPosix).toMatchSnapshot('posix');
+    expect(serializedWin32).toMatchSnapshot('win32');
+
+    expect(serializedPosix).toEqual(serializedWin32);
+  });
+});

--- a/apps/heft/src/pluginFramework/tests/__snapshots__/IncrementalBuildInfo.test.ts.snap
+++ b/apps/heft/src/pluginFramework/tests/__snapshots__/IncrementalBuildInfo.test.ts.snap
@@ -1,0 +1,35 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`serializeBuildInfo Has expected serialized format: posix 1`] = `
+Object {
+  "configHash": "foobar",
+  "fileDependencies": Object {
+    "../c/output1": 0,
+    "../c/output2": Array [
+      0,
+      1,
+    ],
+  },
+  "inputFileVersions": Object {
+    "../c/file1": "1",
+    "../c/file2": "2",
+  },
+}
+`;
+
+exports[`serializeBuildInfo Has expected serialized format: win32 1`] = `
+Object {
+  "configHash": "foobar",
+  "fileDependencies": Object {
+    "../c/output1": 0,
+    "../c/output2": Array [
+      0,
+      1,
+    ],
+  },
+  "inputFileVersions": Object {
+    "../c/file1": "1",
+    "../c/file2": "2",
+  },
+}
+`;

--- a/apps/heft/src/pluginFramework/tests/__snapshots__/IncrementalBuildInfo.test.ts.snap
+++ b/apps/heft/src/pluginFramework/tests/__snapshots__/IncrementalBuildInfo.test.ts.snap
@@ -4,7 +4,9 @@ exports[`serializeBuildInfo Has expected serialized format: posix 1`] = `
 Object {
   "configHash": "foobar",
   "fileDependencies": Object {
-    "../c/output1": 0,
+    "../c/output1": Array [
+      0,
+    ],
     "../c/output2": Array [
       0,
       1,
@@ -21,7 +23,9 @@ exports[`serializeBuildInfo Has expected serialized format: win32 1`] = `
 Object {
   "configHash": "foobar",
   "fileDependencies": Object {
-    "../c/output1": 0,
+    "../c/output1": Array [
+      0,
+    ],
     "../c/output2": Array [
       0,
       1,

--- a/apps/heft/src/plugins/CopyFilesPlugin.ts
+++ b/apps/heft/src/plugins/CopyFilesPlugin.ts
@@ -231,7 +231,7 @@ async function _copyFilesInnerAsync(
     return;
   }
 
-  let copiedFolderOrFileCount: number = 0;
+  let copiedFileCount: number = 0;
   let linkedFileCount: number = 0;
   await Async.forEachAsync(
     copyDescriptorsWithWork,
@@ -247,7 +247,7 @@ async function _copyFilesInnerAsync(
           `Linked "${copyDescriptor.sourcePath}" to "${copyDescriptor.destinationPath}".`
         );
       } else {
-        copiedFolderOrFileCount++;
+        copiedFileCount++;
         await FileSystem.copyFilesAsync({
           sourcePath: copyDescriptor.sourcePath,
           destinationPath: copyDescriptor.destinationPath,
@@ -261,9 +261,8 @@ async function _copyFilesInnerAsync(
     { concurrency: Constants.maxParallelism }
   );
 
-  const folderOrFilesPlural: string = copiedFolderOrFileCount === 1 ? '' : 's';
   terminal.writeLine(
-    `Copied ${copiedFolderOrFileCount} file${folderOrFilesPlural} and ` +
+    `Copied ${copiedFileCount} file${copiedFileCount === 1 ? '' : 's'} and ` +
       `linked ${linkedFileCount} file${linkedFileCount === 1 ? '' : 's'}`
   );
 

--- a/build-tests/heft-copy-files-test/config/rush-project.json
+++ b/build-tests/heft-copy-files-test/config/rush-project.json
@@ -13,7 +13,8 @@
         "out-images2",
         "out-images3",
         "out-images4",
-        "out-images5"
+        "out-images5",
+        "temp/build"
       ]
     }
   ]

--- a/common/changes/@rushstack/heft/copy-file-if-changed_2024-09-26-22-16.json
+++ b/common/changes/@rushstack/heft/copy-file-if-changed_2024-09-26-22-16.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Update file copy logic to use an incremental cache file in the temp directory for the current task to avoid unnecessary file writes.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft"
+}


### PR DESCRIPTION
## Summary
Fixes #4942

Updates the underlying logic in Heft's `copy-files-plugin` to write an incremental cache file, that will be used to only copy files where the inputs have changed. This also impacts the file copy in `heft-typescript-plugin`.

Adds a new API to read and write incremental cache files, for use by other plugins.

## Details
Incremental cache files store a config hash, a list of input files with SHA-256 hashes, and optionally a mapping from output file names to indices of input files.

Each task will get its own unique `file-copy.json` cache file in the task's temp folder if there are a non-zero number of copy operations configured for the task.

## How it was tested
Using `build-tests/heft-copy-files-plugin`.

## Impacted documentation
Copy files.