### PR TITLE
[workspace-resolve] Allow configuration of which resolvers to apply to

### DIFF
--- a/common/changes/@rushstack/webpack-workspace-resolve-plugin/resolver-cache-fixes_2025-01-10-19-44.json
+++ b/common/changes/@rushstack/webpack-workspace-resolve-plugin/resolver-cache-fixes_2025-01-10-19-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/webpack-workspace-resolve-plugin",
+      "comment": "(BREAKING CHANGE) Switch constructor to an options object. Add option to specify which webpack resolvers to apply the plugin to. Improve performance by using an object literal instead of the spread operator when updating the resolve request. Upgrade compilation target to not polyfill optional chaining.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/webpack-workspace-resolve-plugin"
+}

--- a/common/reviews/api/webpack-workspace-resolve-plugin.api.md
+++ b/common/reviews/api/webpack-workspace-resolve-plugin.api.md
@@ -41,6 +41,7 @@ export interface IWorkspaceLayoutCacheOptions {
 // @beta
 export interface IWorkspaceResolvePluginOptions {
     cache: WorkspaceLayoutCache;
+    resolverNames?: Iterable<string>;
 }
 
 // @beta
@@ -58,7 +59,7 @@ export class WorkspaceLayoutCache {
 
 // @beta
 export class WorkspaceResolvePlugin implements WebpackPluginInstance {
-    constructor(cache: WorkspaceLayoutCache);
+    constructor(options: IWorkspaceResolvePluginOptions);
     // (undocumented)
     apply(compiler: Compiler): void;
 }

--- a/webpack/webpack-workspace-resolve-plugin/src/KnownDescriptionFilePlugin.ts
+++ b/webpack/webpack-workspace-resolve-plugin/src/KnownDescriptionFilePlugin.ts
@@ -96,12 +96,27 @@ export class KnownDescriptionFilePlugin {
           // Store the resolver context since a WeakMap lookup is cheaper than walking the tree again
           contextForPackage.set(descriptionFileData, match);
 
+          // Using the object literal is an order of magnitude faster, at least on node 18.19.1
           const obj: ResolveRequest = {
-            ...request,
-            descriptionFileRoot,
+            path: request.path,
+            context: request.context,
             descriptionFilePath,
+            descriptionFileRoot,
             descriptionFileData,
-            relativePath
+            relativePath,
+            ignoreSymlinks: request.ignoreSymlinks,
+            fullySpecified: request.fullySpecified,
+            __innerRequest: request.__innerRequest,
+            __innerRequest_request: request.__innerRequest_request,
+            __innerRequest_relativePath: request.__innerRequest_relativePath,
+
+            request: request.request,
+            query: request.query,
+            fragment: request.fragment,
+            module: request.module,
+            directory: request.directory,
+            file: request.file,
+            internal: request.internal
           };
 
           // Delegate to the resolver step at `target`.

--- a/webpack/webpack-workspace-resolve-plugin/src/KnownPackageDependenciesPlugin.ts
+++ b/webpack/webpack-workspace-resolve-plugin/src/KnownPackageDependenciesPlugin.ts
@@ -80,16 +80,25 @@ export class KnownPackageDependenciesPlugin {
           (remainingPath.length > 1 && cache.normalizeToSlash?.(remainingPath)) || remainingPath;
         const { descriptionFileRoot } = dependency.value;
         const obj: ResolveRequest = {
-          ...request,
           path: descriptionFileRoot,
+          context: request.context,
+          descriptionFilePath: `${descriptionFileRoot}${cache.resolverPathSeparator}package.json`,
           descriptionFileRoot,
           descriptionFileData: undefined,
-          descriptionFilePath: `${descriptionFileRoot}${cache.resolverPathSeparator}package.json`,
-
-          relativePath: relativePath,
-          request: relativePath,
+          relativePath,
+          ignoreSymlinks: request.ignoreSymlinks,
           fullySpecified,
-          module: false
+          __innerRequest: request.__innerRequest,
+          __innerRequest_request: request.__innerRequest_request,
+          __innerRequest_relativePath: request.__innerRequest_relativePath,
+
+          request: relativePath,
+          query: request.query,
+          fragment: request.fragment,
+          module: false,
+          directory: request.directory,
+          file: request.file,
+          internal: request.internal
         };
         // eslint-disable-next-line @rushstack/no-new-null
         resolver.doResolve(target, obj, null, resolveContext, callback);

--- a/webpack/webpack-workspace-resolve-plugin/src/WorkspaceResolvePlugin.ts
+++ b/webpack/webpack-workspace-resolve-plugin/src/WorkspaceResolvePlugin.ts
@@ -20,7 +20,7 @@ export interface IWorkspaceResolvePluginOptions {
 
   /**
    * Which webpack resolvers to apply the plugin to.
-   * @default ['normal']
+   * @defaultValue ['normal', 'context', 'loader']
    */
   resolverNames?: Iterable<string>;
 }
@@ -36,7 +36,7 @@ export class WorkspaceResolvePlugin implements WebpackPluginInstance {
 
   public constructor(options: IWorkspaceResolvePluginOptions) {
     this._cache = options.cache;
-    this._resolverNames = new Set(options.resolverNames ?? ['normal']);
+    this._resolverNames = new Set(options.resolverNames ?? ['normal', 'context', 'loader']);
   }
 
   public apply(compiler: Compiler): void {

--- a/webpack/webpack-workspace-resolve-plugin/src/WorkspaceResolvePlugin.ts
+++ b/webpack/webpack-workspace-resolve-plugin/src/WorkspaceResolvePlugin.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import type { WebpackPluginInstance, Compiler } from 'webpack';
+import type { WebpackPluginInstance, Compiler, ResolveOptions } from 'webpack';
 
 import type { WorkspaceLayoutCache } from './WorkspaceLayoutCache';
 import { KnownDescriptionFilePlugin } from './KnownDescriptionFilePlugin';
@@ -17,6 +17,12 @@ export interface IWorkspaceResolvePluginOptions {
    * The cache of workspace layout information.
    */
   cache: WorkspaceLayoutCache;
+
+  /**
+   * Which webpack resolvers to apply the plugin to.
+   * @default ['normal']
+   */
+  resolverNames?: Iterable<string>;
 }
 
 /**
@@ -26,48 +32,53 @@ export interface IWorkspaceResolvePluginOptions {
  */
 export class WorkspaceResolvePlugin implements WebpackPluginInstance {
   private readonly _cache: WorkspaceLayoutCache;
+  private readonly _resolverNames: Set<string>;
 
-  public constructor(cache: WorkspaceLayoutCache) {
-    this._cache = cache;
+  public constructor(options: IWorkspaceResolvePluginOptions) {
+    this._cache = options.cache;
+    this._resolverNames = new Set(options.resolverNames ?? ['normal']);
   }
 
   public apply(compiler: Compiler): void {
-    compiler.resolverFactory.hooks.resolveOptions
-      .for('normal')
-      .tap(WorkspaceResolvePlugin.name, (resolveOptions) => {
-        // Omit default `node_modules`
-        if (resolveOptions.modules) {
-          resolveOptions.modules = resolveOptions.modules.filter((modulePath: string) => {
-            return modulePath !== 'node_modules';
-          });
-        } else {
-          resolveOptions.modules = [];
-        }
+    const cache: WorkspaceLayoutCache = this._cache;
 
-        const cache: WorkspaceLayoutCache = this._cache;
+    function handler(resolveOptions: ResolveOptions): ResolveOptions {
+      // Omit default `node_modules`
+      if (resolveOptions.modules) {
+        resolveOptions.modules = resolveOptions.modules.filter((modulePath: string) => {
+          return modulePath !== 'node_modules';
+        });
+      } else {
+        resolveOptions.modules = [];
+      }
 
-        resolveOptions.plugins ??= [];
-        resolveOptions.plugins.push(
-          // Optimize identifying the package.json file for the issuer
-          new KnownDescriptionFilePlugin(cache, 'before-parsed-resolve', 'described-resolve'),
-          // Optimize locating the installed dependencies of the current package
-          new KnownPackageDependenciesPlugin(cache, 'before-raw-module', 'resolve-as-module'),
-          // Optimize loading the package.json file for the destination package (bare specifier)
-          new KnownDescriptionFilePlugin(cache, 'before-resolve-as-module', 'resolve-in-package'),
-          // Optimize loading the package.json file for the destination package (relative path)
-          new KnownDescriptionFilePlugin(cache, 'before-relative', 'described-relative'),
-          // Optimize locating and loading nested package.json for a directory
-          new KnownDescriptionFilePlugin(
-            cache,
-            'before-undescribed-existing-directory',
-            'existing-directory',
-            true
-          ),
-          // Optimize locating and loading nested package.json for a file
-          new KnownDescriptionFilePlugin(cache, 'before-undescribed-raw-file', 'raw-file')
-        );
+      resolveOptions.plugins ??= [];
+      resolveOptions.plugins.push(
+        // Optimize identifying the package.json file for the issuer
+        new KnownDescriptionFilePlugin(cache, 'before-parsed-resolve', 'described-resolve'),
+        // Optimize locating the installed dependencies of the current package
+        new KnownPackageDependenciesPlugin(cache, 'before-raw-module', 'resolve-as-module'),
+        // Optimize loading the package.json file for the destination package (bare specifier)
+        new KnownDescriptionFilePlugin(cache, 'before-resolve-as-module', 'resolve-in-package'),
+        // Optimize loading the package.json file for the destination package (relative path)
+        new KnownDescriptionFilePlugin(cache, 'before-relative', 'described-relative'),
+        // Optimize locating and loading nested package.json for a directory
+        new KnownDescriptionFilePlugin(
+          cache,
+          'before-undescribed-existing-directory',
+          'existing-directory',
+          true
+        ),
+        // Optimize locating and loading nested package.json for a file
+        new KnownDescriptionFilePlugin(cache, 'before-undescribed-raw-file', 'raw-file')
+      );
 
-        return resolveOptions;
-      });
+      return resolveOptions;
+    }
+    for (const resolverName of this._resolverNames) {
+      compiler.resolverFactory.hooks.resolveOptions
+        .for(resolverName)
+        .tap(WorkspaceResolvePlugin.name, handler);
+    }
   }
 }

--- a/webpack/webpack-workspace-resolve-plugin/tsconfig.json
+++ b/webpack/webpack-workspace-resolve-plugin/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "./node_modules/local-node-rig/profiles/default/tsconfig-base.json",
   "compilerOptions": {
-    "target": "ES2019",
+    "target": "ES2020",
     "types": ["heft-jest", "node"]
   }
 }


### PR DESCRIPTION
## Summary
Allows the resolver to be applied to the `context` and `loader` resolvers in addition to the `normal` resolver.

## Details
Applies the same performance optimizations as https://github.com/webpack/enhanced-resolve/pull/445
Upgrades the compilation target to ensure that optional chaining is preserved instead of transpiled.

## How it was tested
Unit tests for the core functionality.

## Impacted documentation
Plugin instructions.