### PR TITLE
[rush] Fix logging for non-zero exit codes

### DIFF
--- a/common/changes/@microsoft/rush/stdio-blank-summary_2024-10-29-00-31.json
+++ b/common/changes/@microsoft/rush/stdio-blank-summary_2024-10-29-00-31.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix an issue where if an Operation wrote all logs to stdout, then exited with a non-zero exit code, only the non-zero exit code would show up in the summary.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/logic/operations/OperationExecutionManager.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationExecutionManager.ts
@@ -289,10 +289,12 @@ export class OperationExecutionManager {
     if (message) {
       // This creates the writer, so don't do this until needed
       record.collatedWriter.terminal.writeStderrLine(message);
-      // Ensure that the error message, if present, shows up in the summary
+      // Ensure that the summary isn't blank if we have an error message
+      // If the summary already contains max lines of stderr, this will get dropped, so we hope those lines
+      // are more useful than the final exit code.
       record.stdioSummarizer.writeChunk({
         text: `${message}\n`,
-        kind: TerminalChunkKind.Stderr
+        kind: TerminalChunkKind.Stdout
       });
     }
   }


### PR DESCRIPTION
## Summary
Fixes #4882 

Child process that only writes to stdout but is configured to exit with code 2.
Before:
![image](https://github.com/user-attachments/assets/653eecdd-0f5e-4d0f-9290-2ac524d0b6be)
After:
![image](https://github.com/user-attachments/assets/56ba35a3-5e13-4588-ac23-de209dacad4e)

## Details
With this change, Rush internally writes any fatal error from an Operation to the `stderr` stream of the `StdioSummarizer` instead of the `stdout` stream. This effectively makes the error seen by Rush be treated as lower priority for the logs than any `stderr` output from the Operation itself.

## How it was tested
Added `process.exitCode = 2` to the end of the build script in api-extractor-lib1-test.

## Impacted documentation
Anything about the error reporting for non-zero exit codes.