### PR TITLE
[rush-lib] Fix filtered install behavior when there are dependencies on other subspaces

### DIFF
--- a/common/changes/@microsoft/rush/pedrogomes-fix-install-all-projects_2024-11-26-04-35.json
+++ b/common/changes/@microsoft/rush/pedrogomes-fix-install-all-projects_2024-11-26-04-35.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix install all projects of all subspaces in a monorepo",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/pedrogomes-fix-install-all-projects_2024-11-26-04-35.json
+++ b/common/changes/@microsoft/rush/pedrogomes-fix-install-all-projects_2024-11-26-04-35.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Fix install all projects of all subspaces in a monorepo",
+      "comment": "Fix an issue where filtered installs neglected to install dependencies from other subspaces",
       "type": "none"
     }
   ],

--- a/libraries/rush-lib/src/cli/actions/BaseInstallAction.ts
+++ b/libraries/rush-lib/src/cli/actions/BaseInstallAction.ts
@@ -244,6 +244,7 @@ export abstract class BaseInstallAction extends BaseRushAction {
           console.log(Colorize.green(`Installing for subspace: ${subspace.subspaceName}`));
           let installManagerOptionsForInstall: IInstallManagerOptions;
           if (subspaceInstallationData) {
+            // This will install the selected of projects in the subspace
             const { selectedProjects, pnpmFilterArgumentValues } = subspaceInstallationData;
             installManagerOptionsForInstall = {
               ...installManagerOptions,
@@ -262,8 +263,10 @@ export abstract class BaseInstallAction extends BaseRushAction {
               subspace
             };
           } else {
+            // This will install all projects in the subspace
             installManagerOptionsForInstall = {
               ...installManagerOptions,
+              pnpmFilterArgumentValues: [],
               subspace
             };
           }


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

Fix install all projects of all subspaces in a monorepo

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

## Details

### What happened?

We have a project which depends on ALL of the rest of the local packages of different subspaces.

![CleanShot 2024-11-26 at 13 00 01@2x](https://github.com/user-attachments/assets/4a5ca29a-f49b-435c-8c9c-bea33d6eda57)

When we run `rush install -t P1`, all subspaces except the current, are ignored with the message: "No projects matched the filters in XXX".

In other words, NO dependencies are installed (node_modules folders are empty) for the cross-subspaces that the project requires.

Subspace S1 is installed, but S2 and S3 are not! Both S2 and S3 will show the message "No projects matched the filters in XXX".

### What I expected to happen?

All related cross-subspaces should be properly installed. I would expect no message: "No projects matched the filters in XXX" to be shown.

### The solution

After diagnosing the `pnpm install` command during a subspace installation, we discovered a package filtering parameter for the current project (e.g. `--filter P1`), which fails to exist on any **cross-subspace** dependency. PNPM will then skip each **cross-subspace** installation.

```
/XXX/.rush/node-v18.20.5/pnpm-8.8.0/node_modules/pnpm/bin/pnpm.cjs install --store /YYY/common/temp/pnpm-store --config.cacheDir=/YYY/common/temp/pnpm-store --config.stateDir=/YYY/common/temp/pnpm-store --frozen-lockfile --config.dedupe-peer-dependents=false --reporter ndjson --no-strict-peer-dependencies --config.auto-install-peers=false --config.resolutionMode=highest --config.ignoreCompatibilityDb --recursive --link-workspace-packages false --filter @P1...
```

This filter should NOT exist when Rush wants to install all projects of all subspaces.

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested

1. Create a repository with subspaces enabled: https://rushjs.io/pages/advanced/subspaces/
2. Create 2 subspaces (e.g. default and s1)
3. Create a project inside of s1 and default and add s1 project as a local dependency of default
4. Run `rush install -t <project_of_default>`

The message "No projects matched the filters in XXX" during s1 installation.

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->