### PR TITLE
[rush] Add support for an `"extends"` property in `pnpm-config.json` files.

### DIFF
--- a/apps/heft/src/utilities/CoreConfigFiles.ts
+++ b/apps/heft/src/utilities/CoreConfigFiles.ts
@@ -3,7 +3,7 @@
 
 import * as path from 'path';
 import {
-  ConfigurationFile,
+  ProjectConfigurationFile,
   InheritanceType,
   PathResolutionMethod,
   type IJsonPathMetadataResolverOptions
@@ -59,9 +59,9 @@ export interface IHeftConfigurationJson {
 }
 
 export class CoreConfigFiles {
-  private static _heftConfigFileLoader: ConfigurationFile<IHeftConfigurationJson> | undefined;
+  private static _heftConfigFileLoader: ProjectConfigurationFile<IHeftConfigurationJson> | undefined;
   private static _nodeServiceConfigurationLoader:
-    | ConfigurationFile<INodeServicePluginConfiguration>
+    | ProjectConfigurationFile<INodeServicePluginConfiguration>
     | undefined;
 
   public static heftConfigurationProjectRelativeFilePath: string = `${Constants.projectConfigFolderName}/${Constants.heftConfigurationFilename}`;
@@ -110,7 +110,7 @@ export class CoreConfigFiles {
       };
 
       const schemaObject: object = await import('../schemas/heft.schema.json');
-      CoreConfigFiles._heftConfigFileLoader = new ConfigurationFile<IHeftConfigurationJson>({
+      CoreConfigFiles._heftConfigFileLoader = new ProjectConfigurationFile<IHeftConfigurationJson>({
         projectRelativeFilePath: CoreConfigFiles.heftConfigurationProjectRelativeFilePath,
         jsonSchemaObject: schemaObject,
         propertyInheritanceDefaults: {
@@ -134,7 +134,7 @@ export class CoreConfigFiles {
       });
     }
 
-    const heftConfigFileLoader: ConfigurationFile<IHeftConfigurationJson> =
+    const heftConfigFileLoader: ProjectConfigurationFile<IHeftConfigurationJson> =
       CoreConfigFiles._heftConfigFileLoader;
 
     let configurationFile: IHeftConfigurationJson;
@@ -158,10 +158,11 @@ export class CoreConfigFiles {
         // want to see if it parses. We will use the ConfigurationFile class to load it to ensure
         // that we follow the "extends" chain for the entire config file.
         const legacySchemaObject: object = await import('../schemas/heft-legacy.schema.json');
-        const legacyConfigFileLoader: ConfigurationFile<unknown> = new ConfigurationFile<unknown>({
-          projectRelativeFilePath: CoreConfigFiles.heftConfigurationProjectRelativeFilePath,
-          jsonSchemaObject: legacySchemaObject
-        });
+        const legacyConfigFileLoader: ProjectConfigurationFile<unknown> =
+          new ProjectConfigurationFile<unknown>({
+            projectRelativeFilePath: CoreConfigFiles.heftConfigurationProjectRelativeFilePath,
+            jsonSchemaObject: legacySchemaObject
+          });
         await legacyConfigFileLoader.loadConfigurationFileForProjectAsync(terminal, projectPath, rigConfig);
       } catch (e2) {
         // It doesn't match the legacy schema either. Throw the original error.
@@ -232,7 +233,7 @@ export class CoreConfigFiles {
     if (!CoreConfigFiles._nodeServiceConfigurationLoader) {
       const schemaObject: object = await import('../schemas/node-service.schema.json');
       CoreConfigFiles._nodeServiceConfigurationLoader =
-        new ConfigurationFile<INodeServicePluginConfiguration>({
+        new ProjectConfigurationFile<INodeServicePluginConfiguration>({
           projectRelativeFilePath: CoreConfigFiles.nodeServiceConfigurationProjectRelativeFilePath,
           jsonSchemaObject: schemaObject
         });

--- a/common/changes/@microsoft/rush/support-pnpm-config.json-extends_2024-12-02-23-58.json
+++ b/common/changes/@microsoft/rush/support-pnpm-config.json-extends_2024-12-02-23-58.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add support for an `\"extends\"` property in the `common/config/rush/pnpm-config.json` and `common/config/subspace/*/pnpm-config.json` files.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@rushstack/heft-api-extractor-plugin/support-pnpm-config.json-extends_2024-12-03-03-27.json
+++ b/common/changes/@rushstack/heft-api-extractor-plugin/support-pnpm-config.json-extends_2024-12-03-03-27.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-api-extractor-plugin",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/heft-api-extractor-plugin"
+}

--- a/common/changes/@rushstack/heft-config-file/support-pnpm-config.json-extends_2024-12-02-23-57.json
+++ b/common/changes/@rushstack/heft-config-file/support-pnpm-config.json-extends_2024-12-02-23-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-config-file",
+      "comment": "Add a new `NonProjectConfigurationFile` class that is designed to load absolute-pathed configuration files without rig support.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft-config-file"
+}

--- a/common/changes/@rushstack/heft-config-file/support-pnpm-config.json-extends_2024-12-03-03-27.json
+++ b/common/changes/@rushstack/heft-config-file/support-pnpm-config.json-extends_2024-12-03-03-27.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-config-file",
+      "comment": "Rename `ConfigurationFile` to `ProjectConfigurationFile` and mark `ConfigurationFile` as `@deprecated`.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft-config-file"
+}

--- a/common/changes/@rushstack/heft-jest-plugin/support-pnpm-config.json-extends_2024-12-03-03-27.json
+++ b/common/changes/@rushstack/heft-jest-plugin/support-pnpm-config.json-extends_2024-12-03-03-27.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-jest-plugin",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/heft-jest-plugin"
+}

--- a/common/changes/@rushstack/heft-sass-plugin/support-pnpm-config.json-extends_2024-12-03-03-27.json
+++ b/common/changes/@rushstack/heft-sass-plugin/support-pnpm-config.json-extends_2024-12-03-03-27.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-sass-plugin",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/heft-sass-plugin"
+}

--- a/common/changes/@rushstack/heft-typescript-plugin/support-pnpm-config.json-extends_2024-12-03-03-27.json
+++ b/common/changes/@rushstack/heft-typescript-plugin/support-pnpm-config.json-extends_2024-12-03-03-27.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-typescript-plugin",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/heft-typescript-plugin"
+}

--- a/common/changes/@rushstack/heft/support-pnpm-config.json-extends_2024-12-03-03-27.json
+++ b/common/changes/@rushstack/heft/support-pnpm-config.json-extends_2024-12-03-03-27.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/heft"
+}

--- a/common/reviews/api/heft-config-file.api.md
+++ b/common/reviews/api/heft-config-file.api.md
@@ -7,19 +7,11 @@
 import type { IRigConfig } from '@rushstack/rig-package';
 import type { ITerminal } from '@rushstack/terminal';
 
-// @beta (undocumented)
-export class ConfigurationFile<TConfigurationFile> extends ConfigurationFileBase<TConfigurationFile, IProjectConfigurationFileOptions> {
-    constructor(options: IConfigurationFileOptions<TConfigurationFile, IProjectConfigurationFileOptions>);
-    loadConfigurationFileForProject(terminal: ITerminal, projectPath: string, rigConfig?: IRigConfig): TConfigurationFile;
-    loadConfigurationFileForProjectAsync(terminal: ITerminal, projectPath: string, rigConfig?: IRigConfig): Promise<TConfigurationFile>;
-    readonly projectRelativeFilePath: string;
-    tryLoadConfigurationFileForProject(terminal: ITerminal, projectPath: string, rigConfig?: IRigConfig): TConfigurationFile | undefined;
-    tryLoadConfigurationFileForProjectAsync(terminal: ITerminal, projectPath: string, rigConfig?: IRigConfig): Promise<TConfigurationFile | undefined>;
-    // (undocumented)
-    protected _tryLoadConfigurationFileInRig(terminal: ITerminal, rigConfig: IRigConfig, visitedConfigurationFilePaths: Set<string>): TConfigurationFile | undefined;
-    // (undocumented)
-    protected _tryLoadConfigurationFileInRigAsync(terminal: ITerminal, rigConfig: IRigConfig, visitedConfigurationFilePaths: Set<string>): Promise<TConfigurationFile | undefined>;
-}
+// @beta @deprecated (undocumented)
+export const ConfigurationFile: typeof ProjectConfigurationFile;
+
+// @beta @deprecated (undocumented)
+export type ConfigurationFile<TConfigurationFile> = ProjectConfigurationFile<TConfigurationFile>;
 
 // @beta (undocumented)
 export abstract class ConfigurationFileBase<TConfigurationFile, TExtraOptions extends {}> {
@@ -153,6 +145,20 @@ export enum PathResolutionMethod {
     nodeResolve = "nodeResolve",
     resolvePathRelativeToConfigurationFile = "resolvePathRelativeToConfigurationFile",
     resolvePathRelativeToProjectRoot = "resolvePathRelativeToProjectRoot"
+}
+
+// @beta (undocumented)
+export class ProjectConfigurationFile<TConfigurationFile> extends ConfigurationFileBase<TConfigurationFile, IProjectConfigurationFileOptions> {
+    constructor(options: IConfigurationFileOptions<TConfigurationFile, IProjectConfigurationFileOptions>);
+    loadConfigurationFileForProject(terminal: ITerminal, projectPath: string, rigConfig?: IRigConfig): TConfigurationFile;
+    loadConfigurationFileForProjectAsync(terminal: ITerminal, projectPath: string, rigConfig?: IRigConfig): Promise<TConfigurationFile>;
+    readonly projectRelativeFilePath: string;
+    tryLoadConfigurationFileForProject(terminal: ITerminal, projectPath: string, rigConfig?: IRigConfig): TConfigurationFile | undefined;
+    tryLoadConfigurationFileForProjectAsync(terminal: ITerminal, projectPath: string, rigConfig?: IRigConfig): Promise<TConfigurationFile | undefined>;
+    // (undocumented)
+    protected _tryLoadConfigurationFileInRig(terminal: ITerminal, rigConfig: IRigConfig, visitedConfigurationFilePaths: Set<string>): TConfigurationFile | undefined;
+    // (undocumented)
+    protected _tryLoadConfigurationFileInRigAsync(terminal: ITerminal, rigConfig: IRigConfig, visitedConfigurationFilePaths: Set<string>): Promise<TConfigurationFile | undefined>;
 }
 
 // @beta (undocumented)

--- a/common/reviews/api/heft-config-file.api.md
+++ b/common/reviews/api/heft-config-file.api.md
@@ -4,7 +4,7 @@
 
 ```ts
 
-import { IRigConfig } from '@rushstack/rig-package';
+import type { IRigConfig } from '@rushstack/rig-package';
 import type { ITerminal } from '@rushstack/terminal';
 
 // @beta (undocumented)

--- a/common/reviews/api/heft-config-file.api.md
+++ b/common/reviews/api/heft-config-file.api.md
@@ -164,4 +164,13 @@ export class ProjectConfigurationFile<TConfigurationFile> extends ConfigurationF
 // @beta (undocumented)
 export type PropertyInheritanceCustomFunction<TObject> = (currentObject: TObject, parentObject: TObject) => TObject;
 
+// @beta
+function stripAnnotations<TObject>(obj: TObject): TObject;
+
+declare namespace TestUtilities {
+    export {
+        stripAnnotations
+    }
+}
+
 ```

--- a/common/reviews/api/heft-config-file.api.md
+++ b/common/reviews/api/heft-config-file.api.md
@@ -4,47 +4,61 @@
 
 ```ts
 
-import type { IRigConfig } from '@rushstack/rig-package';
+import { IRigConfig } from '@rushstack/rig-package';
 import type { ITerminal } from '@rushstack/terminal';
 
 // @beta (undocumented)
-export class ConfigurationFile<TConfigurationFile> {
-    constructor(options: IConfigurationFileOptions<TConfigurationFile>);
-    // @internal (undocumented)
-    static _formatPathForLogging: (path: string) => string;
-    getObjectSourceFilePath<TObject extends object>(obj: TObject): string | undefined;
-    getPropertyOriginalValue<TParentProperty extends object, TValue>(options: IOriginalValueOptions<TParentProperty>): TValue | undefined;
+export class ConfigurationFile<TConfigurationFile> extends ConfigurationFileBase<TConfigurationFile, IProjectConfigurationFileOptions> {
+    constructor(options: IConfigurationFileOptions<TConfigurationFile, IProjectConfigurationFileOptions>);
     loadConfigurationFileForProject(terminal: ITerminal, projectPath: string, rigConfig?: IRigConfig): TConfigurationFile;
     loadConfigurationFileForProjectAsync(terminal: ITerminal, projectPath: string, rigConfig?: IRigConfig): Promise<TConfigurationFile>;
     readonly projectRelativeFilePath: string;
     tryLoadConfigurationFileForProject(terminal: ITerminal, projectPath: string, rigConfig?: IRigConfig): TConfigurationFile | undefined;
     tryLoadConfigurationFileForProjectAsync(terminal: ITerminal, projectPath: string, rigConfig?: IRigConfig): Promise<TConfigurationFile | undefined>;
+    // (undocumented)
+    protected _tryLoadConfigurationFileInRig(terminal: ITerminal, rigConfig: IRigConfig, visitedConfigurationFilePaths: Set<string>): TConfigurationFile | undefined;
+    // (undocumented)
+    protected _tryLoadConfigurationFileInRigAsync(terminal: ITerminal, rigConfig: IRigConfig, visitedConfigurationFilePaths: Set<string>): Promise<TConfigurationFile | undefined>;
 }
 
 // @beta (undocumented)
-export type IConfigurationFileOptions<TConfigurationFile> = IConfigurationFileOptionsWithJsonSchemaFilePath<TConfigurationFile> | IConfigurationFileOptionsWithJsonSchemaObject<TConfigurationFile>;
+export abstract class ConfigurationFileBase<TConfigurationFile, TExtraOptions extends {}> {
+    constructor(options: IConfigurationFileOptions<TConfigurationFile, TExtraOptions>);
+    // @internal (undocumented)
+    static _formatPathForLogging: (path: string) => string;
+    getObjectSourceFilePath<TObject extends object>(obj: TObject): string | undefined;
+    getPropertyOriginalValue<TParentProperty extends object, TValue>(options: IOriginalValueOptions<TParentProperty>): TValue | undefined;
+    // (undocumented)
+    protected _loadConfigurationFileInnerWithCache(terminal: ITerminal, resolvedConfigurationFilePath: string, visitedConfigurationFilePaths: Set<string>, rigConfig: IRigConfig | undefined): TConfigurationFile;
+    // (undocumented)
+    protected _loadConfigurationFileInnerWithCacheAsync(terminal: ITerminal, resolvedConfigurationFilePath: string, visitedConfigurationFilePaths: Set<string>, rigConfig: IRigConfig | undefined): Promise<TConfigurationFile>;
+    // (undocumented)
+    protected abstract _tryLoadConfigurationFileInRig(terminal: ITerminal, rigConfig: IRigConfig, visitedConfigurationFilePaths: Set<string>): TConfigurationFile | undefined;
+    // (undocumented)
+    protected abstract _tryLoadConfigurationFileInRigAsync(terminal: ITerminal, rigConfig: IRigConfig, visitedConfigurationFilePaths: Set<string>): Promise<TConfigurationFile | undefined>;
+}
+
+// @beta (undocumented)
+export type IConfigurationFileOptions<TConfigurationFile, TExtraOptions extends object> = IConfigurationFileOptionsWithJsonSchemaFilePath<TConfigurationFile, TExtraOptions> | IConfigurationFileOptionsWithJsonSchemaObject<TConfigurationFile, TExtraOptions>;
 
 // @beta (undocumented)
 export interface IConfigurationFileOptionsBase<TConfigurationFile> {
     jsonPathMetadata?: IJsonPathsMetadata<TConfigurationFile>;
-    projectRelativeFilePath: string;
     propertyInheritance?: IPropertiesInheritance<TConfigurationFile>;
     propertyInheritanceDefaults?: IPropertyInheritanceDefaults;
 }
 
 // @beta (undocumented)
-export interface IConfigurationFileOptionsWithJsonSchemaFilePath<TConfigurationFile> extends IConfigurationFileOptionsBase<TConfigurationFile> {
-    // (undocumented)
-    jsonSchemaObject?: never;
+export type IConfigurationFileOptionsWithJsonSchemaFilePath<TConfigurationFile, TExtraOptions extends {}> = IConfigurationFileOptionsBase<TConfigurationFile> & TExtraOptions & {
     jsonSchemaPath: string;
-}
+    jsonSchemaObject?: never;
+};
 
 // @beta (undocumented)
-export interface IConfigurationFileOptionsWithJsonSchemaObject<TConfigurationFile> extends IConfigurationFileOptionsBase<TConfigurationFile> {
+export type IConfigurationFileOptionsWithJsonSchemaObject<TConfigurationFile, TExtraOptions extends {}> = IConfigurationFileOptionsBase<TConfigurationFile> & TExtraOptions & {
     jsonSchemaObject: object;
-    // (undocumented)
     jsonSchemaPath?: never;
-}
+};
 
 // @beta
 export interface ICustomJsonPathMetadata<TConfigurationFile> {
@@ -96,6 +110,11 @@ export interface IOriginalValueOptions<TParentProperty> {
 }
 
 // @beta (undocumented)
+export interface IProjectConfigurationFileOptions {
+    projectRelativeFilePath: string;
+}
+
+// @beta (undocumented)
 export type IPropertiesInheritance<TConfigurationFile> = {
     [propertyName in keyof TConfigurationFile]?: IPropertyInheritance<InheritanceType.append | InheritanceType.merge | InheritanceType.replace> | ICustomPropertyInheritance<TConfigurationFile[propertyName]>;
 };
@@ -112,6 +131,18 @@ export interface IPropertyInheritanceDefaults {
     array?: IPropertyInheritance<InheritanceType.append | InheritanceType.replace>;
     // (undocumented)
     object?: IPropertyInheritance<InheritanceType.merge | InheritanceType.replace>;
+}
+
+// @beta (undocumented)
+export class NonProjectConfigurationFile<TConfigurationFile> extends ConfigurationFileBase<TConfigurationFile, {}> {
+    loadConfigurationFile(terminal: ITerminal, filePath: string): TConfigurationFile;
+    loadConfigurationFileAsync(terminal: ITerminal, filePath: string): Promise<TConfigurationFile>;
+    tryLoadConfigurationFile(terminal: ITerminal, filePath: string): TConfigurationFile | undefined;
+    tryLoadConfigurationFileAsync(terminal: ITerminal, filePath: string): Promise<TConfigurationFile | undefined>;
+    // (undocumented)
+    protected _tryLoadConfigurationFileInRig(terminal: ITerminal, rigConfig: IRigConfig, visitedConfigurationFilePaths: Set<string>): TConfigurationFile | undefined;
+    // (undocumented)
+    protected _tryLoadConfigurationFileInRigAsync(terminal: ITerminal, rigConfig: IRigConfig, visitedConfigurationFilePaths: Set<string>): Promise<TConfigurationFile | undefined>;
 }
 
 // @beta (undocumented)

--- a/heft-plugins/heft-api-extractor-plugin/src/ApiExtractorPlugin.ts
+++ b/heft-plugins/heft-api-extractor-plugin/src/ApiExtractorPlugin.ts
@@ -9,7 +9,7 @@ import type {
   HeftConfiguration,
   IHeftTaskRunIncrementalHookOptions
 } from '@rushstack/heft';
-import { ConfigurationFile } from '@rushstack/heft-config-file';
+import { ProjectConfigurationFile } from '@rushstack/heft-config-file';
 
 import { ApiExtractorRunner } from './ApiExtractorRunner';
 import apiExtractorConfigSchema from './schemas/api-extractor-task.schema.json';
@@ -51,7 +51,7 @@ export default class ApiExtractorPlugin implements IHeftTaskPlugin {
   private _apiExtractor: typeof TApiExtractor | undefined;
   private _apiExtractorConfigurationFilePath: string | undefined | typeof UNINITIALIZED = UNINITIALIZED;
   private _apiExtractorTaskConfigurationFileLoader:
-    | ConfigurationFile<IApiExtractorTaskConfiguration>
+    | ProjectConfigurationFile<IApiExtractorTaskConfiguration>
     | undefined;
   private _printedWatchWarning: boolean = false;
 
@@ -156,10 +156,11 @@ export default class ApiExtractorPlugin implements IHeftTaskPlugin {
     heftConfiguration: HeftConfiguration
   ): Promise<IApiExtractorTaskConfiguration | undefined> {
     if (!this._apiExtractorTaskConfigurationFileLoader) {
-      this._apiExtractorTaskConfigurationFileLoader = new ConfigurationFile<IApiExtractorTaskConfiguration>({
-        projectRelativeFilePath: TASK_CONFIG_RELATIVE_PATH,
-        jsonSchemaObject: apiExtractorConfigSchema
-      });
+      this._apiExtractorTaskConfigurationFileLoader =
+        new ProjectConfigurationFile<IApiExtractorTaskConfiguration>({
+          projectRelativeFilePath: TASK_CONFIG_RELATIVE_PATH,
+          jsonSchemaObject: apiExtractorConfigSchema
+        });
     }
 
     return await this._apiExtractorTaskConfigurationFileLoader.tryLoadConfigurationFileForProjectAsync(

--- a/heft-plugins/heft-jest-plugin/src/JestPlugin.ts
+++ b/heft-plugins/heft-jest-plugin/src/JestPlugin.ts
@@ -24,7 +24,7 @@ import type {
   CommandLineStringListParameter
 } from '@rushstack/heft';
 import {
-  ConfigurationFile,
+  ProjectConfigurationFile,
   type ICustomJsonPathMetadata,
   type IJsonPathMetadataResolverOptions,
   InheritanceType,
@@ -139,7 +139,7 @@ interface IPendingTestRun {
  * @internal
  */
 export default class JestPlugin implements IHeftTaskPlugin<IJestPluginOptions> {
-  private static _jestConfigurationFileLoader: ConfigurationFile<IHeftJestConfiguration> | undefined;
+  private static _jestConfigurationFileLoader: ProjectConfigurationFile<IHeftJestConfiguration> | undefined;
 
   private _jestPromise: Promise<unknown> | undefined;
   private _pendingTestRuns: Set<IPendingTestRun> = new Set();
@@ -677,7 +677,7 @@ export default class JestPlugin implements IHeftTaskPlugin<IJestPluginOptions> {
   public static _getJestConfigurationLoader(
     buildFolder: string,
     projectRelativeFilePath: string
-  ): ConfigurationFile<IHeftJestConfiguration> {
+  ): ProjectConfigurationFile<IHeftJestConfiguration> {
     if (!JestPlugin._jestConfigurationFileLoader) {
       // By default, ConfigurationFile will replace all objects, so we need to provide merge functions for these
       const shallowObjectInheritanceFunc: <T extends Record<string, unknown> | undefined>(
@@ -722,7 +722,7 @@ export default class JestPlugin implements IHeftTaskPlugin<IJestPluginOptions> {
           resolveAsModule: true
         });
 
-      JestPlugin._jestConfigurationFileLoader = new ConfigurationFile<IHeftJestConfiguration>({
+      JestPlugin._jestConfigurationFileLoader = new ProjectConfigurationFile<IHeftJestConfiguration>({
         projectRelativeFilePath: projectRelativeFilePath,
         // Bypass Jest configuration validation
         jsonSchemaObject: anythingSchema,

--- a/heft-plugins/heft-jest-plugin/src/test/JestPlugin.test.ts
+++ b/heft-plugins/heft-jest-plugin/src/test/JestPlugin.test.ts
@@ -4,7 +4,7 @@
 import * as path from 'path';
 import type { Config } from '@jest/types';
 import type { IHeftTaskSession, HeftConfiguration, CommandLineParameter } from '@rushstack/heft';
-import type { ConfigurationFile } from '@rushstack/heft-config-file';
+import type { ProjectConfigurationFile } from '@rushstack/heft-config-file';
 import { Import, JsonFile } from '@rushstack/node-core-library';
 import { StringBufferTerminalProvider, Terminal } from '@rushstack/terminal';
 
@@ -74,7 +74,7 @@ describe('JestConfigLoader', () => {
     // Because we require the built modules, we need to set our rootDir to be in the 'lib' folder, since transpilation
     // means that we don't run on the built test assets directly
     const rootDir: string = path.resolve(__dirname, '..', '..', 'lib', 'test', 'project1');
-    const loader: ConfigurationFile<IHeftJestConfiguration> = JestPlugin._getJestConfigurationLoader(
+    const loader: ProjectConfigurationFile<IHeftJestConfiguration> = JestPlugin._getJestConfigurationLoader(
       rootDir,
       'config/jest.config.json'
     );
@@ -161,7 +161,7 @@ describe('JestConfigLoader', () => {
     // Because we require the built modules, we need to set our rootDir to be in the 'lib' folder, since transpilation
     // means that we don't run on the built test assets directly
     const rootDir: string = path.resolve(__dirname, '..', '..', 'lib', 'test', 'project2');
-    const loader: ConfigurationFile<IHeftJestConfiguration> = JestPlugin._getJestConfigurationLoader(
+    const loader: ProjectConfigurationFile<IHeftJestConfiguration> = JestPlugin._getJestConfigurationLoader(
       rootDir,
       'config/jest.config.json'
     );

--- a/heft-plugins/heft-sass-plugin/src/SassPlugin.ts
+++ b/heft-plugins/heft-sass-plugin/src/SassPlugin.ts
@@ -10,7 +10,7 @@ import type {
   IHeftTaskRunIncrementalHookOptions,
   IWatchedFileState
 } from '@rushstack/heft';
-import { ConfigurationFile } from '@rushstack/heft-config-file';
+import { ProjectConfigurationFile } from '@rushstack/heft-config-file';
 
 import { type ISassConfiguration, SassProcessor } from './SassProcessor';
 import sassConfigSchema from './schemas/heft-sass-plugin.schema.json';
@@ -21,7 +21,7 @@ const PLUGIN_NAME: 'sass-plugin' = 'sass-plugin';
 const SASS_CONFIGURATION_LOCATION: string = 'config/sass.json';
 
 export default class SassPlugin implements IHeftPlugin {
-  private static _sassConfigurationLoader: ConfigurationFile<ISassConfigurationJson> | undefined;
+  private static _sassConfigurationLoader: ProjectConfigurationFile<ISassConfigurationJson> | undefined;
   private _sassConfiguration: ISassConfiguration | undefined;
   private _sassProcessor: SassProcessor | undefined;
 
@@ -105,7 +105,7 @@ export default class SassPlugin implements IHeftPlugin {
   ): Promise<ISassConfiguration> {
     if (!this._sassConfiguration) {
       if (!SassPlugin._sassConfigurationLoader) {
-        SassPlugin._sassConfigurationLoader = new ConfigurationFile({
+        SassPlugin._sassConfigurationLoader = new ProjectConfigurationFile({
           projectRelativeFilePath: SASS_CONFIGURATION_LOCATION,
           jsonSchemaObject: sassConfigSchema
         });

--- a/heft-plugins/heft-typescript-plugin/src/TypeScriptPlugin.ts
+++ b/heft-plugins/heft-typescript-plugin/src/TypeScriptPlugin.ts
@@ -7,7 +7,7 @@ import type * as TTypescript from 'typescript';
 import { SyncHook } from 'tapable';
 import { FileSystem, Path } from '@rushstack/node-core-library';
 import type { ITerminal } from '@rushstack/terminal';
-import { ConfigurationFile, InheritanceType, PathResolutionMethod } from '@rushstack/heft-config-file';
+import { ProjectConfigurationFile, InheritanceType, PathResolutionMethod } from '@rushstack/heft-config-file';
 import type {
   HeftConfiguration,
   IHeftTaskSession,
@@ -127,7 +127,7 @@ export interface ITypeScriptPluginAccessor {
   readonly onChangedFilesHook: SyncHook<IChangedFilesHookOptions>;
 }
 
-let _typeScriptConfigurationFileLoader: ConfigurationFile<ITypeScriptConfigurationJson> | undefined;
+let _typeScriptConfigurationFileLoader: ProjectConfigurationFile<ITypeScriptConfigurationJson> | undefined;
 const _typeScriptConfigurationFilePromiseCache: Map<
   string,
   Promise<ITypeScriptConfigurationJson | undefined>
@@ -149,7 +149,7 @@ export async function loadTypeScriptConfigurationFileAsync(
   if (!typescriptConfigurationFilePromise) {
     // Ensure that the file loader has been initialized.
     if (!_typeScriptConfigurationFileLoader) {
-      _typeScriptConfigurationFileLoader = new ConfigurationFile<ITypeScriptConfigurationJson>({
+      _typeScriptConfigurationFileLoader = new ProjectConfigurationFile<ITypeScriptConfigurationJson>({
         projectRelativeFilePath: 'config/typescript.json',
         jsonSchemaObject: typescriptConfigSchema,
         propertyInheritance: {
@@ -173,7 +173,7 @@ export async function loadTypeScriptConfigurationFileAsync(
   return await typescriptConfigurationFilePromise;
 }
 
-let _partialTsconfigFileLoader: ConfigurationFile<IPartialTsconfig> | undefined;
+let _partialTsconfigFileLoader: ProjectConfigurationFile<IPartialTsconfig> | undefined;
 const _partialTsconfigFilePromiseCache: Map<string, Promise<IPartialTsconfig | undefined>> = new Map();
 
 function getTsconfigFilePath(
@@ -213,7 +213,7 @@ export async function loadPartialTsconfigFileAsync(
     } else {
       // Ensure that the file loader has been initialized.
       if (!_partialTsconfigFileLoader) {
-        _partialTsconfigFileLoader = new ConfigurationFile<IPartialTsconfig>({
+        _partialTsconfigFileLoader = new ProjectConfigurationFile<IPartialTsconfig>({
           projectRelativeFilePath: typeScriptConfigurationJson?.project || 'tsconfig.json',
           jsonSchemaObject: anythingSchema,
           propertyInheritance: {

--- a/libraries/heft-config-file/src/ConfigurationFileBase.ts
+++ b/libraries/heft-config-file/src/ConfigurationFileBase.ts
@@ -74,9 +74,11 @@ export enum PathResolutionMethod {
 }
 
 const CONFIGURATION_FILE_MERGE_BEHAVIOR_FIELD_REGEX: RegExp = /^\$([^\.]+)\.inheritanceType$/;
-const CONFIGURATION_FILE_FIELD_ANNOTATION: unique symbol = Symbol('configuration-file-field-annotation');
+export const CONFIGURATION_FILE_FIELD_ANNOTATION: unique symbol = Symbol(
+  'configuration-file-field-annotation'
+);
 
-interface IAnnotatedField<TField> {
+export interface IAnnotatedField<TField> {
   [CONFIGURATION_FILE_FIELD_ANNOTATION]: IConfigurationFileFieldAnnotation<TField>;
 }
 

--- a/libraries/heft-config-file/src/ConfigurationFileBase.ts
+++ b/libraries/heft-config-file/src/ConfigurationFileBase.ts
@@ -209,11 +209,6 @@ export interface IJsonPathsMetadata<TConfigurationFile> {
  */
 export interface IConfigurationFileOptionsBase<TConfigurationFile> {
   /**
-   * A project root-relative path to the configuration file that should be loaded.
-   */
-  projectRelativeFilePath: string;
-
-  /**
    * Use this property to specify how JSON nodes are postprocessed.
    */
   jsonPathMetadata?: IJsonPathsMetadata<TConfigurationFile>;
@@ -234,33 +229,39 @@ export interface IConfigurationFileOptionsBase<TConfigurationFile> {
 /**
  * @beta
  */
-export interface IConfigurationFileOptionsWithJsonSchemaFilePath<TConfigurationFile>
-  extends IConfigurationFileOptionsBase<TConfigurationFile> {
-  /**
-   * The path to the schema for the configuration file.
-   */
-  jsonSchemaPath: string;
-  jsonSchemaObject?: never;
-}
+export type IConfigurationFileOptionsWithJsonSchemaFilePath<
+  TConfigurationFile,
+  TExtraOptions extends {}
+> = IConfigurationFileOptionsBase<TConfigurationFile> &
+  TExtraOptions & {
+    /**
+     * The path to the schema for the configuration file.
+     */
+    jsonSchemaPath: string;
+    jsonSchemaObject?: never;
+  };
 
 /**
  * @beta
  */
-export interface IConfigurationFileOptionsWithJsonSchemaObject<TConfigurationFile>
-  extends IConfigurationFileOptionsBase<TConfigurationFile> {
-  /**
-   * The schema for the configuration file.
-   */
-  jsonSchemaObject: object;
-  jsonSchemaPath?: never;
-}
+export type IConfigurationFileOptionsWithJsonSchemaObject<
+  TConfigurationFile,
+  TExtraOptions extends {}
+> = IConfigurationFileOptionsBase<TConfigurationFile> &
+  TExtraOptions & {
+    /**
+     * The schema for the configuration file.
+     */
+    jsonSchemaObject: object;
+    jsonSchemaPath?: never;
+  };
 
 /**
  * @beta
  */
-export type IConfigurationFileOptions<TConfigurationFile> =
-  | IConfigurationFileOptionsWithJsonSchemaFilePath<TConfigurationFile>
-  | IConfigurationFileOptionsWithJsonSchemaObject<TConfigurationFile>;
+export type IConfigurationFileOptions<TConfigurationFile, TExtraOptions extends object> =
+  | IConfigurationFileOptionsWithJsonSchemaFilePath<TConfigurationFile, TExtraOptions>
+  | IConfigurationFileOptionsWithJsonSchemaObject<TConfigurationFile, TExtraOptions>;
 
 interface IJsonPathCallbackObject {
   path: string;
@@ -280,11 +281,8 @@ export interface IOriginalValueOptions<TParentProperty> {
 /**
  * @beta
  */
-export class ConfigurationFile<TConfigurationFile> {
+export abstract class ConfigurationFileBase<TConfigurationFile, TExtraOptions extends {}> {
   private readonly _getSchema: () => JsonSchema;
-
-  /** {@inheritDoc IConfigurationFileOptionsBase.projectRelativeFilePath} */
-  public readonly projectRelativeFilePath: string;
 
   private readonly _jsonPathMetadata: IJsonPathsMetadata<TConfigurationFile>;
   private readonly _propertyInheritanceTypes: IPropertiesInheritance<TConfigurationFile>;
@@ -302,9 +300,7 @@ export class ConfigurationFile<TConfigurationFile> {
   private readonly _configPromiseCache: Map<string, Promise<TConfigurationFile>> = new Map();
   private readonly _packageJsonLookup: PackageJsonLookup = new PackageJsonLookup();
 
-  public constructor(options: IConfigurationFileOptions<TConfigurationFile>) {
-    this.projectRelativeFilePath = options.projectRelativeFilePath;
-
+  public constructor(options: IConfigurationFileOptions<TConfigurationFile, TExtraOptions>) {
     if (options.jsonSchemaObject) {
       this._getSchema = () => JsonSchema.fromLoadedObject(options.jsonSchemaObject);
     } else {
@@ -314,82 +310,6 @@ export class ConfigurationFile<TConfigurationFile> {
     this._jsonPathMetadata = options.jsonPathMetadata || {};
     this._propertyInheritanceTypes = options.propertyInheritance || {};
     this._defaultPropertyInheritance = options.propertyInheritanceDefaults || {};
-  }
-
-  /**
-   * Find and return a configuration file for the specified project, automatically resolving
-   * `extends` properties and handling rigged configuration files. Will throw an error if a configuration
-   * file cannot be found in the rig or project config folder.
-   */
-  public loadConfigurationFileForProject(
-    terminal: ITerminal,
-    projectPath: string,
-    rigConfig?: IRigConfig
-  ): TConfigurationFile {
-    const projectConfigurationFilePath: string = this._getConfigurationFilePathForProject(projectPath);
-    return this._loadConfigurationFileInnerWithCache(
-      terminal,
-      projectConfigurationFilePath,
-      new Set<string>(),
-      rigConfig
-    );
-  }
-
-  /**
-   * Find and return a configuration file for the specified project, automatically resolving
-   * `extends` properties and handling rigged configuration files. Will throw an error if a configuration
-   * file cannot be found in the rig or project config folder.
-   */
-  public async loadConfigurationFileForProjectAsync(
-    terminal: ITerminal,
-    projectPath: string,
-    rigConfig?: IRigConfig
-  ): Promise<TConfigurationFile> {
-    const projectConfigurationFilePath: string = this._getConfigurationFilePathForProject(projectPath);
-    return await this._loadConfigurationFileInnerWithCacheAsync(
-      terminal,
-      projectConfigurationFilePath,
-      new Set<string>(),
-      rigConfig
-    );
-  }
-
-  /**
-   * This function is identical to {@link ConfigurationFile.loadConfigurationFileForProject}, except
-   * that it returns `undefined` instead of throwing an error if the configuration file cannot be found.
-   */
-  public tryLoadConfigurationFileForProject(
-    terminal: ITerminal,
-    projectPath: string,
-    rigConfig?: IRigConfig
-  ): TConfigurationFile | undefined {
-    try {
-      return this.loadConfigurationFileForProject(terminal, projectPath, rigConfig);
-    } catch (e) {
-      if (FileSystem.isNotExistError(e as Error)) {
-        return undefined;
-      }
-      throw e;
-    }
-  }
-
-  /**
-   * This function is identical to {@link ConfigurationFile.loadConfigurationFileForProjectAsync}, except
-   * that it returns `undefined` instead of throwing an error if the configuration file cannot be found.
-   */
-  public async tryLoadConfigurationFileForProjectAsync(
-    terminal: ITerminal,
-    projectPath: string,
-    rigConfig?: IRigConfig
-  ): Promise<TConfigurationFile | undefined> {
-    try {
-      return await this.loadConfigurationFileForProjectAsync(terminal, projectPath, rigConfig);
-    } catch (e) {
-      if (FileSystem.isNotExistError(e as Error)) {
-        return undefined;
-      }
-      throw e;
-    }
   }
 
   /**
@@ -430,14 +350,14 @@ export class ConfigurationFile<TConfigurationFile> {
     }
   }
 
-  private _loadConfigurationFileInnerWithCache(
+  protected _loadConfigurationFileInnerWithCache(
     terminal: ITerminal,
     resolvedConfigurationFilePath: string,
     visitedConfigurationFilePaths: Set<string>,
     rigConfig: IRigConfig | undefined
   ): TConfigurationFile {
     if (visitedConfigurationFilePaths.has(resolvedConfigurationFilePath)) {
-      const resolvedConfigurationFilePathForLogging: string = ConfigurationFile._formatPathForLogging(
+      const resolvedConfigurationFilePathForLogging: string = ConfigurationFileBase._formatPathForLogging(
         resolvedConfigurationFilePath
       );
       throw new Error(
@@ -461,14 +381,14 @@ export class ConfigurationFile<TConfigurationFile> {
     return cacheEntry;
   }
 
-  private async _loadConfigurationFileInnerWithCacheAsync(
+  protected async _loadConfigurationFileInnerWithCacheAsync(
     terminal: ITerminal,
     resolvedConfigurationFilePath: string,
     visitedConfigurationFilePaths: Set<string>,
     rigConfig: IRigConfig | undefined
   ): Promise<TConfigurationFile> {
     if (visitedConfigurationFilePaths.has(resolvedConfigurationFilePath)) {
-      const resolvedConfigurationFilePathForLogging: string = ConfigurationFile._formatPathForLogging(
+      const resolvedConfigurationFilePathForLogging: string = ConfigurationFileBase._formatPathForLogging(
         resolvedConfigurationFilePath
       );
       throw new Error(
@@ -496,6 +416,18 @@ export class ConfigurationFile<TConfigurationFile> {
 
     return await cacheEntryPromise;
   }
+
+  protected abstract _tryLoadConfigurationFileInRig(
+    terminal: ITerminal,
+    rigConfig: IRigConfig,
+    visitedConfigurationFilePaths: Set<string>
+  ): TConfigurationFile | undefined;
+
+  protected abstract _tryLoadConfigurationFileInRigAsync(
+    terminal: ITerminal,
+    rigConfig: IRigConfig,
+    visitedConfigurationFilePaths: Set<string>
+  ): Promise<TConfigurationFile | undefined>;
 
   private _parseAndResolveConfigurationFile(
     fileText: string,
@@ -546,7 +478,7 @@ export class ConfigurationFile<TConfigurationFile> {
     visitedConfigurationFilePaths: Set<string>,
     rigConfig: IRigConfig | undefined
   ): TConfigurationFile {
-    const resolvedConfigurationFilePathForLogging: string = ConfigurationFile._formatPathForLogging(
+    const resolvedConfigurationFilePathForLogging: string = ConfigurationFileBase._formatPathForLogging(
       resolvedConfigurationFilePath
     );
 
@@ -634,7 +566,7 @@ export class ConfigurationFile<TConfigurationFile> {
     visitedConfigurationFilePaths: Set<string>,
     rigConfig: IRigConfig | undefined
   ): Promise<TConfigurationFile> {
-    const resolvedConfigurationFilePathForLogging: string = ConfigurationFile._formatPathForLogging(
+    const resolvedConfigurationFilePathForLogging: string = ConfigurationFileBase._formatPathForLogging(
       resolvedConfigurationFilePath
     );
 
@@ -713,76 +645,6 @@ export class ConfigurationFile<TConfigurationFile> {
     return result as TConfigurationFile;
   }
 
-  private _tryLoadConfigurationFileInRig(
-    terminal: ITerminal,
-    rigConfig: IRigConfig,
-    visitedConfigurationFilePaths: Set<string>
-  ): TConfigurationFile | undefined {
-    if (rigConfig.rigFound) {
-      const rigProfileFolder: string = rigConfig.getResolvedProfileFolder();
-      try {
-        return this._loadConfigurationFileInnerWithCache(
-          terminal,
-          nodeJsPath.resolve(rigProfileFolder, this.projectRelativeFilePath),
-          visitedConfigurationFilePaths,
-          undefined
-        );
-      } catch (e) {
-        // Ignore cases where a configuration file doesn't exist in a rig
-        if (!FileSystem.isNotExistError(e as Error)) {
-          throw e;
-        } else {
-          terminal.writeDebugLine(
-            `Configuration file "${
-              this.projectRelativeFilePath
-            }" not found in rig ("${ConfigurationFile._formatPathForLogging(rigProfileFolder)}")`
-          );
-        }
-      }
-    } else {
-      terminal.writeDebugLine(
-        `No rig found for "${ConfigurationFile._formatPathForLogging(rigConfig.projectFolderPath)}"`
-      );
-    }
-
-    return undefined;
-  }
-
-  private async _tryLoadConfigurationFileInRigAsync(
-    terminal: ITerminal,
-    rigConfig: IRigConfig,
-    visitedConfigurationFilePaths: Set<string>
-  ): Promise<TConfigurationFile | undefined> {
-    if (rigConfig.rigFound) {
-      const rigProfileFolder: string = await rigConfig.getResolvedProfileFolderAsync();
-      try {
-        return await this._loadConfigurationFileInnerWithCacheAsync(
-          terminal,
-          nodeJsPath.resolve(rigProfileFolder, this.projectRelativeFilePath),
-          visitedConfigurationFilePaths,
-          undefined
-        );
-      } catch (e) {
-        // Ignore cases where a configuration file doesn't exist in a rig
-        if (!FileSystem.isNotExistError(e as Error)) {
-          throw e;
-        } else {
-          terminal.writeDebugLine(
-            `Configuration file "${
-              this.projectRelativeFilePath
-            }" not found in rig ("${ConfigurationFile._formatPathForLogging(rigProfileFolder)}")`
-          );
-        }
-      }
-    } else {
-      terminal.writeDebugLine(
-        `No rig found for "${ConfigurationFile._formatPathForLogging(rigConfig.projectFolderPath)}"`
-      );
-    }
-
-    return undefined;
-  }
-
   private _annotateProperties<TObject>(resolvedConfigurationFilePath: string, obj: TObject): void {
     if (!obj) {
       return;
@@ -830,7 +692,7 @@ export class ConfigurationFile<TConfigurationFile> {
           this._packageJsonLookup.tryGetPackageFolderFor(configurationFilePath);
         if (!packageRoot) {
           throw new Error(
-            `Could not find a package root for path "${ConfigurationFile._formatPathForLogging(
+            `Could not find a package root for path "${ConfigurationFileBase._formatPathForLogging(
               configurationFilePath
             )}"`
           );
@@ -1120,9 +982,5 @@ export class ConfigurationFile<TConfigurationFile> {
     }
 
     return result;
-  }
-
-  private _getConfigurationFilePathForProject(projectPath: string): string {
-    return nodeJsPath.resolve(projectPath, this.projectRelativeFilePath);
   }
 }

--- a/libraries/heft-config-file/src/NonProjectConfigurationFile.ts
+++ b/libraries/heft-config-file/src/NonProjectConfigurationFile.ts
@@ -3,9 +3,9 @@
 
 import { FileSystem } from '@rushstack/node-core-library';
 import type { ITerminal } from '@rushstack/terminal';
+import type { IRigConfig } from '@rushstack/rig-package';
 
 import { ConfigurationFileBase } from './ConfigurationFileBase';
-import { IRigConfig } from '@rushstack/rig-package';
 
 /**
  * @beta

--- a/libraries/heft-config-file/src/NonProjectConfigurationFile.ts
+++ b/libraries/heft-config-file/src/NonProjectConfigurationFile.ts
@@ -1,0 +1,91 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { FileSystem } from '@rushstack/node-core-library';
+import type { ITerminal } from '@rushstack/terminal';
+
+import { ConfigurationFileBase } from './ConfigurationFileBase';
+import { IRigConfig } from '@rushstack/rig-package';
+
+/**
+ * @beta
+ */
+export class NonProjectConfigurationFile<TConfigurationFile> extends ConfigurationFileBase<
+  TConfigurationFile,
+  {}
+> {
+  /**
+   * Load the configuration file at the specified absolute path, automatically resolving
+   * `extends` properties. Will throw an error if the file cannot be found.
+   */
+  public loadConfigurationFile(terminal: ITerminal, filePath: string): TConfigurationFile {
+    return this._loadConfigurationFileInnerWithCache(terminal, filePath, new Set<string>(), undefined);
+  }
+
+  /**
+   * Load the configuration file at the specified absolute path, automatically resolving
+   * `extends` properties. Will throw an error if the file cannot be found.
+   */
+  public async loadConfigurationFileAsync(
+    terminal: ITerminal,
+    filePath: string
+  ): Promise<TConfigurationFile> {
+    return await this._loadConfigurationFileInnerWithCacheAsync(
+      terminal,
+      filePath,
+      new Set<string>(),
+      undefined
+    );
+  }
+
+  /**
+   * This function is identical to {@link NonProjectConfigurationFile.loadConfigurationFile}, except
+   * that it returns `undefined` instead of throwing an error if the configuration file cannot be found.
+   */
+  public tryLoadConfigurationFile(terminal: ITerminal, filePath: string): TConfigurationFile | undefined {
+    try {
+      return this.loadConfigurationFile(terminal, filePath);
+    } catch (e) {
+      if (FileSystem.isNotExistError(e as Error)) {
+        return undefined;
+      }
+      throw e;
+    }
+  }
+
+  /**
+   * This function is identical to {@link NonProjectConfigurationFile.loadConfigurationFileAsync}, except
+   * that it returns `undefined` instead of throwing an error if the configuration file cannot be found.
+   */
+  public async tryLoadConfigurationFileAsync(
+    terminal: ITerminal,
+    filePath: string
+  ): Promise<TConfigurationFile | undefined> {
+    try {
+      return await this.loadConfigurationFileAsync(terminal, filePath);
+    } catch (e) {
+      if (FileSystem.isNotExistError(e as Error)) {
+        return undefined;
+      }
+      throw e;
+    }
+  }
+
+  protected _tryLoadConfigurationFileInRig(
+    terminal: ITerminal,
+    rigConfig: IRigConfig,
+    visitedConfigurationFilePaths: Set<string>
+  ): TConfigurationFile | undefined {
+    // This is a no-op because we don't support rigging for non-project configuration files
+    return undefined;
+  }
+
+  protected async _tryLoadConfigurationFileInRigAsync(
+    terminal: ITerminal,
+    rigConfig: IRigConfig,
+    visitedConfigurationFilePaths: Set<string>
+  ): Promise<TConfigurationFile | undefined> {
+    // This is a no-op because we don't support rigging for non-project configuration files
+    return undefined;
+  }
+}

--- a/libraries/heft-config-file/src/ProjectConfigurationFile.ts
+++ b/libraries/heft-config-file/src/ProjectConfigurationFile.ts
@@ -1,0 +1,187 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import * as nodeJsPath from 'path';
+import { FileSystem } from '@rushstack/node-core-library';
+import type { ITerminal } from '@rushstack/terminal';
+import type { IRigConfig } from '@rushstack/rig-package';
+
+import { ConfigurationFileBase, IConfigurationFileOptions } from './ConfigurationFileBase';
+
+/**
+ * @beta
+ */
+export interface IProjectConfigurationFileOptions {
+  /**
+   * A project root-relative path to the configuration file that should be loaded.
+   */
+  projectRelativeFilePath: string;
+}
+
+/**
+ * @beta
+ */
+export class ProjectConfigurationFile<TConfigurationFile> extends ConfigurationFileBase<
+  TConfigurationFile,
+  IProjectConfigurationFileOptions
+> {
+  /** {@inheritDoc IProjectConfigurationFileOptions.projectRelativeFilePath} */
+  public readonly projectRelativeFilePath: string;
+
+  public constructor(
+    options: IConfigurationFileOptions<TConfigurationFile, IProjectConfigurationFileOptions>
+  ) {
+    super(options);
+    this.projectRelativeFilePath = options.projectRelativeFilePath;
+  }
+
+  /**
+   * Find and return a configuration file for the specified project, automatically resolving
+   * `extends` properties and handling rigged configuration files. Will throw an error if a configuration
+   * file cannot be found in the rig or project config folder.
+   */
+  public loadConfigurationFileForProject(
+    terminal: ITerminal,
+    projectPath: string,
+    rigConfig?: IRigConfig
+  ): TConfigurationFile {
+    const projectConfigurationFilePath: string = this._getConfigurationFilePathForProject(projectPath);
+    return this._loadConfigurationFileInnerWithCache(
+      terminal,
+      projectConfigurationFilePath,
+      new Set<string>(),
+      rigConfig
+    );
+  }
+
+  /**
+   * Find and return a configuration file for the specified project, automatically resolving
+   * `extends` properties and handling rigged configuration files. Will throw an error if a configuration
+   * file cannot be found in the rig or project config folder.
+   */
+  public async loadConfigurationFileForProjectAsync(
+    terminal: ITerminal,
+    projectPath: string,
+    rigConfig?: IRigConfig
+  ): Promise<TConfigurationFile> {
+    const projectConfigurationFilePath: string = this._getConfigurationFilePathForProject(projectPath);
+    return await this._loadConfigurationFileInnerWithCacheAsync(
+      terminal,
+      projectConfigurationFilePath,
+      new Set<string>(),
+      rigConfig
+    );
+  }
+
+  /**
+   * This function is identical to {@link ConfigurationFile.loadConfigurationFileForProject}, except
+   * that it returns `undefined` instead of throwing an error if the configuration file cannot be found.
+   */
+  public tryLoadConfigurationFileForProject(
+    terminal: ITerminal,
+    projectPath: string,
+    rigConfig?: IRigConfig
+  ): TConfigurationFile | undefined {
+    try {
+      return this.loadConfigurationFileForProject(terminal, projectPath, rigConfig);
+    } catch (e) {
+      if (FileSystem.isNotExistError(e as Error)) {
+        return undefined;
+      }
+      throw e;
+    }
+  }
+
+  /**
+   * This function is identical to {@link ConfigurationFile.loadConfigurationFileForProjectAsync}, except
+   * that it returns `undefined` instead of throwing an error if the configuration file cannot be found.
+   */
+  public async tryLoadConfigurationFileForProjectAsync(
+    terminal: ITerminal,
+    projectPath: string,
+    rigConfig?: IRigConfig
+  ): Promise<TConfigurationFile | undefined> {
+    try {
+      return await this.loadConfigurationFileForProjectAsync(terminal, projectPath, rigConfig);
+    } catch (e) {
+      if (FileSystem.isNotExistError(e as Error)) {
+        return undefined;
+      }
+      throw e;
+    }
+  }
+
+  protected _tryLoadConfigurationFileInRig(
+    terminal: ITerminal,
+    rigConfig: IRigConfig,
+    visitedConfigurationFilePaths: Set<string>
+  ): TConfigurationFile | undefined {
+    if (rigConfig.rigFound) {
+      const rigProfileFolder: string = rigConfig.getResolvedProfileFolder();
+      try {
+        return this._loadConfigurationFileInnerWithCache(
+          terminal,
+          nodeJsPath.resolve(rigProfileFolder, this.projectRelativeFilePath),
+          visitedConfigurationFilePaths,
+          undefined
+        );
+      } catch (e) {
+        // Ignore cases where a configuration file doesn't exist in a rig
+        if (!FileSystem.isNotExistError(e as Error)) {
+          throw e;
+        } else {
+          terminal.writeDebugLine(
+            `Configuration file "${
+              this.projectRelativeFilePath
+            }" not found in rig ("${ConfigurationFileBase._formatPathForLogging(rigProfileFolder)}")`
+          );
+        }
+      }
+    } else {
+      terminal.writeDebugLine(
+        `No rig found for "${ConfigurationFileBase._formatPathForLogging(rigConfig.projectFolderPath)}"`
+      );
+    }
+
+    return undefined;
+  }
+
+  protected async _tryLoadConfigurationFileInRigAsync(
+    terminal: ITerminal,
+    rigConfig: IRigConfig,
+    visitedConfigurationFilePaths: Set<string>
+  ): Promise<TConfigurationFile | undefined> {
+    if (rigConfig.rigFound) {
+      const rigProfileFolder: string = await rigConfig.getResolvedProfileFolderAsync();
+      try {
+        return await this._loadConfigurationFileInnerWithCacheAsync(
+          terminal,
+          nodeJsPath.resolve(rigProfileFolder, this.projectRelativeFilePath),
+          visitedConfigurationFilePaths,
+          undefined
+        );
+      } catch (e) {
+        // Ignore cases where a configuration file doesn't exist in a rig
+        if (!FileSystem.isNotExistError(e as Error)) {
+          throw e;
+        } else {
+          terminal.writeDebugLine(
+            `Configuration file "${
+              this.projectRelativeFilePath
+            }" not found in rig ("${ConfigurationFileBase._formatPathForLogging(rigProfileFolder)}")`
+          );
+        }
+      }
+    } else {
+      terminal.writeDebugLine(
+        `No rig found for "${ConfigurationFileBase._formatPathForLogging(rigConfig.projectFolderPath)}"`
+      );
+    }
+
+    return undefined;
+  }
+
+  private _getConfigurationFilePathForProject(projectPath: string): string {
+    return nodeJsPath.resolve(projectPath, this.projectRelativeFilePath);
+  }
+}

--- a/libraries/heft-config-file/src/ProjectConfigurationFile.ts
+++ b/libraries/heft-config-file/src/ProjectConfigurationFile.ts
@@ -6,7 +6,7 @@ import { FileSystem } from '@rushstack/node-core-library';
 import type { ITerminal } from '@rushstack/terminal';
 import type { IRigConfig } from '@rushstack/rig-package';
 
-import { ConfigurationFileBase, IConfigurationFileOptions } from './ConfigurationFileBase';
+import { ConfigurationFileBase, type IConfigurationFileOptions } from './ConfigurationFileBase';
 
 /**
  * @beta

--- a/libraries/heft-config-file/src/ProjectConfigurationFile.ts
+++ b/libraries/heft-config-file/src/ProjectConfigurationFile.ts
@@ -74,7 +74,7 @@ export class ProjectConfigurationFile<TConfigurationFile> extends ConfigurationF
   }
 
   /**
-   * This function is identical to {@link ConfigurationFile.loadConfigurationFileForProject}, except
+   * This function is identical to {@link ProjectConfigurationFile.loadConfigurationFileForProject}, except
    * that it returns `undefined` instead of throwing an error if the configuration file cannot be found.
    */
   public tryLoadConfigurationFileForProject(
@@ -93,7 +93,7 @@ export class ProjectConfigurationFile<TConfigurationFile> extends ConfigurationF
   }
 
   /**
-   * This function is identical to {@link ConfigurationFile.loadConfigurationFileForProjectAsync}, except
+   * This function is identical to {@link ProjectConfigurationFile.loadConfigurationFileForProjectAsync}, except
    * that it returns `undefined` instead of throwing an error if the configuration file cannot be found.
    */
   public async tryLoadConfigurationFileForProjectAsync(

--- a/libraries/heft-config-file/src/TestUtilities.ts
+++ b/libraries/heft-config-file/src/TestUtilities.ts
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { CONFIGURATION_FILE_FIELD_ANNOTATION, type IAnnotatedField } from './ConfigurationFileBase';
+
+/**
+ * Returns an object with investigative annotations stripped, useful for snapshot testing.
+ *
+ * @beta
+ */
+export function stripAnnotations<TObject>(obj: TObject): TObject {
+  if (typeof obj !== 'object' || obj === null) {
+    return obj;
+  } else if (Array.isArray(obj)) {
+    const result: unknown[] = [];
+    for (const value of obj) {
+      result.push(stripAnnotations(value));
+    }
+
+    return result as TObject;
+  } else {
+    const clonedObj: TObject = { ...obj } as TObject;
+    delete (clonedObj as Partial<IAnnotatedField<unknown>>)[CONFIGURATION_FILE_FIELD_ANNOTATION];
+    for (const [name, value] of Object.entries(clonedObj as object)) {
+      clonedObj[name as keyof TObject] = stripAnnotations<TObject[keyof TObject]>(
+        value as TObject[keyof TObject]
+      );
+    }
+
+    return clonedObj;
+  }
+}

--- a/libraries/heft-config-file/src/index.ts
+++ b/libraries/heft-config-file/src/index.ts
@@ -29,9 +29,20 @@ export {
   type PropertyInheritanceCustomFunction
 } from './ConfigurationFileBase';
 
-export {
-  // TODO: REname this export to `ProjectConfigurationFile` in the next major version bump
-  ProjectConfigurationFile as ConfigurationFile,
-  type IProjectConfigurationFileOptions
-} from './ProjectConfigurationFile';
+import { ProjectConfigurationFile } from './ProjectConfigurationFile';
+
+/**
+ * @deprecated Use {@link ProjectConfigurationFile} instead.
+ * @beta
+ */
+export const ConfigurationFile: typeof ProjectConfigurationFile = ProjectConfigurationFile;
+
+/**
+ * @deprecated Use {@link ProjectConfigurationFile} instead.
+ * @beta
+ */
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export type ConfigurationFile<TConfigurationFile> = ProjectConfigurationFile<TConfigurationFile>;
+
+export { ProjectConfigurationFile, type IProjectConfigurationFileOptions } from './ProjectConfigurationFile';
 export { NonProjectConfigurationFile } from './NonProjectConfigurationFile';

--- a/libraries/heft-config-file/src/index.ts
+++ b/libraries/heft-config-file/src/index.ts
@@ -46,3 +46,5 @@ export type ConfigurationFile<TConfigurationFile> = ProjectConfigurationFile<TCo
 
 export { ProjectConfigurationFile, type IProjectConfigurationFileOptions } from './ProjectConfigurationFile';
 export { NonProjectConfigurationFile } from './NonProjectConfigurationFile';
+
+export * as TestUtilities from './TestUtilities';

--- a/libraries/heft-config-file/src/index.ts
+++ b/libraries/heft-config-file/src/index.ts
@@ -9,7 +9,7 @@
  */
 
 export {
-  ConfigurationFile,
+  ConfigurationFileBase,
   type IConfigurationFileOptionsBase,
   type IConfigurationFileOptionsWithJsonSchemaFilePath,
   type IConfigurationFileOptionsWithJsonSchemaObject,
@@ -27,4 +27,11 @@ export {
   type IPropertyInheritanceDefaults,
   PathResolutionMethod,
   type PropertyInheritanceCustomFunction
-} from './ConfigurationFile';
+} from './ConfigurationFileBase';
+
+export {
+  // TODO: REname this export to `ProjectConfigurationFile` in the next major version bump
+  ProjectConfigurationFile as ConfigurationFile,
+  type IProjectConfigurationFileOptions
+} from './ProjectConfigurationFile';
+export { NonProjectConfigurationFile } from './NonProjectConfigurationFile';

--- a/libraries/heft-config-file/src/test/ConfigurationFile.test.ts
+++ b/libraries/heft-config-file/src/test/ConfigurationFile.test.ts
@@ -201,7 +201,7 @@ describe('ConfigurationFile', () => {
 
         expect(JSON.stringify(loadedConfigFile)).toEqual(JSON.stringify(expectedConfigFile));
         expect(configFileLoader.getObjectSourceFilePath(loadedConfigFile)).toEqual(
-          nodeJsPath.resolve(__dirname, projectRelativeFilePath)
+          `${__dirname}/${projectRelativeFilePath}`
         );
         expect(
           configFileLoader.getPropertyOriginalValue({ parentObject: loadedConfigFile, propertyName: 'thing' })
@@ -219,7 +219,7 @@ describe('ConfigurationFile', () => {
 
         expect(JSON.stringify(loadedConfigFile)).toEqual(JSON.stringify(expectedConfigFile));
         expect(configFileLoader.getObjectSourceFilePath(loadedConfigFile)).toEqual(
-          nodeJsPath.resolve(__dirname, projectRelativeFilePath)
+          `${__dirname}/${projectRelativeFilePath}`
         );
         expect(
           configFileLoader.getPropertyOriginalValue({ parentObject: loadedConfigFile, propertyName: 'thing' })

--- a/libraries/heft-config-file/src/test/ConfigurationFile.test.ts
+++ b/libraries/heft-config-file/src/test/ConfigurationFile.test.ts
@@ -1,16 +1,18 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+/* eslint-disable max-lines */
+
 import * as nodeJsPath from 'path';
 import { FileSystem, JsonFile, Path, Text } from '@rushstack/node-core-library';
 import { StringBufferTerminalProvider, Terminal } from '@rushstack/terminal';
 import { RigConfig } from '@rushstack/rig-package';
 
 import { ProjectConfigurationFile } from '../ProjectConfigurationFile';
-import { PathResolutionMethod, InheritanceType } from '../ConfigurationFileBase';
+import { PathResolutionMethod, InheritanceType, ConfigurationFileBase } from '../ConfigurationFileBase';
 import { NonProjectConfigurationFile } from '../NonProjectConfigurationFile';
 
-describe(ProjectConfigurationFile.name, () => {
+describe('ConfigurationFile', () => {
   const projectRoot: string = nodeJsPath.resolve(__dirname, '..', '..');
   let terminalProvider: StringBufferTerminalProvider;
   let terminal: Terminal;
@@ -18,7 +20,7 @@ describe(ProjectConfigurationFile.name, () => {
   beforeEach(() => {
     const formatPathForLogging: (path: string) => string = (path: string) =>
       `<project root>/${Path.convertToSlashes(nodeJsPath.relative(projectRoot, path))}`;
-    jest.spyOn(ProjectConfigurationFile, '_formatPathForLogging').mockImplementation(formatPathForLogging);
+    jest.spyOn(ConfigurationFileBase, '_formatPathForLogging').mockImplementation(formatPathForLogging);
     jest.spyOn(JsonFile, '_formatPathForError').mockImplementation(formatPathForLogging);
 
     terminalProvider = new StringBufferTerminalProvider(false);

--- a/libraries/heft-config-file/src/test/__snapshots__/ConfigurationFile.test.ts.snap
+++ b/libraries/heft-config-file/src/test/__snapshots__/ConfigurationFile.test.ts.snap
@@ -280,6 +280,26 @@ Object {
 }
 `;
 
+exports[`ConfigurationFile A simple config file with a JSON schema object The NonProjectConfigurationFile version works correctly 1`] = `
+Object {
+  "debug": "",
+  "error": "",
+  "log": "",
+  "verbose": "",
+  "warning": "",
+}
+`;
+
+exports[`ConfigurationFile A simple config file with a JSON schema object The NonProjectConfigurationFile version works correctly async 1`] = `
+Object {
+  "debug": "",
+  "error": "",
+  "log": "",
+  "verbose": "",
+  "warning": "",
+}
+`;
+
 exports[`ConfigurationFile A simple config file with a JSON schema path Correctly loads the config file 1`] = `
 Object {
   "debug": "",
@@ -331,6 +351,26 @@ Object {
 `;
 
 exports[`ConfigurationFile A simple config file with a JSON schema path Correctly resolves paths relative to the project root async 1`] = `
+Object {
+  "debug": "",
+  "error": "",
+  "log": "",
+  "verbose": "",
+  "warning": "",
+}
+`;
+
+exports[`ConfigurationFile A simple config file with a JSON schema path The NonProjectConfigurationFile version works correctly 1`] = `
+Object {
+  "debug": "",
+  "error": "",
+  "log": "",
+  "verbose": "",
+  "warning": "",
+}
+`;
+
+exports[`ConfigurationFile A simple config file with a JSON schema path The NonProjectConfigurationFile version works correctly async 1`] = `
 Object {
   "debug": "",
   "error": "",

--- a/libraries/rush-lib/src/api/RushProjectConfiguration.ts
+++ b/libraries/rush-lib/src/api/RushProjectConfiguration.ts
@@ -3,7 +3,7 @@
 
 import { AlreadyReportedError, Async, Path } from '@rushstack/node-core-library';
 import type { ITerminal } from '@rushstack/terminal';
-import { ConfigurationFile, InheritanceType } from '@rushstack/heft-config-file';
+import { ProjectConfigurationFile, InheritanceType } from '@rushstack/heft-config-file';
 import { RigConfig } from '@rushstack/rig-package';
 
 import type { RushConfigurationProject } from './RushConfigurationProject';
@@ -147,8 +147,8 @@ interface IOldRushProjectJson {
   buildCacheOptions?: unknown;
 }
 
-const RUSH_PROJECT_CONFIGURATION_FILE: ConfigurationFile<IRushProjectJson> =
-  new ConfigurationFile<IRushProjectJson>({
+const RUSH_PROJECT_CONFIGURATION_FILE: ProjectConfigurationFile<IRushProjectJson> =
+  new ProjectConfigurationFile<IRushProjectJson>({
     projectRelativeFilePath: `config/${RushConstants.rushProjectConfigFilename}`,
     jsonSchemaObject: schemaJson,
     propertyInheritance: {
@@ -230,8 +230,8 @@ const RUSH_PROJECT_CONFIGURATION_FILE: ConfigurationFile<IRushProjectJson> =
     }
   });
 
-const OLD_RUSH_PROJECT_CONFIGURATION_FILE: ConfigurationFile<IOldRushProjectJson> =
-  new ConfigurationFile<IOldRushProjectJson>({
+const OLD_RUSH_PROJECT_CONFIGURATION_FILE: ProjectConfigurationFile<IOldRushProjectJson> =
+  new ProjectConfigurationFile<IOldRushProjectJson>({
     projectRelativeFilePath: RUSH_PROJECT_CONFIGURATION_FILE.projectRelativeFilePath,
     jsonSchemaObject: anythingSchemaJson
   });

--- a/libraries/rush-lib/src/logic/pnpm/PnpmOptionsConfiguration.ts
+++ b/libraries/rush-lib/src/logic/pnpm/PnpmOptionsConfiguration.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import { JsonFile, type JsonObject, JsonSchema } from '@rushstack/node-core-library';
+import { JsonFile, type JsonObject } from '@rushstack/node-core-library';
 import { NonProjectConfigurationFile } from '@rushstack/heft-config-file';
 import { ConsoleTerminalProvider, Terminal } from '@rushstack/terminal';
 

--- a/libraries/rush-lib/src/logic/pnpm/PnpmOptionsConfiguration.ts
+++ b/libraries/rush-lib/src/logic/pnpm/PnpmOptionsConfiguration.ts
@@ -163,8 +163,6 @@ export interface IPnpmOptionsJson extends IPackageManagerOptionsJsonBase {
  * @public
  */
 export class PnpmOptionsConfiguration extends PackageManagerOptionsConfigurationBase {
-  private static _jsonSchema: JsonSchema = JsonSchema.fromLoadedObject(schemaJson);
-
   private readonly _json: JsonObject;
   private _globalPatchedDependencies: Record<string, string> | undefined;
 
@@ -441,7 +439,7 @@ export class PnpmOptionsConfiguration extends PackageManagerOptionsConfiguration
 
     const pnpmOptionsConfigFile: NonProjectConfigurationFile<IPnpmOptionsJson> =
       new NonProjectConfigurationFile({
-        jsonSchemaObject: PnpmOptionsConfiguration._jsonSchema
+        jsonSchemaObject: schemaJson
       });
     const pnpmOptionJson: IPnpmOptionsJson = pnpmOptionsConfigFile.loadConfigurationFile(
       terminal,

--- a/libraries/rush-lib/src/logic/pnpm/PnpmOptionsConfiguration.ts
+++ b/libraries/rush-lib/src/logic/pnpm/PnpmOptionsConfiguration.ts
@@ -3,7 +3,7 @@
 
 import { JsonFile, type JsonObject, JsonSchema } from '@rushstack/node-core-library';
 import { NonProjectConfigurationFile } from '@rushstack/heft-config-file';
-import { ConsoleTerminalProvider, ITerminal, Terminal } from '@rushstack/terminal';
+import { ConsoleTerminalProvider, Terminal } from '@rushstack/terminal';
 
 import {
   type IPackageManagerOptionsJsonBase,
@@ -437,7 +437,7 @@ export class PnpmOptionsConfiguration extends PackageManagerOptionsConfiguration
     commonTempFolder: string
   ): PnpmOptionsConfiguration {
     // TODO: plumb through the terminal
-    const terminal: ITerminal = new Terminal(new ConsoleTerminalProvider());
+    const terminal: Terminal = new Terminal(new ConsoleTerminalProvider());
 
     const pnpmOptionsConfigFile: NonProjectConfigurationFile<IPnpmOptionsJson> =
       new NonProjectConfigurationFile({

--- a/libraries/rush-lib/src/logic/pnpm/PnpmOptionsConfiguration.ts
+++ b/libraries/rush-lib/src/logic/pnpm/PnpmOptionsConfiguration.ts
@@ -2,6 +2,8 @@
 // See LICENSE in the project root for license information.
 
 import { JsonFile, type JsonObject, JsonSchema } from '@rushstack/node-core-library';
+import { NonProjectConfigurationFile } from '@rushstack/heft-config-file';
+import { ConsoleTerminalProvider, ITerminal, Terminal } from '@rushstack/terminal';
 
 import {
   type IPackageManagerOptionsJsonBase,
@@ -434,9 +436,16 @@ export class PnpmOptionsConfiguration extends PackageManagerOptionsConfiguration
     jsonFilename: string,
     commonTempFolder: string
   ): PnpmOptionsConfiguration {
-    const pnpmOptionJson: IPnpmOptionsJson = JsonFile.loadAndValidate(
-      jsonFilename,
-      PnpmOptionsConfiguration._jsonSchema
+    // TODO: plumb through the terminal
+    const terminal: ITerminal = new Terminal(new ConsoleTerminalProvider());
+
+    const pnpmOptionsConfigFile: NonProjectConfigurationFile<IPnpmOptionsJson> =
+      new NonProjectConfigurationFile({
+        jsonSchemaObject: PnpmOptionsConfiguration._jsonSchema
+      });
+    const pnpmOptionJson: IPnpmOptionsJson = pnpmOptionsConfigFile.loadConfigurationFile(
+      terminal,
+      jsonFilename
     );
     return new PnpmOptionsConfiguration(pnpmOptionJson || {}, commonTempFolder, jsonFilename);
   }

--- a/libraries/rush-lib/src/logic/pnpm/test/PnpmOptionsConfiguration.test.ts
+++ b/libraries/rush-lib/src/logic/pnpm/test/PnpmOptionsConfiguration.test.ts
@@ -3,6 +3,7 @@
 
 import * as path from 'path';
 import { PnpmOptionsConfiguration } from '../PnpmOptionsConfiguration';
+import { TestUtilities } from '@rushstack/heft-config-file';
 
 const fakeCommonTempFolder: string = path.join(__dirname, 'common', 'temp');
 
@@ -31,14 +32,14 @@ describe(PnpmOptionsConfiguration.name, () => {
       fakeCommonTempFolder
     );
 
-    expect(pnpmConfiguration.globalOverrides).toEqual({
+    expect(TestUtilities.stripAnnotations(pnpmConfiguration.globalOverrides)).toEqual({
       foo: '^1.0.0',
       quux: 'npm:@myorg/quux@^1.0.0',
       'bar@^2.1.0': '3.0.0',
       'qar@1>zoo': '2'
     });
 
-    expect(pnpmConfiguration.environmentVariables).toEqual({
+    expect(TestUtilities.stripAnnotations(pnpmConfiguration.environmentVariables)).toEqual({
       NODE_OPTIONS: {
         value: '--max-old-space-size=4096',
         override: false
@@ -52,7 +53,7 @@ describe(PnpmOptionsConfiguration.name, () => {
       fakeCommonTempFolder
     );
 
-    expect(pnpmConfiguration.globalPackageExtensions).toEqual({
+    expect(TestUtilities.stripAnnotations(pnpmConfiguration.globalPackageExtensions)).toEqual({
       'react-redux': {
         peerDependencies: {
           'react-dom': '*'
@@ -67,6 +68,9 @@ describe(PnpmOptionsConfiguration.name, () => {
       fakeCommonTempFolder
     );
 
-    expect(pnpmConfiguration.globalNeverBuiltDependencies).toEqual(['fsevents', 'level']);
+    expect(TestUtilities.stripAnnotations(pnpmConfiguration.globalNeverBuiltDependencies)).toEqual([
+      'fsevents',
+      'level'
+    ]);
   });
 });

--- a/libraries/rush-lib/src/logic/test/InstallHelpers.test.ts
+++ b/libraries/rush-lib/src/logic/test/InstallHelpers.test.ts
@@ -1,10 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import { InstallHelpers } from '../installManager/InstallHelpers';
-import { RushConfiguration } from '../../api/RushConfiguration';
 import { type IPackageJson, JsonFile } from '@rushstack/node-core-library';
 import { StringBufferTerminalProvider, Terminal } from '@rushstack/terminal';
+import { TestUtilities } from '@rushstack/heft-config-file';
+
+import { InstallHelpers } from '../installManager/InstallHelpers';
+import { RushConfiguration } from '../../api/RushConfiguration';
 
 describe('InstallHelpers', () => {
   describe('generateCommonPackageJson', () => {
@@ -48,7 +50,7 @@ describe('InstallHelpers', () => {
         terminal
       );
       const packageJson: IPackageJson = mockJsonFileSave.mock.calls[0][0];
-      expect(packageJson).toEqual(
+      expect(TestUtilities.stripAnnotations(packageJson)).toEqual(
         expect.objectContaining({
           pnpm: {
             overrides: {

--- a/libraries/rush-lib/src/schemas/pnpm-config.schema.json
+++ b/libraries/rush-lib/src/schemas/pnpm-config.schema.json
@@ -10,6 +10,11 @@
       "type": "string"
     },
 
+    "extends": {
+      "description": "Optionally specifies another JSON config file that this file extends from. This provides a way for standard settings to be shared across multiple projects.",
+      "type": "string"
+    },
+
     "useWorkspaces": {
       "description": "If true, then `rush install` and `rush update` will use the PNPM workspaces feature to perform the install, instead of the old model where Rush generated the symlinks for each projects's node_modules folder. This option is strongly recommended. The default value is false.",
       "type": "boolean"

--- a/rush-plugins/rush-serve-plugin/src/RushProjectServeConfigFile.ts
+++ b/rush-plugins/rush-serve-plugin/src/RushProjectServeConfigFile.ts
@@ -3,7 +3,7 @@
 
 import path from 'path';
 
-import { ConfigurationFile, InheritanceType } from '@rushstack/heft-config-file';
+import { ProjectConfigurationFile, InheritanceType } from '@rushstack/heft-config-file';
 import { Async } from '@rushstack/node-core-library';
 import type { ITerminal } from '@rushstack/terminal';
 import { RigConfig } from '@rushstack/rig-package';
@@ -39,10 +39,10 @@ export interface IRoutingRule {
 }
 
 export class RushServeConfiguration {
-  private readonly _loader: ConfigurationFile<IRushProjectServeJson>;
+  private readonly _loader: ProjectConfigurationFile<IRushProjectServeJson>;
 
   public constructor() {
-    this._loader = new ConfigurationFile<IRushProjectServeJson>({
+    this._loader = new ProjectConfigurationFile<IRushProjectServeJson>({
       projectRelativeFilePath: 'config/rush-project-serve.json',
       jsonSchemaObject: rushProjectServeSchema,
       propertyInheritance: {


### PR DESCRIPTION
## Summary

Add support for an `"extends"` property in `pnpm-config.json` files.

Also refactors and expands the `@rushstack/heft-config-file` project to include a new API designed for loading configuration files not in projects.

## How it was tested

Tested in a branch that has subspace `pnpm-config.json` files in subspaces that extend from the `common/config/rush/pnpm-config.json` file.

## Impacted documentation

A note should be added to https://rushjs.io/pages/configs/pnpm-config_json/#docusaurus_skipToContent_fallback