### PR TITLE
[heft] Fix portability of configHash for incremental file copy

### DIFF
--- a/apps/heft/src/operations/runners/TaskOperationRunner.ts
+++ b/apps/heft/src/operations/runners/TaskOperationRunner.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+import { createHash, type Hash } from 'node:crypto';
+
 import {
   type IOperationRunner,
   type IOperationRunnerContext,
@@ -10,7 +12,12 @@ import {
 import { AlreadyReportedError, InternalError } from '@rushstack/node-core-library';
 
 import type { HeftTask } from '../../pluginFramework/HeftTask';
-import { copyFilesAsync, normalizeCopyOperation } from '../../plugins/CopyFilesPlugin';
+import {
+  copyFilesAsync,
+  type ICopyOperation,
+  asAbsoluteCopyOperation,
+  asRelativeCopyOperation
+} from '../../plugins/CopyFilesPlugin';
 import { deleteFilesAsync } from '../../plugins/DeleteFilesPlugin';
 import type {
   HeftTaskSession,
@@ -51,6 +58,7 @@ export class TaskOperationRunner implements IOperationRunner {
   private readonly _options: ITaskOperationRunnerOptions;
 
   private _fileOperations: IHeftTaskFileOperations | undefined = undefined;
+  private _copyConfigHash: string | undefined;
   private _watchFileSystemAdapter: WatchFileSystemAdapter | undefined = undefined;
 
   public readonly silent: boolean = false;
@@ -99,12 +107,31 @@ export class TaskOperationRunner implements IOperationRunner {
         deleteOperations: new Set()
       });
 
-      // Do this here so that we only need to do it once for each run
-      for (const copyOperation of fileOperations.copyOperations) {
-        normalizeCopyOperation(rootFolderPath, copyOperation);
+      let copyConfigHash: string | undefined;
+      const { copyOperations } = fileOperations;
+      if (copyOperations.size > 0) {
+        // Do this here so that we only need to do it once for each Heft invocation
+        const hasher: Hash | undefined = createHash('sha256');
+        const absolutePathCopyOperations: Set<ICopyOperation> = new Set();
+        for (const copyOperation of fileOperations.copyOperations) {
+          // The paths in the `fileOperations` object may be either absolute or relative
+          // For execution we need absolute paths.
+          const absoluteOperation: ICopyOperation = asAbsoluteCopyOperation(rootFolderPath, copyOperation);
+          absolutePathCopyOperations.add(absoluteOperation);
+
+          // For portability of the hash we need relative paths.
+          const portableCopyOperation: ICopyOperation = asRelativeCopyOperation(
+            rootFolderPath,
+            absoluteOperation
+          );
+          hasher.update(JSON.stringify(portableCopyOperation));
+        }
+        fileOperations.copyOperations = absolutePathCopyOperations;
+        copyConfigHash = hasher.digest('base64');
       }
 
       this._fileOperations = fileOperations;
+      this._copyConfigHash = copyConfigHash;
     }
 
     const shouldRunIncremental: boolean = isWatchMode && hooks.runIncremental.isUsed();
@@ -177,13 +204,15 @@ export class TaskOperationRunner implements IOperationRunner {
 
     if (this._fileOperations) {
       const { copyOperations, deleteOperations } = this._fileOperations;
+      const copyConfigHash: string | undefined = this._copyConfigHash;
 
       await Promise.all([
-        copyOperations.size > 0
+        copyConfigHash
           ? copyFilesAsync(
               copyOperations,
               logger.terminal,
               `${taskSession.tempFolderPath}/file-copy.json`,
+              copyConfigHash,
               isWatchMode ? getWatchFileSystemAdapter() : undefined
             )
           : Promise.resolve(),

--- a/apps/heft/src/pluginFramework/IncrementalBuildInfo.ts
+++ b/apps/heft/src/pluginFramework/IncrementalBuildInfo.ts
@@ -55,7 +55,7 @@ export interface ISerializedIncrementalBuildInfo {
 /**
  * Converts an absolute path to a path relative to a base path.
  */
-const makePathRelative: (absolutePath: string, basePath: string) => string =
+export const makePathRelative: (absolutePath: string, basePath: string) => string =
   process.platform === 'win32'
     ? (absolutePath: string, basePath: string) => {
         // On Windows, need to normalize slashes

--- a/apps/heft/src/plugins/DeleteFilesPlugin.ts
+++ b/apps/heft/src/plugins/DeleteFilesPlugin.ts
@@ -8,7 +8,7 @@ import type { ITerminal } from '@rushstack/terminal';
 import { Constants } from '../utilities/Constants';
 import {
   getFileSelectionSpecifierPathsAsync,
-  normalizeFileSelectionSpecifier,
+  asAbsoluteFileSelectionSpecifier,
   type IFileSelectionSpecifier
 } from './FileGlobSpecifier';
 import type { HeftConfiguration } from '../configuration/HeftConfiguration';
@@ -43,11 +43,14 @@ async function _getPathsToDeleteAsync(
   await Async.forEachAsync(
     deleteOperations,
     async (deleteOperation: IDeleteOperation) => {
-      normalizeFileSelectionSpecifier(rootFolderPath, deleteOperation);
+      const absoluteSpecifier: IDeleteOperation = asAbsoluteFileSelectionSpecifier(
+        rootFolderPath,
+        deleteOperation
+      );
 
       // Glob the files under the source path and add them to the set of files to delete
       const sourcePaths: Map<string, fs.Dirent> = await getFileSelectionSpecifierPathsAsync({
-        fileGlobSpecifier: deleteOperation,
+        fileGlobSpecifier: absoluteSpecifier,
         includeFolders: true
       });
       for (const [sourcePath, dirent] of sourcePaths) {

--- a/apps/heft/src/plugins/FileGlobSpecifier.ts
+++ b/apps/heft/src/plugins/FileGlobSpecifier.ts
@@ -178,13 +178,17 @@ export async function getFileSelectionSpecifierPathsAsync(
   return results;
 }
 
-export function normalizeFileSelectionSpecifier(
+export function asAbsoluteFileSelectionSpecifier<TSpecifier extends IFileSelectionSpecifier>(
   rootPath: string,
-  fileGlobSpecifier: IFileSelectionSpecifier
-): void {
+  fileGlobSpecifier: TSpecifier
+): TSpecifier {
   const { sourcePath } = fileGlobSpecifier;
-  fileGlobSpecifier.sourcePath = sourcePath ? path.resolve(rootPath, sourcePath) : rootPath;
-  fileGlobSpecifier.includeGlobs = getIncludedGlobPatterns(fileGlobSpecifier);
+  return {
+    ...fileGlobSpecifier,
+    sourcePath: sourcePath ? path.resolve(rootPath, sourcePath) : rootPath,
+    includeGlobs: getIncludedGlobPatterns(fileGlobSpecifier),
+    fileExtensions: undefined
+  };
 }
 
 function getIncludedGlobPatterns(fileGlobSpecifier: IFileSelectionSpecifier): string[] {

--- a/common/changes/@rushstack/heft/copy-files-hash_2024-10-01-20-05.json
+++ b/common/changes/@rushstack/heft/copy-files-hash_2024-10-01-20-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Ensure `configHash` for file copy incremental cache file is portable.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft"
+}


### PR DESCRIPTION
## Summary
Fixes an issue where the configHash for incremental file copy state was calculated by hashing absolute paths and was therefore not portable.

## Details
Fixes the hash to be calculated using relative paths.
Moves hash computation to avoid duplicate work on watch mode rebuilds.

## How it was tested
Existing build tests, plus running `heft-webpack5-everything-test` under debugger and validating the inputs to the hash were relative, since these come from `heft-typescript-plugin` and are therefore a more interesting case than the `CopyFilesPlugin`.

## Impacted documentation
None