### PR TITLE
[node-core-library] Provide `retryCount` parameter to actions executed using `Async.runWithRetriesAsync`

### DIFF
--- a/common/changes/@rushstack/node-core-library/user-danade-AddRetryCount_2025-01-08-22-19.json
+++ b/common/changes/@rushstack/node-core-library/user-danade-AddRetryCount_2025-01-08-22-19.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/node-core-library",
+      "comment": "Provide the `retryCount` parameter to actions executed using `Async.runWithRetriesAsync`",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/node-core-library"
+}

--- a/common/reviews/api/node-core-library.api.md
+++ b/common/reviews/api/node-core-library.api.md
@@ -616,11 +616,8 @@ export interface IRealNodeModulePathResolverOptions {
 
 // @public (undocumented)
 export interface IRunWithRetriesOptions<TResult> {
-    // (undocumented)
-    action: () => Promise<TResult> | TResult;
-    // (undocumented)
+    action: (retryCount: number) => Promise<TResult> | TResult;
     maxRetries: number;
-    // (undocumented)
     retryDelayMs?: number;
 }
 

--- a/libraries/node-core-library/src/Async.ts
+++ b/libraries/node-core-library/src/Async.ts
@@ -32,8 +32,20 @@ export interface IAsyncParallelismOptions {
  * @public
  */
 export interface IRunWithRetriesOptions<TResult> {
-  action: () => Promise<TResult> | TResult;
+  /**
+   * The action to be performed. The action is repeatedly executed until it completes without throwing or the
+   * maximum number of retries is reached.
+   *
+   * @param retryCount - The number of times the action has been retried.
+   */
+  action: (retryCount: number) => Promise<TResult> | TResult;
+  /**
+   * The maximum number of times the action should be retried.
+   */
   maxRetries: number;
+  /**
+   * The delay in milliseconds between retries.
+   */
   retryDelayMs?: number;
 }
 
@@ -313,13 +325,13 @@ export class Async {
     maxRetries,
     retryDelayMs = 0
   }: IRunWithRetriesOptions<TResult>): Promise<TResult> {
-    let retryCounter: number = 0;
+    let retryCount: number = 0;
     // eslint-disable-next-line no-constant-condition
     while (true) {
       try {
-        return await action();
+        return await action(retryCount);
       } catch (e) {
-        if (++retryCounter > maxRetries) {
+        if (++retryCount > maxRetries) {
           throw e;
         } else if (retryDelayMs > 0) {
           await Async.sleepAsync(retryDelayMs);


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

Provides the current retry count when running an action with retries. Allows avoiding the need to create an external variable to track in cases where this info is needed.