### PR TITLE
[rush] Treat disabled noops as noop instead of skipped

### DIFF
--- a/common/changes/@microsoft/rush/main_2024-12-13-20-32.json
+++ b/common/changes/@microsoft/rush/main_2024-12-13-20-32.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "When a no-op operation is not in scope, reflect its result as no-op instead of skipped, so that downstream operations can still write to the build cache.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
@@ -313,7 +313,12 @@ export class OperationExecutionRecord implements IOperationRunnerContext, IOpera
         this.status = earlyReturnStatus;
       } else {
         // If the operation is disabled, skip the runner and directly mark as Skipped.
-        this.status = this.operation.enabled ? await this.runner.executeAsync(this) : OperationStatus.Skipped;
+        // However, if the operation is a NoOp, return NoOp so that cache entries can still be written.
+        this.status = this.operation.enabled
+          ? await this.runner.executeAsync(this)
+          : this.runner.isNoOp
+            ? OperationStatus.NoOp
+            : OperationStatus.Skipped;
       }
       // Delegate global state reporting
       await onResult(this);


### PR DESCRIPTION
## Summary
Ensure that noops don't block cache writing, even if they are disabled.

## Details
During phased command execution, if a disabled operation is identified as a No-Op, return `OperationStatus.NoOp` instead of `OperationStatus.Skipped`, since by definition a No-Op should not write any files.

## How it was tested
Fiddled with command-line.json so that `@rushstack/eslint-patch` would depend on a noop in `@rushstack/tree-pattern`, then ran `rush build -o eslint-patch --verbose` and verified that it wrote a cache entry.

## Impacted documentation
None, since this is expected.