### PR TITLE
[rush-lib] Fix overrides settings and package extensions conditions

### DIFF
--- a/common/changes/@microsoft/rush/pedrogomes-fix-pnpm-overrides_2024-11-25-03-53.json
+++ b/common/changes/@microsoft/rush/pedrogomes-fix-pnpm-overrides_2024-11-25-03-53.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Consider subspace pnpm globalOverrides during installation",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/pedrogomes-fix-pnpm-overrides_2024-11-25-03-53.json
+++ b/common/changes/@microsoft/rush/pedrogomes-fix-pnpm-overrides_2024-11-25-03-53.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Consider subspace pnpm globalOverrides during installation",
+      "comment": "Fix an issue where Rush sometimes incorrectly reported \"The overrides settings doesn't match the current shrinkwrap\" when using subspaces",
       "type": "none"
     }
   ],

--- a/common/changes/@microsoft/rush/pedrogomes-fix-pnpm-overrides_2024-11-27-06-31.json
+++ b/common/changes/@microsoft/rush/pedrogomes-fix-pnpm-overrides_2024-11-27-06-31.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix an issue where Rush sometimes incorrectly reported \"The package extension hash doesn't match the current shrinkwrap.\" when using subspaces",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/assets/rush-init/common/config/rush/pnpm-config.json
+++ b/libraries/rush-lib/assets/rush-init/common/config/rush/pnpm-config.json
@@ -1,6 +1,11 @@
 /**
  * This configuration file provides settings specific to the PNPM package manager.
  * More documentation is available on the Rush website: https://rushjs.io
+ *
+ * Rush normally looks for this file in `common/config/rush/pnpm-config.json`.  However,
+ * if `subspacesEnabled` is true in subspaces.json, then Rush will instead first look
+ * for `common/config/subspaces/<name>/pnpm-config.json`.  (If the file exists in both places,
+ * then the file under `common/config/rush` is ignored.)
  */
 {
   "$schema": "https://developer.microsoft.com/json-schemas/rush/v5/pnpm-config.schema.json",

--- a/libraries/rush-lib/src/logic/ShrinkwrapFileFactory.ts
+++ b/libraries/rush-lib/src/logic/ShrinkwrapFileFactory.ts
@@ -2,7 +2,6 @@
 // See LICENSE in the project root for license information.
 
 import type { PackageManagerName } from '../api/packageManager/PackageManager';
-import type { PackageManagerOptionsConfigurationBase } from './base/BasePackageManagerOptionsConfiguration';
 import type { BaseShrinkwrapFile } from './base/BaseShrinkwrapFile';
 import { NpmShrinkwrapFile } from './npm/NpmShrinkwrapFile';
 import { PnpmShrinkwrapFile } from './pnpm/PnpmShrinkwrapFile';
@@ -11,7 +10,6 @@ import { YarnShrinkwrapFile } from './yarn/YarnShrinkwrapFile';
 export class ShrinkwrapFileFactory {
   public static getShrinkwrapFile(
     packageManager: PackageManagerName,
-    packageManagerOptions: PackageManagerOptionsConfigurationBase,
     shrinkwrapFilename: string
   ): BaseShrinkwrapFile | undefined {
     switch (packageManager) {
@@ -28,7 +26,6 @@ export class ShrinkwrapFileFactory {
 
   public static parseShrinkwrapFile(
     packageManager: PackageManagerName,
-    packageManagerOptions: PackageManagerOptionsConfigurationBase,
     shrinkwrapContent: string
   ): BaseShrinkwrapFile | undefined {
     switch (packageManager) {

--- a/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
+++ b/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
@@ -255,7 +255,6 @@ export abstract class BaseInstallManager {
         const committedShrinkwrapFileName: string = subspace.getCommittedShrinkwrapFilePath(variant);
         const shrinkwrapFile: BaseShrinkwrapFile | undefined = ShrinkwrapFileFactory.getShrinkwrapFile(
           this.rushConfiguration.packageManager,
-          this.rushConfiguration.packageManagerOptions,
           committedShrinkwrapFileName
         );
         shrinkwrapFile?.validateShrinkwrapAfterUpdate(this.rushConfiguration, subspace, this._terminal);
@@ -464,7 +463,6 @@ export abstract class BaseInstallManager {
       try {
         shrinkwrapFile = ShrinkwrapFileFactory.getShrinkwrapFile(
           this.rushConfiguration.packageManager,
-          this.rushConfiguration.packageManagerOptions,
           committedShrinkwrapFileName
         );
       } catch (ex) {

--- a/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
+++ b/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
@@ -42,6 +42,7 @@ import { Colorize, ConsoleTerminalProvider } from '@rushstack/terminal';
 import { BaseLinkManager, SymlinkKind } from '../base/BaseLinkManager';
 import { FlagFile } from '../../api/FlagFile';
 import { Stopwatch } from '../../utilities/Stopwatch';
+import type { PnpmOptionsConfiguration } from '../pnpm/PnpmOptionsConfiguration';
 
 export interface IPnpmModules {
   hoistedDependencies: { [dep in string]: { [depPath in string]: string } };
@@ -372,8 +373,16 @@ export class WorkspaceInstallManager extends BaseInstallManager {
     }
 
     // Check if overrides and globalOverrides are the same
+    const repoPnpmConfiguration: PnpmOptionsConfiguration = this.rushConfiguration.pnpmOptions;
+    const subspacePnpmConfiguration: PnpmOptionsConfiguration | undefined = subspace.getPnpmOptions();
+
+    const mergedGlobalOverrides: Record<string, string> = {
+      ...(repoPnpmConfiguration.globalOverrides ?? {}),
+      ...(subspacePnpmConfiguration?.globalOverrides ?? {})
+    };
+
     const overridesAreEqual: boolean = objectsAreDeepEqual<Record<string, string>>(
-      this.rushConfiguration.pnpmOptions.globalOverrides ?? {},
+      mergedGlobalOverrides,
       shrinkwrapFile?.overrides ? Object.fromEntries(shrinkwrapFile?.overrides) : {}
     );
 

--- a/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
+++ b/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
@@ -373,16 +373,13 @@ export class WorkspaceInstallManager extends BaseInstallManager {
     }
 
     // Check if overrides and globalOverrides are the same
-    const repoPnpmConfiguration: PnpmOptionsConfiguration = this.rushConfiguration.pnpmOptions;
     const subspacePnpmConfiguration: PnpmOptionsConfiguration | undefined = subspace.getPnpmOptions();
-
-    const mergedGlobalOverrides: Record<string, string> = {
-      ...(repoPnpmConfiguration.globalOverrides ?? {}),
-      ...(subspacePnpmConfiguration?.globalOverrides ?? {})
-    };
+    const globalOverrides: Record<string, string> | undefined = subspacePnpmConfiguration
+      ? subspacePnpmConfiguration.globalOverrides
+      : this.rushConfiguration.pnpmOptions.globalOverrides;
 
     const overridesAreEqual: boolean = objectsAreDeepEqual<Record<string, string>>(
-      mergedGlobalOverrides,
+      globalOverrides ?? {},
       shrinkwrapFile?.overrides ? Object.fromEntries(shrinkwrapFile?.overrides) : {}
     );
 

--- a/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
+++ b/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
@@ -373,13 +373,11 @@ export class WorkspaceInstallManager extends BaseInstallManager {
     }
 
     // Check if overrides and globalOverrides are the same
-    const subspacePnpmConfiguration: PnpmOptionsConfiguration | undefined = subspace.getPnpmOptions();
-    const globalOverrides: Record<string, string> | undefined = subspacePnpmConfiguration
-      ? subspacePnpmConfiguration.globalOverrides
-      : this.rushConfiguration.pnpmOptions.globalOverrides;
+    const pnpmOptions: PnpmOptionsConfiguration =
+      subspace.getPnpmOptions() || this.rushConfiguration.pnpmOptions;
 
     const overridesAreEqual: boolean = objectsAreDeepEqual<Record<string, string>>(
-      globalOverrides ?? {},
+      pnpmOptions.globalOverrides ?? {},
       shrinkwrapFile?.overrides ? Object.fromEntries(shrinkwrapFile?.overrides) : {}
     );
 
@@ -390,7 +388,7 @@ export class WorkspaceInstallManager extends BaseInstallManager {
 
     // Check if packageExtensionsChecksum matches globalPackageExtension's hash
     const packageExtensionsChecksum: string | undefined = this._getPackageExtensionChecksum(
-      this.rushConfiguration.pnpmOptions.globalPackageExtensions
+      pnpmOptions.globalPackageExtensions
     );
     const packageExtensionsChecksumAreEqual: boolean =
       packageExtensionsChecksum === shrinkwrapFile?.packageExtensionsChecksum;
@@ -639,7 +637,6 @@ export class WorkspaceInstallManager extends BaseInstallManager {
     // projects with dependencies, a lockfile won't be generated.
     const tempShrinkwrapFile: BaseShrinkwrapFile | undefined = ShrinkwrapFileFactory.getShrinkwrapFile(
       this.rushConfiguration.packageManager,
-      this.rushConfiguration.pnpmOptions,
       subspace.getTempShrinkwrapFilename()
     );
 

--- a/libraries/rush-lib/src/logic/policy/ShrinkwrapFilePolicy.ts
+++ b/libraries/rush-lib/src/logic/policy/ShrinkwrapFilePolicy.ts
@@ -25,7 +25,6 @@ export function validate(
   console.log('Validating package manager shrinkwrap file.\n');
   const shrinkwrapFile: BaseShrinkwrapFile | undefined = ShrinkwrapFileFactory.getShrinkwrapFile(
     rushConfiguration.packageManager,
-    rushConfiguration.packageManagerOptions,
     subspace.getCommittedShrinkwrapFilePath(variant)
   );
 

--- a/libraries/rush-lib/src/logic/test/ShrinkwrapFile.test.ts
+++ b/libraries/rush-lib/src/logic/test/ShrinkwrapFile.test.ts
@@ -13,7 +13,7 @@ import type { RushConfigurationProject } from '../../api/RushConfigurationProjec
 
 describe(NpmShrinkwrapFile.name, () => {
   const filename: string = `${__dirname}/shrinkwrapFile/npm-shrinkwrap.json`;
-  const shrinkwrapFile: BaseShrinkwrapFile = ShrinkwrapFileFactory.getShrinkwrapFile('npm', {}, filename)!;
+  const shrinkwrapFile: BaseShrinkwrapFile = ShrinkwrapFileFactory.getShrinkwrapFile('npm', filename)!;
 
   it('verifies root-level dependency', () => {
     expect(shrinkwrapFile.hasCompatibleTopLevelDependency(new DependencySpecifier('q', '~1.5.0'))).toEqual(
@@ -97,11 +97,7 @@ describe(PnpmShrinkwrapFile.name, () => {
         __dirname,
         '../../../src/logic/test/shrinkwrapFile/non-workspace-pnpm-lock-v5.yaml'
       );
-      const shrinkwrapFile: BaseShrinkwrapFile = ShrinkwrapFileFactory.getShrinkwrapFile(
-        'pnpm',
-        {},
-        filename
-      )!;
+      const shrinkwrapFile: BaseShrinkwrapFile = ShrinkwrapFileFactory.getShrinkwrapFile('pnpm', filename)!;
 
       validateNonWorkspaceLockfile(shrinkwrapFile);
     });
@@ -111,11 +107,7 @@ describe(PnpmShrinkwrapFile.name, () => {
         __dirname,
         '../../../src/logic/test/shrinkwrapFile/non-workspace-pnpm-lock-v5.3.yaml'
       );
-      const shrinkwrapFile: BaseShrinkwrapFile = ShrinkwrapFileFactory.getShrinkwrapFile(
-        'pnpm',
-        {},
-        filename
-      )!;
+      const shrinkwrapFile: BaseShrinkwrapFile = ShrinkwrapFileFactory.getShrinkwrapFile('pnpm', filename)!;
 
       validateNonWorkspaceLockfile(shrinkwrapFile);
     });
@@ -125,11 +117,7 @@ describe(PnpmShrinkwrapFile.name, () => {
         __dirname,
         '../../../src/logic/test/shrinkwrapFile/non-workspace-pnpm-lock-v6.1.yaml'
       );
-      const shrinkwrapFile: BaseShrinkwrapFile = ShrinkwrapFileFactory.getShrinkwrapFile(
-        'pnpm',
-        {},
-        filename
-      )!;
+      const shrinkwrapFile: BaseShrinkwrapFile = ShrinkwrapFileFactory.getShrinkwrapFile('pnpm', filename)!;
 
       validateNonWorkspaceLockfile(shrinkwrapFile);
     });
@@ -179,11 +167,7 @@ describe(PnpmShrinkwrapFile.name, () => {
         __dirname,
         '../../../src/logic/test/shrinkwrapFile/workspace-pnpm-lock-v5.3.yaml'
       );
-      const shrinkwrapFile: BaseShrinkwrapFile = ShrinkwrapFileFactory.getShrinkwrapFile(
-        'pnpm',
-        {},
-        filename
-      )!;
+      const shrinkwrapFile: BaseShrinkwrapFile = ShrinkwrapFileFactory.getShrinkwrapFile('pnpm', filename)!;
 
       validateWorkspaceLockfile(shrinkwrapFile);
     });
@@ -193,11 +177,7 @@ describe(PnpmShrinkwrapFile.name, () => {
         __dirname,
         '../../../src/logic/test/shrinkwrapFile/workspace-pnpm-lock-v5.3.yaml'
       );
-      const shrinkwrapFile: BaseShrinkwrapFile = ShrinkwrapFileFactory.getShrinkwrapFile(
-        'pnpm',
-        {},
-        filename
-      )!;
+      const shrinkwrapFile: BaseShrinkwrapFile = ShrinkwrapFileFactory.getShrinkwrapFile('pnpm', filename)!;
 
       validateWorkspaceLockfile(shrinkwrapFile);
     });


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

Consider subspace pnpm `globalOverrides` and `globalPackageExtensions` during install & update

## Details

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

### What happened?

During rush installation `rush install -t .`, some subspace lock files were being considered "out of date" with the warning: "The overrides settings doesn't match the current shrinkwrap.", even though nothing was changed.

We identified that one of the subspaces had ~10 global overrides (e.g. common/config/subspaces/unified_wallet/pnpm-config.json), which were the **same** as stated in its shrinkwrap file (e.g. common/config/subspaces/unified_wallet/pnpm-lock.yaml). BUT the warning was still being logged for this subspace.

### What I expected to happen?

Rush should consider each subspace pnpm-config.json file during shrinkwrap up-to-date evaluation. 
I would expect no warning being logged, if the subspace shrinkwrap `overrides` parameter is synched with the pnpm-config `globalOverrides` parameter.

### The solution

Update overrides settings condition in `WorkspaceInstallManager`, by choosing between the objects:
- Repository pnpm-config `globalOverrides`
- Current subspace pnpm-config `globalOverrides`

Update package extension hash condition in `WorkspaceInstallManager`, by choosing between the objects:
- Repository pnpm-config `globalPackageExtensions`
- Current subspace pnpm-config `globalPackageExtensions`


## How it was tested

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

1. Create a repository with subspaces enabled: https://rushjs.io/pages/advanced/subspaces/
2. Update common/config/subspaces/default/pnpm-config.json, by adding a new entry into `globalOverrides`
3. Run `rush update --subspace default`

The shrinkfile `overrides` is now updated with the new added `globalOverrides` entry.

4. Run `rush install --subspace default`

The warning: "The overrides settings doesn't match the current shrinkwrap." will be shown in the terminal. This warning is incorrect.

## Impacted documentation

https://rushjs.io/pages/advanced/subspaces/

**Related issue:** https://github.com/microsoft/rushstack-websites/pull/235

<!--------------------------------------------------------------------------
👉 STEP 7: Does your PR affect anything that is discussed in the website docs?
     If so, please paste the URL of each affected web page, so we will
     remember to update the documentation after your PR is merged.
     (Updating the website is appreciated but not required.)
     If no docs are impacted, delete the "Impacted documentation" section.

     If you modified a JSON schema, remember to update init templates such as:
     rush-lib/assets/rush-init/*.json
     api-extractor/src/schemas/api-extractor-template.json
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 8: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
