### PR TITLE
[rush] Add support for premajor and prepatch bump types

### DIFF
--- a/common/changes/@microsoft/rush/support-premajor-prepatch-version-bump-type_2024-11-07-06-42.json
+++ b/common/changes/@microsoft/rush/support-premajor-prepatch-version-bump-type_2024-11-07-06-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add support for premajor and prepatch bump types",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/config/rush/version-policies.json
+++ b/common/config/rush/version-policies.json
@@ -40,7 +40,7 @@
   //    * When creating a release branch in Git, this field should be updated according to the
   //    * type of release.
   //    *
-  //    * Valid values are: "prerelease", "preminor", "minor", "patch", "major"
+  //    * Valid values are: "prerelease", "prepatch", "preminor", "premajor", "minor", "patch", "major"
   //    */
   //   "nextBump": "prerelease",
   //

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -87,7 +87,11 @@ export enum BumpType {
     // (undocumented)
     'patch' = 2,
     // (undocumented)
+    'premajor' = 6,
+    // (undocumented)
     'preminor' = 3,
+    // (undocumented)
+    'prepatch' = 7,
     // (undocumented)
     'prerelease' = 1
 }

--- a/libraries/rush-lib/assets/rush-init/common/config/rush/version-policies.json
+++ b/libraries/rush-lib/assets/rush-init/common/config/rush/version-policies.json
@@ -41,7 +41,7 @@
      * When creating a release branch in Git, this field should be updated according to the
      * type of release.
      *
-     * Valid values are: "prerelease", "preminor", "minor", "patch", "major"
+     * Valid values are: "prerelease", "prepatch", "preminor", "premajor", "minor", "patch", "major"
      */
     "nextBump": "prerelease",
 

--- a/libraries/rush-lib/src/api/VersionPolicy.ts
+++ b/libraries/rush-lib/src/api/VersionPolicy.ts
@@ -25,8 +25,6 @@ import { cloneDeep } from '../utilities/objectUtilities';
  * This is a copy of the semver ReleaseType enum, but with the `none` value added and
  * the `premajor` and `prepatch` omitted.
  * See {@link LockStepVersionPolicy._getReleaseType}.
- *
- * TODO: Consider supporting `premajor` and `prepatch` in the future.
  */
 export enum BumpType {
   // No version bump
@@ -40,7 +38,11 @@ export enum BumpType {
   // Minor version bump
   'minor' = 4,
   // Major version bump
-  'major' = 5
+  'major' = 5,
+  // Premajor version bump
+  'premajor' = 6,
+  // Prepatch version bump
+  'prepatch' = 7
 }
 
 /**

--- a/libraries/rush-lib/src/api/test/VersionPolicy.test.ts
+++ b/libraries/rush-lib/src/api/test/VersionPolicy.test.ts
@@ -9,13 +9,20 @@ import { VersionPolicy, LockStepVersionPolicy, IndividualVersionPolicy, BumpType
 describe(VersionPolicy.name, () => {
   describe(LockStepVersionPolicy.name, () => {
     const filename: string = `${__dirname}/jsonFiles/rushWithLockVersion.json`;
-    const versionPolicyConfig: VersionPolicyConfiguration = new VersionPolicyConfiguration(filename);
+    let versionPolicyConfig: VersionPolicyConfiguration;
     let versionPolicy1: VersionPolicy;
     let versionPolicy2: VersionPolicy;
+    let versionPolicy3: VersionPolicy;
+    let versionPolicy4: VersionPolicy;
+    let versionPolicy5: VersionPolicy;
 
     beforeEach(() => {
+      versionPolicyConfig = new VersionPolicyConfiguration(filename);
       versionPolicy1 = versionPolicyConfig.getVersionPolicy('testPolicy1');
       versionPolicy2 = versionPolicyConfig.getVersionPolicy('testPolicy2');
+      versionPolicy3 = versionPolicyConfig.getVersionPolicy('testPolicy3');
+      versionPolicy4 = versionPolicyConfig.getVersionPolicy('testPolicy4');
+      versionPolicy5 = versionPolicyConfig.getVersionPolicy('testPolicy5');
     });
 
     it('loads configuration.', () => {
@@ -90,12 +97,55 @@ describe(VersionPolicy.name, () => {
       expect(lockStepVersionPolicy.nextBump).toEqual(undefined);
     });
 
+    it('bumps version for premajor release', () => {
+      expect(versionPolicy1).toBeInstanceOf(LockStepVersionPolicy);
+      const lockStepVersionPolicy: LockStepVersionPolicy = versionPolicy1 as LockStepVersionPolicy;
+      lockStepVersionPolicy.bump(BumpType.premajor, 'pr');
+      expect(lockStepVersionPolicy.version).toEqual('2.0.0-pr.0');
+      expect(lockStepVersionPolicy.nextBump).toEqual(BumpType.patch);
+    });
+
+    it('patch gets rid of prerelease version made with premajor', () => {
+      expect(versionPolicy3).toBeInstanceOf(LockStepVersionPolicy);
+      const lockStepVersionPolicy: LockStepVersionPolicy = versionPolicy3 as LockStepVersionPolicy;
+      expect(lockStepVersionPolicy.nextBump).toEqual(undefined);
+      lockStepVersionPolicy.bump(BumpType.patch);
+      expect(lockStepVersionPolicy.version).toEqual('1.0.0');
+      expect(lockStepVersionPolicy.nextBump).toEqual(undefined);
+    });
+
     it('bumps version for preminor release', () => {
       expect(versionPolicy1).toBeInstanceOf(LockStepVersionPolicy);
       const lockStepVersionPolicy: LockStepVersionPolicy = versionPolicy1 as LockStepVersionPolicy;
       lockStepVersionPolicy.bump(BumpType.preminor, 'pr');
       expect(lockStepVersionPolicy.version).toEqual('1.2.0-pr.0');
       expect(lockStepVersionPolicy.nextBump).toEqual(BumpType.patch);
+    });
+
+    it('patch gets rid of prerelease version made with preminor', () => {
+      expect(versionPolicy4).toBeInstanceOf(LockStepVersionPolicy);
+      const lockStepVersionPolicy: LockStepVersionPolicy = versionPolicy4 as LockStepVersionPolicy;
+      expect(lockStepVersionPolicy.nextBump).toEqual(undefined);
+      lockStepVersionPolicy.bump(BumpType.patch);
+      expect(lockStepVersionPolicy.version).toEqual('1.1.0');
+      expect(lockStepVersionPolicy.nextBump).toEqual(undefined);
+    });
+
+    it('bumps version for prepatch release', () => {
+      expect(versionPolicy1).toBeInstanceOf(LockStepVersionPolicy);
+      const lockStepVersionPolicy: LockStepVersionPolicy = versionPolicy1 as LockStepVersionPolicy;
+      lockStepVersionPolicy.bump(BumpType.prepatch, 'pr');
+      expect(lockStepVersionPolicy.version).toEqual('1.1.1-pr.0');
+      expect(lockStepVersionPolicy.nextBump).toEqual(BumpType.patch);
+    });
+
+    it('patch gets rid of prepatch version made with preminor', () => {
+      expect(versionPolicy5).toBeInstanceOf(LockStepVersionPolicy);
+      const lockStepVersionPolicy: LockStepVersionPolicy = versionPolicy5 as LockStepVersionPolicy;
+      expect(lockStepVersionPolicy.nextBump).toEqual(undefined);
+      lockStepVersionPolicy.bump(BumpType.patch);
+      expect(lockStepVersionPolicy.version).toEqual('1.1.1');
+      expect(lockStepVersionPolicy.nextBump).toEqual(undefined);
     });
 
     it('bumps version for minor release', () => {

--- a/libraries/rush-lib/src/api/test/__snapshots__/RushCommandLine.test.ts.snap
+++ b/libraries/rush-lib/src/api/test/__snapshots__/RushCommandLine.test.ts.snap
@@ -1091,7 +1091,7 @@ Object {
           "shortName": undefined,
         },
         Object {
-          "description": "Overrides the bump type in the version-policy.json for the specified version policy. Valid BUMPTYPE values include: prerelease, patch, preminor, minor, major. This setting only works for lock-step version policy in bump action.",
+          "description": "Overrides the bump type in the version-policy.json for the specified version policy. Valid BUMPTYPE values include: prerelease, prepatch, patch, preminor, minor, premajor and major. This setting only works for lock-step version policy in bump action.",
           "environmentVariable": undefined,
           "kind": "String",
           "longName": "--override-bump",

--- a/libraries/rush-lib/src/api/test/jsonFiles/rushWithLockVersion.json
+++ b/libraries/rush-lib/src/api/test/jsonFiles/rushWithLockVersion.json
@@ -9,5 +9,20 @@
     "policyName": "testPolicy2",
     "definitionName": "lockStepVersion",
     "version": "1.2.0"
+  },
+  {
+    "policyName": "testPolicy3",
+    "definitionName": "lockStepVersion",
+    "version": "1.0.0-pr.0"
+  },
+  {
+    "policyName": "testPolicy4",
+    "definitionName": "lockStepVersion",
+    "version": "1.1.0-pr.0"
+  },
+  {
+    "policyName": "testPolicy5",
+    "definitionName": "lockStepVersion",
+    "version": "1.1.1-pr.0"
   }
 ]

--- a/libraries/rush-lib/src/cli/actions/VersionAction.ts
+++ b/libraries/rush-lib/src/cli/actions/VersionAction.ts
@@ -75,7 +75,7 @@ export class VersionAction extends BaseRushAction {
       argumentName: 'BUMPTYPE',
       description:
         'Overrides the bump type in the version-policy.json for the specified version policy. ' +
-        'Valid BUMPTYPE values include: prerelease, patch, preminor, minor, major. ' +
+        'Valid BUMPTYPE values include: prerelease, prepatch, patch, preminor, minor, premajor and major. ' +
         'This setting only works for lock-step version policy in bump action.'
     });
     this._prereleaseIdentifier = this.defineStringParameter({
@@ -202,7 +202,7 @@ export class VersionAction extends BaseRushAction {
     if (this._overwriteBump.value && !Enum.tryGetValueByKey(BumpType, this._overwriteBump.value)) {
       throw new Error(
         'The value of override-bump is not valid.  ' +
-          'Valid values include prerelease, patch, preminor, minor, and major'
+          'Valid values include prerelease, prepatch, patch, preminor, minor, premajor and major'
       );
     }
   }

--- a/libraries/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
+++ b/libraries/rush-lib/src/cli/test/__snapshots__/CommandLineHelp.test.ts.snap
@@ -1410,9 +1410,9 @@ Optional arguments:
   --override-bump BUMPTYPE
                         Overrides the bump type in the version-policy.json 
                         for the specified version policy. Valid BUMPTYPE 
-                        values include: prerelease, patch, preminor, minor, 
-                        major. This setting only works for lock-step version 
-                        policy in bump action.
+                        values include: prerelease, prepatch, patch, preminor,
+                         minor, premajor and major. This setting only works 
+                        for lock-step version policy in bump action.
   --override-prerelease-id ID
                         Overrides the prerelease identifier in the version 
                         value of version-policy.json for the specified 

--- a/libraries/rush-lib/src/schemas/version-policies.schema.json
+++ b/libraries/rush-lib/src/schemas/version-policies.schema.json
@@ -68,7 +68,7 @@
         },
         "nextBump": {
           "description": "Type of next version bump",
-          "enum": ["none", "prerelease", "preminor", "minor", "patch", "major"]
+          "enum": ["none", "prerelease", "prepatch", "preminor", "premajor", "minor", "patch", "major"]
         },
         "mainProject": {
           "description": "The main project for this version policy",


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

Simple change to allow premajor and prepatch bump types.

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

## Details

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested

I've added unit tests for "premajor" and "prepatch" as well as additional ones that make sure using bump type "patch" gets rid of any prerelease identifier.

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

## Impacted documentation

https://rushjs.io/pages/commands/rush_version/

https://rushjs.io/pages/configs/version-policies_json/

<!--------------------------------------------------------------------------
👉 STEP 7: Does your PR affect anything that is discussed in the website docs?
     If so, please paste the URL of each affected web page, so we will
     remember to update the documentation after your PR is merged.
     (Updating the website is appreciated but not required.)
     If no docs are impacted, delete the "Impacted documentation" section.

     If you modified a JSON schema, remember to update init templates such as:
     rush-lib/assets/rush-init/*.json
     api-extractor/src/schemas/api-extractor-template.json
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 8: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
