### PR TITLE
fix: allow injected dependencies when subspaces are disabled

### DIFF
--- a/common/changes/@microsoft/rush/sennyeya-allow-injected-deps-outside-of-subspaces_2024-12-26-19-45.json
+++ b/common/changes/@microsoft/rush/sennyeya-allow-injected-deps-outside-of-subspaces_2024-12-26-19-45.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Allow injected dependencies without enabling subspaces.",
+      "type": "none",
+      "packageName": "@microsoft/rush"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "aramissennyeydd@users.noreply.github.com"
+}

--- a/libraries/rush-lib/src/logic/RepoStateFile.ts
+++ b/libraries/rush-lib/src/logic/RepoStateFile.ts
@@ -200,7 +200,7 @@ export class RepoStateFile {
       this._modified = true;
     }
 
-    if (rushConfiguration.isPnpm && rushConfiguration.subspacesFeatureEnabled) {
+    if (rushConfiguration.isPnpm) {
       const packageJsonInjectedDependenciesHash: string | undefined =
         subspace.getPackageJsonInjectedDependenciesHash(variant);
 


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->


Original question in Zulip: https://rushstack.zulipchat.com/#narrow/channel/262513-general/topic/Injected.20Dependencies.20and.20Subspaces/near/490904453

I'm trying to enable injected dependencies and was getting some confusing error messages (and a lack of `repo-state.json` changes) that indicated something wasn't updating as it should have. Looks like injected dependencies were gated at some point between subspaces and I can't see a great reason why they should be.

## Details

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

Remove check for having subspaces enabled when using injected dependencies.

## How it was tested

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

Tested in our repository that the repo-state file had changes after running `rush update` and that subsequent runs were cached.

## Impacted documentation

<!--------------------------------------------------------------------------
👉 STEP 7: Does your PR affect anything that is discussed in the website docs?
     If so, please paste the URL of each affected web page, so we will
     remember to update the documentation after your PR is merged.
     (Updating the website is appreciated but not required.)
     If no docs are impacted, delete the "Impacted documentation" section.

     If you modified a JSON schema, remember to update init templates such as:
     rush-lib/assets/rush-init/*.json
     api-extractor/src/schemas/api-extractor-template.json
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 8: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
