### PR TITLE
[eslint-bulk] Fix caching during eslintrc lookup

### DIFF
--- a/common/changes/@rushstack/eslint-patch/eslint-cache-bug_2025-01-07-00-34.json
+++ b/common/changes/@rushstack/eslint-patch/eslint-cache-bug_2025-01-07-00-34.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-patch",
+      "comment": "Fix a performance issue when locating \".eslint-bulk-suppressions.json\".",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/eslint-patch"
+}

--- a/eslint/eslint-patch/src/eslint-bulk-suppressions/bulk-suppressions-patch.ts
+++ b/eslint/eslint-patch/src/eslint-bulk-suppressions/bulk-suppressions-patch.ts
@@ -110,7 +110,9 @@ function findEslintrcFolderPathForNormalizedFileAbsolutePath(normalizedFilePath:
   ) {
     const cachedEslintrcFolderPath: string | undefined = eslintrcPathByFileOrFolderPath.get(currentFolder);
     if (cachedEslintrcFolderPath) {
-      return cachedEslintrcFolderPath;
+      // Need to cache this result into the intermediate paths
+      eslintrcFolderPath = cachedEslintrcFolderPath;
+      break;
     }
 
     pathsToCache.push(currentFolder);


### PR DESCRIPTION
## Summary
Fixes an issue where a number of results of probing for `.eslintrc.cjs` and `.eslintrc.js` files weren't being cached.

## Details
In a folder structure like:
```
src/
 a/
  1/
 b/
  c/
  d/
```

Searching for the `.eslintrc.cjs` file from `a/1/` wrote cache records for `src/`, `src/a/`, and `src/a/1/`. However, a subsequent lookup in `src/b/c/` would find the cache record for `src/`, but not write cache records to `src/b/` or `src/b/c/`, resulting in duplicative searches for all subsequent files in these folders.

## How it was tested
Under fstrace to observe the disk probes.

## Impacted documentation
None. This is the expected behavior.