### PR TITLE
[rush-lib] Fix issue with `MaxListenersExceeded` while using the HTTP build cache plugin

### DIFF
--- a/common/changes/@microsoft/rush/user-danade-RemoveSocketErrorHandler_2025-01-09-20-04.json
+++ b/common/changes/@microsoft/rush/user-danade-RemoveSocketErrorHandler_2025-01-09-20-04.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix an issue where MaxListenersExceeded would get thrown when using the HTTP build cache plugin",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/utilities/WebClient.ts
+++ b/libraries/rush-lib/src/utilities/WebClient.ts
@@ -199,11 +199,6 @@ const makeRequestAsync: FetchFn = async (
           resolve(result);
         });
       })
-        .on('socket', (socket: Socket) => {
-          socket.on('error', (error: Error) => {
-            reject(error);
-          });
-        })
         .on('error', (error: Error) => {
           reject(error);
         })

--- a/libraries/rush-lib/src/utilities/WebClient.ts
+++ b/libraries/rush-lib/src/utilities/WebClient.ts
@@ -6,7 +6,6 @@ import * as process from 'process';
 import type * as http from 'http';
 import { request as httpRequest, type IncomingMessage } from 'node:http';
 import { request as httpsRequest, type RequestOptions } from 'node:https';
-import type { Socket } from 'node:net';
 import { Import, LegacyAdapters } from '@rushstack/node-core-library';
 
 const createHttpsProxyAgent: typeof import('https-proxy-agent') = Import.lazy('https-proxy-agent', require);


### PR DESCRIPTION
## Summary
Removes unnecessary error handling when dealing with ECONNRESET-like errors. Fixes #5061.

## Details
An error handler was added to the socket to deal with ECONNRESET and other ECONN* errors that seemingly wouldn't bubble up. These errors were difficult to validate the fix against, so minimal testing of the change was done. However, errors began to arrise due to socket reuse in the http/https libraries during periods of high request utilization against the same host, leading to too many error handlers being added to individual sockets.

This change removes the socket handler, as we validated by looking at Node source code that socket errors _should_ bubble up to the request error handler. See: https://github.com/nodejs/node/blob/14b6317641751590ebe5d87d4f15822ae3fdb7d6/lib/_http_client.js#L497

## How it was tested
Locally calling the HTTP library and confirming that easy-to-reproduce ECONN* errors would bubble up to the request error handler.

## Impacted documentation

N/A