### PR TITLE
[rush] Look for `:incremental` suffixed scripts in watch mode

### DIFF
--- a/common/changes/@microsoft/rush/script-priority_2024-10-03-01-47.json
+++ b/common/changes/@microsoft/rush/script-priority_2024-10-03-01-47.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Changes the behavior of phased commands in watch mode to, when running a phase `_phase:<name>` in all iterations after the first, prefer a script entry named `_phase:<name>:incremental` if such a script exists. The build cache will expect the outputs from the corresponding `_phase:<name>` script (with otherwise the same inputs) to be equivalent when looking for a cache hit.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/logic/operations/IPCOperationRunnerPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/IPCOperationRunnerPlugin.ts
@@ -55,13 +55,15 @@ export class IPCOperationRunnerPlugin implements IPhasedCommandPlugin {
             continue;
           }
 
+          const { scripts } = project.packageJson;
+          if (!scripts) {
+            continue;
+          }
+
           const { name: phaseName } = phase;
 
-          const { scripts } = project.packageJson;
-          const rawScript: string | undefined = [
-            !isInitial && scripts?.[`${phaseName}:incremental:ipc`],
-            scripts?.[`${phaseName}:ipc`]
-          ].find((x): x is string => typeof x === 'string');
+          const rawScript: string | undefined =
+            (!isInitial ? scripts[`${phaseName}:incremental:ipc`] : undefined) ?? scripts[`${phaseName}:ipc`];
 
           if (!rawScript) {
             continue;

--- a/libraries/rush-lib/src/logic/operations/ShardedPhaseOperationPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/ShardedPhaseOperationPlugin.ts
@@ -128,9 +128,7 @@ function spliceShards(existingOperations: Set<Operation>, context: ICreateOperat
       ];
 
       const { scripts } = project.packageJson;
-      const commandToRun: string | undefined = [phase.shellCommand, scripts?.[phase.name]].find(
-        (x) => typeof x === 'string'
-      );
+      const commandToRun: string | undefined = phase.shellCommand ?? scripts?.[phase.name];
 
       operation.logFilenameIdentifier = `${baseLogFilenameIdentifier}_collate`;
       operation.runner = initializeShellOperationRunner({

--- a/libraries/rush-lib/src/logic/operations/ShardedPhaseOperationPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/ShardedPhaseOperationPlugin.ts
@@ -13,10 +13,8 @@ import { NullOperationRunner } from './NullOperationRunner';
 import { Operation } from './Operation';
 import { OperationStatus } from './OperationStatus';
 import {
-  formatCommand,
   getCustomParameterValuesByPhase,
   getDisplayName,
-  getScriptToRun,
   initializeShellOperationRunner
 } from './ShellOperationRunnerPlugin';
 
@@ -129,11 +127,10 @@ function spliceShards(existingOperations: Set<Operation>, context: ICreateOperat
         `--shard-count="${shards}"`
       ];
 
-      const rawCommandToRun: string | undefined = getScriptToRun(project, phase.name, phase.shellCommand);
-
-      const commandToRun: string | undefined = rawCommandToRun
-        ? formatCommand(rawCommandToRun, collatorParameters)
-        : undefined;
+      const { scripts } = project.packageJson;
+      const commandToRun: string | undefined = [phase.shellCommand, scripts?.[phase.name]].find(
+        (x) => typeof x === 'string'
+      );
 
       operation.logFilenameIdentifier = `${baseLogFilenameIdentifier}_collate`;
       operation.runner = initializeShellOperationRunner({
@@ -141,11 +138,12 @@ function spliceShards(existingOperations: Set<Operation>, context: ICreateOperat
         project,
         displayName: collatorDisplayName,
         rushConfiguration,
-        commandToRun: commandToRun
+        commandToRun,
+        customParameterValues: collatorParameters
       });
 
       const shardOperationName: string = `${phase.name}:shard`;
-      const baseCommand: string | undefined = getScriptToRun(project, shardOperationName, undefined);
+      const baseCommand: string | undefined = scripts?.[shardOperationName];
       if (baseCommand === undefined) {
         throw new Error(
           `The project '${project.packageName}' does not define a '${phase.name}:shard' command in the 'scripts' section of its package.json`
@@ -205,14 +203,11 @@ function spliceShards(existingOperations: Set<Operation>, context: ICreateOperat
 
         const shardDisplayName: string = `${getDisplayName(phase, project)} - shard ${shard}/${shards}`;
 
-        const shardedCommandToRun: string | undefined = baseCommand
-          ? formatCommand(baseCommand, shardedParameters)
-          : undefined;
-
         shardOperation.runner = initializeShellOperationRunner({
           phase,
           project,
-          commandToRun: shardedCommandToRun,
+          commandToRun: baseCommand,
+          customParameterValues: shardedParameters,
           displayName: shardDisplayName,
           rushConfiguration
         });

--- a/libraries/rush-lib/src/logic/operations/ShellOperationRunner.ts
+++ b/libraries/rush-lib/src/logic/operations/ShellOperationRunner.ts
@@ -19,6 +19,7 @@ export interface IOperationRunnerOptions {
   rushProject: RushConfigurationProject;
   rushConfiguration: RushConfiguration;
   commandToRun: string;
+  commandForHash: string;
   displayName: string;
   phase: IPhase;
   environment?: IEnvironment;
@@ -38,6 +39,7 @@ export class ShellOperationRunner implements IOperationRunner {
   public readonly warningsAreAllowed: boolean;
 
   private readonly _commandToRun: string;
+  private readonly _commandForHash: string;
 
   private readonly _rushProject: RushConfigurationProject;
   private readonly _rushConfiguration: RushConfiguration;
@@ -53,6 +55,7 @@ export class ShellOperationRunner implements IOperationRunner {
     this._rushProject = options.rushProject;
     this._rushConfiguration = options.rushConfiguration;
     this._commandToRun = options.commandToRun;
+    this._commandForHash = options.commandForHash;
     this._environment = options.environment;
   }
 
@@ -65,7 +68,7 @@ export class ShellOperationRunner implements IOperationRunner {
   }
 
   public getConfigHash(): string {
-    return this._commandToRun;
+    return this._commandForHash;
   }
 
   private async _executeAsync(context: IOperationRunnerContext): Promise<OperationStatus> {

--- a/libraries/rush-lib/src/logic/operations/ShellOperationRunnerPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/ShellOperationRunnerPlugin.ts
@@ -84,7 +84,7 @@ export function initializeShellOperationRunner(options: {
 }): IOperationRunner {
   const { phase, project, commandToRun: rawCommandToRun, displayName } = options;
 
-  if (rawCommandToRun === undefined && phase.missingScriptBehavior === 'error') {
+  if (typeof rawCommandToRun !== 'string' && phase.missingScriptBehavior === 'error') {
     throw new Error(
       `The project '${project.packageName}' does not define a '${phase.name}' command in the 'scripts' section of its package.json`
     );

--- a/libraries/rush-lib/src/logic/operations/ShellOperationRunnerPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/ShellOperationRunnerPlugin.ts
@@ -31,7 +31,7 @@ function createShellOperations(
   operations: Set<Operation>,
   context: ICreateOperationsContext
 ): Set<Operation> {
-  const { rushConfiguration } = context;
+  const { rushConfiguration, isInitial } = context;
 
   const getCustomParameterValuesForPhase: (phase: IPhase) => ReadonlyArray<string> =
     getCustomParameterValuesByPhase();
@@ -44,17 +44,25 @@ function createShellOperations(
       const customParameterValues: ReadonlyArray<string> = getCustomParameterValuesForPhase(phase);
 
       const displayName: string = getDisplayName(phase, project);
+      const { name: phaseName, shellCommand } = phase;
 
-      const rawCommandToRun: string | undefined = getScriptToRun(project, phase.name, phase.shellCommand);
-
-      const commandToRun: string | undefined =
-        rawCommandToRun !== undefined ? formatCommand(rawCommandToRun, customParameterValues) : undefined;
+      const { scripts } = project.packageJson;
+      const commandForHash: string | undefined = [shellCommand, scripts?.[phaseName]].find(
+        (x): x is string => typeof x === 'string'
+      );
+      const commandToRun: string | undefined = [
+        shellCommand,
+        !isInitial && scripts?.[`${phaseName}:incremental`],
+        scripts?.[phaseName]
+      ].find((x): x is string => typeof x === 'string');
 
       operation.runner = initializeShellOperationRunner({
         phase,
         project,
         displayName,
+        commandForHash,
         commandToRun,
+        customParameterValues,
         rushConfiguration
       });
     }
@@ -69,18 +77,28 @@ export function initializeShellOperationRunner(options: {
   displayName: string;
   rushConfiguration: RushConfiguration;
   commandToRun: string | undefined;
+  commandForHash?: string;
+  customParameterValues: ReadonlyArray<string>;
 }): IOperationRunner {
-  const { phase, project, rushConfiguration, commandToRun, displayName } = options;
+  const { phase, project, commandToRun: rawCommandToRun, displayName } = options;
 
-  if (commandToRun === undefined && phase.missingScriptBehavior === 'error') {
+  if (rawCommandToRun === undefined && phase.missingScriptBehavior === 'error') {
     throw new Error(
       `The project '${project.packageName}' does not define a '${phase.name}' command in the 'scripts' section of its package.json`
     );
   }
 
-  if (commandToRun) {
+  if (rawCommandToRun) {
+    const { rushConfiguration, commandForHash: rawCommandForHash } = options;
+
+    const commandToRun: string = formatCommand(rawCommandToRun, options.customParameterValues);
+    const commandForHash: string = rawCommandForHash
+      ? formatCommand(rawCommandForHash, options.customParameterValues)
+      : commandToRun;
+
     return new ShellOperationRunner({
-      commandToRun: commandToRun || '',
+      commandToRun,
+      commandForHash,
       displayName,
       phase,
       rushConfiguration,
@@ -94,22 +112,6 @@ export function initializeShellOperationRunner(options: {
       silent: phase.missingScriptBehavior === 'silent'
     });
   }
-}
-
-export function getScriptToRun(
-  rushProject: RushConfigurationProject,
-  commandToRun: string,
-  shellCommand: string | undefined
-): string | undefined {
-  const { scripts } = rushProject.packageJson;
-
-  const rawCommand: string | undefined | null = shellCommand ?? scripts?.[commandToRun];
-
-  if (rawCommand === undefined || rawCommand === null) {
-    return undefined;
-  }
-
-  return rawCommand;
 }
 
 /**

--- a/libraries/rush-lib/src/logic/operations/ShellOperationRunnerPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/ShellOperationRunnerPlugin.ts
@@ -47,14 +47,16 @@ function createShellOperations(
       const { name: phaseName, shellCommand } = phase;
 
       const { scripts } = project.packageJson;
-      const commandForHash: string | undefined = [shellCommand, scripts?.[phaseName]].find(
-        (x): x is string => typeof x === 'string'
-      );
-      const commandToRun: string | undefined = [
-        shellCommand,
-        !isInitial && scripts?.[`${phaseName}:incremental`],
-        scripts?.[phaseName]
-      ].find((x): x is string => typeof x === 'string');
+
+      // This is the command that will be used to identify the cache entry for this operation
+      const commandForHash: string | undefined = shellCommand ?? scripts?.[phaseName];
+
+      // For execution of non-initial runs, prefer the `:incremental` script if it exists.
+      // However, the `shellCommand` value still takes precedence per the spec for that feature.
+      const commandToRun: string | undefined =
+        shellCommand ??
+        (!isInitial ? scripts?.[`${phaseName}:incremental`] : undefined) ??
+        scripts?.[phaseName];
 
       operation.runner = initializeShellOperationRunner({
         phase,

--- a/libraries/rush-lib/src/schemas/command-line.schema.json
+++ b/libraries/rush-lib/src/schemas/command-line.schema.json
@@ -218,7 +218,7 @@
                 },
                 "watchPhases": {
                   "title": "Watch Phases",
-                  "description": "List *exactly* the phases that should be run in watch mode for this command. If this property is specified and non-empty, after the phases defined in the \"phases\" property run, a file watcher will be started to watch projects for changes, and will run the phases listed in this property on changed projects.",
+                  "description": "List *exactly* the phases that should be run in watch mode for this command. If this property is specified and non-empty, after the phases defined in the \"phases\" property run, a file watcher will be started to watch projects for changes, and will run the phases listed in this property on changed projects. Rush will prefer scripts named \"${phaseName}:incremental\" over \"${phaseName}\" for every iteration after the first, so you can reuse the same phase name but define different scripts, e.g. to not clean on incremental runs.",
                   "type": "array",
                   "items": {
                     "type": "string"


### PR DESCRIPTION
## Summary
Changes the algorithm for executing phased commands in watch mode to prefer a script named `_phase:<name>:incremental` for every iteration after the first. The typical scenario for such would be to omit cleaning from an incremental run.

## Details
The build cache will still treat the `:incremental` commands as having the same cache key as the non-incremental command, so later iterations can still encounter cache hits. However, cache writes do not occur in iterations after the first.

## How it was tested
Temporarily added a `_phase:build:incremental` to a project and ran `rush start`. Validated that the `_phase:build:incremental` script was used for the second iteration. Validated that modifying inputs back to a state known to be present in the cache resulted in a cache hit.

## Impacted documentation
Documentation on phased commands.