### PR TITLE
[rush] Fix build cache ids when "enableSubpathScan" is enabled

### DIFF
--- a/common/changes/@microsoft/rush/git-filter-fixes_2024-12-14-00-09.json
+++ b/common/changes/@microsoft/rush/git-filter-fixes_2024-12-14-00-09.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix an issue with the `enableSubpathScan` experiment where the set of returned hashes would result in incorrect build cache identifiers when using `--only`.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
+++ b/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
@@ -556,7 +556,12 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
 
     const analyzer: ProjectChangeAnalyzer = new ProjectChangeAnalyzer(this.rushConfiguration);
     const getInputsSnapshotAsync: GetInputsSnapshotAsyncFn | undefined =
-      await analyzer._tryGetSnapshotProviderAsync(projectConfigurations, terminal, projectSelection);
+      await analyzer._tryGetSnapshotProviderAsync(
+        projectConfigurations,
+        terminal,
+        // We need to include all dependencies, otherwise build cache id calculation will be incorrect
+        Selection.expandAllDependencies(projectSelection)
+      );
     const initialSnapshot: IInputsSnapshot | undefined = await getInputsSnapshotAsync?.();
 
     repoStateStopwatch.stop();

--- a/libraries/rush-lib/src/logic/ProjectChangeAnalyzer.ts
+++ b/libraries/rush-lib/src/logic/ProjectChangeAnalyzer.ts
@@ -296,9 +296,10 @@ export class ProjectChangeAnalyzer {
 
       if (
         projectSelection &&
+        projectSelection.size > 0 &&
         this._rushConfiguration.experimentsConfiguration.configuration.enableSubpathScan
       ) {
-        filterPath = Array.from(projectSelection).map(({ projectFolder }) => projectFolder);
+        filterPath = Array.from(projectSelection, ({ projectFolder }) => projectFolder);
       }
 
       return async function tryGetSnapshotAsync(): Promise<IInputsSnapshot | undefined> {


### PR DESCRIPTION
## Summary
Fixes an issue with the "enableSubpathScan" experiment where the `--only` and `--impacted-by` selection operators would compute incorrect build cache ids and therefore cause cache misses.

## Details
Computation of build cache ids always requires the file hashes of all dependencies of selected projects, because the cache id is a function of the cache ids of the operation dependencies (approximately).

## How it was tested
Enabled the experiment and verified that running `rush build -o worker-pool --verbose` was a cache hit.
For comparison, reverted this change and did the same and verified a cache miss.

## Impacted documentation
Since the experiment description doesn't specify exactly what filtering is applied, none.