### PR TITLE
[rush-lib] Add --timeline parameter for all phased commands

### DIFF
--- a/common/changes/@microsoft/rush/enelson-add-timeline-param_2025-01-18-21-32.json
+++ b/common/changes/@microsoft/rush/enelson-add-timeline-param_2025-01-18-21-32.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Allow --timeline option for all phased commands",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
+++ b/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
@@ -195,13 +195,13 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
           ' to specify a count that is equal to the number of CPU cores. If this parameter is omitted,' +
           ' then the default value depends on the operating system and number of CPU cores.'
       });
-      this._timelineParameter = this.defineFlagParameter({
-        parameterLongName: '--timeline',
-        description:
-          'After the build is complete, print additional statistics and CPU usage information,' +
-          ' including an ASCII chart of the start and stop times for each operation.'
-      });
     }
+    this._timelineParameter = this.defineFlagParameter({
+      parameterLongName: '--timeline',
+      description:
+        'After the build is complete, print additional statistics and CPU usage information,' +
+        ' including an ASCII chart of the start and stop times for each operation.'
+    });
     this._cobuildPlanParameter = this.defineFlagParameter({
       parameterLongName: '--log-cobuild-plan',
       description:


### PR DESCRIPTION
## Summary

Allow the `--timeline` option even if a phased command does not support parallelism.

## Details

Today, the `--timeline` option is only available on the command line if a phased command supports parallelism.

However, this option is useful in many cases even if there is no parallelism -- the histogram can help identify visually which projects are bottlenecks in the execution flow, and the summary at the end is helpful for showing the breakdown of total time spent in the different phases across all projects.

## How it was tested

 - Unit tests passing
 - Ran local Rush monorepo against these changes to confirm `--timeline` option was available

## Impacted documentation

 - N/A

