### PR TITLE
[rush] Fix an issue where incremental building (with LegacySkipPlugin) would not work when no-op operations were present in the process

### DIFF
--- a/common/changes/@microsoft/rush/fix-legacy-incremental-building_2024-11-06-17-29.json
+++ b/common/changes/@microsoft/rush/fix-legacy-incremental-building_2024-11-06-17-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix an issue where incremental building (with LegacySkipPlugin) would not work when no-op operations were present in the process",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/logic/operations/LegacySkipPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/LegacySkipPlugin.ts
@@ -79,7 +79,7 @@ export class LegacySkipPlugin implements IPhasedCommandPlugin {
           const { operation } = record;
           const { associatedProject, runner, logFilenameIdentifier } = operation;
           if (!associatedProject || !runner) {
-            return;
+            continue;
           }
 
           if (!runner.cacheable) {
@@ -88,7 +88,7 @@ export class LegacySkipPlugin implements IPhasedCommandPlugin {
               packageDeps: undefined,
               packageDepsPath: ''
             });
-            return;
+            continue;
           }
 
           const packageDepsFilename: string = `package-deps_${logFilenameIdentifier}.json`;
@@ -109,7 +109,7 @@ export class LegacySkipPlugin implements IPhasedCommandPlugin {
 
             if (!fileHashes) {
               logGitWarning = true;
-              return;
+              continue;
             }
 
             const files: Record<string, string> = {};


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

In our project we have a several packages that are "buildless" and we enable "ignoreMissingScript" for build command through command-line.json (we don't use phased commands).

After upgrading to latest version of Rush, I discovered that incremental building stopped working in random scenarios.

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

## Details

I've tracked down the issue to LegacySkipPlugin beforeExecuteOperations hook. Turns out that "for" loop inside that hook used "return" statements instead of "continue" to skip registering operations as incremental. I've replaced all of them and verified that fix is working.

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested

Tested on repository with multiple "no-op" build packages.

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

## Impacted documentation

<!--------------------------------------------------------------------------
👉 STEP 7: Does your PR affect anything that is discussed in the website docs?
     If so, please paste the URL of each affected web page, so we will
     remember to update the documentation after your PR is merged.
     (Updating the website is appreciated but not required.)
     If no docs are impacted, delete the "Impacted documentation" section.

     If you modified a JSON schema, remember to update init templates such as:
     rush-lib/assets/rush-init/*.json
     api-extractor/src/schemas/api-extractor-template.json
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 8: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
