### PR TITLE
[rush] Update rush-http-build-cache-plugin to use WebClient instead of node-fetch

### DIFF
--- a/common/changes/@microsoft/rush/remove-node-fetch-http-from-http_2024-12-04-02-57.json
+++ b/common/changes/@microsoft/rush/remove-node-fetch-http-from-http_2024-12-04-02-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Remove the `node-fetch` dependency from `@rushstack/rush-http-build-cache-plugin`.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/config/subspaces/default/pnpm-lock.yaml
+++ b/common/config/subspaces/default/pnpm-lock.yaml
@@ -4051,9 +4051,6 @@ importers:
       https-proxy-agent:
         specifier: ~5.0.0
         version: 5.0.1
-      node-fetch:
-        specifier: 2.6.7
-        version: 2.6.7
     devDependencies:
       '@microsoft/rush-lib':
         specifier: workspace:*
@@ -4064,9 +4061,6 @@ importers:
       '@rushstack/terminal':
         specifier: workspace:*
         version: link:../../libraries/terminal
-      '@types/node-fetch':
-        specifier: 2.6.2
-        version: 2.6.2
       local-node-rig:
         specifier: workspace:*
         version: link:../../rigs/local-node-rig

--- a/rush-plugins/rush-http-build-cache-plugin/package.json
+++ b/rush-plugins/rush-http-build-cache-plugin/package.json
@@ -21,14 +21,12 @@
   "dependencies": {
     "@rushstack/node-core-library": "workspace:*",
     "@rushstack/rush-sdk": "workspace:*",
-    "https-proxy-agent": "~5.0.0",
-    "node-fetch": "2.6.7"
+    "https-proxy-agent": "~5.0.0"
   },
   "devDependencies": {
     "@microsoft/rush-lib": "workspace:*",
     "@rushstack/heft": "workspace:*",
     "@rushstack/terminal": "workspace:*",
-    "local-node-rig": "workspace:*",
-    "@types/node-fetch": "2.6.2"
+    "local-node-rig": "workspace:*"
   }
 }

--- a/rush-plugins/rush-http-build-cache-plugin/src/RushHttpBuildCachePlugin.ts
+++ b/rush-plugins/rush-http-build-cache-plugin/src/RushHttpBuildCachePlugin.ts
@@ -2,7 +2,7 @@
 // See LICENSE in the project root for license information.
 
 import type { IRushPlugin, RushSession, RushConfiguration } from '@rushstack/rush-sdk';
-import type { IHttpBuildCacheProviderOptions } from './HttpBuildCacheProvider';
+import type { IHttpBuildCacheProviderOptions, UploadMethod } from './HttpBuildCacheProvider';
 
 const PLUGIN_NAME: string = 'HttpBuildCachePlugin';
 
@@ -18,7 +18,7 @@ export interface IRushHttpBuildCachePluginConfig {
   /**
    * The HTTP method to use when writing to the cache (defaults to PUT).
    */
-  uploadMethod?: string;
+  uploadMethod?: UploadMethod;
 
   /**
    * An optional set of HTTP headers to pass to the cache server.

--- a/rush-plugins/rush-http-build-cache-plugin/src/index.ts
+++ b/rush-plugins/rush-http-build-cache-plugin/src/index.ts
@@ -4,4 +4,4 @@
 import { RushHttpBuildCachePlugin } from './RushHttpBuildCachePlugin';
 
 export default RushHttpBuildCachePlugin;
-export type { IHttpBuildCacheProviderOptions } from './HttpBuildCacheProvider';
+export type { IHttpBuildCacheProviderOptions, UploadMethod } from './HttpBuildCacheProvider';


### PR DESCRIPTION
## Summary

Similar to https://github.com/microsoft/rushstack/pull/5025, this PR updates the `rush-http-build-cache-plugin` to use `WebClient` instead of `node-fetch`.

## How it was tested

Will be published as a prerelease.

## Impacted documentation

None.