### PR TITLE
[heft-jest-plugin, repo] Fix issues with punycode in `jest-environment-jsdom` and add Node 22 to the repo test matrix.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,8 @@ jobs:
           - NodeVersion: 18.18.x
             NodeVersionDisplayName: 18
             OS: windows-latest
-          - NodeVersion: 20.18.x
-            NodeVersionDisplayName: 20
+          - NodeVersion: 22.12.x
+            NodeVersionDisplayName: 22
             OS: windows-latest
     name: Node.js v${{ matrix.NodeVersionDisplayName }} (${{ matrix.OS }})
     runs-on: ${{ matrix.OS }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,14 +12,17 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - NodeVersion: 18.18.x
+          - NodeVersion: 18.20.x
             NodeVersionDisplayName: 18
             OS: ubuntu-latest
-          - NodeVersion: 20.9.x
+          - NodeVersion: 20.18.x
             NodeVersionDisplayName: 20
             OS: ubuntu-latest
-          - NodeVersion: 18.18.x
-            NodeVersionDisplayName: 18
+          - NodeVersion: 22.12.x
+            NodeVersionDisplayName: 22
+            OS: ubuntu-latest
+          - NodeVersion: 20.18.x
+            NodeVersionDisplayName: 20
             OS: windows-latest
     name: Node.js v${{ matrix.NodeVersionDisplayName }} (${{ matrix.OS }})
     runs-on: ${{ matrix.OS }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,10 @@ jobs:
           - NodeVersion: 22.12.x
             NodeVersionDisplayName: 22
             OS: ubuntu-latest
+            # TODO: Remove
+          - NodeVersion: 18.18.x
+            NodeVersionDisplayName: 18
+            OS: windows-latest
           - NodeVersion: 20.18.x
             NodeVersionDisplayName: 20
             OS: windows-latest

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -69,7 +69,7 @@
 			"type": "node",
 			"request": "attach",
 			"port": 9229,
-      "outFiles": [],
+			"outFiles": [],
 		},
 		{
 			"name": "Launch Rush Extension",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -68,7 +68,8 @@
 			"name": "Attach",
 			"type": "node",
 			"request": "attach",
-			"port": 9229
+			"port": 9229,
+      "outFiles": [],
 		},
 		{
 			"name": "Launch Rush Extension",

--- a/apps/api-extractor/package.json
+++ b/apps/api-extractor/package.json
@@ -52,8 +52,8 @@
     "typescript": "5.4.2"
   },
   "devDependencies": {
-    "@rushstack/heft-node-rig": "2.6.43",
-    "@rushstack/heft": "0.68.9",
+    "@rushstack/heft-node-rig": "2.6.44",
+    "@rushstack/heft": "0.68.10",
     "@types/heft-jest": "1.0.1",
     "@types/lodash": "4.14.116",
     "@types/minimatch": "3.0.5",

--- a/apps/heft/package.json
+++ b/apps/heft/package.json
@@ -50,8 +50,8 @@
   "devDependencies": {
     "@microsoft/api-extractor": "workspace:*",
     "local-eslint-config": "workspace:*",
-    "@rushstack/heft": "0.68.9",
-    "@rushstack/heft-node-rig": "2.6.43",
+    "@rushstack/heft": "0.68.10",
+    "@rushstack/heft-node-rig": "2.6.44",
     "@types/heft-jest": "1.0.1",
     "@types/node": "18.17.15",
     "@types/watchpack": "2.4.0",

--- a/common/changes/@microsoft/api-extractor-model/heft-jest-punycode_2024-12-10-05-37.json
+++ b/common/changes/@microsoft/api-extractor-model/heft-jest-punycode_2024-12-10-05-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor-model",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor-model"
+}

--- a/common/changes/@microsoft/api-extractor/heft-jest-punycode_2024-12-10-05-37.json
+++ b/common/changes/@microsoft/api-extractor/heft-jest-punycode_2024-12-10-05-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor"
+}

--- a/common/changes/@rushstack/eslint-patch/heft-jest-punycode_2024-12-10-05-37.json
+++ b/common/changes/@rushstack/eslint-patch/heft-jest-punycode_2024-12-10-05-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-patch",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/eslint-patch"
+}

--- a/common/changes/@rushstack/eslint-plugin-packlets/heft-jest-punycode_2024-12-10-05-37.json
+++ b/common/changes/@rushstack/eslint-plugin-packlets/heft-jest-punycode_2024-12-10-05-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-plugin-packlets",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/eslint-plugin-packlets"
+}

--- a/common/changes/@rushstack/eslint-plugin-security/heft-jest-punycode_2024-12-10-05-37.json
+++ b/common/changes/@rushstack/eslint-plugin-security/heft-jest-punycode_2024-12-10-05-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-plugin-security",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/eslint-plugin-security"
+}

--- a/common/changes/@rushstack/eslint-plugin/heft-jest-punycode_2024-12-10-05-37.json
+++ b/common/changes/@rushstack/eslint-plugin/heft-jest-punycode_2024-12-10-05-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-plugin",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/eslint-plugin"
+}

--- a/common/changes/@rushstack/heft-api-extractor-plugin/heft-jest-punycode_2024-12-10-05-37.json
+++ b/common/changes/@rushstack/heft-api-extractor-plugin/heft-jest-punycode_2024-12-10-05-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-api-extractor-plugin",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/heft-api-extractor-plugin"
+}

--- a/common/changes/@rushstack/heft-config-file/heft-jest-punycode_2024-12-10-05-37.json
+++ b/common/changes/@rushstack/heft-config-file/heft-jest-punycode_2024-12-10-05-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-config-file",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/heft-config-file"
+}

--- a/common/changes/@rushstack/heft-jest-plugin/heft-jest-punycode_2024-12-10-01-46.json
+++ b/common/changes/@rushstack/heft-jest-plugin/heft-jest-punycode_2024-12-10-01-46.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-jest-plugin",
+      "comment": "Inject `punycode` into the NodeJS module cache in Node versions 22 and above to work around a deprecation warning.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft-jest-plugin"
+}

--- a/common/changes/@rushstack/heft-lint-plugin/heft-jest-punycode_2024-12-10-05-37.json
+++ b/common/changes/@rushstack/heft-lint-plugin/heft-jest-punycode_2024-12-10-05-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-lint-plugin",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/heft-lint-plugin"
+}

--- a/common/changes/@rushstack/heft-typescript-plugin/heft-jest-punycode_2024-12-10-05-37.json
+++ b/common/changes/@rushstack/heft-typescript-plugin/heft-jest-punycode_2024-12-10-05-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-typescript-plugin",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/heft-typescript-plugin"
+}

--- a/common/changes/@rushstack/heft/heft-jest-punycode_2024-12-10-05-37.json
+++ b/common/changes/@rushstack/heft/heft-jest-punycode_2024-12-10-05-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/heft"
+}

--- a/common/changes/@rushstack/node-core-library/heft-jest-punycode_2024-12-10-05-37.json
+++ b/common/changes/@rushstack/node-core-library/heft-jest-punycode_2024-12-10-05-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/node-core-library",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/node-core-library"
+}

--- a/common/changes/@rushstack/operation-graph/heft-jest-punycode_2024-12-10-05-37.json
+++ b/common/changes/@rushstack/operation-graph/heft-jest-punycode_2024-12-10-05-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/operation-graph",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/operation-graph"
+}

--- a/common/changes/@rushstack/rig-package/heft-jest-punycode_2024-12-10-05-37.json
+++ b/common/changes/@rushstack/rig-package/heft-jest-punycode_2024-12-10-05-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/rig-package",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/rig-package"
+}

--- a/common/changes/@rushstack/terminal/heft-jest-punycode_2024-12-10-05-37.json
+++ b/common/changes/@rushstack/terminal/heft-jest-punycode_2024-12-10-05-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/terminal",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/terminal"
+}

--- a/common/changes/@rushstack/tree-pattern/heft-jest-punycode_2024-12-10-05-37.json
+++ b/common/changes/@rushstack/tree-pattern/heft-jest-punycode_2024-12-10-05-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/tree-pattern",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/tree-pattern"
+}

--- a/common/changes/@rushstack/ts-command-line/heft-jest-punycode_2024-12-10-05-37.json
+++ b/common/changes/@rushstack/ts-command-line/heft-jest-punycode_2024-12-10-05-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/ts-command-line",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/ts-command-line"
+}

--- a/common/config/azure-pipelines/templates/install-node.yaml
+++ b/common/config/azure-pipelines/templates/install-node.yaml
@@ -1,7 +1,7 @@
 parameters:
   - name: NodeMajorVersion
     type: number
-    default: 18
+    default: 20
 
 steps:
   - task: NodeTool@0

--- a/common/config/rush/nonbrowser-approved-packages.json
+++ b/common/config/rush/nonbrowser-approved-packages.json
@@ -787,6 +787,10 @@
       "allowedCategories": [ "libraries" ]
     },
     {
+      "name": "punycode",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
       "name": "read-package-tree",
       "allowedCategories": [ "libraries" ]
     },

--- a/common/config/subspaces/build-tests-subspace/pnpm-lock.yaml
+++ b/common/config/subspaces/build-tests-subspace/pnpm-lock.yaml
@@ -126,10 +126,10 @@ importers:
         version: file:../../../apps/heft(@types/node@18.17.15)
       '@rushstack/heft-lint-plugin':
         specifier: file:../../heft-plugins/heft-lint-plugin
-        version: file:../../../heft-plugins/heft-lint-plugin(@rushstack/heft@0.68.9)(@types/node@18.17.15)
+        version: file:../../../heft-plugins/heft-lint-plugin(@rushstack/heft@0.68.10)(@types/node@18.17.15)
       '@rushstack/heft-typescript-plugin':
         specifier: file:../../heft-plugins/heft-typescript-plugin
-        version: file:../../../heft-plugins/heft-typescript-plugin(@rushstack/heft@0.68.9)(@types/node@18.17.15)
+        version: file:../../../heft-plugins/heft-typescript-plugin(@rushstack/heft@0.68.10)(@types/node@18.17.15)
       eslint:
         specifier: ~8.57.0
         version: 8.57.1
@@ -6277,7 +6277,7 @@ packages:
       - typescript
     dev: true
 
-  file:../../../heft-plugins/heft-api-extractor-plugin(@rushstack/heft@0.68.9)(@types/node@18.17.15):
+  file:../../../heft-plugins/heft-api-extractor-plugin(@rushstack/heft@0.68.10)(@types/node@18.17.15):
     resolution: {directory: ../../../heft-plugins/heft-api-extractor-plugin, type: directory}
     id: file:../../../heft-plugins/heft-api-extractor-plugin
     name: '@rushstack/heft-api-extractor-plugin'
@@ -6292,7 +6292,7 @@ packages:
       - '@types/node'
     dev: true
 
-  file:../../../heft-plugins/heft-jest-plugin(@rushstack/heft@0.68.9)(@types/node@18.17.15)(jest-environment-node@29.5.0):
+  file:../../../heft-plugins/heft-jest-plugin(@rushstack/heft@0.68.10)(@types/node@18.17.15)(jest-environment-node@29.5.0):
     resolution: {directory: ../../../heft-plugins/heft-jest-plugin, type: directory}
     id: file:../../../heft-plugins/heft-jest-plugin
     name: '@rushstack/heft-jest-plugin'
@@ -6318,6 +6318,7 @@ packages:
       jest-resolve: 29.5.0
       jest-snapshot: 29.5.0
       lodash: 4.17.21
+      punycode: 2.3.1
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -6326,7 +6327,7 @@ packages:
       - ts-node
     dev: true
 
-  file:../../../heft-plugins/heft-lint-plugin(@rushstack/heft@0.68.9)(@types/node@18.17.15):
+  file:../../../heft-plugins/heft-lint-plugin(@rushstack/heft@0.68.10)(@types/node@18.17.15):
     resolution: {directory: ../../../heft-plugins/heft-lint-plugin, type: directory}
     id: file:../../../heft-plugins/heft-lint-plugin
     name: '@rushstack/heft-lint-plugin'
@@ -6340,7 +6341,7 @@ packages:
       - '@types/node'
     dev: true
 
-  file:../../../heft-plugins/heft-typescript-plugin(@rushstack/heft@0.68.9)(@types/node@18.17.15):
+  file:../../../heft-plugins/heft-typescript-plugin(@rushstack/heft@0.68.10)(@types/node@18.17.15):
     resolution: {directory: ../../../heft-plugins/heft-typescript-plugin, type: directory}
     id: file:../../../heft-plugins/heft-typescript-plugin
     name: '@rushstack/heft-typescript-plugin'
@@ -6565,7 +6566,7 @@ packages:
     transitivePeerDependencies:
       - '@types/node'
 
-  file:../../../rigs/heft-node-rig(@rushstack/heft@0.68.9)(@types/node@18.17.15):
+  file:../../../rigs/heft-node-rig(@rushstack/heft@0.68.10)(@types/node@18.17.15):
     resolution: {directory: ../../../rigs/heft-node-rig, type: directory}
     id: file:../../../rigs/heft-node-rig
     name: '@rushstack/heft-node-rig'
@@ -6575,10 +6576,10 @@ packages:
       '@microsoft/api-extractor': file:../../../apps/api-extractor(@types/node@18.17.15)
       '@rushstack/eslint-config': file:../../../eslint/eslint-config(eslint@8.57.1)(typescript@5.4.5)
       '@rushstack/heft': file:../../../apps/heft(@types/node@18.17.15)
-      '@rushstack/heft-api-extractor-plugin': file:../../../heft-plugins/heft-api-extractor-plugin(@rushstack/heft@0.68.9)(@types/node@18.17.15)
-      '@rushstack/heft-jest-plugin': file:../../../heft-plugins/heft-jest-plugin(@rushstack/heft@0.68.9)(@types/node@18.17.15)(jest-environment-node@29.5.0)
-      '@rushstack/heft-lint-plugin': file:../../../heft-plugins/heft-lint-plugin(@rushstack/heft@0.68.9)(@types/node@18.17.15)
-      '@rushstack/heft-typescript-plugin': file:../../../heft-plugins/heft-typescript-plugin(@rushstack/heft@0.68.9)(@types/node@18.17.15)
+      '@rushstack/heft-api-extractor-plugin': file:../../../heft-plugins/heft-api-extractor-plugin(@rushstack/heft@0.68.10)(@types/node@18.17.15)
+      '@rushstack/heft-jest-plugin': file:../../../heft-plugins/heft-jest-plugin(@rushstack/heft@0.68.10)(@types/node@18.17.15)(jest-environment-node@29.5.0)
+      '@rushstack/heft-lint-plugin': file:../../../heft-plugins/heft-lint-plugin(@rushstack/heft@0.68.10)(@types/node@18.17.15)
+      '@rushstack/heft-typescript-plugin': file:../../../heft-plugins/heft-typescript-plugin(@rushstack/heft@0.68.10)(@types/node@18.17.15)
       '@types/heft-jest': 1.0.1
       eslint: 8.57.1
       jest-environment-node: 29.5.0
@@ -6598,7 +6599,7 @@ packages:
     dependencies:
       '@microsoft/api-extractor': file:../../../apps/api-extractor(@types/node@18.17.15)
       '@rushstack/heft': file:../../../apps/heft(@types/node@18.17.15)
-      '@rushstack/heft-node-rig': file:../../../rigs/heft-node-rig(@rushstack/heft@0.68.9)(@types/node@18.17.15)
+      '@rushstack/heft-node-rig': file:../../../rigs/heft-node-rig(@rushstack/heft@0.68.10)(@types/node@18.17.15)
       '@types/heft-jest': 1.0.1
       '@types/node': 18.17.15
       eslint: 8.57.1

--- a/common/config/subspaces/build-tests-subspace/repo-state.json
+++ b/common/config/subspaces/build-tests-subspace/repo-state.json
@@ -2,5 +2,5 @@
 {
   "pnpmShrinkwrapHash": "a3198248beff4dfe8ef9d9c798b873ead75ef5cd",
   "preferredVersionsHash": "ce857ea0536b894ec8f346aaea08cfd85a5af648",
-  "packageJsonInjectedDependenciesHash": "6c875ef5825705b3f5e31fa4fc1a251a0b15a3b4"
+  "packageJsonInjectedDependenciesHash": "35920c267d4a49b8de4b78d88cf91c7f46b83ebb"
 }

--- a/common/config/subspaces/build-tests-subspace/repo-state.json
+++ b/common/config/subspaces/build-tests-subspace/repo-state.json
@@ -1,6 +1,6 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "91719dffed0a42aec00fee22b00e6c236b96fc7e",
+  "pnpmShrinkwrapHash": "a3198248beff4dfe8ef9d9c798b873ead75ef5cd",
   "preferredVersionsHash": "ce857ea0536b894ec8f346aaea08cfd85a5af648",
-  "packageJsonInjectedDependenciesHash": "7bb5b296a95ab3932d6ffa5b97edd5ea79613f33"
+  "packageJsonInjectedDependenciesHash": "6c875ef5825705b3f5e31fa4fc1a251a0b15a3b4"
 }

--- a/common/config/subspaces/default/pnpm-lock.yaml
+++ b/common/config/subspaces/default/pnpm-lock.yaml
@@ -2695,6 +2695,9 @@ importers:
       lodash:
         specifier: ~4.17.15
         version: 4.17.21
+      punycode:
+        specifier: ~2.3.1
+        version: 2.3.1
     devDependencies:
       '@jest/types':
         specifier: 29.5.0

--- a/common/config/subspaces/default/pnpm-lock.yaml
+++ b/common/config/subspaces/default/pnpm-lock.yaml
@@ -93,11 +93,11 @@ importers:
         version: 5.4.2
     devDependencies:
       '@rushstack/heft':
-        specifier: 0.68.9
-        version: 0.68.9(@types/node@18.17.15)
+        specifier: 0.68.10
+        version: 0.68.10(@types/node@18.17.15)
       '@rushstack/heft-node-rig':
-        specifier: 2.6.43
-        version: 2.6.43(@rushstack/heft@0.68.9)(@types/node@18.17.15)(supports-color@8.1.1)
+        specifier: 2.6.44
+        version: 2.6.44(@rushstack/heft@0.68.10)(@types/node@18.17.15)(supports-color@8.1.1)
       '@types/heft-jest':
         specifier: 1.0.1
         version: 1.0.1
@@ -163,11 +163,11 @@ importers:
         specifier: workspace:*
         version: link:../api-extractor
       '@rushstack/heft':
-        specifier: 0.68.9
-        version: 0.68.9(@types/node@18.17.15)
+        specifier: 0.68.10
+        version: 0.68.10(@types/node@18.17.15)
       '@rushstack/heft-node-rig':
-        specifier: 2.6.43
-        version: 2.6.43(@rushstack/heft@0.68.9)(@types/node@18.17.15)(supports-color@8.1.1)
+        specifier: 2.6.44
+        version: 2.6.44(@rushstack/heft@0.68.10)(@types/node@18.17.15)(supports-color@8.1.1)
       '@types/heft-jest':
         specifier: 1.0.1
         version: 1.0.1
@@ -2405,11 +2405,11 @@ importers:
   ../../../eslint/eslint-patch:
     devDependencies:
       '@rushstack/heft':
-        specifier: 0.68.9
-        version: 0.68.9(@types/node@18.17.15)
+        specifier: 0.68.10
+        version: 0.68.10(@types/node@18.17.15)
       '@rushstack/heft-node-rig':
-        specifier: 2.6.43
-        version: 2.6.43(@rushstack/heft@0.68.9)(@types/node@18.17.15)(supports-color@8.1.1)
+        specifier: 2.6.44
+        version: 2.6.44(@rushstack/heft@0.68.10)(@types/node@18.17.15)(supports-color@8.1.1)
       '@types/eslint':
         specifier: 8.56.10
         version: 8.56.10
@@ -2442,11 +2442,11 @@ importers:
         specifier: ~3.0.0
         version: 3.0.2
       '@rushstack/heft':
-        specifier: 0.68.9
-        version: 0.68.9(@types/node@18.17.15)
+        specifier: 0.68.10
+        version: 0.68.10(@types/node@18.17.15)
       '@rushstack/heft-node-rig':
-        specifier: 2.6.43
-        version: 2.6.43(@rushstack/heft@0.68.9)(@types/node@18.17.15)(supports-color@8.1.1)
+        specifier: 2.6.44
+        version: 2.6.44(@rushstack/heft@0.68.10)(@types/node@18.17.15)(supports-color@8.1.1)
       '@types/eslint':
         specifier: 8.56.10
         version: 8.56.10
@@ -2488,11 +2488,11 @@ importers:
         version: 8.1.0(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.4.2)
     devDependencies:
       '@rushstack/heft':
-        specifier: 0.68.9
-        version: 0.68.9(@types/node@18.17.15)
+        specifier: 0.68.10
+        version: 0.68.10(@types/node@18.17.15)
       '@rushstack/heft-node-rig':
-        specifier: 2.6.43
-        version: 2.6.43(@rushstack/heft@0.68.9)(@types/node@18.17.15)(supports-color@8.1.1)
+        specifier: 2.6.44
+        version: 2.6.44(@rushstack/heft@0.68.10)(@types/node@18.17.15)(supports-color@8.1.1)
       '@types/eslint':
         specifier: 8.56.10
         version: 8.56.10
@@ -2534,11 +2534,11 @@ importers:
         specifier: ~3.0.0
         version: 3.0.2
       '@rushstack/heft':
-        specifier: 0.68.9
-        version: 0.68.9(@types/node@18.17.15)
+        specifier: 0.68.10
+        version: 0.68.10(@types/node@18.17.15)
       '@rushstack/heft-node-rig':
-        specifier: 2.6.43
-        version: 2.6.43(@rushstack/heft@0.68.9)(@types/node@18.17.15)(supports-color@8.1.1)
+        specifier: 2.6.44
+        version: 2.6.44(@rushstack/heft@0.68.10)(@types/node@18.17.15)(supports-color@8.1.1)
       '@types/eslint':
         specifier: 8.56.10
         version: 8.56.10
@@ -2623,8 +2623,8 @@ importers:
         specifier: workspace:*
         version: link:../../apps/heft
       '@rushstack/heft-node-rig':
-        specifier: 2.6.43
-        version: 2.6.43(@rushstack/heft@..+..+apps+heft)(@types/node@18.17.15)(jest-environment-jsdom@29.5.0)
+        specifier: 2.6.44
+        version: 2.6.44(@rushstack/heft@..+..+apps+heft)(@types/node@18.17.15)(jest-environment-jsdom@29.5.0)
       '@rushstack/terminal':
         specifier: workspace:*
         version: link:../../libraries/terminal
@@ -2706,8 +2706,8 @@ importers:
         specifier: workspace:*
         version: link:../../apps/heft
       '@rushstack/heft-node-rig':
-        specifier: 2.6.43
-        version: 2.6.43(@rushstack/heft@..+..+apps+heft)(@types/node@18.17.15)(jest-environment-jsdom@29.5.0)
+        specifier: 2.6.44
+        version: 2.6.44(@rushstack/heft@..+..+apps+heft)(@types/node@18.17.15)(jest-environment-jsdom@29.5.0)
       '@types/heft-jest':
         specifier: 1.0.1
         version: 1.0.1
@@ -2749,8 +2749,8 @@ importers:
         specifier: workspace:*
         version: link:../../apps/heft
       '@rushstack/heft-node-rig':
-        specifier: 2.6.43
-        version: 2.6.43(@rushstack/heft@..+..+apps+heft)(@types/node@18.17.15)(jest-environment-jsdom@29.5.0)
+        specifier: 2.6.44
+        version: 2.6.44(@rushstack/heft@..+..+apps+heft)(@types/node@18.17.15)(jest-environment-jsdom@29.5.0)
       '@rushstack/heft-typescript-plugin':
         specifier: workspace:*
         version: link:../heft-typescript-plugin
@@ -2895,8 +2895,8 @@ importers:
         specifier: workspace:*
         version: link:../../apps/heft
       '@rushstack/heft-node-rig':
-        specifier: 2.6.43
-        version: 2.6.43(@rushstack/heft@..+..+apps+heft)(@types/node@18.17.15)(jest-environment-jsdom@29.5.0)
+        specifier: 2.6.44
+        version: 2.6.44(@rushstack/heft@..+..+apps+heft)(@types/node@18.17.15)(jest-environment-jsdom@29.5.0)
       '@rushstack/terminal':
         specifier: workspace:*
         version: link:../../libraries/terminal
@@ -3003,11 +3003,11 @@ importers:
         version: link:../node-core-library
     devDependencies:
       '@rushstack/heft':
-        specifier: 0.68.9
-        version: 0.68.9(@types/node@18.17.15)
+        specifier: 0.68.10
+        version: 0.68.10(@types/node@18.17.15)
       '@rushstack/heft-node-rig':
-        specifier: 2.6.43
-        version: 2.6.43(@rushstack/heft@0.68.9)(@types/node@18.17.15)(supports-color@8.1.1)
+        specifier: 2.6.44
+        version: 2.6.44(@rushstack/heft@0.68.10)(@types/node@18.17.15)(supports-color@8.1.1)
       '@types/heft-jest':
         specifier: 1.0.1
         version: 1.0.1
@@ -3059,11 +3059,11 @@ importers:
         version: 10.2.0
     devDependencies:
       '@rushstack/heft':
-        specifier: 0.68.9
-        version: 0.68.9(@types/node@18.17.15)
+        specifier: 0.68.10
+        version: 0.68.10(@types/node@18.17.15)
       '@rushstack/heft-node-rig':
-        specifier: 2.6.43
-        version: 2.6.43(@rushstack/heft@0.68.9)(@types/node@18.17.15)(supports-color@8.1.1)
+        specifier: 2.6.44
+        version: 2.6.44(@rushstack/heft@0.68.10)(@types/node@18.17.15)(supports-color@8.1.1)
       '@types/heft-jest':
         specifier: 1.0.1
         version: 1.0.1
@@ -3173,11 +3173,11 @@ importers:
         version: 7.5.4
     devDependencies:
       '@rushstack/heft':
-        specifier: 0.68.9
-        version: 0.68.9(@types/node@18.17.15)
+        specifier: 0.68.10
+        version: 0.68.10(@types/node@18.17.15)
       '@rushstack/heft-node-rig':
-        specifier: 2.6.43
-        version: 2.6.43(@rushstack/heft@0.68.9)(@types/node@18.17.15)(supports-color@8.1.1)
+        specifier: 2.6.44
+        version: 2.6.44(@rushstack/heft@0.68.10)(@types/node@18.17.15)(supports-color@8.1.1)
       '@types/fs-extra':
         specifier: 7.0.0
         version: 7.0.0
@@ -3210,11 +3210,11 @@ importers:
         version: link:../terminal
     devDependencies:
       '@rushstack/heft':
-        specifier: 0.68.9
-        version: 0.68.9(@types/node@18.17.15)
+        specifier: 0.68.10
+        version: 0.68.10(@types/node@18.17.15)
       '@rushstack/heft-node-rig':
-        specifier: 2.6.43
-        version: 2.6.43(@rushstack/heft@0.68.9)(@types/node@18.17.15)(supports-color@8.1.1)
+        specifier: 2.6.44
+        version: 2.6.44(@rushstack/heft@0.68.10)(@types/node@18.17.15)(supports-color@8.1.1)
       '@types/heft-jest':
         specifier: 1.0.1
         version: 1.0.1
@@ -3309,11 +3309,11 @@ importers:
         version: 3.1.1
     devDependencies:
       '@rushstack/heft':
-        specifier: 0.68.9
-        version: 0.68.9(@types/node@18.17.15)
+        specifier: 0.68.10
+        version: 0.68.10(@types/node@18.17.15)
       '@rushstack/heft-node-rig':
-        specifier: 2.6.43
-        version: 2.6.43(@rushstack/heft@0.68.9)(@types/node@18.17.15)(supports-color@8.1.1)
+        specifier: 2.6.44
+        version: 2.6.44(@rushstack/heft@0.68.10)(@types/node@18.17.15)(supports-color@8.1.1)
       '@types/heft-jest':
         specifier: 1.0.1
         version: 1.0.1
@@ -3621,11 +3621,11 @@ importers:
         version: 8.1.1
     devDependencies:
       '@rushstack/heft':
-        specifier: 0.68.9
-        version: 0.68.9(@types/node@18.17.15)
+        specifier: 0.68.10
+        version: 0.68.10(@types/node@18.17.15)
       '@rushstack/heft-node-rig':
-        specifier: 2.6.43
-        version: 2.6.43(@rushstack/heft@0.68.9)(@types/node@18.17.15)(supports-color@8.1.1)
+        specifier: 2.6.44
+        version: 2.6.44(@rushstack/heft@0.68.10)(@types/node@18.17.15)(supports-color@8.1.1)
       '@types/heft-jest':
         specifier: 1.0.1
         version: 1.0.1
@@ -3645,11 +3645,11 @@ importers:
         specifier: 4.1.0
         version: 4.1.0(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.4.2)
       '@rushstack/heft':
-        specifier: 0.68.9
-        version: 0.68.9(@types/node@18.17.15)
+        specifier: 0.68.10
+        version: 0.68.10(@types/node@18.17.15)
       '@rushstack/heft-node-rig':
-        specifier: 2.6.43
-        version: 2.6.43(@rushstack/heft@0.68.9)(@types/node@18.17.15)(supports-color@8.1.1)
+        specifier: 2.6.44
+        version: 2.6.44(@rushstack/heft@0.68.10)(@types/node@18.17.15)(supports-color@8.1.1)
       '@types/heft-jest':
         specifier: 1.0.1
         version: 1.0.1
@@ -3679,11 +3679,11 @@ importers:
         version: 0.3.2
     devDependencies:
       '@rushstack/heft':
-        specifier: 0.68.9
-        version: 0.68.9(@types/node@18.17.15)
+        specifier: 0.68.10
+        version: 0.68.10(@types/node@18.17.15)
       '@rushstack/heft-node-rig':
-        specifier: 2.6.43
-        version: 2.6.43(@rushstack/heft@0.68.9)(@types/node@18.17.15)(supports-color@8.1.1)
+        specifier: 2.6.44
+        version: 2.6.44(@rushstack/heft@0.68.10)(@types/node@18.17.15)(supports-color@8.1.1)
       '@types/heft-jest':
         specifier: 1.0.1
         version: 1.0.1
@@ -9496,15 +9496,6 @@ packages:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.4.15
 
-  /@jsep-plugin/assignment@1.2.1(jsep@1.3.9):
-    resolution: {integrity: sha512-gaHqbubTi29aZpVbBlECRpmdia+L5/lh2BwtIJTmtxdbecEyyX/ejAOg7eQDGNvGOUmPY7Z2Yxdy9ioyH/VJeA==}
-    engines: {node: '>= 10.16.0'}
-    peerDependencies:
-      jsep: ^0.4.0||^1.0.0
-    dependencies:
-      jsep: 1.3.9
-    dev: true
-
   /@jsep-plugin/assignment@1.3.0(jsep@1.4.0):
     resolution: {integrity: sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==}
     engines: {node: '>= 10.16.0'}
@@ -9512,16 +9503,6 @@ packages:
       jsep: ^0.4.0||^1.0.0
     dependencies:
       jsep: 1.4.0
-    dev: false
-
-  /@jsep-plugin/regex@1.0.3(jsep@1.3.9):
-    resolution: {integrity: sha512-XfZgry4DwEZvSFtS/6Y+R48D7qJYJK6R9/yJFyUFHCIUMEEHuJ4X95TDgJp5QkmzfLYvapMPzskV5HpIDrREug==}
-    engines: {node: '>= 10.16.0'}
-    peerDependencies:
-      jsep: ^0.4.0||^1.0.0
-    dependencies:
-      jsep: 1.3.9
-    dev: true
 
   /@jsep-plugin/regex@1.0.4(jsep@1.4.0):
     resolution: {integrity: sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==}
@@ -9530,7 +9511,6 @@ packages:
       jsep: ^0.4.0||^1.0.0
     dependencies:
       jsep: 1.4.0
-    dev: false
 
   /@jsonjoy.com/base64@1.1.2(tslib@2.3.1):
     resolution: {integrity: sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==}
@@ -10684,46 +10664,46 @@ packages:
       - typescript
     dev: true
 
-  /@rushstack/heft-api-extractor-plugin@0.3.59(@rushstack/heft@..+..+apps+heft)(@types/node@18.17.15):
-    resolution: {integrity: sha512-H2J8H8l9wyexk2AbHXq1WkeKWTORAEnwtcbVjINqWdzrGkZGAHyH2z5snTpTGUGP6McHd6/MgfHfCfct0UQXLg==}
+  /@rushstack/heft-api-extractor-plugin@0.3.60(@rushstack/heft@..+..+apps+heft)(@types/node@18.17.15):
+    resolution: {integrity: sha512-LmSfSiwSQRV7DlJ0/eHxWbmkiMhDMcT0I8NTBA/US+b5XTRj3lP6Ae+bKrGMgUijXH+hpWnmeeE3OpNI0HdjCA==}
     peerDependencies:
       '@rushstack/heft': '*'
     dependencies:
       '@rushstack/heft': link:../../../apps/heft
-      '@rushstack/heft-config-file': 0.16.0(@types/node@18.17.15)
+      '@rushstack/heft-config-file': 0.16.1(@types/node@18.17.15)
       '@rushstack/node-core-library': 5.10.0(@types/node@18.17.15)
       semver: 7.5.4
     transitivePeerDependencies:
       - '@types/node'
     dev: true
 
-  /@rushstack/heft-api-extractor-plugin@0.3.59(@rushstack/heft@0.68.9)(@types/node@18.17.15):
-    resolution: {integrity: sha512-H2J8H8l9wyexk2AbHXq1WkeKWTORAEnwtcbVjINqWdzrGkZGAHyH2z5snTpTGUGP6McHd6/MgfHfCfct0UQXLg==}
+  /@rushstack/heft-api-extractor-plugin@0.3.60(@rushstack/heft@0.68.10)(@types/node@18.17.15):
+    resolution: {integrity: sha512-LmSfSiwSQRV7DlJ0/eHxWbmkiMhDMcT0I8NTBA/US+b5XTRj3lP6Ae+bKrGMgUijXH+hpWnmeeE3OpNI0HdjCA==}
     peerDependencies:
       '@rushstack/heft': '*'
     dependencies:
-      '@rushstack/heft': 0.68.9(@types/node@18.17.15)
-      '@rushstack/heft-config-file': 0.16.0(@types/node@18.17.15)
+      '@rushstack/heft': 0.68.10(@types/node@18.17.15)
+      '@rushstack/heft-config-file': 0.16.1(@types/node@18.17.15)
       '@rushstack/node-core-library': 5.10.0(@types/node@18.17.15)
       semver: 7.5.4
     transitivePeerDependencies:
       - '@types/node'
     dev: true
 
-  /@rushstack/heft-config-file@0.16.0(@types/node@18.17.15):
-    resolution: {integrity: sha512-kafsrpM7xtDaw0iZL9J+qodH9UN5BmDkNHJamS4p/wgp+Y1QCjhv9cC7B9VEAA5lmrRIFwtBOgOaah2W9Vsc/g==}
+  /@rushstack/heft-config-file@0.16.1(@types/node@18.17.15):
+    resolution: {integrity: sha512-9cgriyprJJb0b7zWBBhM75FicLQ8/NPEHrd5Dy1KRYWtEDVvg47+16RIJcco12dfLwAc2DJ9w6DH6a1omCGr/w==}
     engines: {node: '>=10.13.0'}
     dependencies:
       '@rushstack/node-core-library': 5.10.0(@types/node@18.17.15)
       '@rushstack/rig-package': 0.5.3
       '@rushstack/terminal': 0.14.3(@types/node@18.17.15)
-      jsonpath-plus: 10.1.0
+      jsonpath-plus: 10.2.0
     transitivePeerDependencies:
       - '@types/node'
     dev: true
 
-  /@rushstack/heft-jest-plugin@0.13.2(@rushstack/heft@..+..+apps+heft)(@types/node@18.17.15)(jest-environment-jsdom@29.5.0)(jest-environment-node@29.5.0):
-    resolution: {integrity: sha512-fNVifoLX0vWYdD7/TnfpKel0+4If5ndJFiyGCO3EHtlJBx+orRAErFdRB7qd0xwq+IVTXK3jpfaklYzInAd0Ig==}
+  /@rushstack/heft-jest-plugin@0.13.3(@rushstack/heft@..+..+apps+heft)(@types/node@18.17.15)(jest-environment-jsdom@29.5.0)(jest-environment-node@29.5.0):
+    resolution: {integrity: sha512-pxFEBhWdnb28MOA+KdWs/MuuJiTAFaUPvfVIHFpKM1+REwf8GR2GpGSP/lrLCkgGWmO8ZgkZDMcI/0jyNiXrMA==}
     peerDependencies:
       '@rushstack/heft': '*'
       jest-environment-jsdom: ^29.5.0
@@ -10738,7 +10718,7 @@ packages:
       '@jest/reporters': 29.5.0(supports-color@8.1.1)
       '@jest/transform': 29.5.0(supports-color@8.1.1)
       '@rushstack/heft': link:../../../apps/heft
-      '@rushstack/heft-config-file': 0.16.0(@types/node@18.17.15)
+      '@rushstack/heft-config-file': 0.16.1(@types/node@18.17.15)
       '@rushstack/node-core-library': 5.10.0(@types/node@18.17.15)
       '@rushstack/terminal': 0.14.3(@types/node@18.17.15)
       jest-config: 29.5.0(@types/node@18.17.15)(supports-color@8.1.1)
@@ -10755,8 +10735,8 @@ packages:
       - ts-node
     dev: true
 
-  /@rushstack/heft-jest-plugin@0.13.2(@rushstack/heft@0.68.9)(@types/node@18.17.15)(jest-environment-node@29.5.0)(supports-color@8.1.1):
-    resolution: {integrity: sha512-fNVifoLX0vWYdD7/TnfpKel0+4If5ndJFiyGCO3EHtlJBx+orRAErFdRB7qd0xwq+IVTXK3jpfaklYzInAd0Ig==}
+  /@rushstack/heft-jest-plugin@0.13.3(@rushstack/heft@0.68.10)(@types/node@18.17.15)(jest-environment-node@29.5.0)(supports-color@8.1.1):
+    resolution: {integrity: sha512-pxFEBhWdnb28MOA+KdWs/MuuJiTAFaUPvfVIHFpKM1+REwf8GR2GpGSP/lrLCkgGWmO8ZgkZDMcI/0jyNiXrMA==}
     peerDependencies:
       '@rushstack/heft': '*'
       jest-environment-jsdom: ^29.5.0
@@ -10770,8 +10750,8 @@ packages:
       '@jest/core': 29.5.0(supports-color@8.1.1)
       '@jest/reporters': 29.5.0(supports-color@8.1.1)
       '@jest/transform': 29.5.0(supports-color@8.1.1)
-      '@rushstack/heft': 0.68.9(@types/node@18.17.15)
-      '@rushstack/heft-config-file': 0.16.0(@types/node@18.17.15)
+      '@rushstack/heft': 0.68.10(@types/node@18.17.15)
+      '@rushstack/heft-config-file': 0.16.1(@types/node@18.17.15)
       '@rushstack/node-core-library': 5.10.0(@types/node@18.17.15)
       '@rushstack/terminal': 0.14.3(@types/node@18.17.15)
       jest-config: 29.5.0(@types/node@18.17.15)(supports-color@8.1.1)
@@ -10787,8 +10767,8 @@ packages:
       - ts-node
     dev: true
 
-  /@rushstack/heft-lint-plugin@0.5.8(@rushstack/heft@..+..+apps+heft)(@types/node@18.17.15):
-    resolution: {integrity: sha512-6qF9ThXO83Fhz4rvU9wDQIAmDbDPWgfvgrMCgZqunH6/5Z4vvb7aVOqSt6Uhp5lu9rZlV5uJv1KUAYYiTZ5JKQ==}
+  /@rushstack/heft-lint-plugin@0.5.9(@rushstack/heft@..+..+apps+heft)(@types/node@18.17.15):
+    resolution: {integrity: sha512-WERCG5NGztWPeZgm177ozXfya1Ubh67rmIAoGNWBz97PF8lMkUm3gkXK09RUpjv65k8vPJnaAQ/mkGS6c7qGQQ==}
     peerDependencies:
       '@rushstack/heft': '*'
     dependencies:
@@ -10799,30 +10779,30 @@ packages:
       - '@types/node'
     dev: true
 
-  /@rushstack/heft-lint-plugin@0.5.8(@rushstack/heft@0.68.9)(@types/node@18.17.15):
-    resolution: {integrity: sha512-6qF9ThXO83Fhz4rvU9wDQIAmDbDPWgfvgrMCgZqunH6/5Z4vvb7aVOqSt6Uhp5lu9rZlV5uJv1KUAYYiTZ5JKQ==}
+  /@rushstack/heft-lint-plugin@0.5.9(@rushstack/heft@0.68.10)(@types/node@18.17.15):
+    resolution: {integrity: sha512-WERCG5NGztWPeZgm177ozXfya1Ubh67rmIAoGNWBz97PF8lMkUm3gkXK09RUpjv65k8vPJnaAQ/mkGS6c7qGQQ==}
     peerDependencies:
       '@rushstack/heft': '*'
     dependencies:
-      '@rushstack/heft': 0.68.9(@types/node@18.17.15)
+      '@rushstack/heft': 0.68.10(@types/node@18.17.15)
       '@rushstack/node-core-library': 5.10.0(@types/node@18.17.15)
       semver: 7.5.4
     transitivePeerDependencies:
       - '@types/node'
     dev: true
 
-  /@rushstack/heft-node-rig@2.6.43(@rushstack/heft@..+..+apps+heft)(@types/node@18.17.15)(jest-environment-jsdom@29.5.0):
-    resolution: {integrity: sha512-EYBrXBTU/RfoAaoUGZCTPd54d1BxlDr0foeDDYXrg5VNugHTHZYyFqTOgJ85qiOw7dhS2vEoo45qa2Axht9rsg==}
+  /@rushstack/heft-node-rig@2.6.44(@rushstack/heft@..+..+apps+heft)(@types/node@18.17.15)(jest-environment-jsdom@29.5.0):
+    resolution: {integrity: sha512-C4CcyxopBMkum3/4OLdYAZ7ZOgMtnDMZLCtYpRAt3uSumuf9+Umvm5BmdPmqw0FCzmxsdpsYm34xRB9oDwG9sw==}
     peerDependencies:
       '@rushstack/heft': '*'
     dependencies:
       '@microsoft/api-extractor': 7.48.0(@types/node@18.17.15)
       '@rushstack/eslint-config': 4.1.0(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.4.2)
       '@rushstack/heft': link:../../../apps/heft
-      '@rushstack/heft-api-extractor-plugin': 0.3.59(@rushstack/heft@..+..+apps+heft)(@types/node@18.17.15)
-      '@rushstack/heft-jest-plugin': 0.13.2(@rushstack/heft@..+..+apps+heft)(@types/node@18.17.15)(jest-environment-jsdom@29.5.0)(jest-environment-node@29.5.0)
-      '@rushstack/heft-lint-plugin': 0.5.8(@rushstack/heft@..+..+apps+heft)(@types/node@18.17.15)
-      '@rushstack/heft-typescript-plugin': 0.6.2(@rushstack/heft@..+..+apps+heft)(@types/node@18.17.15)
+      '@rushstack/heft-api-extractor-plugin': 0.3.60(@rushstack/heft@..+..+apps+heft)(@types/node@18.17.15)
+      '@rushstack/heft-jest-plugin': 0.13.3(@rushstack/heft@..+..+apps+heft)(@types/node@18.17.15)(jest-environment-jsdom@29.5.0)(jest-environment-node@29.5.0)
+      '@rushstack/heft-lint-plugin': 0.5.9(@rushstack/heft@..+..+apps+heft)(@types/node@18.17.15)
+      '@rushstack/heft-typescript-plugin': 0.6.3(@rushstack/heft@..+..+apps+heft)(@types/node@18.17.15)
       '@types/heft-jest': 1.0.1
       eslint: 8.57.0(supports-color@8.1.1)
       jest-environment-node: 29.5.0
@@ -10836,18 +10816,18 @@ packages:
       - ts-node
     dev: true
 
-  /@rushstack/heft-node-rig@2.6.43(@rushstack/heft@0.68.9)(@types/node@18.17.15)(supports-color@8.1.1):
-    resolution: {integrity: sha512-EYBrXBTU/RfoAaoUGZCTPd54d1BxlDr0foeDDYXrg5VNugHTHZYyFqTOgJ85qiOw7dhS2vEoo45qa2Axht9rsg==}
+  /@rushstack/heft-node-rig@2.6.44(@rushstack/heft@0.68.10)(@types/node@18.17.15)(supports-color@8.1.1):
+    resolution: {integrity: sha512-C4CcyxopBMkum3/4OLdYAZ7ZOgMtnDMZLCtYpRAt3uSumuf9+Umvm5BmdPmqw0FCzmxsdpsYm34xRB9oDwG9sw==}
     peerDependencies:
       '@rushstack/heft': '*'
     dependencies:
       '@microsoft/api-extractor': 7.48.0(@types/node@18.17.15)
       '@rushstack/eslint-config': 4.1.0(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.4.2)
-      '@rushstack/heft': 0.68.9(@types/node@18.17.15)
-      '@rushstack/heft-api-extractor-plugin': 0.3.59(@rushstack/heft@0.68.9)(@types/node@18.17.15)
-      '@rushstack/heft-jest-plugin': 0.13.2(@rushstack/heft@0.68.9)(@types/node@18.17.15)(jest-environment-node@29.5.0)(supports-color@8.1.1)
-      '@rushstack/heft-lint-plugin': 0.5.8(@rushstack/heft@0.68.9)(@types/node@18.17.15)
-      '@rushstack/heft-typescript-plugin': 0.6.2(@rushstack/heft@0.68.9)(@types/node@18.17.15)
+      '@rushstack/heft': 0.68.10(@types/node@18.17.15)
+      '@rushstack/heft-api-extractor-plugin': 0.3.60(@rushstack/heft@0.68.10)(@types/node@18.17.15)
+      '@rushstack/heft-jest-plugin': 0.13.3(@rushstack/heft@0.68.10)(@types/node@18.17.15)(jest-environment-node@29.5.0)(supports-color@8.1.1)
+      '@rushstack/heft-lint-plugin': 0.5.9(@rushstack/heft@0.68.10)(@types/node@18.17.15)
+      '@rushstack/heft-typescript-plugin': 0.6.3(@rushstack/heft@0.68.10)(@types/node@18.17.15)
       '@types/heft-jest': 1.0.1
       eslint: 8.57.0(supports-color@8.1.1)
       jest-environment-node: 29.5.0
@@ -10861,13 +10841,13 @@ packages:
       - ts-node
     dev: true
 
-  /@rushstack/heft-typescript-plugin@0.6.2(@rushstack/heft@..+..+apps+heft)(@types/node@18.17.15):
-    resolution: {integrity: sha512-/CdYHmWJTSpPnZwaJwuyRiyqA4ouAkwjT3Wy3V9ugEO7YGOg0RzJPJ3VPqvElkXvhjh/vBHaAHmDYPgoIOjudg==}
+  /@rushstack/heft-typescript-plugin@0.6.3(@rushstack/heft@..+..+apps+heft)(@types/node@18.17.15):
+    resolution: {integrity: sha512-jO9PAv450d7RikGmxMv1qv9Gp8SQv6DRp+zE8+pEZiHaeWWBBDRlmVP7RuiLrboiM4BqlPGeQVS786wWBGjSdQ==}
     peerDependencies:
       '@rushstack/heft': '*'
     dependencies:
       '@rushstack/heft': link:../../../apps/heft
-      '@rushstack/heft-config-file': 0.16.0(@types/node@18.17.15)
+      '@rushstack/heft-config-file': 0.16.1(@types/node@18.17.15)
       '@rushstack/node-core-library': 5.10.0(@types/node@18.17.15)
       '@types/tapable': 1.0.6
       semver: 7.5.4
@@ -10876,13 +10856,13 @@ packages:
       - '@types/node'
     dev: true
 
-  /@rushstack/heft-typescript-plugin@0.6.2(@rushstack/heft@0.68.9)(@types/node@18.17.15):
-    resolution: {integrity: sha512-/CdYHmWJTSpPnZwaJwuyRiyqA4ouAkwjT3Wy3V9ugEO7YGOg0RzJPJ3VPqvElkXvhjh/vBHaAHmDYPgoIOjudg==}
+  /@rushstack/heft-typescript-plugin@0.6.3(@rushstack/heft@0.68.10)(@types/node@18.17.15):
+    resolution: {integrity: sha512-jO9PAv450d7RikGmxMv1qv9Gp8SQv6DRp+zE8+pEZiHaeWWBBDRlmVP7RuiLrboiM4BqlPGeQVS786wWBGjSdQ==}
     peerDependencies:
       '@rushstack/heft': '*'
     dependencies:
-      '@rushstack/heft': 0.68.9(@types/node@18.17.15)
-      '@rushstack/heft-config-file': 0.16.0(@types/node@18.17.15)
+      '@rushstack/heft': 0.68.10(@types/node@18.17.15)
+      '@rushstack/heft-config-file': 0.16.1(@types/node@18.17.15)
       '@rushstack/node-core-library': 5.10.0(@types/node@18.17.15)
       '@types/tapable': 1.0.6
       semver: 7.5.4
@@ -10891,12 +10871,12 @@ packages:
       - '@types/node'
     dev: true
 
-  /@rushstack/heft@0.68.9(@types/node@18.17.15):
-    resolution: {integrity: sha512-po9dcjRtM1TbVsDeE1PpNCQoNpjx+J3KhUKNfiOSoyZ5wocCGiWNx4Np20S3xjLMtin1P0PfUADRaqidqnzmdQ==}
+  /@rushstack/heft@0.68.10(@types/node@18.17.15):
+    resolution: {integrity: sha512-oN7vtr8AsNt1tqg7AAYsslHybuxZ3ek36BKRz3LrsZEoC6Iop9VtPIc4AvPHytRgvc8+ZYVVQhRiHWE8Lan5sw==}
     engines: {node: '>=10.13.0'}
     hasBin: true
     dependencies:
-      '@rushstack/heft-config-file': 0.16.0(@types/node@18.17.15)
+      '@rushstack/heft-config-file': 0.16.1(@types/node@18.17.15)
       '@rushstack/node-core-library': 5.10.0(@types/node@18.17.15)
       '@rushstack/operation-graph': 0.2.34(@types/node@18.17.15)
       '@rushstack/rig-package': 0.5.3
@@ -21929,15 +21909,9 @@ packages:
       - supports-color
       - utf-8-validate
 
-  /jsep@1.3.9:
-    resolution: {integrity: sha512-i1rBX5N7VPl0eYb6+mHNp52sEuaS2Wi8CDYx1X5sn9naevL78+265XJqy1qENEk7mRKwS06NHpUqiBwR7qeodw==}
-    engines: {node: '>= 10.16.0'}
-    dev: true
-
   /jsep@1.4.0:
     resolution: {integrity: sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==}
     engines: {node: '>= 10.16.0'}
-    dev: false
 
   /jsesc@0.5.0:
     resolution: {integrity: sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==}
@@ -21999,16 +21973,6 @@ packages:
       graceful-fs: 4.2.11
     dev: true
 
-  /jsonpath-plus@10.1.0:
-    resolution: {integrity: sha512-gHfV1IYqH8uJHYVTs8BJX1XKy2/rR93+f8QQi0xhx95aCiXn1ettYAd5T+7FU6wfqyDoX/wy0pm/fL3jOKJ9Lg==}
-    engines: {node: '>=18.0.0'}
-    hasBin: true
-    dependencies:
-      '@jsep-plugin/assignment': 1.2.1(jsep@1.3.9)
-      '@jsep-plugin/regex': 1.0.3(jsep@1.3.9)
-      jsep: 1.3.9
-    dev: true
-
   /jsonpath-plus@10.2.0:
     resolution: {integrity: sha512-T9V+8iNYKFL2n2rF+w02LBOT2JjDnTjioaNFrxRy0Bv1y/hNsqR/EBK7Ojy2ythRHwmz2cRIls+9JitQGZC/sw==}
     engines: {node: '>=18.0.0'}
@@ -22017,7 +21981,6 @@ packages:
       '@jsep-plugin/assignment': 1.3.0(jsep@1.4.0)
       '@jsep-plugin/regex': 1.0.4(jsep@1.4.0)
       jsep: 1.4.0
-    dev: false
 
   /jsonschema@1.4.1:
     resolution: {integrity: sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ==}

--- a/common/config/subspaces/default/repo-state.json
+++ b/common/config/subspaces/default/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "a16c50e7c3a5c71207ebe5a237087380b9f1253b",
+  "pnpmShrinkwrapHash": "387d2507a3b0dee1dd0ca694ced243f0edaa0dc1",
   "preferredVersionsHash": "ce857ea0536b894ec8f346aaea08cfd85a5af648"
 }

--- a/eslint/eslint-patch/package.json
+++ b/eslint/eslint-patch/package.json
@@ -30,8 +30,8 @@
     "patch"
   ],
   "devDependencies": {
-    "@rushstack/heft": "0.68.9",
-    "@rushstack/heft-node-rig": "2.6.43",
+    "@rushstack/heft": "0.68.10",
+    "@rushstack/heft-node-rig": "2.6.44",
     "@types/eslint": "8.56.10",
     "@types/node": "18.17.15",
     "@typescript-eslint/types": "~5.59.2",

--- a/eslint/eslint-plugin-packlets/package.json
+++ b/eslint/eslint-plugin-packlets/package.json
@@ -30,8 +30,8 @@
     "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
   },
   "devDependencies": {
-    "@rushstack/heft": "0.68.9",
-    "@rushstack/heft-node-rig": "2.6.43",
+    "@rushstack/heft": "0.68.10",
+    "@rushstack/heft-node-rig": "2.6.44",
     "@types/eslint": "8.56.10",
     "@types/estree": "1.0.5",
     "@types/heft-jest": "1.0.1",

--- a/eslint/eslint-plugin-security/package.json
+++ b/eslint/eslint-plugin-security/package.json
@@ -30,8 +30,8 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "~3.0.0",
-    "@rushstack/heft": "0.68.9",
-    "@rushstack/heft-node-rig": "2.6.43",
+    "@rushstack/heft": "0.68.10",
+    "@rushstack/heft-node-rig": "2.6.44",
     "@types/eslint": "8.56.10",
     "@types/estree": "1.0.5",
     "@types/heft-jest": "1.0.1",

--- a/eslint/eslint-plugin/package.json
+++ b/eslint/eslint-plugin/package.json
@@ -34,8 +34,8 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "~3.0.0",
-    "@rushstack/heft": "0.68.9",
-    "@rushstack/heft-node-rig": "2.6.43",
+    "@rushstack/heft": "0.68.10",
+    "@rushstack/heft-node-rig": "2.6.44",
     "@types/eslint": "8.56.10",
     "@types/estree": "1.0.5",
     "@types/heft-jest": "1.0.1",

--- a/heft-plugins/heft-api-extractor-plugin/package.json
+++ b/heft-plugins/heft-api-extractor-plugin/package.json
@@ -26,7 +26,7 @@
     "@microsoft/api-extractor": "workspace:*",
     "local-eslint-config": "workspace:*",
     "@rushstack/heft": "workspace:*",
-    "@rushstack/heft-node-rig": "2.6.43",
+    "@rushstack/heft-node-rig": "2.6.44",
     "@rushstack/terminal": "workspace:*",
     "@types/heft-jest": "1.0.1",
     "@types/node": "18.17.15",

--- a/heft-plugins/heft-jest-plugin/package.json
+++ b/heft-plugins/heft-jest-plugin/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@jest/types": "29.5.0",
-    "@rushstack/heft-node-rig": "2.6.43",
+    "@rushstack/heft-node-rig": "2.6.44",
     "@rushstack/heft": "workspace:*",
     "@types/heft-jest": "1.0.1",
     "@types/lodash": "4.14.116",

--- a/heft-plugins/heft-jest-plugin/package.json
+++ b/heft-plugins/heft-jest-plugin/package.json
@@ -38,7 +38,8 @@
     "jest-config": "~29.5.0",
     "jest-resolve": "~29.5.0",
     "jest-snapshot": "~29.5.0",
-    "lodash": "~4.17.15"
+    "lodash": "~4.17.15",
+    "punycode": "~2.3.1"
   },
   "devDependencies": {
     "@jest/types": "29.5.0",

--- a/heft-plugins/heft-jest-plugin/src/JestPlugin.ts
+++ b/heft-plugins/heft-jest-plugin/src/JestPlugin.ts
@@ -122,6 +122,7 @@ const PLUGIN_NAME: 'jest-plugin' = 'jest-plugin';
 const PLUGIN_PACKAGE_NAME: '@rushstack/heft-jest-plugin' = '@rushstack/heft-jest-plugin';
 const PLUGIN_PACKAGE_FOLDER: string = path.resolve(__dirname, '..');
 const JEST_CONFIGURATION_LOCATION: 'config/jest.config.json' = `config/jest.config.json`;
+export const JEST_CONFIG_JSDOM_PACKAGE_NAME: 'jest-environment-jsdom' = 'jest-environment-jsdom';
 
 const ROOTDIR_TOKEN: '<rootDir>' = '<rootDir>';
 const CONFIGDIR_TOKEN: '<configDir>' = '<configDir>';
@@ -140,6 +141,7 @@ interface IPendingTestRun {
  */
 export default class JestPlugin implements IHeftTaskPlugin<IJestPluginOptions> {
   private static _jestConfigurationFileLoader: ProjectConfigurationFile<IHeftJestConfiguration> | undefined;
+  private static _includedJestEnvironmentJsdomPath: string | undefined;
 
   private _jestPromise: Promise<unknown> | undefined;
   private _pendingTestRuns: Set<IPendingTestRun> = new Set();
@@ -980,27 +982,47 @@ export default class JestPlugin implements IHeftTaskPlugin<IJestPluginOptions> {
               filePath: propertyValue,
               requireResolveFunction
             });
+
           case 'testSequencer':
             return resolveSequencer(/*resolver:*/ undefined, {
               rootDir: configDir,
               filePath: propertyValue,
               requireResolveFunction
             });
+
           case 'testEnvironment':
-            return resolveTestEnvironment({
+            const testEnvironment: string = resolveTestEnvironment({
               rootDir: configDir,
               testEnvironment: propertyValue,
               requireResolveFunction
             });
+
+            if (propertyValue === JEST_CONFIG_JSDOM_PACKAGE_NAME) {
+              // If the testEnvironment is the included jest-environment-jsdom,
+              // redirect to the version that injects punycode for Node >= 22.
+              if (!JestPlugin._includedJestEnvironmentJsdomPath) {
+                JestPlugin._includedJestEnvironmentJsdomPath = require.resolve(
+                  JEST_CONFIG_JSDOM_PACKAGE_NAME
+                );
+              }
+
+              if (JestPlugin._includedJestEnvironmentJsdomPath === testEnvironment) {
+                return `${__dirname}/exports/patched-jest-environment-jsdom.js`;
+              }
+            }
+
+            return testEnvironment;
+
           case 'watchPlugins':
             return resolveWatchPlugin(/*resolver:*/ undefined, {
               rootDir: configDir,
               filePath: propertyValue,
               requireResolveFunction
             });
+
           case 'preset':
             // Do not allow use of presets and extends together, since that would create a
-            // confusing heirarchy.
+            // confusing hierarchy.
             if (
               configurationFile.preset &&
               (configurationFile as IHeftJestConfigurationWithExtends).extends
@@ -1038,6 +1060,7 @@ export default class JestPlugin implements IHeftTaskPlugin<IJestPluginOptions> {
             } else {
               return propertyValue;
             }
+
           default:
             // We know the value will be non-null since resolve will throw an error if it is null
             // and non-optional

--- a/heft-plugins/heft-jest-plugin/src/exports/patched-jest-environment-jsdom.ts
+++ b/heft-plugins/heft-jest-plugin/src/exports/patched-jest-environment-jsdom.ts
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+const PUNYCODE_MODULE_NAME: 'punycode' = 'punycode';
+const nodeMajorVersion: number = parseInt(process.versions.node, 10);
+if (nodeMajorVersion >= 22) {
+  // Inject the "punycode" module into the Node.js module cache in Node >=22. JSDom has indirect
+  // dependencies on this module, which is marked as deprecated in Node >=22.
+  const punycode: unknown = require('punycode/punycode');
+  require.cache[PUNYCODE_MODULE_NAME] = {
+    id: PUNYCODE_MODULE_NAME,
+    path: PUNYCODE_MODULE_NAME,
+    exports: punycode,
+    isPreloading: false,
+    require,
+    filename: PUNYCODE_MODULE_NAME,
+    loaded: true,
+    parent: undefined,
+    children: [],
+    paths: []
+  };
+}
+
+module.exports = require('jest-environment-jsdom');

--- a/heft-plugins/heft-jest-plugin/src/patches/jestWorkerPatch.ts
+++ b/heft-plugins/heft-jest-plugin/src/patches/jestWorkerPatch.ts
@@ -28,23 +28,19 @@ import { Import, FileSystem } from '@rushstack/node-core-library';
 // the IPC message is not received from the child process before the timeout elapses.  The mitigation is to
 // increase the delay.  (Jest itself seems to be a significant contributor to machine load, so perhaps reducing
 // Jest's parallelism could also help.)
-//
-// This patch also injects the "punycode" module into the Node.js module cache in Node >=22. JSDom has indirect
-// dependencies on this module, which is marked as deprecated in Node >=22.
 
 interface IBaseWorkerPoolModule {
   default: unknown;
 }
 
+// Follow the NPM dependency chain to find the module path for BaseWorkerPool.js
+// heft --> @jest/core --> @jest/reporters --> jest-worker
+
 const PATCHED_FORCE_EXIT_DELAY: number = 7000; // 7 seconds
 const patchName: string = path.basename(__filename);
-const PUNYCODE_MODULE_NAME: 'punycode' = 'punycode';
 
 function applyPatch(): void {
   try {
-    // Follow the NPM dependency chain to find the module path for BaseWorkerPool.js
-    // heft-jest-plugin --> @jest/core --> @jest/reporters --> jest-worker
-
     let contextFolder: string = __dirname;
     // Resolve the "@jest/core" package relative to Heft
     contextFolder = Import.resolvePackage({ packageName: '@jest/core', baseFolderPath: contextFolder });
@@ -134,25 +130,6 @@ function applyPatch(): void {
     console.error();
 
     throw e;
-  }
-
-  const nodeMajorVersion: number = parseInt(process.versions.node, 10);
-  if (nodeMajorVersion >= 22) {
-    // Inject punycode into Node module cache for Node 22 and higher
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const punycode: unknown = require('punycode/punycode');
-    require.cache[PUNYCODE_MODULE_NAME] = {
-      id: PUNYCODE_MODULE_NAME,
-      path: PUNYCODE_MODULE_NAME,
-      exports: punycode,
-      isPreloading: false,
-      require,
-      filename: PUNYCODE_MODULE_NAME,
-      loaded: true,
-      parent: undefined,
-      children: [],
-      paths: []
-    };
   }
 }
 

--- a/heft-plugins/heft-jest-plugin/src/test/JestPlugin.test.ts
+++ b/heft-plugins/heft-jest-plugin/src/test/JestPlugin.test.ts
@@ -5,10 +5,14 @@ import * as path from 'path';
 import type { Config } from '@jest/types';
 import type { IHeftTaskSession, HeftConfiguration, CommandLineParameter } from '@rushstack/heft';
 import type { ProjectConfigurationFile } from '@rushstack/heft-config-file';
-import { Import, JsonFile } from '@rushstack/node-core-library';
+import { Import, JsonFile, Path } from '@rushstack/node-core-library';
 import { StringBufferTerminalProvider, Terminal } from '@rushstack/terminal';
 
-import { default as JestPlugin, type IHeftJestConfiguration } from '../JestPlugin';
+import {
+  JEST_CONFIG_JSDOM_PACKAGE_NAME,
+  default as JestPlugin,
+  type IHeftJestConfiguration
+} from '../JestPlugin';
 
 interface IPartialHeftPluginJson {
   taskPlugins?: {
@@ -80,7 +84,7 @@ describe('JestConfigLoader', () => {
     );
     const loadedConfig: IHeftJestConfiguration = await loader.loadConfigurationFileForProjectAsync(
       terminal,
-      path.join(__dirname, '..', '..', 'lib', 'test', 'project1')
+      rootDir
     );
 
     expect(loadedConfig.preset).toBe(undefined);
@@ -167,7 +171,7 @@ describe('JestConfigLoader', () => {
     );
     const loadedConfig: IHeftJestConfiguration = await loader.loadConfigurationFileForProjectAsync(
       terminal,
-      path.resolve(__dirname, '..', '..', 'lib', 'test', 'project2')
+      rootDir
     );
 
     expect(loadedConfig.setupFiles?.length).toBe(1);
@@ -177,5 +181,26 @@ describe('JestConfigLoader', () => {
     // is resolved, implying it came from Jest directly
     expect(loadedConfig.testEnvironment).toContain('jest-environment-jsdom');
     expect(loadedConfig.testEnvironment).toMatch(/index.js$/);
+  });
+
+  it('the default web config const matches the name in the config JSON file', async () => {
+    const { testEnvironment } = await JsonFile.loadAsync(`${__dirname}/../../includes/jest-web.config.json`);
+    expect(testEnvironment).toEqual(JEST_CONFIG_JSDOM_PACKAGE_NAME);
+  });
+
+  it('replaces jest-environment-jsdom with the patched version', async () => {
+    // Because we require the built modules, we need to set our rootDir to be in the 'lib' folder, since transpilation
+    // means that we don't run on the built test assets directly
+    const rootDir: string = path.resolve(__dirname, '..', '..', 'lib', 'test', 'project3');
+    const loader: ProjectConfigurationFile<IHeftJestConfiguration> = JestPlugin._getJestConfigurationLoader(
+      rootDir,
+      'config/jest.config.json'
+    );
+    const loadedConfig: IHeftJestConfiguration = await loader.loadConfigurationFileForProjectAsync(
+      terminal,
+      rootDir
+    );
+    const testEnvironment: string = Path.convertToPlatformDefault(loadedConfig.testEnvironment!);
+    expect(testEnvironment).toEqual(require.resolve('../exports/patched-jest-environment-jsdom'));
   });
 });

--- a/heft-plugins/heft-jest-plugin/src/test/project3/config/jest.config.json
+++ b/heft-plugins/heft-jest-plugin/src/test/project3/config/jest.config.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../../includes/jest-web.config.json"
+}

--- a/heft-plugins/heft-lint-plugin/package.json
+++ b/heft-plugins/heft-lint-plugin/package.json
@@ -25,7 +25,7 @@
     "local-eslint-config": "workspace:*",
     "@rushstack/heft": "workspace:*",
     "@rushstack/heft-typescript-plugin": "workspace:*",
-    "@rushstack/heft-node-rig": "2.6.43",
+    "@rushstack/heft-node-rig": "2.6.44",
     "@rushstack/terminal": "workspace:*",
     "@types/eslint": "8.56.10",
     "@types/heft-jest": "1.0.1",

--- a/heft-plugins/heft-typescript-plugin/package.json
+++ b/heft-plugins/heft-typescript-plugin/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "local-eslint-config": "workspace:*",
     "@rushstack/heft": "workspace:*",
-    "@rushstack/heft-node-rig": "2.6.43",
+    "@rushstack/heft-node-rig": "2.6.44",
     "@rushstack/terminal": "workspace:*",
     "@types/node": "18.17.15",
     "@types/semver": "7.5.0",

--- a/libraries/api-extractor-model/package.json
+++ b/libraries/api-extractor-model/package.json
@@ -23,8 +23,8 @@
   },
   "devDependencies": {
     "local-eslint-config": "workspace:*",
-    "@rushstack/heft": "0.68.9",
-    "@rushstack/heft-node-rig": "2.6.43",
+    "@rushstack/heft": "0.68.10",
+    "@rushstack/heft-node-rig": "2.6.44",
     "@types/heft-jest": "1.0.1",
     "@types/node": "18.17.15"
   }

--- a/libraries/heft-config-file/package.json
+++ b/libraries/heft-config-file/package.json
@@ -28,8 +28,8 @@
   },
   "devDependencies": {
     "local-eslint-config": "workspace:*",
-    "@rushstack/heft": "0.68.9",
-    "@rushstack/heft-node-rig": "2.6.43",
+    "@rushstack/heft": "0.68.10",
+    "@rushstack/heft-node-rig": "2.6.44",
     "@types/heft-jest": "1.0.1",
     "@types/node": "18.17.15"
   }

--- a/libraries/node-core-library/package.json
+++ b/libraries/node-core-library/package.json
@@ -27,8 +27,8 @@
   },
   "devDependencies": {
     "local-eslint-config": "workspace:*",
-    "@rushstack/heft": "0.68.9",
-    "@rushstack/heft-node-rig": "2.6.43",
+    "@rushstack/heft": "0.68.10",
+    "@rushstack/heft-node-rig": "2.6.44",
     "@types/fs-extra": "7.0.0",
     "@types/heft-jest": "1.0.1",
     "@types/jju": "1.4.1",

--- a/libraries/node-core-library/src/test/LockFile.test.ts
+++ b/libraries/node-core-library/src/test/LockFile.test.ts
@@ -346,14 +346,13 @@ describe(LockFile.name, () => {
 
         // create an open lockfile
         const resourceName: string = 'test';
-        const lockFileName: string = LockFile.getLockFilePath(testFolder, resourceName);
-        const lockFileHandle: FileWriter = FileWriter.open(lockFileName, { exclusive: true });
+        const lockFileHandle: LockFile | undefined = LockFile.tryAcquire(testFolder, resourceName);
+        expect(lockFileHandle).toBeDefined();
 
         const lock: LockFile | undefined = LockFile.tryAcquire(testFolder, resourceName);
-
         // this lock should be undefined since there is an existing lock
         expect(lock).toBeUndefined();
-        lockFileHandle.close();
+        lockFileHandle!.release();
       });
 
       test('can acquire and close a dirty lockfile', () => {

--- a/libraries/operation-graph/package.json
+++ b/libraries/operation-graph/package.json
@@ -21,8 +21,8 @@
   },
   "devDependencies": {
     "local-eslint-config": "workspace:*",
-    "@rushstack/heft": "0.68.9",
-    "@rushstack/heft-node-rig": "2.6.43",
+    "@rushstack/heft": "0.68.10",
+    "@rushstack/heft-node-rig": "2.6.44",
     "@types/heft-jest": "1.0.1",
     "@types/node": "18.17.15"
   },

--- a/libraries/rig-package/package.json
+++ b/libraries/rig-package/package.json
@@ -21,8 +21,8 @@
   },
   "devDependencies": {
     "local-eslint-config": "workspace:*",
-    "@rushstack/heft-node-rig": "2.6.43",
-    "@rushstack/heft": "0.68.9",
+    "@rushstack/heft-node-rig": "2.6.44",
+    "@rushstack/heft": "0.68.10",
     "@types/heft-jest": "1.0.1",
     "@types/node": "18.17.15",
     "@types/resolve": "1.20.2",

--- a/libraries/terminal/package.json
+++ b/libraries/terminal/package.json
@@ -20,8 +20,8 @@
     "supports-color": "~8.1.1"
   },
   "devDependencies": {
-    "@rushstack/heft": "0.68.9",
-    "@rushstack/heft-node-rig": "2.6.43",
+    "@rushstack/heft": "0.68.10",
+    "@rushstack/heft-node-rig": "2.6.44",
     "@types/heft-jest": "1.0.1",
     "@types/node": "18.17.15",
     "@types/supports-color": "8.1.3",

--- a/libraries/tree-pattern/package.json
+++ b/libraries/tree-pattern/package.json
@@ -17,8 +17,8 @@
   },
   "devDependencies": {
     "@rushstack/eslint-config": "4.1.0",
-    "@rushstack/heft": "0.68.9",
-    "@rushstack/heft-node-rig": "2.6.43",
+    "@rushstack/heft": "0.68.10",
+    "@rushstack/heft-node-rig": "2.6.44",
     "@types/heft-jest": "1.0.1",
     "@types/node": "18.17.15",
     "eslint": "~8.57.0",

--- a/libraries/ts-command-line/package.json
+++ b/libraries/ts-command-line/package.json
@@ -23,8 +23,8 @@
   },
   "devDependencies": {
     "local-eslint-config": "workspace:*",
-    "@rushstack/heft": "0.68.9",
-    "@rushstack/heft-node-rig": "2.6.43",
+    "@rushstack/heft": "0.68.10",
+    "@rushstack/heft-node-rig": "2.6.44",
     "@types/heft-jest": "1.0.1",
     "@types/node": "18.17.15"
   }

--- a/rush.json
+++ b/rush.json
@@ -16,7 +16,7 @@
    * path segment in the "$schema" field for all your Rush config files.  This will ensure
    * correct error-underlining and tab-completion for editors such as VS Code.
    */
-  "rushVersion": "5.144.1-pr5037.0",
+  "rushVersion": "5.145.0",
 
   /**
    * The next field selects which package manager should be installed and determines its version.

--- a/rush.json
+++ b/rush.json
@@ -16,7 +16,7 @@
    * path segment in the "$schema" field for all your Rush config files.  This will ensure
    * correct error-underlining and tab-completion for editors such as VS Code.
    */
-  "rushVersion": "5.143.0-pr5009.1",
+  "rushVersion": "5.144.1-pr5037.0",
 
   /**
    * The next field selects which package manager should be installed and determines its version.
@@ -42,7 +42,7 @@
    * LTS schedule: https://nodejs.org/en/about/releases/
    * LTS versions: https://nodejs.org/en/download/releases/
    */
-  "nodeSupportedVersionRange": ">=18.15.0 <19.0.0 || >=20.9.0 <21.0.0",
+  "nodeSupportedVersionRange": ">=18.15.0 <19.0.0 || >=20.9.0 <21.0.0 || >=22.12.0 <23.0.0",
 
   /**
    * If the version check above fails, Rush will display a message showing the current


### PR DESCRIPTION
## Summary

Importing `punycode` emits a deprecating warning starting in Node 22 and `jsdom` imports `punycode`. This PR introduces a patch that injects `punycode` into the NodeJS require cache before loading `jest-environment-jsdom`.

This PR also adds Node 22 to the test matrix.

Fixes https://github.com/microsoft/rushstack/issues/5033 and https://github.com/microsoft/rushstack/issues/5008

## How it was tested

Built and ran unit tests.

~~Note that the `node-core-library` tests are failing in Node 22 on Windows and need to be investigated.~~

## Impacted documentation

The `punycode` injection should be documented.