### PR TITLE
[rush] New parameters for Azure Storage plugin

### DIFF
--- a/common/changes/@microsoft/rush/azure-default-credential_2024-11-07-22-38.json
+++ b/common/changes/@microsoft/rush/azure-default-credential_2024-11-07-22-38.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Adds two new properties to the configuration for `rush-azure-storage-build-cache-plugin`: `loginFlow` selects the flow to use for interactive authentication to Entra ID, and `readRequiresAuthentication` specifies that a SAS token is required for read and therefore expired authentication is always fatal.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/reviews/api/rush-azure-storage-build-cache-plugin.api.md
+++ b/common/reviews/api/rush-azure-storage-build-cache-plugin.api.md
@@ -47,7 +47,7 @@ export abstract class AzureAuthenticationBase {
     tryGetCachedCredentialAsync(options: ITryGetCachedCredentialOptionsLogWarning): Promise<ICredentialCacheEntry | undefined>;
     // (undocumented)
     updateCachedCredentialAsync(terminal: ITerminal, credential: string): Promise<void>;
-    updateCachedCredentialInteractiveAsync(terminal: ITerminal, onlyIfExistingCredentialExpiresAfter?: Date): Promise<void>;
+    updateCachedCredentialInteractiveAsync(terminal: ITerminal, onlyIfExistingCredentialExpiresBefore?: Date): Promise<void>;
 }
 
 // @public (undocumented)

--- a/rush-plugins/rush-azure-storage-build-cache-plugin/src/RushAzureInteractiveAuthPlugin.ts
+++ b/rush-plugins/rush-azure-storage-build-cache-plugin/src/RushAzureInteractiveAuthPlugin.ts
@@ -27,7 +27,7 @@ export interface IAzureInteractiveAuthOptions {
 
   /**
    * Login flow to use for interactive authentication.
-   * @defaultValue 'deviceCode'
+   * @defaultValue 'AdoCodespacesAuth' if on GitHub Codespaces, 'InteractiveBrowser' otherwise
    */
   readonly loginFlow?: LoginFlowType;
 
@@ -86,7 +86,7 @@ export default class RushAzureInteractieAuthPlugin implements IRushPlugin {
         storageContainerName,
         azureEnvironment = 'AzurePublicCloud',
         minimumValidityInMinutes,
-        loginFlow = 'DeviceCode'
+        loginFlow = process.env.CODESPACES ? 'AdoCodespacesAuth' : 'InteractiveBrowser'
       } = options;
 
       const logger: ILogger = rushSession.getLogger(PLUGIN_NAME);

--- a/rush-plugins/rush-azure-storage-build-cache-plugin/src/RushAzureStorageBuildCachePlugin.ts
+++ b/rush-plugins/rush-azure-storage-build-cache-plugin/src/RushAzureStorageBuildCachePlugin.ts
@@ -2,7 +2,7 @@
 // See LICENSE in the project root for license information.
 
 import type { IRushPlugin, RushSession, RushConfiguration } from '@rushstack/rush-sdk';
-import type { AzureEnvironmentName } from './AzureAuthenticationBase';
+import type { AzureEnvironmentName, LoginFlowType } from './AzureAuthenticationBase';
 
 const PLUGIN_NAME: string = 'AzureStorageBuildCachePlugin';
 
@@ -26,6 +26,12 @@ interface IAzureBlobStorageConfigurationJson {
   azureEnvironment?: AzureEnvironmentName;
 
   /**
+   * Login flow to use for interactive authentication.
+   * @defaultValue 'AdoCodespacesAuth' if on GitHub Codespaces, 'InteractiveBrowser' otherwise
+   */
+  readonly loginFlow?: LoginFlowType;
+
+  /**
    * An optional prefix for cache item blob names.
    */
   blobPrefix?: string;
@@ -34,6 +40,11 @@ interface IAzureBlobStorageConfigurationJson {
    * If set to true, allow writing to the cache. Defaults to false.
    */
   isCacheWriteAllowed?: boolean;
+
+  /**
+   * If set to true, reading the cache requires authentication. Defaults to false.
+   */
+  readRequiresAuthentication?: boolean;
 }
 
 /**
@@ -55,7 +66,9 @@ export class RushAzureStorageBuildCachePlugin implements IRushPlugin {
           storageContainerName: azureBlobStorageConfiguration.storageContainerName,
           azureEnvironment: azureBlobStorageConfiguration.azureEnvironment,
           blobPrefix: azureBlobStorageConfiguration.blobPrefix,
-          isCacheWriteAllowed: !!azureBlobStorageConfiguration.isCacheWriteAllowed
+          loginFlow: azureBlobStorageConfiguration.loginFlow,
+          isCacheWriteAllowed: !!azureBlobStorageConfiguration.isCacheWriteAllowed,
+          readRequiresAuthentication: !!azureBlobStorageConfiguration.readRequiresAuthentication
         });
       });
     });

--- a/rush-plugins/rush-azure-storage-build-cache-plugin/src/schemas/azure-blob-storage-config.schema.json
+++ b/rush-plugins/rush-azure-storage-build-cache-plugin/src/schemas/azure-blob-storage-config.schema.json
@@ -41,9 +41,9 @@
       "description": "If set to true, allow writing to the cache. Defaults to false."
     },
 
-    "isAnonymousReadAllowed": {
+    "readRequiresAuthentication": {
       "type": "boolean",
-      "description": "If set to true, the cache can be read without authentication. Defaults to false."
+      "description": "If set to true, reading the cache requires authentication. Defaults to false."
     }
   }
 }

--- a/rush-plugins/rush-azure-storage-build-cache-plugin/src/schemas/azure-blob-storage-config.schema.json
+++ b/rush-plugins/rush-azure-storage-build-cache-plugin/src/schemas/azure-blob-storage-config.schema.json
@@ -25,6 +25,12 @@
       "enum": ["AzurePublicCloud", "AzureChina", "AzureGermany", "AzureGovernment"]
     },
 
+    "loginFlow": {
+      "type": "string",
+      "description": "The Entra ID login flow to use. Defaults to 'AdoCodespacesAuth' on GitHub Codespaces, 'InteractiveBrowser' otherwise.",
+      "enum": ["AdoCodespacesAuth", "InteractiveBrowser", "DeviceCode"]
+    },
+
     "blobPrefix": {
       "type": "string",
       "description": "An optional prefix for cache item blob names."
@@ -33,6 +39,11 @@
     "isCacheWriteAllowed": {
       "type": "boolean",
       "description": "If set to true, allow writing to the cache. Defaults to false."
+    },
+
+    "isAnonymousReadAllowed": {
+      "type": "boolean",
+      "description": "If set to true, the cache can be read without authentication. Defaults to false."
     }
   }
 }

--- a/rush-plugins/rush-azure-storage-build-cache-plugin/src/schemas/azure-interactive-auth.schema.json
+++ b/rush-plugins/rush-azure-storage-build-cache-plugin/src/schemas/azure-interactive-auth.schema.json
@@ -25,6 +25,12 @@
       "enum": ["AzurePublicCloud", "AzureChina", "AzureGermany", "AzureGovernment"]
     },
 
+    "loginFlow": {
+      "type": "string",
+      "description": "The Entra ID login flow to use. Defaults to 'AdoCodespacesAuth' on GitHub Codespaces, 'InteractiveBrowser' otherwise.",
+      "enum": ["AdoCodespacesAuth", "InteractiveBrowser", "DeviceCode"]
+    },
+
     "minimumValidityInMinutes": {
       "type": "number",
       "description": "If specified and a credential exists that will be valid for at least this many minutes from the time of execution, no action will be taken."


### PR DESCRIPTION
## Summary
Improve configurability of `rush-azure-storage-build-cache-plugin`.

## Details
Adds new configuration properties:
- `loginFlow` allows specifying the interactive login flow to use: one of `AdoCodespacesAuth`, `InteractiveBrowser` or `DeviceCode`. Defaults to `InteractiveBrowser` (will fall back to `DeviceCode`).
- `readRequiresAuthentication` will make not having a valid SAS token a fatal error during cache read.

## How it was tested
PR release