### PR TITLE
[heft-storybook-plugin] Add support for the --docs parameter to the Heft storybook plugin.

### DIFF
--- a/common/changes/@rushstack/heft-storybook-plugin/add-docs-to-storybook_2025-01-16-21-48.json
+++ b/common/changes/@rushstack/heft-storybook-plugin/add-docs-to-storybook_2025-01-16-21-48.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-storybook-plugin",
+      "comment": "Add support for the `--docs` parameter.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft-storybook-plugin"
+}

--- a/heft-plugins/heft-storybook-plugin/heft-plugin.json
+++ b/heft-plugins/heft-storybook-plugin/heft-plugin.json
@@ -18,6 +18,11 @@
           "longName": "--storybook-test",
           "description": "Executes a stripped down build-storybook for testing purposes.",
           "parameterKind": "flag"
+        },
+        {
+          "longName": "--docs",
+          "description": "Execute storybook in docs mode.",
+          "parameterKind": "flag"
         }
       ]
     }


### PR DESCRIPTION
## Summary

Adds support for the --docs parameter to the Heft storybook plugin.

## How it was tested

Ran in a project that wants to use this parameter.