### PR TITLE
[heft] Fix incremental copy cache file

### DIFF
--- a/apps/heft/src/pluginFramework/IncrementalBuildInfo.ts
+++ b/apps/heft/src/pluginFramework/IncrementalBuildInfo.ts
@@ -171,7 +171,7 @@ export async function writeBuildInfoAsync(state: IIncrementalBuildInfo, filePath
   const serializedBuildInfo: ISerializedIncrementalBuildInfo = serializeBuildInfo(
     state,
     (absolutePath: string) => {
-      return makePathRelative(basePath, absolutePath);
+      return makePathRelative(absolutePath, basePath);
     }
   );
 

--- a/apps/heft/src/plugins/CopyFilesPlugin.ts
+++ b/apps/heft/src/plugins/CopyFilesPlugin.ts
@@ -186,7 +186,9 @@ async function _copyFilesInnerAsync(
     oldBuildInfo = undefined;
   }
 
-  const inputFileVersions: Map<string, string> = new Map();
+  // Since in watch mode only changed files will get passed in, need to ensure that all files from
+  // the previous build are still tracked.
+  const inputFileVersions: Map<string, string> = new Map(oldBuildInfo?.inputFileVersions);
 
   const buildInfo: IIncrementalBuildInfo = {
     configHash,

--- a/common/changes/@rushstack/heft/copy-file-watch_2024-09-30-20-22.json
+++ b/common/changes/@rushstack/heft/copy-file-watch_2024-09-30-20-22.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Include all previous `inputFileVersions` in incremental copy files cache file during watch mode. Fix incorrect serialization of cache file for file copy.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft"
+}


### PR DESCRIPTION
## Summary
Fixes bugs in #4943
 
## Details
Ensures that the file copy incremental cache file contains the correct entries.
Ensures that the file copy incremental cache file preserves all entries during a watch mode rebuild, and not only the entries that were changed in the most recent incremental iteration.

## How it was tested
Running `heft build-watch` in `build-tests/heft-file-copy-test` and validating the content of the cache file.

## Impacted documentation
None