### PR TITLE
[node-core-library] Fix semantics of RealNodeModulePath

### DIFF
--- a/common/changes/@rushstack/node-core-library/trim-trailing-slash_2024-12-13-02-11.json
+++ b/common/changes/@rushstack/node-core-library/trim-trailing-slash_2024-12-13-02-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/node-core-library",
+      "comment": "Fix handling of trailing slashes and relative paths in RealNodeModulePath to match semantics of `fs.realpathSync.native`.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/node-core-library"
+}

--- a/common/reviews/api/node-core-library.api.md
+++ b/common/reviews/api/node-core-library.api.md
@@ -845,7 +845,7 @@ export class ProtectableMap<K, V> {
 
 // @public
 export class RealNodeModulePathResolver {
-    constructor(options: IRealNodeModulePathResolverOptions);
+    constructor(options?: IRealNodeModulePathResolverOptions);
     clearCache(): void;
     readonly realNodeModulePath: (input: string) => string;
 }

--- a/common/reviews/api/node-core-library.api.md
+++ b/common/reviews/api/node-core-library.api.md
@@ -611,7 +611,7 @@ export interface IRealNodeModulePathResolverOptions {
     // (undocumented)
     fs: Pick<typeof nodeFs, 'lstatSync' | 'readlinkSync'>;
     // (undocumented)
-    path: Pick<typeof nodePath, 'format' | 'isAbsolute' | 'parse' | 'resolve' | 'sep'>;
+    path: Pick<typeof nodePath, 'format' | 'isAbsolute' | 'join' | 'parse' | 'resolve' | 'sep'>;
 }
 
 // @public (undocumented)

--- a/common/reviews/api/node-core-library.api.md
+++ b/common/reviews/api/node-core-library.api.md
@@ -611,7 +611,7 @@ export interface IRealNodeModulePathResolverOptions {
     // (undocumented)
     fs: Pick<typeof nodeFs, 'lstatSync' | 'readlinkSync'>;
     // (undocumented)
-    path: Pick<typeof nodePath, 'isAbsolute' | 'normalize' | 'resolve' | 'sep'>;
+    path: Pick<typeof nodePath, 'format' | 'isAbsolute' | 'parse' | 'resolve' | 'sep'>;
 }
 
 // @public (undocumented)

--- a/common/reviews/api/node-core-library.api.md
+++ b/common/reviews/api/node-core-library.api.md
@@ -609,9 +609,9 @@ export interface IReadLinesFromIterableOptions {
 // @public
 export interface IRealNodeModulePathResolverOptions {
     // (undocumented)
-    fs: Pick<typeof nodeFs, 'lstatSync' | 'readlinkSync'>;
+    fs?: Partial<Pick<typeof nodeFs, 'lstatSync' | 'readlinkSync'>>;
     // (undocumented)
-    path: Pick<typeof nodePath, 'format' | 'isAbsolute' | 'join' | 'parse' | 'resolve' | 'sep'>;
+    path?: Partial<Pick<typeof nodePath, 'isAbsolute' | 'join' | 'resolve' | 'sep'>>;
 }
 
 // @public (undocumented)
@@ -845,7 +845,7 @@ export class ProtectableMap<K, V> {
 
 // @public
 export class RealNodeModulePathResolver {
-    constructor(options?: IRealNodeModulePathResolverOptions);
+    constructor(options: IRealNodeModulePathResolverOptions);
     clearCache(): void;
     readonly realNodeModulePath: (input: string) => string;
 }

--- a/libraries/node-core-library/src/RealNodeModulePath.ts
+++ b/libraries/node-core-library/src/RealNodeModulePath.ts
@@ -41,7 +41,7 @@ export class RealNodeModulePathResolver {
   private readonly _fs: Required<NonNullable<IRealNodeModulePathResolverOptions['fs']>>;
   private readonly _path: Required<NonNullable<IRealNodeModulePathResolverOptions['path']>>;
 
-  public constructor(options: IRealNodeModulePathResolverOptions) {
+  public constructor(options: IRealNodeModulePathResolverOptions = {}) {
     const {
       fs: { lstatSync = nodeFs.lstatSync, readlinkSync = nodeFs.readlinkSync } = nodeFs,
       path: {
@@ -50,7 +50,7 @@ export class RealNodeModulePathResolver {
         resolve = nodePath.resolve,
         sep = nodePath.sep
       } = nodePath
-    } = options ?? {};
+    } = options;
     const cache: Map<string, string> = (this._cache = new Map());
     this._fs = {
       lstatSync,

--- a/libraries/node-core-library/src/test/RealNodeModulePath.test.ts
+++ b/libraries/node-core-library/src/test/RealNodeModulePath.test.ts
@@ -35,8 +35,8 @@ describe('realNodeModulePath', () => {
       resolver.clearCache();
     });
 
-    it('should return the input path if it does not contain node_modules', () => {
-      for (const input of ['/foo/bar', '/', 'ab', '../foo/bar/baz']) {
+    it('should return the input path if it is absolute and does not contain node_modules', () => {
+      for (const input of ['/foo/bar', '/']) {
         expect(realNodeModulePath(input)).toBe(input);
 
         expect(mocklstatSync).not.toHaveBeenCalled();
@@ -48,6 +48,16 @@ describe('realNodeModulePath', () => {
       mocklstatSync.mockReturnValueOnce({ isSymbolicLink: () => false } as unknown as fs.Stats);
 
       expect(realNodeModulePath('/foo/node_modules/foo')).toBe('/foo/node_modules/foo');
+
+      expect(mocklstatSync).toHaveBeenCalledWith('/foo/node_modules/foo');
+      expect(mocklstatSync).toHaveBeenCalledTimes(1);
+      expect(mockReadlinkSync).toHaveBeenCalledTimes(0);
+    });
+
+    it('should trim a trailing slash from the input path if it is not a symbolic link', () => {
+      mocklstatSync.mockReturnValueOnce({ isSymbolicLink: () => false } as unknown as fs.Stats);
+
+      expect(realNodeModulePath('/foo/node_modules/foo/')).toBe('/foo/node_modules/foo');
 
       expect(mocklstatSync).toHaveBeenCalledWith('/foo/node_modules/foo');
       expect(mocklstatSync).toHaveBeenCalledTimes(1);
@@ -66,12 +76,25 @@ describe('realNodeModulePath', () => {
       expect(mockReadlinkSync).toHaveBeenCalledTimes(1);
     });
 
+    it('Should trim trailing slash from absolute link targets', () => {
+      mocklstatSync.mockReturnValueOnce({ isSymbolicLink: () => true } as unknown as fs.Stats);
+      mockReadlinkSync.mockReturnValueOnce('/link/target/');
+
+      expect(realNodeModulePath('/foo/node_modules/link/bar')).toBe('/link/target/bar');
+
+      expect(mocklstatSync).toHaveBeenCalledWith('/foo/node_modules/link');
+      expect(mocklstatSync).toHaveBeenCalledTimes(1);
+      expect(mockReadlinkSync).toHaveBeenCalledWith('/foo/node_modules/link', 'utf8');
+      expect(mockReadlinkSync).toHaveBeenCalledTimes(1);
+    });
+
     it('Caches resolved symlinks', () => {
       mocklstatSync.mockReturnValueOnce({ isSymbolicLink: () => true } as unknown as fs.Stats);
       mockReadlinkSync.mockReturnValueOnce('/link/target');
 
       expect(realNodeModulePath('/foo/node_modules/link')).toBe('/link/target');
       expect(realNodeModulePath('/foo/node_modules/link/bar')).toBe('/link/target/bar');
+      expect(realNodeModulePath('/foo/node_modules/link/')).toBe('/link/target');
 
       expect(mocklstatSync).toHaveBeenCalledWith('/foo/node_modules/link');
       expect(mocklstatSync).toHaveBeenCalledTimes(1);
@@ -155,8 +178,8 @@ describe('realNodeModulePath', () => {
       resolver.clearCache();
     });
 
-    it('should return the input path if it does not contain node_modules', () => {
-      for (const input of ['C:\\foo\\bar', 'C:\\', 'ab', '..\\foo\\bar\\baz']) {
+    it('should return the input path if it is absolute and does not contain node_modules', () => {
+      for (const input of ['C:\\foo\\bar', 'C:\\']) {
         mocklstatSync.mockReturnValueOnce({ isSymbolicLink: () => true } as unknown as fs.Stats);
 
         expect(realNodeModulePath(input)).toBe(input);
@@ -166,8 +189,8 @@ describe('realNodeModulePath', () => {
       }
     });
 
-    it('should return the normalized input path if it does not contain node_modules', () => {
-      for (const input of ['C:/foo/bar', 'C:/', 'ab', '../foo/bar/baz']) {
+    it('should return the normalized input path if it is absolute and does not contain node_modules', () => {
+      for (const input of ['C:/foo/bar', 'C:/']) {
         mocklstatSync.mockReturnValueOnce({ isSymbolicLink: () => true } as unknown as fs.Stats);
 
         expect(realNodeModulePath(input)).toBe(path.win32.normalize(input));
@@ -187,11 +210,33 @@ describe('realNodeModulePath', () => {
       expect(mockReadlinkSync).toHaveBeenCalledTimes(0);
     });
 
+    it('Should trim a trailing path separator if the target is not a symbolic link', () => {
+      mocklstatSync.mockReturnValueOnce({ isSymbolicLink: () => false } as unknown as fs.Stats);
+
+      expect(realNodeModulePath('C:\\foo\\node_modules\\foo\\')).toBe('C:\\foo\\node_modules\\foo');
+
+      expect(mocklstatSync).toHaveBeenCalledWith('C:\\foo\\node_modules\\foo');
+      expect(mocklstatSync).toHaveBeenCalledTimes(1);
+      expect(mockReadlinkSync).toHaveBeenCalledTimes(0);
+    });
+
     it('Should handle absolute link targets', () => {
       mocklstatSync.mockReturnValueOnce({ isSymbolicLink: () => true } as unknown as fs.Stats);
       mockReadlinkSync.mockReturnValueOnce('C:\\link\\target');
 
-      expect(realNodeModulePath('C:\\foo\\node_modules\\link')).toBe('C:\\link\\target');
+      expect(realNodeModulePath('C:\\foo\\node_modules\\link\\relative')).toBe('C:\\link\\target\\relative');
+
+      expect(mocklstatSync).toHaveBeenCalledWith('C:\\foo\\node_modules\\link');
+      expect(mocklstatSync).toHaveBeenCalledTimes(1);
+      expect(mockReadlinkSync).toHaveBeenCalledWith('C:\\foo\\node_modules\\link', 'utf8');
+      expect(mockReadlinkSync).toHaveBeenCalledTimes(1);
+    });
+
+    it('Should trim a trailing path separator from an absolute link target', () => {
+      mocklstatSync.mockReturnValueOnce({ isSymbolicLink: () => true } as unknown as fs.Stats);
+      mockReadlinkSync.mockReturnValueOnce('C:\\link\\target\\');
+
+      expect(realNodeModulePath('C:\\foo\\node_modules\\link\\relative')).toBe('C:\\link\\target\\relative');
 
       expect(mocklstatSync).toHaveBeenCalledWith('C:\\foo\\node_modules\\link');
       expect(mocklstatSync).toHaveBeenCalledTimes(1);

--- a/libraries/node-core-library/src/test/RealNodeModulePath.test.ts
+++ b/libraries/node-core-library/src/test/RealNodeModulePath.test.ts
@@ -194,11 +194,11 @@ describe('realNodeModulePath', () => {
       expect(mockReadlinkSync).not.toHaveBeenCalled();
     });
 
-    it('should return the normalized input path if it is absolute and does not contain node_modules', () => {
-      for (const input of ['C:/foo/bar', 'C:/']) {
+    it('should return the resolved input path if it is absolute and does not contain node_modules', () => {
+      for (const input of ['C:/foo/bar', 'C:/', 'ab', '../b/c/d']) {
         mocklstatSync.mockReturnValueOnce({ isSymbolicLink: () => true } as unknown as fs.Stats);
 
-        expect(realNodeModulePath(input)).toBe(path.win32.normalize(input));
+        expect(realNodeModulePath(input)).toBe(path.win32.resolve(input));
 
         expect(mocklstatSync).not.toHaveBeenCalled();
         expect(mockReadlinkSync).not.toHaveBeenCalled();

--- a/libraries/node-core-library/src/test/RealNodeModulePath.test.ts
+++ b/libraries/node-core-library/src/test/RealNodeModulePath.test.ts
@@ -180,13 +180,18 @@ describe('realNodeModulePath', () => {
 
     it('should return the input path if it is absolute and does not contain node_modules', () => {
       for (const input of ['C:\\foo\\bar', 'C:\\']) {
-        mocklstatSync.mockReturnValueOnce({ isSymbolicLink: () => true } as unknown as fs.Stats);
-
         expect(realNodeModulePath(input)).toBe(input);
 
         expect(mocklstatSync).not.toHaveBeenCalled();
         expect(mockReadlinkSync).not.toHaveBeenCalled();
       }
+    });
+
+    it('should trim extra trailing separators from the root', () => {
+      expect(realNodeModulePath('C:////')).toBe('C:\\');
+
+      expect(mocklstatSync).not.toHaveBeenCalled();
+      expect(mockReadlinkSync).not.toHaveBeenCalled();
     });
 
     it('should return the normalized input path if it is absolute and does not contain node_modules', () => {


### PR DESCRIPTION
## Summary
Updates `RealNodeModulePath` to match the behavior of `fs.realpathSync.native` with respect to relative paths and trailing slashes.

## Details
Relative paths go through `path.resolve`, which will join them with the current working directory.
If the path has one or more trailing path separators, they will be removed, unless the path is a root, at which point it will be normalized to one trailing path separator.

Switched to using `path.join` to ensure that empty path segments get pruned.

This will somewhat slow the performance, since `path.parse` and `path.format` are a bit more work that previous API calls, but it will produce correct results on Windows when link targets are absolute paths with trailing path separators.

## How it was tested
Additional unit tests.

## Impacted documentation
None. Semantics of `fs.realpathSync.native` are matched, as is the purpose of the API.
