### PR TITLE
[rush-lib] Fix shrinkwrap-deps.json missing file

### DIFF
--- a/common/changes/@microsoft/rush/pedrogomes-fix-non-existing-hashes_2024-11-28-07-23.json
+++ b/common/changes/@microsoft/rush/pedrogomes-fix-non-existing-hashes_2024-11-28-07-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix an issue where Rush sometimes incorrectly reported \"fatal: could not open 'packages/xxx/.rush/temp/shrinkwrap-deps.json' for reading: No such file or directory\" when using subspaces",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

Fixes a regression where Rush sometimes incorrectly reports "fatal: could not open 'packages/xxx/.rush/temp/shrinkwrap-deps.json' for reading: No such file or directory" when using subspaces.

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

## Details

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

### What happened?

![CleanShot 2024-11-28 at 15 34 37@2x](https://github.com/user-attachments/assets/1c408a67-aac3-40d6-8aef-2a268aa653e8)

We have a repository with 3 subspaces: S1, S2 and S3. At the same time, we made changes to the project P1.

When running `rush install --from git:origin/master`, Rush will install the dependencies for S1 and S2, but NOT S3, which is correct! BUT, when running `rush build --from git:origin/master`, Rush fails with the message: 

```
Error calculating the state of the repo. (inner error: Error: git --no-optional-locks exited with code 128:
fatal: could not open 'packages/P5/.rush/temp/shrinkwrap-deps.json' for reading: No such file or directory
```

`shrinkwrap-deps.json` wasn't added to P5, because the subspace S3 wasn't installed.

### What I expected to happen?

No error message should be printed by Rush and build script should be successfully finished.

### The solution

Revert to the previous Rush workspace snapshot logic (version 5.139.0), by skipping the `shrinkwrap-deps.json` hashing for all unrelated projects.

**Current state**
```typescript
for (const project of rushConfiguration.projects) {
  const projectShrinkwrapFilePath: string = BaseProjectShrinkwrapFile.getFilePathForProject(project);
  absoluteFilePathsToCheck.push(projectShrinkwrapFilePath);
  const relativeProjectShrinkwrapFilePath: string = Path.convertToSlashes(
    path.relative(rootDirectory, projectShrinkwrapFilePath)
  );
  
  additionalRelativePathsToHash.push(relativeProjectShrinkwrapFilePath);
  }
  
  await Async.forEachAsync(absoluteFilePathsToCheck, async (filePath: string) => {
  // Non existing srinkwrap-deps.json are NOT skipped, because we are not removing them from additionalRelativePathsToHash!
  if (!rushConfiguration.subspacesFeatureEnabled && !(await FileSystem.existsAsync(filePath))) {
    throw new Error(
      `A project dependency file (${filePath}) is missing. You may need to run ` +
        '"rush install" or "rush update".'
    );
  }
});
```

**Previous working state**
```typescript
await Async.forEachAsync(
  this._rushConfiguration.projects,
  async (project: RushConfigurationProject) => {
    const projectShrinkwrapFilePath: string =
      BaseProjectShrinkwrapFile.getFilePathForProject(project);
    if (!(await FileSystem.existsAsync(projectShrinkwrapFilePath))) {
      // Missing shrinkwrap of subspace project is allowed because subspace projects can be partial installed
      if (this._rushConfiguration.subspacesFeatureEnabled) {
        // Non existing srinkwrap-deps.json are skipped, because they are not being added to additionalFilesToHash!
        return;
      }
      throw new Error(
        `A project dependency file (${projectShrinkwrapFilePath}) is missing. You may need to run ` +
          '"rush install" or "rush update".'
      );
    }
    const relativeProjectShrinkwrapFilePath: string = Path.convertToSlashes(
      path.relative(rootDir, projectShrinkwrapFilePath)
    );
    additionalFilesToHash.push(relativeProjectShrinkwrapFilePath);
  }
);
```

## How it was tested

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

1. Create a repository with subspaces enabled: https://rushjs.io/pages/advanced/subspaces/
2. Create 3 subspaces (e.g. default, S1 and S2)
3. Create a project inside of each subspace, and add S1 project as a local dependency of default
4. Commit a new change to the project of default (don't need to push)
5. Run `rush install --from git:origin/master` (default and S1 will be installed)
6. Run `rush build --from git:origin/master`

The message "fatal: could not open 'packages/<project_of_S2>/.rush/temp/shrinkwrap-deps.json' for reading: No such file or directory" will appear and the build script will fail.
