### PR TITLE
[heft] Stop using true-case-path

### DIFF
--- a/apps/heft/package.json
+++ b/apps/heft/package.json
@@ -45,7 +45,6 @@
     "git-repo-info": "~2.1.0",
     "ignore": "~5.1.6",
     "tapable": "1.1.3",
-    "true-case-path": "~2.2.1",
     "watchpack": "2.4.0"
   },
   "devDependencies": {

--- a/apps/heft/src/configuration/HeftConfiguration.ts
+++ b/apps/heft/src/configuration/HeftConfiguration.ts
@@ -4,7 +4,6 @@
 import * as path from 'path';
 import { type IPackageJson, PackageJsonLookup, InternalError, Path } from '@rushstack/node-core-library';
 import { Terminal, type ITerminalProvider, type ITerminal } from '@rushstack/terminal';
-import { trueCasePathSync } from 'true-case-path';
 import { type IRigConfig, RigConfig } from '@rushstack/rig-package';
 
 import { Constants } from '../utilities/Constants';
@@ -161,11 +160,12 @@ export class HeftConfiguration {
     );
     if (packageJsonPath) {
       let buildFolderPath: string = path.dirname(packageJsonPath);
-      // The CWD path's casing may be incorrect on a case-insensitive filesystem. Some tools, like Jest
-      // expect the casing of the project path to be correct and produce unexpected behavior when the casing
-      // isn't correct.
-      // This ensures the casing of the project folder is correct.
-      buildFolderPath = trueCasePathSync(buildFolderPath);
+      // On Windows it is possible for the drive letter in the CWD to be lowercase, but the normalized naming is uppercase
+      // Force it to always be uppercase for consistency.
+      buildFolderPath =
+        process.platform === 'win32'
+          ? buildFolderPath.charAt(0).toUpperCase() + buildFolderPath.slice(1)
+          : buildFolderPath;
       configuration._buildFolderPath = buildFolderPath;
     } else {
       throw new Error('No package.json file found. Are you in a project folder?');

--- a/common/changes/@rushstack/heft/kill-true-case-path_2024-10-11-23-03.json
+++ b/common/changes/@rushstack/heft/kill-true-case-path_2024-10-11-23-03.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Remove usage of true-case-path in favor of manually adjusting the drive letter casing to avoid confusing file system tracing tools with unnecessary directory enumerations.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft"
+}

--- a/common/config/subspaces/build-tests-subspace/repo-state.json
+++ b/common/config/subspaces/build-tests-subspace/repo-state.json
@@ -2,5 +2,5 @@
 {
   "pnpmShrinkwrapHash": "5b75a8ef91af53a8caf52319e5eb0042c4d06852",
   "preferredVersionsHash": "ce857ea0536b894ec8f346aaea08cfd85a5af648",
-  "packageJsonInjectedDependenciesHash": "5ff2fabbffcfb22bb3e29f56c997f7c762e89d20"
+  "packageJsonInjectedDependenciesHash": "31e2e4a94050edab124897e4049a6c1d94c21c91"
 }

--- a/common/config/subspaces/default/pnpm-lock.yaml
+++ b/common/config/subspaces/default/pnpm-lock.yaml
@@ -155,9 +155,6 @@ importers:
       tapable:
         specifier: 1.1.3
         version: 1.1.3
-      true-case-path:
-        specifier: ~2.2.1
-        version: 2.2.1
       watchpack:
         specifier: 2.4.0
         version: 2.4.0


### PR DESCRIPTION
## Summary
Remove usage of `true-case-path` in Heft.

## Details
The implementation of `true-case-path` performs directory enumeration of every folder between the file system root and heft's working directory. Usage of this tool was motivated by issues with drive letter casing normalization on Windows, but the implementation of doing so in true-case-path is just a hardcoded "if on Windows, uppercase the drive letter", so we may as well just do the same directly.

The directory enumerations cause problems when running inside of build systems that monitor file system accesses, since they cause the system to see the process as enumerating root-level folders.

## How it was tested
The pipelines for this PR cover Heft sufficiently.

## Impacted documentation
None.