### PR TITLE
Fix the issue of accessing shouldEnsureConsistentVersions  method incorrectly.

### DIFF
--- a/common/changes/@microsoft/rush/bugfix-no-unnecessary-condition_2025-01-03-10-05.json
+++ b/common/changes/@microsoft/rush/bugfix-no-unnecessary-condition_2025-01-03-10-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix an issue with evaluation of `shouldEnsureConsistentVersions` when the value is not constant across subspaces or variants.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/cli/actions/VersionAction.ts
+++ b/libraries/rush-lib/src/cli/actions/VersionAction.ts
@@ -216,8 +216,8 @@ export class VersionAction extends BaseRushAction {
     // Validate result of all subspaces
     for (const subspace of rushConfig.subspaces) {
       // Respect the `ensureConsistentVersions` field in rush.json
-      if (!subspace.shouldEnsureConsistentVersions) {
-        return;
+      if (!subspace.shouldEnsureConsistentVersions(variant)) {
+        continue;
       }
 
       const mismatchFinder: VersionMismatchFinder = VersionMismatchFinder.getMismatches(rushConfig, {


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

Rush version command throws the following error where I had set ensureConsistentVersions to false in my rush repo.

```text
ERROR: Unable to finish version bump because inconsistencies were encountered. Run "rush check" to find more details.
```
<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

## Details

`shouldEnsureConsistentVersions` is a function not a variable.

https://github.com/microsoft/rushstack/blob/7aa7b9f8943359b660b5f563a8496b738b6e4f40/libraries/rush-lib/src/api/Subspace.ts#L328-L335

Therefore, the condition expression here is always true.

https://github.com/microsoft/rushstack/blob/7aa7b9f8943359b660b5f563a8496b738b6e4f40/libraries/rush-lib/src/cli/actions/VersionAction.ts#L219-L221

This issue is introduced by https://github.com/microsoft/rushstack/pull/4927


<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested

[no-unnecessary-condition](https://typescript-eslint.io/rules/no-unnecessary-condition/) may help us permanently avoid this problem.


<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

## Impacted documentation

<!--------------------------------------------------------------------------
👉 STEP 7: Does your PR affect anything that is discussed in the website docs?
     If so, please paste the URL of each affected web page, so we will
     remember to update the documentation after your PR is merged.
     (Updating the website is appreciated but not required.)
     If no docs are impacted, delete the "Impacted documentation" section.

     If you modified a JSON schema, remember to update init templates such as:
     rush-lib/assets/rush-init/*.json
     api-extractor/src/schemas/api-extractor-template.json
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 8: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
