### PR TITLE
[heft-jest] Fix node-modules-symlink-resolver

### DIFF
--- a/common/changes/@rushstack/heft-jest-plugin/fix-jest-bug_2024-11-22-23-43.json
+++ b/common/changes/@rushstack/heft-jest-plugin/fix-jest-bug_2024-11-22-23-43.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-jest-plugin",
+      "comment": "Fix a bug in `jest-node-modules-symlink-resolver` with respect to evaluating paths that don't exist. Expected behavior in that situation is to return the input path.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft-jest-plugin"
+}

--- a/heft-plugins/heft-jest-plugin/src/JestRealPathPatch.ts
+++ b/heft-plugins/heft-jest-plugin/src/JestRealPathPatch.ts
@@ -5,7 +5,6 @@ import * as path from 'node:path';
 import { RealNodeModulePathResolver } from '@rushstack/node-core-library/lib/RealNodeModulePath';
 
 const jestResolvePackageFolder: string = path.dirname(require.resolve('jest-resolve/package.json'));
-const jestResolveFileWalkersPath: string = path.resolve(jestResolvePackageFolder, './build/fileWalkers.js');
 
 const jestUtilPackageFolder: string = path.dirname(
   require.resolve('jest-util/package.json', { paths: [jestResolvePackageFolder] })
@@ -13,11 +12,6 @@ const jestUtilPackageFolder: string = path.dirname(
 const jestUtilTryRealpathPath: string = path.resolve(jestUtilPackageFolder, './build/tryRealpath.js');
 
 const { realNodeModulePath }: RealNodeModulePathResolver = new RealNodeModulePathResolver();
-
-const fileWalkersModule: {
-  realpathSync: (filePath: string) => string;
-} = require(jestResolveFileWalkersPath);
-fileWalkersModule.realpathSync = realNodeModulePath;
 
 const tryRealpathModule: {
   default: (filePath: string) => string;
@@ -28,6 +22,7 @@ tryRealpathModule.default = (input: string): string => {
   } catch (error) {
     // Not using the helper from FileSystem here because this code loads in every Jest worker process
     // and FileSystem has a lot of extra dependencies
+    // These error codes cloned from the logic in jest-util's tryRealpath.js
     if (error.code !== 'ENOENT' && error.code !== 'EISDIR') {
       throw error;
     }


### PR DESCRIPTION
## Summary
For Jest, specifically, the `realpathSync` function inside of `jest-resolve` is supposed to return the input path if part of the path does not exist.

## Details
Since `jest-resolve`'s `realpathSync` internally calls `jest-util`'s `tryRealpathSync`, and the latter is already overridden, this PR just removes the separate override in jest-resolve in favor of relying on `tryRealpathSync` being overridden centrally.

Note that this ends up caching all the paths twice, but that's less of a concern than the syscalls this feature is avoiding.

## How it was tested
Local test invocation.

## Impacted documentation
None