### PR TITLE
[rush] Build cache schema reconciliation

### DIFF
--- a/common/changes/@microsoft/rush/fix-build-cache-schema_2024-11-19-23-27.json
+++ b/common/changes/@microsoft/rush/fix-build-cache-schema_2024-11-19-23-27.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Update schema for build-cache.json to include recent updates to the @rushstack/rush-azure-storage-build-cache-plugin.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/config/rush/version-policies.json
+++ b/common/config/rush/version-policies.json
@@ -103,7 +103,7 @@
     "policyName": "rush",
     "definitionName": "lockStepVersion",
     "version": "5.141.0",
-    "nextBump": "minor",
+    "nextBump": "patch",
     "mainProject": "@microsoft/rush"
   }
 ]

--- a/libraries/rush-lib/assets/rush-init/common/config/rush/build-cache.json
+++ b/libraries/rush-lib/assets/rush-init/common/config/rush/build-cache.json
@@ -68,7 +68,17 @@
     /**
      * If set to true, allow writing to the cache. Defaults to false.
      */
-    // "isCacheWriteAllowed": true
+    // "isCacheWriteAllowed": true,
+
+    /**
+     * The Entra ID login flow to use. Defaults to 'AdoCodespacesAuth' on GitHub Codespaces, 'InteractiveBrowser' otherwise.
+     */
+    // "loginFlow": "InteractiveBrowser",
+
+    /**
+     * If set to true, reading the cache requires authentication. Defaults to false.
+     */
+    // "readRequiresAuthentication": true
   },
 
   /**

--- a/libraries/rush-lib/src/schemas/build-cache.schema.json
+++ b/libraries/rush-lib/src/schemas/build-cache.schema.json
@@ -54,6 +54,11 @@
               "description": "The Azure environment the storage account exists in. Defaults to AzurePublicCloud.",
               "enum": ["AzurePublicCloud", "AzureChina", "AzureGermany", "AzureGovernment"]
             },
+            "loginFlow": {
+              "type": "string",
+              "description": "The Entra ID login flow to use. Defaults to 'AdoCodespacesAuth' on GitHub Codespaces, 'InteractiveBrowser' otherwise.",
+              "enum": ["AdoCodespacesAuth", "InteractiveBrowser", "DeviceCode"]
+            },
             "blobPrefix": {
               "type": "string",
               "description": "An optional prefix for cache item blob names."
@@ -61,6 +66,10 @@
             "isCacheWriteAllowed": {
               "type": "boolean",
               "description": "If set to true, allow writing to the cache. Defaults to false."
+            },
+            "readRequiresAuthentication": {
+              "type": "boolean",
+              "description": "If set to true, reading the cache requires authentication. Defaults to false."
             }
           }
         },


### PR DESCRIPTION
## Summary
Updates the schema in build-cache.json so that the features in #4995 can be used.

## Details
Adds `loginFlow` and `readRequiresAuthentication` properties to the build cache schema.

## How it was tested
Built to verify that the schema still accepts existing values.

## Impacted documentation
Content of the build-cache.schema.json