### PR TITLE
[api-extractor] pass compilerOptions into getModeForUsageLocation to fix TS 5.6

### DIFF
--- a/apps/api-extractor/src/analyzer/ExportAnalyzer.ts
+++ b/apps/api-extractor/src/analyzer/ExportAnalyzer.ts
@@ -265,7 +265,11 @@ export class ExportAnalyzer {
       : importOrExportDeclaration.moduleSpecifier;
     const mode: ts.ModuleKind.CommonJS | ts.ModuleKind.ESNext | undefined =
       specifier && ts.isStringLiteralLike(specifier)
-        ? TypeScriptInternals.getModeForUsageLocation(importOrExportDeclaration.getSourceFile(), specifier)
+        ? TypeScriptInternals.getModeForUsageLocation(
+            importOrExportDeclaration.getSourceFile(),
+            specifier,
+            this._program.getCompilerOptions()
+          )
         : undefined;
 
     const resolvedModule: ts.ResolvedModuleFull | undefined = TypeScriptInternals.getResolvedModule(
@@ -905,7 +909,8 @@ export class ExportAnalyzer {
       ts.isStringLiteralLike(importOrExportDeclaration.moduleSpecifier)
         ? TypeScriptInternals.getModeForUsageLocation(
             importOrExportDeclaration.getSourceFile(),
-            importOrExportDeclaration.moduleSpecifier
+            importOrExportDeclaration.moduleSpecifier,
+            this._program.getCompilerOptions()
           )
         : undefined;
     const resolvedModule: ts.ResolvedModuleFull | undefined = TypeScriptInternals.getResolvedModule(

--- a/apps/api-extractor/src/analyzer/TypeScriptInternals.ts
+++ b/apps/api-extractor/src/analyzer/TypeScriptInternals.ts
@@ -102,12 +102,13 @@ export class TypeScriptInternals {
    */
   public static getModeForUsageLocation(
     file: { impliedNodeFormat?: ts.SourceFile['impliedNodeFormat'] },
-    usage: ts.StringLiteralLike | undefined
+    usage: ts.StringLiteralLike,
+    compilerOptions: ts.CompilerOptions
   ): ts.ModuleKind.CommonJS | ts.ModuleKind.ESNext | undefined {
     // Compiler internal:
     // https://github.com/microsoft/TypeScript/blob/v4.7.2/src/compiler/program.ts#L568
 
-    return (ts as any).getModeForUsageLocation?.(file, usage);
+    return ts.getModeForUsageLocation?.(file, usage, compilerOptions);
   }
 
   /**

--- a/common/changes/@microsoft/api-extractor/fix-5.6_2024-10-14-19-47.json
+++ b/common/changes/@microsoft/api-extractor/fix-5.6_2024-10-14-19-47.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Pass compilerOptions into getModeForUsageLocation",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor"
+}

--- a/common/changes/@microsoft/api-extractor/fix-5.6_2024-10-14-19-47.json
+++ b/common/changes/@microsoft/api-extractor/fix-5.6_2024-10-14-19-47.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/api-extractor",
-      "comment": "Pass compilerOptions into getModeForUsageLocation",
+      "comment": "Fix a compatibility issue with usage of `getModeForUsageLocation` in TypeScript 5.6",
       "type": "patch"
     }
   ],


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

Fixes #4919

## Details

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

`getModeForUsageLocation` has required compiler options for a while, but this was hidden by an `as any`. Passing in the compiler options prevents the crash.

## How it was tested

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

I made the same change in `node_modules` for typescript-eslint, and api-extractor no longer crashed.

It's not clear to me how to test this otherwise without also upgrading the repo to TS 5.6.

## Impacted documentation

<!--------------------------------------------------------------------------
👉 STEP 7: Does your PR affect anything that is discussed in the website docs?
     If so, please paste the URL of each affected web page, so we will
     remember to update the documentation after your PR is merged.
     (Updating the website is appreciated but not required.)
     If no docs are impacted, delete the "Impacted documentation" section.

     If you modified a JSON schema, remember to update init templates such as:
     rush-lib/assets/rush-init/*.json
     api-extractor/src/schemas/api-extractor-template.json
--------------------------------------------------------------------------->

None.

<!--------------------------------------------------------------------------
👉 STEP 8: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
