### PR TITLE
[rush] Add support for common/temp/.rush-override

### DIFF
--- a/apps/rush/src/MinimalRushConfiguration.ts
+++ b/apps/rush/src/MinimalRushConfiguration.ts
@@ -18,10 +18,12 @@ interface IMinimalRushConfigurationJson {
  * decide which version of Rush should be installed/used.
  */
 export class MinimalRushConfiguration {
+  private _rushJsonFilename: string;
   private _rushVersion: string;
   private _commonRushConfigFolder: string;
 
   private constructor(minimalRushConfigurationJson: IMinimalRushConfigurationJson, rushJsonFilename: string) {
+    this._rushJsonFilename = rushJsonFilename;
     this._rushVersion =
       minimalRushConfigurationJson.rushVersion || minimalRushConfigurationJson.rushMinimumVersion;
     this._commonRushConfigFolder = path.join(
@@ -50,6 +52,10 @@ export class MinimalRushConfiguration {
     } catch (e) {
       return undefined;
     }
+  }
+
+  public get rushJsonFilename(): string {
+    return this._rushJsonFilename;
   }
 
   /**

--- a/apps/rush/src/RushVersionSelector.ts
+++ b/apps/rush/src/RushVersionSelector.ts
@@ -24,52 +24,66 @@ export class RushVersionSelector {
 
   public async ensureRushVersionInstalledAsync(
     version: string,
+    overridePath: string | undefined,
     configuration: MinimalRushConfiguration | undefined,
     executeOptions: ILaunchOptions
   ): Promise<void> {
     const isLegacyRushVersion: boolean = semver.lt(version, '4.0.0');
-    const expectedRushPath: string = path.join(this._rushGlobalFolder.nodeSpecificPath, `rush-${version}`);
 
-    const installMarker: _FlagFile = new _FlagFile(expectedRushPath, 'last-install', {
-      node: process.versions.node
-    });
+    let rushPath: string;
 
-    let installIsValid: boolean = await installMarker.isValidAsync();
-    if (!installIsValid) {
-      // Need to install Rush
-      console.log(`Rush version ${version} is not currently installed. Installing...`);
+    if (overridePath) {
+      rushPath = overridePath;
+    } else {
+      const expectedRushPath: string = path.join(this._rushGlobalFolder.nodeSpecificPath, `rush-${version}`);
 
-      const resourceName: string = `rush-${version}`;
+      const installMarker: _FlagFile = new _FlagFile(expectedRushPath, 'last-install', {
+        node: process.versions.node
+      });
 
-      console.log(`Trying to acquire lock for ${resourceName}`);
+      let installIsValid: boolean = await installMarker.isValidAsync();
+      if (!installIsValid) {
+        // Need to install Rush
+        console.log(`Rush version ${version} is not currently installed. Installing...`);
 
-      const lock: LockFile = await LockFile.acquire(expectedRushPath, resourceName);
-      installIsValid = await installMarker.isValidAsync();
-      if (installIsValid) {
-        console.log('Another process performed the installation.');
+        const resourceName: string = `rush-${version}`;
+
+        console.log(`Trying to acquire lock for ${resourceName}`);
+
+        const lock: LockFile = await LockFile.acquire(expectedRushPath, resourceName);
+        installIsValid = await installMarker.isValidAsync();
+        if (installIsValid) {
+          console.log('Another process performed the installation.');
+        } else {
+          await Utilities.installPackageInDirectoryAsync({
+            directory: expectedRushPath,
+            packageName: isLegacyRushVersion ? '@microsoft/rush' : '@microsoft/rush-lib',
+            version: version,
+            tempPackageTitle: 'rush-local-install',
+            maxInstallAttempts: MAX_INSTALL_ATTEMPTS,
+            // This is using a local configuration to install a package in a shared global location.
+            // Generally that's a bad practice, but in this case if we can successfully install
+            // the package at all, we can reasonably assume it's good for all the repositories.
+            // In particular, we'll assume that two different NPM registries cannot have two
+            // different implementations of the same version of the same package.
+            // This was needed for: https://github.com/microsoft/rushstack/issues/691
+            commonRushConfigFolder: configuration ? configuration.commonRushConfigFolder : undefined,
+            suppressOutput: true
+          });
+
+          console.log(`Successfully installed Rush version ${version} in ${expectedRushPath}.`);
+
+          // If we've made it here without exception, write the flag file
+          await installMarker.createAsync();
+
+          lock.release();
+        }
+      }
+
+      if (semver.lt(version, '4.0.0')) {
+        rushPath = path.join(expectedRushPath, 'node_modules', '@microsoft', 'rush');
       } else {
-        await Utilities.installPackageInDirectoryAsync({
-          directory: expectedRushPath,
-          packageName: isLegacyRushVersion ? '@microsoft/rush' : '@microsoft/rush-lib',
-          version: version,
-          tempPackageTitle: 'rush-local-install',
-          maxInstallAttempts: MAX_INSTALL_ATTEMPTS,
-          // This is using a local configuration to install a package in a shared global location.
-          // Generally that's a bad practice, but in this case if we can successfully install
-          // the package at all, we can reasonably assume it's good for all the repositories.
-          // In particular, we'll assume that two different NPM registries cannot have two
-          // different implementations of the same version of the same package.
-          // This was needed for: https://github.com/microsoft/rushstack/issues/691
-          commonRushConfigFolder: configuration ? configuration.commonRushConfigFolder : undefined,
-          suppressOutput: true
-        });
-
-        console.log(`Successfully installed Rush version ${version} in ${expectedRushPath}.`);
-
-        // If we've made it here without exception, write the flag file
-        await installMarker.createAsync();
-
-        lock.release();
+        rushPath = path.join(expectedRushPath, 'node_modules', '@microsoft', 'rush-lib');
       }
     }
 
@@ -77,16 +91,16 @@ export class RushVersionSelector {
       // In old versions, requiring the entry point invoked the command-line parser immediately,
       // so fail if "rushx" or "rush-pnpm" was used
       RushCommandSelector.failIfNotInvokedAsRush(version);
-      require(path.join(expectedRushPath, 'node_modules', '@microsoft', 'rush', 'lib', 'rush'));
+      require(path.join(rushPath, 'lib', 'rush'));
     } else if (semver.lt(version, '4.0.0')) {
       // In old versions, requiring the entry point invoked the command-line parser immediately,
       // so fail if "rushx" or "rush-pnpm" was used
       RushCommandSelector.failIfNotInvokedAsRush(version);
-      require(path.join(expectedRushPath, 'node_modules', '@microsoft', 'rush', 'lib', 'start'));
+      require(path.join(rushPath, 'lib', 'start'));
     } else {
       // For newer rush-lib, RushCommandSelector can test whether "rushx" is supported or not
       const rushCliEntrypoint: {} = require(
-        path.join(expectedRushPath, 'node_modules', '@microsoft', 'rush-lib', 'lib', 'index')
+        path.join(rushPath, 'lib', 'index')
       );
       RushCommandSelector.execute(this._currentPackageVersion, rushCliEntrypoint, executeOptions);
     }

--- a/common/changes/@microsoft/rush/rush-override-support_2024-11-09-01-59.json
+++ b/common/changes/@microsoft/rush/rush-override-support_2024-11-09-01-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add support for overriding rush with custom installation path through common/temp/.rush-override file",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

While contributing to Rush, I've discovered that there's no easy way to test it with other repos on my PC (I was manually replacing installation in AppData/.rush directory) so I've decided to create this PR that hopefully makes it easier.

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

## Details

PR introduces support for common/temp/.rush-override file that can contain path to the custom rush installation. This way, contributors can override the Rush installation used by the repository and test any changes that are being made to Rush.

.rush-override shouldn't be ever tracked by git so I've decided to use common/temp directory as it should be added to .gitignore in every Rush monorepo.

If common/temp/.rush-override is present, user is presented with warning similar to the one that is displayed when using RUSH_PREVIEW_VERSION environment variable.

![image](https://github.com/user-attachments/assets/c6e9a445-e0f9-4e33-b88b-d4eb2ae9313a)

(one potential thing I would like to include here is for a warning to display the path to custom Rush installation)

If common/temp/.rush-override points to invalid Rush installation (the only check for now is verifying that package.json exists), command terminates with following error:

![image](https://github.com/user-attachments/assets/95e411e9-62cf-4422-9377-8fcae98ad850)


<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested

I've created common/temp/.rush-override that points to custom Rush installation and executed `node apps\rush\bin\rush build --help` - seems to be working.

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

## Impacted documentation

<!--------------------------------------------------------------------------
👉 STEP 7: Does your PR affect anything that is discussed in the website docs?
     If so, please paste the URL of each affected web page, so we will
     remember to update the documentation after your PR is merged.
     (Updating the website is appreciated but not required.)
     If no docs are impacted, delete the "Impacted documentation" section.

     If you modified a JSON schema, remember to update init templates such as:
     rush-lib/assets/rush-init/*.json
     api-extractor/src/schemas/api-extractor-template.json
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 8: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
