### PR TITLE
[heft-typescript-plugin] feat: support typescript 5.6

### DIFF
--- a/common/changes/@rushstack/heft-typescript-plugin/heft-typescript-plugin-typescript-56-support_2024-10-13-22-44.json
+++ b/common/changes/@rushstack/heft-typescript-plugin/heft-typescript-plugin-typescript-56-support_2024-10-13-22-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-typescript-plugin",
+      "comment": "Support typescript v5.6",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft-typescript-plugin"
+}

--- a/heft-plugins/heft-typescript-plugin/src/TypeScriptBuilder.ts
+++ b/heft-plugins/heft-typescript-plugin/src/TypeScriptBuilder.ts
@@ -11,7 +11,11 @@ import { JsonFile, type IPackageJson, Path, FileError } from '@rushstack/node-co
 import type { ITerminal } from '@rushstack/terminal';
 import type { IScopedLogger } from '@rushstack/heft';
 
-import type { ExtendedTypeScript, IExtendedSolutionBuilder } from './internalTypings/TypeScriptInternals';
+import type {
+  ExtendedBuilderProgram,
+  ExtendedTypeScript,
+  IExtendedSolutionBuilder
+} from './internalTypings/TypeScriptInternals';
 import type { ITypeScriptConfigurationJson } from './TypeScriptPlugin';
 import type { PerformanceMeasurer } from './Performance';
 import type {
@@ -1297,14 +1301,11 @@ export class TypeScriptBuilder {
   }
 }
 
-type BuilderProgramWithInternals = TTypescript.BuilderProgram & {
-  state?: { changedFilesSet: Set<string> };
-  getState(): { changedFilesSet: Set<string> };
-};
 function getFilesToTranspileFromBuilderProgram(
   builderProgram: TTypescript.BuilderProgram
 ): Map<string, string> {
-  const program: BuilderProgramWithInternals = builderProgram as unknown as BuilderProgramWithInternals;
+  const program: ExtendedBuilderProgram = builderProgram as unknown as ExtendedBuilderProgram;
+  // getState was removed in Typescript 5.6, replaced with state
   const changedFilesSet: Set<string> = (program.state ?? program.getState()).changedFilesSet;
 
   const filesToTranspile: Map<string, string> = new Map();

--- a/heft-plugins/heft-typescript-plugin/src/TypeScriptBuilder.ts
+++ b/heft-plugins/heft-typescript-plugin/src/TypeScriptBuilder.ts
@@ -111,7 +111,7 @@ const OLDEST_SUPPORTED_TS_MAJOR_VERSION: number = 2;
 const OLDEST_SUPPORTED_TS_MINOR_VERSION: number = 9;
 
 const NEWEST_SUPPORTED_TS_MAJOR_VERSION: number = 5;
-const NEWEST_SUPPORTED_TS_MINOR_VERSION: number = 4;
+const NEWEST_SUPPORTED_TS_MINOR_VERSION: number = 6;
 
 interface ITypeScriptTool {
   ts: ExtendedTypeScript;
@@ -1297,12 +1297,16 @@ export class TypeScriptBuilder {
   }
 }
 
+type BuilderProgramWithInternals = TTypescript.BuilderProgram & {
+  state?: { changedFilesSet: Set<string> };
+  getState(): { changedFilesSet: Set<string> };
+};
 function getFilesToTranspileFromBuilderProgram(
   builderProgram: TTypescript.BuilderProgram
 ): Map<string, string> {
-  const changedFilesSet: Set<string> = (
-    builderProgram as unknown as { getState(): { changedFilesSet: Set<string> } }
-  ).getState().changedFilesSet;
+  const program: BuilderProgramWithInternals = builderProgram as unknown as BuilderProgramWithInternals;
+  const changedFilesSet: Set<string> = (program.state ?? program.getState()).changedFilesSet;
+
   const filesToTranspile: Map<string, string> = new Map();
   for (const fileName of changedFilesSet) {
     const sourceFile: TTypescript.SourceFile | undefined = builderProgram.getSourceFile(fileName);

--- a/heft-plugins/heft-typescript-plugin/src/internalTypings/TypeScriptInternals.ts
+++ b/heft-plugins/heft-typescript-plugin/src/internalTypings/TypeScriptInternals.ts
@@ -98,3 +98,14 @@ export interface IExtendedTypeScript {
 }
 
 export type ExtendedTypeScript = typeof TTypescript & IExtendedTypeScript;
+
+export type ExtendedBuilderProgram = TTypescript.BuilderProgram & {
+  /**
+   * Typescript 5.6+
+   */
+  state?: { changedFilesSet: Set<string> };
+  /**
+   * Typescript < 5.6
+   */
+  getState(): { changedFilesSet: Set<string> };
+};


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

Updates the heft typescript plugin for breaking changes made to the typescript internals that the plugin relies on
<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

## Details

The breakage was caused by an internal change of `BuilderProgram.getState()` to `BuilderProgram.state` in [this](https://github.com/microsoft/TypeScript/commit/b9d96df61f01375da6504f37a31151cfdce0645c) commit. 

Changing the code to use `.state` instead of `.getState()` if `state` is defined was the only change required

Fixes #4921 
<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested

Linked into our monorepo and a full build of all packages was done
Then everything was started in watch mode and a webpack based package was started up to verify that watch mode changes are still picked up correctly

Our monorepo does not use heft for linting so I haven't tested if this change still works correctly with the heft lint plugin
<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

## Impacted documentation

<!--------------------------------------------------------------------------
👉 STEP 7: Does your PR affect anything that is discussed in the website docs?
     If so, please paste the URL of each affected web page, so we will
     remember to update the documentation after your PR is merged.
     (Updating the website is appreciated but not required.)
     If no docs are impacted, delete the "Impacted documentation" section.

     If you modified a JSON schema, remember to update init templates such as:
     rush-lib/assets/rush-init/*.json
     api-extractor/src/schemas/api-extractor-template.json
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 8: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
