### PR TITLE
[api-extractor] Add support for new TS declaration format when using module resolution 'bundler' or 'nodenext'

### DIFF
--- a/apps/api-extractor/src/api/ExtractorConfig.ts
+++ b/apps/api-extractor/src/api/ExtractorConfig.ts
@@ -258,8 +258,11 @@ export class ExtractorConfig {
     path.join(__dirname, '../schemas/api-extractor-defaults.json')
   );
 
-  /** Match all three flavors for type declaration files (.d.ts, .d.mts, .d.cts) */
-  private static readonly _declarationFileExtensionRegExp: RegExp = /\.d\.(c|m)?ts$/i;
+  /**
+   * Match all three flavors for type declaration files (.d.ts, .d.mts, .d.cts)
+   * including the new TS 5 bundle resolutions (.d.\{extension\}.ts, .d.\{extension\}.mts, .d.\{extension\}.cts)
+   **/
+  private static readonly _declarationFileExtensionRegExp: RegExp = /\.d(\.[^./\\]+)?\.(c|m)?ts$/i;
 
   /** {@inheritDoc IConfigFile.projectFolder} */
   public readonly projectFolder: string;

--- a/apps/api-extractor/src/api/IConfigFile.ts
+++ b/apps/api-extractor/src/api/IConfigFile.ts
@@ -450,7 +450,7 @@ export interface IConfigFile {
    *
    * @remarks
    *
-   * The file extension must be ".d.ts" and not ".ts".
+   * The file extension must be a declaration file (e.g. ".d.ts", ".d.mts", ".d.{extension}.ts"), not ".ts".
    * The path is resolved relative to the "projectFolder" location.
    */
   mainEntryPointFilePath: string;

--- a/apps/api-extractor/src/api/IConfigFile.ts
+++ b/apps/api-extractor/src/api/IConfigFile.ts
@@ -450,7 +450,7 @@ export interface IConfigFile {
    *
    * @remarks
    *
-   * The file extension must be a declaration file (e.g. ".d.ts", ".d.mts", ".d.{extension}.ts"), not ".ts".
+   * The file extension must be a declaration file (e.g. ".d.ts", ".d.mts", ".d.\{extension\}.ts"), not ".ts".
    * The path is resolved relative to the "projectFolder" location.
    */
   mainEntryPointFilePath: string;

--- a/apps/api-extractor/src/api/test/ExtractorConfig.test.ts
+++ b/apps/api-extractor/src/api/test/ExtractorConfig.test.ts
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { ExtractorConfig } from '../ExtractorConfig';
+
+describe('ExtractorConfig', () => {
+  describe('hasDtsFileExtension', () => {
+    it.each([
+      ['test.ts', false],
+      ['test.cts', false],
+      ['test.mts', false],
+      ['test.d.ts', true],
+      ['test.d.mts', true],
+      ['test.d.cts', true],
+      ['test.css', false],
+      ['test.css.ts', false],
+      ['test.css.d.ts', true],
+      ['test.d.css.ts', true],
+      ['test.json', false],
+      ['test.json.ts', false],
+      ['test.json.d.ts', true],
+      ['test.d.json.ts', true],
+      ['video.d.mp4.ts', true],
+      ['font.d.woff2.ts', true],
+      ['model.d.3mf.ts', true]
+    ])('file "%s" has dts file extension equals "%s"', (file, expected) => {
+      const result = ExtractorConfig.hasDtsFileExtension(file);
+      expect(result).toEqual(expected);
+    });
+  });
+});

--- a/apps/api-extractor/src/schemas/api-extractor-template.json
+++ b/apps/api-extractor/src/schemas/api-extractor-template.json
@@ -38,7 +38,7 @@
    * (REQUIRED) Specifies the .d.ts file to be used as the starting point for analysis.  API Extractor
    * analyzes the symbols exported by this module.
    *
-   * The file extension must be ".d.ts" and not ".ts".
+   * The file extension must be a declaration file (e.g. ".d.ts", ".d.mts", ".d.{extension}.ts"), not ".ts".
    *
    * The path is resolved relative to the folder of the config file that contains the setting; to change this,
    * prepend a folder token such as "<projectFolder>".

--- a/build-tests-samples/heft-web-rig-library-tutorial/config/api-extractor.json
+++ b/build-tests-samples/heft-web-rig-library-tutorial/config/api-extractor.json
@@ -40,7 +40,7 @@
    * (REQUIRED) Specifies the .d.ts file to be used as the starting point for analysis.  API Extractor
    * analyzes the symbols exported by this module.
    *
-   * The file extension must be ".d.ts" and not ".ts".
+   * The file extension must be a declaration file (e.g. ".d.ts", ".d.mts", ".d.{extension}.ts"), not ".ts".
    *
    * The path is resolved relative to the folder of the config file that contains the setting; to change this,
    * prepend a folder token such as "<projectFolder>".

--- a/common/changes/@microsoft/api-extractor/bartvandenende-wm-4899_2026-06-08-04-32.json
+++ b/common/changes/@microsoft/api-extractor/bartvandenende-wm-4899_2026-06-08-04-32.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Add support for new d.ts extension format when using TS moduleResolution 'bundler' or 'nodenext'.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor"
+}


### PR DESCRIPTION
## Summary

Add support for new TS declaration format when using module resolution 'bundler' or 'nodenext'

fixes https://github.com/microsoft/rushstack/issues/4899

## Details

TS 5.x started to support new `moduleResolution` `bundler` and `nodenext` (or `node16`) which changes the behaviour of TS declaration files for arbitrary extensions like `.json` and `.css`.

> By default, this import will raise an error to let you know that TypeScript doesn’t understand this file type and your runtime might not support importing it. But if you’ve configured your runtime or bundler to handle it, you can suppress the error with the new --allowArbitraryExtensions compiler option.
> 
> Note that historically, a similar effect has often been achievable by adding a declaration file named app.css.d.ts instead of app.d.css.ts - however, this just worked through Node’s require resolution rules for CommonJS. Strictly speaking, the former is interpreted as a declaration file for a JavaScript file named app.css.js. Because relative files imports need to include extensions in Node’s ESM support, TypeScript would error on our example in an ESM file under --moduleResolution node16 or nodenext
> 
> 

By enabling the TS [allowArbitraryExtensions](https://www.typescriptlang.org/tsconfig/#allowArbitraryExtensions) setting, declaration files can be imported with the new module resolutions but are required to follow the `{file basename}.d.{extension}.ts` pattern. 

This PR updates the regex in `ExtractorConfig` which detect if a file is a declaration file to be inclusive of the new pattern.

## How it was tested

unit test

## Impacted documentation

N/A
