### PR TITLE
[rush] Fix an issue where the ability to skip 'rush install' may be incorrectly calculated when using the variants feature.

### DIFF
--- a/common/changes/@microsoft/rush/fix-a-missing-variant-case_2024-12-02-22-05.json
+++ b/common/changes/@microsoft/rush/fix-a-missing-variant-case_2024-12-02-22-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix an issue where the ability to skip `rush install` may be incorrectly calculated when using the variants feature.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -1499,7 +1499,7 @@ export class Subspace {
     // @beta
     getPackageJsonInjectedDependenciesHash(variant?: string): string | undefined;
     // @beta
-    getPnpmConfigFilePath(variant?: string): string;
+    getPnpmConfigFilePath(): string;
     // @beta
     getPnpmfilePath(variant?: string): string;
     // @beta

--- a/libraries/rush-lib/src/api/Subspace.ts
+++ b/libraries/rush-lib/src/api/Subspace.ts
@@ -75,11 +75,10 @@ export class Subspace {
   public getPnpmOptions(): PnpmOptionsConfiguration | undefined {
     if (!this._cachedPnpmOptionsInitialized) {
       // Calculate these outside the try/catch block since their error messages shouldn't be annotated:
-      const subspaceConfigFolder: string = this.getSubspaceConfigFolderPath();
       const subspaceTempFolder: string = this.getSubspaceTempFolderPath();
       try {
         this._cachedPnpmOptions = PnpmOptionsConfiguration.loadFromJsonFileOrThrow(
-          `${subspaceConfigFolder}/${RushConstants.pnpmConfigFilename}`,
+          this.getPnpmConfigFilePath(),
           subspaceTempFolder
         );
         this._cachedPnpmOptionsInitialized = true;
@@ -303,8 +302,8 @@ export class Subspace {
    * Example: `C:\MyRepo\common\subspaces\my-subspace\pnpm-config.json`
    * @beta
    */
-  public getPnpmConfigFilePath(variant?: string): string {
-    return this.getVariantDependentSubspaceConfigFolderPath(variant) + '/' + RushConstants.pnpmConfigFilename;
+  public getPnpmConfigFilePath(): string {
+    return this.getSubspaceConfigFolderPath() + '/' + RushConstants.pnpmConfigFilename;
   }
 
   /**

--- a/libraries/rush-lib/src/api/Subspace.ts
+++ b/libraries/rush-lib/src/api/Subspace.ts
@@ -206,7 +206,6 @@ export class Subspace {
    * - Lockfiles: (i.e. - `pnpm-lock.yaml`, `npm-shrinkwrap.json`, `yarn.lock`, etc)
    * - 'common-versions.json'
    * - 'pnpmfile.js'/'.pnpmfile.cjs'
-   * - 'pnpm-config.js'
    */
   public getVariantDependentSubspaceConfigFolderPath(variant: string | undefined): string {
     const subspaceConfigFolderPath: string = this.getSubspaceConfigFolderPath();

--- a/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
+++ b/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
@@ -399,7 +399,7 @@ export abstract class BaseInstallManager {
     potentiallyChangedFiles.push(subspace.getCommonVersionsFilePath(variant));
 
     // Add pnpm-config.json file to the potentially changed files list.
-    potentiallyChangedFiles.push(subspace.getPnpmConfigFilePath(variant));
+    potentiallyChangedFiles.push(subspace.getPnpmConfigFilePath());
 
     if (this.rushConfiguration.packageManager === 'pnpm') {
       // If the repo is using pnpmfile.js, consider that also


### PR DESCRIPTION
## Summary

Fixes an issue where the ability to skip 'rush install' may be incorrectly calculated when using the variants feature.

## Details

The only code path where a variant-dependent `pnpm-config.json` file referenced is in the install detection code. This removes the variant from that code path.

## How it was tested

Tested by running `rush install` with and without `package.json` changes.

## Impacted documentation

None.