### PR TITLE
Enhance LookupByPath, Fix win32 paths in webpack-workspace-resolve-plugin

### DIFF
--- a/common/changes/@rushstack/lookup-by-path/lookup-enhancements_2024-12-17-22-37.json
+++ b/common/changes/@rushstack/lookup-by-path/lookup-enhancements_2024-12-17-22-37.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@rushstack/lookup-by-path",
-      "comment": "Update all methods to accept optional override delimiters. Add `size`, `entries(), `get()`, `has()`, `removeItem()`. Make class iterable.\nExplicitly exclude `undefined` from the allowed types for the type parameter `TItem`.",
+      "comment": "Update all methods to accept optional override delimiters. Add `size`, `entries(), `get()`, `has()`, `removeItem()`. Make class iterable.\nExplicitly exclude `undefined` and `null` from the allowed types for the type parameter `TItem`.",
       "type": "minor"
     }
   ],

--- a/common/changes/@rushstack/lookup-by-path/lookup-enhancements_2024-12-17-22-37.json
+++ b/common/changes/@rushstack/lookup-by-path/lookup-enhancements_2024-12-17-22-37.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@rushstack/lookup-by-path",
-      "comment": "Update all methods to accept optional override delimiters. Add `size`, `entries(), `get()`, and `has()`. Make class iterable.",
+      "comment": "Update all methods to accept optional override delimiters. Add `size`, `entries(), `get()`, `has()`, `removeItem()`. Make class iterable.\nExplicitly exclude `undefined` from the allowed types for the type parameter `TItem`.",
       "type": "minor"
     }
   ],

--- a/common/changes/@rushstack/lookup-by-path/lookup-enhancements_2024-12-17-22-37.json
+++ b/common/changes/@rushstack/lookup-by-path/lookup-enhancements_2024-12-17-22-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/lookup-by-path",
+      "comment": "Update all methods to accept optional override delimiters. Add `size`, `entries(), `get()`, and `has()`. Make class iterable.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/lookup-by-path"
+}

--- a/common/changes/@rushstack/webpack-workspace-resolve-plugin/lookup-enhancements_2024-12-17-22-42.json
+++ b/common/changes/@rushstack/webpack-workspace-resolve-plugin/lookup-enhancements_2024-12-17-22-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/webpack-workspace-resolve-plugin",
+      "comment": "Fix a bug with path handling on Windows. Tap hooks earlier to ensure that these plugins run before builtin behavior.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/webpack-workspace-resolve-plugin"
+}

--- a/common/reviews/api/lookup-by-path.api.md
+++ b/common/reviews/api/lookup-by-path.api.md
@@ -5,14 +5,14 @@
 ```ts
 
 // @beta
-export interface IPrefixMatch<TItem> {
+export interface IPrefixMatch<TItem extends {} | null> {
     index: number;
     lastMatch?: IPrefixMatch<TItem>;
     value: TItem;
 }
 
 // @beta
-export interface IReadonlyLookupByPath<TItem> extends Iterable<[string, TItem]> {
+export interface IReadonlyLookupByPath<TItem extends {} | null> extends Iterable<[string, TItem]> {
     [Symbol.iterator](query?: string, delimiter?: string): IterableIterator<[string, TItem]>;
     entries(query?: string, delimiter?: string): IterableIterator<[string, TItem]>;
     findChildPath(childPath: string, delimiter?: string): TItem | undefined;
@@ -25,10 +25,11 @@ export interface IReadonlyLookupByPath<TItem> extends Iterable<[string, TItem]> 
 }
 
 // @beta
-export class LookupByPath<TItem> implements IReadonlyLookupByPath<TItem> {
+export class LookupByPath<TItem extends {} | null> implements IReadonlyLookupByPath<TItem> {
     [Symbol.iterator](query?: string, delimiter?: string): IterableIterator<[string, TItem]>;
     constructor(entries?: Iterable<[string, TItem]>, delimiter?: string);
     clear(): this;
+    deleteItem(query: string, delimeter?: string): boolean;
     readonly delimiter: string;
     entries(query?: string, delimiter?: string): IterableIterator<[string, TItem]>;
     findChildPath(childPath: string, delimiter?: string): TItem | undefined;

--- a/common/reviews/api/lookup-by-path.api.md
+++ b/common/reviews/api/lookup-by-path.api.md
@@ -12,24 +12,35 @@ export interface IPrefixMatch<TItem> {
 }
 
 // @beta
-export interface IReadonlyLookupByPath<TItem> {
-    findChildPath(childPath: string): TItem | undefined;
+export interface IReadonlyLookupByPath<TItem> extends Iterable<[string, TItem]> {
+    [Symbol.iterator](query?: string, delimiter?: string): IterableIterator<[string, TItem]>;
+    entries(query?: string, delimiter?: string): IterableIterator<[string, TItem]>;
+    findChildPath(childPath: string, delimiter?: string): TItem | undefined;
     findChildPathFromSegments(childPathSegments: Iterable<string>): TItem | undefined;
-    findLongestPrefixMatch(query: string): IPrefixMatch<TItem> | undefined;
-    groupByChild<TInfo>(infoByPath: Map<string, TInfo>): Map<TItem, Map<string, TInfo>>;
+    findLongestPrefixMatch(query: string, delimiter?: string): IPrefixMatch<TItem> | undefined;
+    get(query: string, delimiter?: string): TItem | undefined;
+    groupByChild<TInfo>(infoByPath: Map<string, TInfo>, delimiter?: string): Map<TItem, Map<string, TInfo>>;
+    has(query: string, delimiter?: string): boolean;
+    get size(): number;
 }
 
 // @beta
 export class LookupByPath<TItem> implements IReadonlyLookupByPath<TItem> {
+    [Symbol.iterator](query?: string, delimiter?: string): IterableIterator<[string, TItem]>;
     constructor(entries?: Iterable<[string, TItem]>, delimiter?: string);
+    clear(): this;
     readonly delimiter: string;
-    findChildPath(childPath: string): TItem | undefined;
+    entries(query?: string, delimiter?: string): IterableIterator<[string, TItem]>;
+    findChildPath(childPath: string, delimiter?: string): TItem | undefined;
     findChildPathFromSegments(childPathSegments: Iterable<string>): TItem | undefined;
-    findLongestPrefixMatch(query: string): IPrefixMatch<TItem> | undefined;
-    groupByChild<TInfo>(infoByPath: Map<string, TInfo>): Map<TItem, Map<string, TInfo>>;
+    findLongestPrefixMatch(query: string, delimiter?: string): IPrefixMatch<TItem> | undefined;
+    get(key: string, delimiter?: string): TItem | undefined;
+    groupByChild<TInfo>(infoByPath: Map<string, TInfo>, delimiter?: string): Map<TItem, Map<string, TInfo>>;
+    has(key: string, delimiter?: string): boolean;
     static iteratePathSegments(serializedPath: string, delimiter?: string): Iterable<string>;
-    setItem(serializedPath: string, value: TItem): this;
+    setItem(serializedPath: string, value: TItem, delimiter?: string): this;
     setItemFromSegments(pathSegments: Iterable<string>, value: TItem): this;
+    get size(): number;
 }
 
 ```

--- a/common/reviews/api/lookup-by-path.api.md
+++ b/common/reviews/api/lookup-by-path.api.md
@@ -5,14 +5,14 @@
 ```ts
 
 // @beta
-export interface IPrefixMatch<TItem extends {} | null> {
+export interface IPrefixMatch<TItem extends {}> {
     index: number;
     lastMatch?: IPrefixMatch<TItem>;
     value: TItem;
 }
 
 // @beta
-export interface IReadonlyLookupByPath<TItem extends {} | null> extends Iterable<[string, TItem]> {
+export interface IReadonlyLookupByPath<TItem extends {}> extends Iterable<[string, TItem]> {
     [Symbol.iterator](query?: string, delimiter?: string): IterableIterator<[string, TItem]>;
     entries(query?: string, delimiter?: string): IterableIterator<[string, TItem]>;
     findChildPath(childPath: string, delimiter?: string): TItem | undefined;
@@ -25,7 +25,7 @@ export interface IReadonlyLookupByPath<TItem extends {} | null> extends Iterable
 }
 
 // @beta
-export class LookupByPath<TItem extends {} | null> implements IReadonlyLookupByPath<TItem> {
+export class LookupByPath<TItem extends {}> implements IReadonlyLookupByPath<TItem> {
     [Symbol.iterator](query?: string, delimiter?: string): IterableIterator<[string, TItem]>;
     constructor(entries?: Iterable<[string, TItem]>, delimiter?: string);
     clear(): this;

--- a/libraries/lookup-by-path/src/LookupByPath.ts
+++ b/libraries/lookup-by-path/src/LookupByPath.ts
@@ -4,7 +4,7 @@
 /**
  * A node in the path trie used in LookupByPath
  */
-interface IPathTrieNode<TItem> {
+interface IPathTrieNode<TItem extends {} | null> {
   /**
    * The value that exactly matches the current relative path
    */
@@ -31,7 +31,7 @@ interface IPrefixEntry {
  *
  * @beta
  */
-export interface IPrefixMatch<TItem> {
+export interface IPrefixMatch<TItem extends {} | null> {
   /**
    * The item that matched the prefix
    */
@@ -51,7 +51,7 @@ export interface IPrefixMatch<TItem> {
  *
  * @beta
  */
-export interface IReadonlyLookupByPath<TItem> extends Iterable<[string, TItem]> {
+export interface IReadonlyLookupByPath<TItem extends {} | null> extends Iterable<[string, TItem]> {
   /**
    * Searches for the item associated with `childPath`, or the nearest ancestor of that path that
    * has an associated item.
@@ -178,7 +178,7 @@ export interface IReadonlyLookupByPath<TItem> extends Iterable<[string, TItem]> 
  * ```
  * @beta
  */
-export class LookupByPath<TItem> implements IReadonlyLookupByPath<TItem> {
+export class LookupByPath<TItem extends {} | null> implements IReadonlyLookupByPath<TItem> {
   /**
    * The delimiter used to split paths
    */
@@ -282,6 +282,25 @@ export class LookupByPath<TItem> implements IReadonlyLookupByPath<TItem> {
    */
   public setItem(serializedPath: string, value: TItem, delimiter: string = this.delimiter): this {
     return this.setItemFromSegments(LookupByPath.iteratePathSegments(serializedPath, delimiter), value);
+  }
+
+  /**
+   * Deletes an item if it exists.
+   * @param query - The path to the item to delete
+   * @param delimeter - Optional override delimeter for parsing the query
+   * @returns `true` if the item was found and deleted, `false` otherwise
+   * @remarks
+   * If the node has children with values, they will be retained.
+   */
+  public deleteItem(query: string, delimeter: string = this.delimiter): boolean {
+    const node: IPathTrieNode<TItem> | undefined = this._findNodeAtPrefix(query, delimeter);
+    if (node?.value !== undefined) {
+      node.value = undefined;
+      this._size--;
+      return true;
+    }
+
+    return false;
   }
 
   /**

--- a/libraries/lookup-by-path/src/LookupByPath.ts
+++ b/libraries/lookup-by-path/src/LookupByPath.ts
@@ -4,7 +4,7 @@
 /**
  * A node in the path trie used in LookupByPath
  */
-interface IPathTrieNode<TItem extends {} | null> {
+interface IPathTrieNode<TItem extends {}> {
   /**
    * The value that exactly matches the current relative path
    */
@@ -31,7 +31,7 @@ interface IPrefixEntry {
  *
  * @beta
  */
-export interface IPrefixMatch<TItem extends {} | null> {
+export interface IPrefixMatch<TItem extends {}> {
   /**
    * The item that matched the prefix
    */
@@ -51,7 +51,7 @@ export interface IPrefixMatch<TItem extends {} | null> {
  *
  * @beta
  */
-export interface IReadonlyLookupByPath<TItem extends {} | null> extends Iterable<[string, TItem]> {
+export interface IReadonlyLookupByPath<TItem extends {}> extends Iterable<[string, TItem]> {
   /**
    * Searches for the item associated with `childPath`, or the nearest ancestor of that path that
    * has an associated item.
@@ -178,7 +178,7 @@ export interface IReadonlyLookupByPath<TItem extends {} | null> extends Iterable
  * ```
  * @beta
  */
-export class LookupByPath<TItem extends {} | null> implements IReadonlyLookupByPath<TItem> {
+export class LookupByPath<TItem extends {}> implements IReadonlyLookupByPath<TItem> {
   /**
    * The delimiter used to split paths
    */

--- a/libraries/lookup-by-path/src/LookupByPath.ts
+++ b/libraries/lookup-by-path/src/LookupByPath.ts
@@ -9,6 +9,7 @@ interface IPathTrieNode<TItem extends {}> {
    * The value that exactly matches the current relative path
    */
   value: TItem | undefined;
+
   /**
    * Child nodes by subfolder
    */
@@ -20,6 +21,7 @@ interface IPrefixEntry {
    * The prefix that was matched
    */
   prefix: string;
+
   /**
    * The index of the first character after the matched prefix
    */
@@ -36,10 +38,12 @@ export interface IPrefixMatch<TItem extends {}> {
    * The item that matched the prefix
    */
   value: TItem;
+
   /**
    * The index of the first character after the matched prefix
    */
   index: number;
+
   /**
    * The last match found (with a shorter prefix), if any
    */
@@ -135,6 +139,7 @@ export interface IReadonlyLookupByPath<TItem extends {}> extends Iterable<[strin
    * ```
    */
   entries(query?: string, delimiter?: string): IterableIterator<[string, TItem]>;
+
   /**
    * Iterates over the entries in this trie.
    *
@@ -183,10 +188,12 @@ export class LookupByPath<TItem extends {}> implements IReadonlyLookupByPath<TIt
    * The delimiter used to split paths
    */
   public readonly delimiter: string;
+
   /**
    * The root node of the trie, corresponding to the path ''
    */
   private readonly _root: IPathTrieNode<TItem>;
+
   /**
    * The number of entries in this trie.
    */

--- a/libraries/lookup-by-path/src/test/LookupByPath.test.ts
+++ b/libraries/lookup-by-path/src/test/LookupByPath.test.ts
@@ -284,6 +284,81 @@ describe(LookupByPath.prototype.entries.name, () => {
   });
 });
 
+describe(LookupByPath.prototype.deleteItem.name, () => {
+  it('returns false for an empty tree', () => {
+    expect(new LookupByPath().deleteItem('foo')).toEqual(false);
+  });
+
+  it('deletes the matching node in a trivial tree', () => {
+    const tree = new LookupByPath([['foo', 1]]);
+    expect(tree.deleteItem('foo')).toEqual(true);
+    expect(tree.size).toEqual(0);
+    expect(tree.get('foo')).toEqual(undefined);
+  });
+
+  it('returns false for non-matching paths in a single-layer tree', () => {
+    const tree: LookupByPath<number> = new LookupByPath([
+      ['foo', 1],
+      ['bar', 2],
+      ['baz', 3]
+    ]);
+
+    expect(tree.deleteItem('buzz')).toEqual(false);
+    expect(tree.size).toEqual(3);
+  });
+
+  it('deletes the matching node in a single-layer tree', () => {
+    const tree: LookupByPath<number> = new LookupByPath([
+      ['foo', 1],
+      ['bar', 2],
+      ['baz', 3]
+    ]);
+
+    expect(tree.deleteItem('bar')).toEqual(true);
+    expect(tree.size).toEqual(2);
+    expect(tree.get('bar')).toEqual(undefined);
+  });
+
+  it('deletes the matching node in a multi-layer tree', () => {
+    const tree: LookupByPath<number> = new LookupByPath([
+      ['foo', 1],
+      ['foo/bar', 2],
+      ['foo/bar/baz', 3]
+    ]);
+
+    expect(tree.deleteItem('foo/bar')).toEqual(true);
+    expect(tree.size).toEqual(2);
+    expect(tree.get('foo/bar')).toEqual(undefined);
+    expect(tree.get('foo/bar/baz')).toEqual(3); // child nodes are retained
+  });
+
+  it('returns false for non-matching paths in a multi-layer tree', () => {
+    const tree: LookupByPath<number> = new LookupByPath([
+      ['foo', 1],
+      ['foo/bar', 2],
+      ['foo/bar/baz', 3]
+    ]);
+
+    expect(tree.deleteItem('foo/baz')).toEqual(false);
+    expect(tree.size).toEqual(3);
+  });
+
+  it('handles custom delimiters', () => {
+    const tree: LookupByPath<number> = new LookupByPath(
+      [
+        ['foo,bar', 1],
+        ['foo,bar,baz', 2]
+      ],
+      ','
+    );
+
+    expect(tree.deleteItem('foo\0bar', '\0')).toEqual(true);
+    expect(tree.size).toEqual(1);
+    expect(tree.get('foo\0bar', '\0')).toEqual(undefined);
+    expect(tree.get('foo\0bar\0baz', '\0')).toEqual(2); // child nodes are retained
+  });
+});
+
 describe(LookupByPath.prototype.findChildPath.name, () => {
   it('returns empty for an empty tree', () => {
     expect(new LookupByPath().findChildPath('foo')).toEqual(undefined);

--- a/libraries/lookup-by-path/src/test/LookupByPath.test.ts
+++ b/libraries/lookup-by-path/src/test/LookupByPath.test.ts
@@ -26,6 +26,264 @@ describe(LookupByPath.iteratePathSegments.name, () => {
   });
 });
 
+describe('size', () => {
+  it('returns 0 for an empty tree', () => {
+    expect(new LookupByPath().size).toEqual(0);
+  });
+
+  it('returns the number of nodes for a non-empty tree', () => {
+    const lookup: LookupByPath<number> = new LookupByPath([['foo', 1]]);
+    expect(lookup.size).toEqual(1);
+    lookup.setItem('bar', 2);
+    expect(lookup.size).toEqual(2);
+    lookup.setItem('bar', 4);
+    expect(lookup.size).toEqual(2);
+    lookup.setItem('bar/baz', 1);
+    expect(lookup.size).toEqual(3);
+    lookup.setItem('foo/bar/qux/quux', 1);
+    expect(lookup.size).toEqual(4);
+  });
+});
+
+describe(LookupByPath.prototype.get.name, () => {
+  it('returns undefined for an empty tree', () => {
+    expect(new LookupByPath().get('foo')).toEqual(undefined);
+  });
+
+  it('returns the matching node for a trivial tree', () => {
+    expect(new LookupByPath([['foo', 1]]).get('foo')).toEqual(1);
+  });
+
+  it('returns undefined for non-matching paths in a single-layer tree', () => {
+    const tree: LookupByPath<number> = new LookupByPath([
+      ['foo', 1],
+      ['bar', 2],
+      ['baz', 3]
+    ]);
+
+    expect(tree.get('buzz')).toEqual(undefined);
+    expect(tree.get('foo/bar')).toEqual(undefined);
+  });
+
+  it('returns the matching node for a multi-layer tree', () => {
+    const tree: LookupByPath<number> = new LookupByPath([
+      ['foo', 1],
+      ['foo/bar', 2],
+      ['foo/bar/baz', 3]
+    ]);
+
+    expect(tree.get('foo')).toEqual(1);
+    expect(tree.get('foo/bar')).toEqual(2);
+    expect(tree.get('foo/bar/baz')).toEqual(3);
+
+    expect(tree.get('foo')).toEqual(1);
+    expect(tree.get('foo,bar', ',')).toEqual(2);
+    expect(tree.get('foo\0bar\0baz', '\0')).toEqual(3);
+  });
+
+  it('returns undefined for non-matching paths in a multi-layer tree', () => {
+    const tree: LookupByPath<number> = new LookupByPath([
+      ['foo', 1],
+      ['foo/bar', 2],
+      ['foo/bar/baz', 3]
+    ]);
+
+    expect(tree.get('foo/baz')).toEqual(undefined);
+    expect(tree.get('foo/bar/baz/qux')).toEqual(undefined);
+  });
+});
+
+describe(LookupByPath.prototype.has.name, () => {
+  it('returns false for an empty tree', () => {
+    expect(new LookupByPath().has('foo')).toEqual(false);
+  });
+
+  it('returns true for the matching node in a trivial tree', () => {
+    expect(new LookupByPath([['foo', 1]]).has('foo')).toEqual(true);
+  });
+
+  it('returns false for non-matching paths in a single-layer tree', () => {
+    const tree: LookupByPath<number> = new LookupByPath([
+      ['foo', 1],
+      ['bar', 2],
+      ['baz', 3]
+    ]);
+
+    expect(tree.has('buzz')).toEqual(false);
+    expect(tree.has('foo/bar')).toEqual(false);
+  });
+
+  it('returns true for the matching node in a multi-layer tree', () => {
+    const tree: LookupByPath<number> = new LookupByPath([
+      ['foo', 1],
+      ['foo/bar', 2],
+      ['foo/bar/baz', 3]
+    ]);
+
+    expect(tree.has('foo')).toEqual(true);
+    expect(tree.has('foo/bar')).toEqual(true);
+    expect(tree.has('foo/bar/baz')).toEqual(true);
+
+    expect(tree.has('foo')).toEqual(true);
+    expect(tree.has('foo,bar', ',')).toEqual(true);
+    expect(tree.has('foo\0bar\0baz', '\0')).toEqual(true);
+  });
+
+  it('returns false for non-matching paths in a multi-layer tree', () => {
+    const tree: LookupByPath<number> = new LookupByPath([
+      ['foo', 1],
+      ['foo/bar', 2],
+      ['foo/bar/baz', 3]
+    ]);
+
+    expect(tree.has('foo/baz')).toEqual(false);
+    expect(tree.has('foo/bar/baz/qux')).toEqual(false);
+  });
+});
+
+describe(LookupByPath.prototype.clear.name, () => {
+  it('clears an empty tree', () => {
+    const tree = new LookupByPath();
+    tree.clear();
+    expect(tree.size).toEqual(0);
+  });
+
+  it('clears a single-layer tree', () => {
+    const tree = new LookupByPath([['foo', 1]]);
+    expect(tree.size).toEqual(1);
+    tree.clear();
+    expect(tree.size).toEqual(0);
+  });
+
+  it('clears a multi-layer tree', () => {
+    const tree = new LookupByPath([
+      ['foo', 1],
+      ['foo/bar', 2],
+      ['foo/bar/baz', 3]
+    ]);
+    expect(tree.size).toEqual(3);
+    tree.clear();
+    expect(tree.size).toEqual(0);
+  });
+
+  it('clears a tree with custom delimiters', () => {
+    const tree = new LookupByPath(
+      [
+        ['foo,bar', 1],
+        ['foo,bar,baz', 2]
+      ],
+      ','
+    );
+    expect(tree.size).toEqual(2);
+    tree.clear();
+    expect(tree.size).toEqual(0);
+  });
+});
+
+describe(LookupByPath.prototype.entries.name, () => {
+  it('returns an empty iterator for an empty tree', () => {
+    const tree = new LookupByPath();
+    const result = [...tree];
+    expect(result).toEqual([]);
+  });
+
+  it('returns an iterator for a single-layer tree', () => {
+    const tree: LookupByPath<number> = new LookupByPath([
+      ['foo', 1],
+      ['bar', 2],
+      ['baz', 3]
+    ]);
+
+    const result = [...tree];
+    expect(result.length).toEqual(tree.size);
+    expect(Object.fromEntries(result)).toEqual({
+      foo: 1,
+      bar: 2,
+      baz: 3
+    });
+  });
+
+  it('returns an iterator for a multi-layer tree', () => {
+    const tree: LookupByPath<number> = new LookupByPath([
+      ['foo', 1],
+      ['foo/bar', 2],
+      ['foo/bar/baz', 3]
+    ]);
+
+    const result = [...tree];
+    expect(result.length).toEqual(tree.size);
+    expect(Object.fromEntries(result)).toEqual({
+      foo: 1,
+      'foo/bar': 2,
+      'foo/bar/baz': 3
+    });
+  });
+
+  it('only includes non-empty nodes', () => {
+    const tree: LookupByPath<number> = new LookupByPath([
+      ['foo/bar/baz', 1],
+      ['foo/bar/baz/qux/quux', 2]
+    ]);
+
+    const result = [...tree];
+    expect(result.length).toEqual(tree.size);
+    expect(Object.fromEntries(result)).toEqual({
+      'foo/bar/baz': 1,
+      'foo/bar/baz/qux/quux': 2
+    });
+  });
+
+  it('returns an iterator for a tree with custom delimiters', () => {
+    const tree: LookupByPath<number> = new LookupByPath(
+      [
+        ['foo,bar', 1],
+        ['foo,bar,baz', 2]
+      ],
+      ','
+    );
+
+    const result = [...tree];
+    expect(result.length).toEqual(tree.size);
+    expect(Object.fromEntries(result)).toEqual({
+      'foo,bar': 1,
+      'foo,bar,baz': 2
+    });
+  });
+
+  it('returns an iterator for a subtree', () => {
+    const tree: LookupByPath<number> = new LookupByPath([
+      ['foo', 1],
+      ['foo/bar', 2],
+      ['foo/bar/baz', 3],
+      ['bar', 4],
+      ['bar/baz', 5]
+    ]);
+
+    const result = [...tree.entries('foo')];
+    expect(result.length).toEqual(3);
+    expect(Object.fromEntries(result)).toEqual({
+      foo: 1,
+      'foo/bar': 2,
+      'foo/bar/baz': 3
+    });
+  });
+
+  it('returns an iterator for a subtree with custom delimiters', () => {
+    const tree: LookupByPath<number> = new LookupByPath([
+      ['foo/bar', 1],
+      ['foo/bar/baz', 2],
+      ['bar/baz', 3]
+    ]);
+
+    const result = [...tree.entries('foo', ',')];
+    expect(result.length).toEqual(2);
+    expect(Object.fromEntries(result)).toEqual({
+      'foo,bar': 1,
+      'foo,bar,baz': 2
+    });
+  });
+});
+
 describe(LookupByPath.prototype.findChildPath.name, () => {
   it('returns empty for an empty tree', () => {
     expect(new LookupByPath().findChildPath('foo')).toEqual(undefined);
@@ -101,6 +359,8 @@ describe(LookupByPath.prototype.findChildPath.name, () => {
     );
 
     expect(tree.findChildPath('foo/bar,baz')).toEqual(2);
+    expect(tree.findChildPath('foo,bar,baz', ',')).toEqual(1);
+    expect(tree.findChildPath('foo\0bar\0baz', '\0')).toEqual(1);
     expect(tree.findChildPath('foo,bar/baz')).toEqual(undefined);
     expect(tree.findChildPathFromSegments(['foo', 'bar', 'baz'])).toEqual(1);
   });
@@ -178,6 +438,37 @@ describe(LookupByPath.prototype.groupByChild.name, () => {
     ]);
 
     expect(lookup.groupByChild(infoByPath)).toEqual(expected);
+  });
+
+  it('groups items by the closest group that contains the file path with custom delimiter', () => {
+    const customLookup: LookupByPath<string> = new LookupByPath(
+      [
+        ['foo,bar', 'bar'],
+        ['foo,bar,baz', 'baz']
+      ],
+      ','
+    );
+
+    const infoByPath: Map<string, string> = new Map([
+      ['foo\0bar', 'bar'],
+      ['foo\0bar\0baz', 'baz'],
+      ['foo\0bar\0baz\0qux', 'qux'],
+      ['foo\0bar\0baz\0qux\0quux', 'quux']
+    ]);
+
+    const expected: Map<string, Map<string, string>> = new Map([
+      ['bar', new Map([['foo\0bar', 'bar']])],
+      [
+        'baz',
+        new Map([
+          ['foo\0bar\0baz', 'baz'],
+          ['foo\0bar\0baz\0qux', 'qux'],
+          ['foo\0bar\0baz\0qux\0quux', 'quux']
+        ])
+      ]
+    ]);
+
+    expect(customLookup.groupByChild(infoByPath, '\0')).toEqual(expected);
   });
 
   it('ignores items that do not exist in the lookup', () => {

--- a/webpack/webpack-workspace-resolve-plugin/src/KnownPackageDependenciesPlugin.ts
+++ b/webpack/webpack-workspace-resolve-plugin/src/KnownPackageDependenciesPlugin.ts
@@ -56,7 +56,11 @@ export class KnownPackageDependenciesPlugin {
         let scope: IPrefixMatch<IResolveContext> | undefined =
           cache.contextForPackage.get(descriptionFileData);
         if (!scope) {
-          return callback(new Error(`Expected context for ${request.descriptionFileRoot}`));
+          scope = cache.contextLookup.findLongestPrefixMatch(path);
+          if (!scope) {
+            return callback(new Error(`Expected context for ${request.descriptionFileRoot}`));
+          }
+          cache.contextForPackage.set(descriptionFileData, scope);
         }
 
         let dependency: IPrefixMatch<IResolveContext> | undefined;

--- a/webpack/webpack-workspace-resolve-plugin/src/WorkspaceResolvePlugin.ts
+++ b/webpack/webpack-workspace-resolve-plugin/src/WorkspaceResolvePlugin.ts
@@ -49,17 +49,22 @@ export class WorkspaceResolvePlugin implements WebpackPluginInstance {
         resolveOptions.plugins ??= [];
         resolveOptions.plugins.push(
           // Optimize identifying the package.json file for the issuer
-          new KnownDescriptionFilePlugin(cache, 'parsed-resolve', 'described-resolve'),
+          new KnownDescriptionFilePlugin(cache, 'before-parsed-resolve', 'described-resolve'),
           // Optimize locating the installed dependencies of the current package
-          new KnownPackageDependenciesPlugin(cache, 'raw-module', 'resolve-as-module'),
+          new KnownPackageDependenciesPlugin(cache, 'before-raw-module', 'resolve-as-module'),
           // Optimize loading the package.json file for the destination package (bare specifier)
-          new KnownDescriptionFilePlugin(cache, 'resolve-as-module', 'resolve-in-package'),
+          new KnownDescriptionFilePlugin(cache, 'before-resolve-as-module', 'resolve-in-package'),
           // Optimize loading the package.json file for the destination package (relative path)
-          new KnownDescriptionFilePlugin(cache, 'relative', 'described-relative'),
+          new KnownDescriptionFilePlugin(cache, 'before-relative', 'described-relative'),
           // Optimize locating and loading nested package.json for a directory
-          new KnownDescriptionFilePlugin(cache, 'undescribed-existing-directory', 'existing-directory', true),
+          new KnownDescriptionFilePlugin(
+            cache,
+            'before-undescribed-existing-directory',
+            'existing-directory',
+            true
+          ),
           // Optimize locating and loading nested package.json for a file
-          new KnownDescriptionFilePlugin(cache, 'undescribed-raw-file', 'raw-file')
+          new KnownDescriptionFilePlugin(cache, 'before-undescribed-raw-file', 'raw-file')
         );
 
         return resolveOptions;

--- a/webpack/webpack-workspace-resolve-plugin/src/test/createResolveForTests.ts
+++ b/webpack/webpack-workspace-resolve-plugin/src/test/createResolveForTests.ts
@@ -35,7 +35,7 @@ export function createResolveForTests(
 
   const cache: WorkspaceLayoutCache = new WorkspaceLayoutCache({
     cacheData: {
-      basePath: `${separator}workspace${separator}`,
+      basePath: `/workspace/`,
       contexts: [
         {
           root: 'a',


### PR DESCRIPTION
## Summary
Adds more functionality to `@rushstack/lookup-by-path`, especially with respect to overriding the delimiter per-method.
Fixes path parsing on Windows in `@rushstack/webpack-workspace-resolve-plugin`.

## Details
Adds new methods to `LookupByPath<TItem>`:
- `isEmpty(): boolean`
- `get(query: string, delimiter?: string): TItem | undefined`
- `has(query: string, delimiter?: string): boolean`

Enhances all read/write methods with the optional `delimiter?: string` parameter to allow overriding the delimiter used to parse the input.

Since the Rush cache file contains only `/` as the directory separator, updates the parsing in `WorkspaceLayoutCache` to parse all paths using `/` as the delimiter when hydrating `LookupByPath` instances.

## How it was tested
Added unit tests.

## Impacted documentation
API documentation for `LookupByPath`.