### PR TITLE
[node-core-library] Bump fs-extra to 11.3.0

### DIFF
--- a/build-tests/api-documenter-scenarios/package.json
+++ b/build-tests/api-documenter-scenarios/package.json
@@ -15,7 +15,7 @@
     "@rushstack/node-core-library": "workspace:*",
     "@types/jest": "29.2.5",
     "@types/node": "18.17.15",
-    "fs-extra": "~7.0.1",
+    "fs-extra": "~11.3.0",
     "typescript": "~5.4.2"
   }
 }

--- a/build-tests/api-extractor-d-cts-test/package.json
+++ b/build-tests/api-extractor-d-cts-test/package.json
@@ -13,7 +13,7 @@
     "@microsoft/api-extractor": "workspace:*",
     "@types/jest": "29.2.5",
     "@types/node": "18.17.15",
-    "fs-extra": "~7.0.1",
+    "fs-extra": "~11.3.0",
     "typescript": "~5.4.2"
   }
 }

--- a/build-tests/api-extractor-d-mts-test/package.json
+++ b/build-tests/api-extractor-d-mts-test/package.json
@@ -14,7 +14,7 @@
     "@microsoft/api-extractor": "workspace:*",
     "@types/jest": "29.2.5",
     "@types/node": "18.17.15",
-    "fs-extra": "~7.0.1",
+    "fs-extra": "~11.3.0",
     "typescript": "~5.4.2"
   }
 }

--- a/build-tests/api-extractor-lib1-test/package.json
+++ b/build-tests/api-extractor-lib1-test/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "@microsoft/api-extractor": "workspace:*",
-    "fs-extra": "~7.0.1",
+    "fs-extra": "~11.3.0",
     "typescript": "~2.9.2"
   }
 }

--- a/build-tests/api-extractor-lib2-test/package.json
+++ b/build-tests/api-extractor-lib2-test/package.json
@@ -13,7 +13,7 @@
     "@microsoft/api-extractor": "workspace:*",
     "@types/jest": "29.2.5",
     "@types/node": "18.17.15",
-    "fs-extra": "~7.0.1",
+    "fs-extra": "~11.3.0",
     "typescript": "~5.4.2"
   }
 }

--- a/build-tests/api-extractor-lib3-test/package.json
+++ b/build-tests/api-extractor-lib3-test/package.json
@@ -16,7 +16,7 @@
     "@microsoft/api-extractor": "workspace:*",
     "@types/jest": "29.2.5",
     "@types/node": "18.17.15",
-    "fs-extra": "~7.0.1",
+    "fs-extra": "~11.3.0",
     "typescript": "~5.4.2"
   }
 }

--- a/build-tests/api-extractor-lib4-test/package.json
+++ b/build-tests/api-extractor-lib4-test/package.json
@@ -13,7 +13,7 @@
     "@microsoft/api-extractor": "workspace:*",
     "@types/jest": "29.2.5",
     "@types/node": "18.17.15",
-    "fs-extra": "~7.0.1",
+    "fs-extra": "~11.3.0",
     "typescript": "~5.4.2"
   }
 }

--- a/build-tests/api-extractor-lib5-test/package.json
+++ b/build-tests/api-extractor-lib5-test/package.json
@@ -13,7 +13,7 @@
     "@microsoft/api-extractor": "workspace:*",
     "@types/jest": "29.2.5",
     "@types/node": "18.17.15",
-    "fs-extra": "~7.0.1",
+    "fs-extra": "~11.3.0",
     "typescript": "~5.4.2"
   }
 }

--- a/build-tests/api-extractor-test-01/package.json
+++ b/build-tests/api-extractor-test-01/package.json
@@ -18,7 +18,7 @@
     "@microsoft/api-extractor": "workspace:*",
     "@types/heft-jest": "1.0.1",
     "@types/node": "18.17.15",
-    "fs-extra": "~7.0.1",
+    "fs-extra": "~11.3.0",
     "typescript": "~5.4.2"
   }
 }

--- a/build-tests/api-extractor-test-02/package.json
+++ b/build-tests/api-extractor-test-02/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@microsoft/api-extractor": "workspace:*",
     "@types/node": "18.17.15",
-    "fs-extra": "~7.0.1",
+    "fs-extra": "~11.3.0",
     "typescript": "~5.4.2"
   }
 }

--- a/build-tests/api-extractor-test-03/package.json
+++ b/build-tests/api-extractor-test-03/package.json
@@ -11,7 +11,7 @@
     "@types/jest": "29.2.5",
     "@types/node": "18.17.15",
     "api-extractor-test-02": "workspace:*",
-    "fs-extra": "~7.0.1",
+    "fs-extra": "~11.3.0",
     "typescript": "~5.4.2"
   }
 }

--- a/build-tests/api-extractor-test-04/package.json
+++ b/build-tests/api-extractor-test-04/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@microsoft/api-extractor": "workspace:*",
     "api-extractor-lib1-test": "workspace:*",
-    "fs-extra": "~7.0.1",
+    "fs-extra": "~11.3.0",
     "typescript": "~5.4.2"
   }
 }

--- a/build-tests/ts-command-line-test/package.json
+++ b/build-tests/ts-command-line-test/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@rushstack/ts-command-line": "workspace:*",
     "@types/node": "18.17.15",
-    "fs-extra": "~7.0.1",
+    "fs-extra": "~11.3.0",
     "typescript": "~5.4.2"
   }
 }

--- a/common/changes/@rushstack/node-core-library/bump-fs-extra_2025-01-29-22-16.json
+++ b/common/changes/@rushstack/node-core-library/bump-fs-extra_2025-01-29-22-16.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/node-core-library",
+      "comment": "Update fs-extra to 11.3.0.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/node-core-library"
+}

--- a/common/config/subspaces/build-tests-subspace/pnpm-lock.yaml
+++ b/common/config/subspaces/build-tests-subspace/pnpm-lock.yaml
@@ -126,10 +126,10 @@ importers:
         version: file:../../../apps/heft(@types/node@18.17.15)
       '@rushstack/heft-lint-plugin':
         specifier: file:../../heft-plugins/heft-lint-plugin
-        version: file:../../../heft-plugins/heft-lint-plugin(@rushstack/heft@0.68.12)(@types/node@18.17.15)
+        version: file:../../../heft-plugins/heft-lint-plugin(@rushstack/heft@0.68.13)(@types/node@18.17.15)
       '@rushstack/heft-typescript-plugin':
         specifier: file:../../heft-plugins/heft-typescript-plugin
-        version: file:../../../heft-plugins/heft-typescript-plugin(@rushstack/heft@0.68.12)(@types/node@18.17.15)
+        version: file:../../../heft-plugins/heft-typescript-plugin(@rushstack/heft@0.68.13)(@types/node@18.17.15)
       eslint:
         specifier: ~8.57.0
         version: 8.57.1
@@ -2972,13 +2972,13 @@ packages:
       combined-stream: 1.0.8
       mime-types: 2.1.35
 
-  /fs-extra@7.0.1:
-    resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
-    engines: {node: '>=6 <7 || >=8'}
+  /fs-extra@11.3.0:
+    resolution: {integrity: sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==}
+    engines: {node: '>=14.14'}
     dependencies:
       graceful-fs: 4.2.11
-      jsonfile: 4.0.0
-      universalify: 0.1.2
+      jsonfile: 6.1.0
+      universalify: 2.0.1
 
   /fs-minipass@2.1.0:
     resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
@@ -4218,8 +4218,10 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
-  /jsonfile@4.0.0:
-    resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
+  /jsonfile@6.1.0:
+    resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
+    dependencies:
+      universalify: 2.0.1
     optionalDependencies:
       graceful-fs: 4.2.11
 
@@ -5840,9 +5842,9 @@ packages:
     dependencies:
       crypto-random-string: 2.0.0
 
-  /universalify@0.1.2:
-    resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
-    engines: {node: '>= 4.0.0'}
+  /universalify@2.0.1:
+    resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
+    engines: {node: '>= 10.0.0'}
 
   /update-browserslist-db@1.1.1(browserslist@4.24.2):
     resolution: {integrity: sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==}
@@ -6312,7 +6314,7 @@ packages:
       - typescript
     dev: true
 
-  file:../../../heft-plugins/heft-api-extractor-plugin(@rushstack/heft@0.68.12)(@types/node@18.17.15):
+  file:../../../heft-plugins/heft-api-extractor-plugin(@rushstack/heft@0.68.13)(@types/node@18.17.15):
     resolution: {directory: ../../../heft-plugins/heft-api-extractor-plugin, type: directory}
     id: file:../../../heft-plugins/heft-api-extractor-plugin
     name: '@rushstack/heft-api-extractor-plugin'
@@ -6327,7 +6329,7 @@ packages:
       - '@types/node'
     dev: true
 
-  file:../../../heft-plugins/heft-jest-plugin(@rushstack/heft@0.68.12)(@types/node@18.17.15)(jest-environment-node@29.5.0):
+  file:../../../heft-plugins/heft-jest-plugin(@rushstack/heft@0.68.13)(@types/node@18.17.15)(jest-environment-node@29.5.0):
     resolution: {directory: ../../../heft-plugins/heft-jest-plugin, type: directory}
     id: file:../../../heft-plugins/heft-jest-plugin
     name: '@rushstack/heft-jest-plugin'
@@ -6362,7 +6364,7 @@ packages:
       - ts-node
     dev: true
 
-  file:../../../heft-plugins/heft-lint-plugin(@rushstack/heft@0.68.12)(@types/node@18.17.15):
+  file:../../../heft-plugins/heft-lint-plugin(@rushstack/heft@0.68.13)(@types/node@18.17.15):
     resolution: {directory: ../../../heft-plugins/heft-lint-plugin, type: directory}
     id: file:../../../heft-plugins/heft-lint-plugin
     name: '@rushstack/heft-lint-plugin'
@@ -6376,7 +6378,7 @@ packages:
       - '@types/node'
     dev: true
 
-  file:../../../heft-plugins/heft-typescript-plugin(@rushstack/heft@0.68.12)(@types/node@18.17.15):
+  file:../../../heft-plugins/heft-typescript-plugin(@rushstack/heft@0.68.13)(@types/node@18.17.15):
     resolution: {directory: ../../../heft-plugins/heft-typescript-plugin, type: directory}
     id: file:../../../heft-plugins/heft-typescript-plugin
     name: '@rushstack/heft-typescript-plugin'
@@ -6444,7 +6446,7 @@ packages:
       ajv: 8.13.0
       ajv-draft-04: 1.0.0(ajv@8.13.0)
       ajv-formats: 3.0.1
-      fs-extra: 7.0.1
+      fs-extra: 11.3.0
       import-lazy: 4.0.0
       jju: 1.4.0
       resolve: 1.22.8
@@ -6603,7 +6605,7 @@ packages:
     transitivePeerDependencies:
       - '@types/node'
 
-  file:../../../rigs/heft-node-rig(@rushstack/heft@0.68.12)(@types/node@18.17.15):
+  file:../../../rigs/heft-node-rig(@rushstack/heft@0.68.13)(@types/node@18.17.15):
     resolution: {directory: ../../../rigs/heft-node-rig, type: directory}
     id: file:../../../rigs/heft-node-rig
     name: '@rushstack/heft-node-rig'
@@ -6613,10 +6615,10 @@ packages:
       '@microsoft/api-extractor': file:../../../apps/api-extractor(@types/node@18.17.15)
       '@rushstack/eslint-config': file:../../../eslint/eslint-config(eslint@8.57.1)(typescript@5.4.5)
       '@rushstack/heft': file:../../../apps/heft(@types/node@18.17.15)
-      '@rushstack/heft-api-extractor-plugin': file:../../../heft-plugins/heft-api-extractor-plugin(@rushstack/heft@0.68.12)(@types/node@18.17.15)
-      '@rushstack/heft-jest-plugin': file:../../../heft-plugins/heft-jest-plugin(@rushstack/heft@0.68.12)(@types/node@18.17.15)(jest-environment-node@29.5.0)
-      '@rushstack/heft-lint-plugin': file:../../../heft-plugins/heft-lint-plugin(@rushstack/heft@0.68.12)(@types/node@18.17.15)
-      '@rushstack/heft-typescript-plugin': file:../../../heft-plugins/heft-typescript-plugin(@rushstack/heft@0.68.12)(@types/node@18.17.15)
+      '@rushstack/heft-api-extractor-plugin': file:../../../heft-plugins/heft-api-extractor-plugin(@rushstack/heft@0.68.13)(@types/node@18.17.15)
+      '@rushstack/heft-jest-plugin': file:../../../heft-plugins/heft-jest-plugin(@rushstack/heft@0.68.13)(@types/node@18.17.15)(jest-environment-node@29.5.0)
+      '@rushstack/heft-lint-plugin': file:../../../heft-plugins/heft-lint-plugin(@rushstack/heft@0.68.13)(@types/node@18.17.15)
+      '@rushstack/heft-typescript-plugin': file:../../../heft-plugins/heft-typescript-plugin(@rushstack/heft@0.68.13)(@types/node@18.17.15)
       '@types/heft-jest': 1.0.1
       eslint: 8.57.1
       jest-environment-node: 29.5.0
@@ -6636,7 +6638,7 @@ packages:
     dependencies:
       '@microsoft/api-extractor': file:../../../apps/api-extractor(@types/node@18.17.15)
       '@rushstack/heft': file:../../../apps/heft(@types/node@18.17.15)
-      '@rushstack/heft-node-rig': file:../../../rigs/heft-node-rig(@rushstack/heft@0.68.12)(@types/node@18.17.15)
+      '@rushstack/heft-node-rig': file:../../../rigs/heft-node-rig(@rushstack/heft@0.68.13)(@types/node@18.17.15)
       '@types/heft-jest': 1.0.1
       '@types/node': 18.17.15
       eslint: 8.57.1

--- a/common/config/subspaces/build-tests-subspace/repo-state.json
+++ b/common/config/subspaces/build-tests-subspace/repo-state.json
@@ -1,6 +1,6 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "923820e32f78d75a466e44761a9d1f825a9dfe29",
+  "pnpmShrinkwrapHash": "033fae07451be7b435c9b4fd8274c1ad39c74035",
   "preferredVersionsHash": "ce857ea0536b894ec8f346aaea08cfd85a5af648",
-  "packageJsonInjectedDependenciesHash": "12c1ab585f49b3980bceb1f266c23c55e7bc9858"
+  "packageJsonInjectedDependenciesHash": "0f4121dfcf69b20aee9c6012b385b633c79600e4"
 }

--- a/common/config/subspaces/default/pnpm-lock.yaml
+++ b/common/config/subspaces/default/pnpm-lock.yaml
@@ -863,8 +863,8 @@ importers:
         specifier: 18.17.15
         version: 18.17.15
       fs-extra:
-        specifier: ~7.0.1
-        version: 7.0.1
+        specifier: ~11.3.0
+        version: 11.3.0
       typescript:
         specifier: ~5.4.2
         version: 5.4.2
@@ -899,8 +899,8 @@ importers:
         specifier: 18.17.15
         version: 18.17.15
       fs-extra:
-        specifier: ~7.0.1
-        version: 7.0.1
+        specifier: ~11.3.0
+        version: 11.3.0
       typescript:
         specifier: ~5.4.2
         version: 5.4.2
@@ -917,8 +917,8 @@ importers:
         specifier: 18.17.15
         version: 18.17.15
       fs-extra:
-        specifier: ~7.0.1
-        version: 7.0.1
+        specifier: ~11.3.0
+        version: 11.3.0
       typescript:
         specifier: ~5.4.2
         version: 5.4.2
@@ -929,8 +929,8 @@ importers:
         specifier: workspace:*
         version: link:../../apps/api-extractor
       fs-extra:
-        specifier: ~7.0.1
-        version: 7.0.1
+        specifier: ~11.3.0
+        version: 11.3.0
       typescript:
         specifier: ~2.9.2
         version: 2.9.2
@@ -947,8 +947,8 @@ importers:
         specifier: 18.17.15
         version: 18.17.15
       fs-extra:
-        specifier: ~7.0.1
-        version: 7.0.1
+        specifier: ~11.3.0
+        version: 11.3.0
       typescript:
         specifier: ~5.4.2
         version: 5.4.2
@@ -969,8 +969,8 @@ importers:
         specifier: 18.17.15
         version: 18.17.15
       fs-extra:
-        specifier: ~7.0.1
-        version: 7.0.1
+        specifier: ~11.3.0
+        version: 11.3.0
       typescript:
         specifier: ~5.4.2
         version: 5.4.2
@@ -987,8 +987,8 @@ importers:
         specifier: 18.17.15
         version: 18.17.15
       fs-extra:
-        specifier: ~7.0.1
-        version: 7.0.1
+        specifier: ~11.3.0
+        version: 11.3.0
       typescript:
         specifier: ~5.4.2
         version: 5.4.2
@@ -1005,8 +1005,8 @@ importers:
         specifier: 18.17.15
         version: 18.17.15
       fs-extra:
-        specifier: ~7.0.1
-        version: 7.0.1
+        specifier: ~11.3.0
+        version: 11.3.0
       typescript:
         specifier: ~5.4.2
         version: 5.4.2
@@ -1070,8 +1070,8 @@ importers:
         specifier: 18.17.15
         version: 18.17.15
       fs-extra:
-        specifier: ~7.0.1
-        version: 7.0.1
+        specifier: ~11.3.0
+        version: 11.3.0
       typescript:
         specifier: ~5.4.2
         version: 5.4.2
@@ -1095,8 +1095,8 @@ importers:
         specifier: 18.17.15
         version: 18.17.15
       fs-extra:
-        specifier: ~7.0.1
-        version: 7.0.1
+        specifier: ~11.3.0
+        version: 11.3.0
       typescript:
         specifier: ~5.4.2
         version: 5.4.2
@@ -1113,8 +1113,8 @@ importers:
         specifier: workspace:*
         version: link:../api-extractor-test-02
       fs-extra:
-        specifier: ~7.0.1
-        version: 7.0.1
+        specifier: ~11.3.0
+        version: 11.3.0
       typescript:
         specifier: ~5.4.2
         version: 5.4.2
@@ -1128,8 +1128,8 @@ importers:
         specifier: workspace:*
         version: link:../api-extractor-lib1-test
       fs-extra:
-        specifier: ~7.0.1
-        version: 7.0.1
+        specifier: ~11.3.0
+        version: 11.3.0
       typescript:
         specifier: ~5.4.2
         version: 5.4.2
@@ -2341,8 +2341,8 @@ importers:
         specifier: 18.17.15
         version: 18.17.15
       fs-extra:
-        specifier: ~7.0.1
-        version: 7.0.1
+        specifier: ~11.3.0
+        version: 11.3.0
       typescript:
         specifier: ~5.4.2
         version: 5.4.2
@@ -3157,8 +3157,8 @@ importers:
         specifier: ~3.0.1
         version: 3.0.1(ajv@8.13.0)
       fs-extra:
-        specifier: ~7.0.1
-        version: 7.0.1
+        specifier: ~11.3.0
+        version: 11.3.0
       import-lazy:
         specifier: ~4.0.0
         version: 4.0.0
@@ -19460,6 +19460,14 @@ packages:
       universalify: 2.0.1
     dev: true
 
+  /fs-extra@11.3.0:
+    resolution: {integrity: sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==}
+    engines: {node: '>=14.14'}
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.1.0
+      universalify: 2.0.1
+
   /fs-extra@7.0.1:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
     engines: {node: '>=6 <7 || >=8'}
@@ -22023,7 +22031,6 @@ packages:
       universalify: 2.0.1
     optionalDependencies:
       graceful-fs: 4.2.11
-    dev: true
 
   /jsonpath-plus@10.2.0:
     resolution: {integrity: sha512-T9V+8iNYKFL2n2rF+w02LBOT2JjDnTjioaNFrxRy0Bv1y/hNsqR/EBK7Ojy2ythRHwmz2cRIls+9JitQGZC/sw==}
@@ -27766,7 +27773,6 @@ packages:
   /universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
-    dev: true
 
   /unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}

--- a/common/config/subspaces/default/repo-state.json
+++ b/common/config/subspaces/default/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "31bb50ce8fea0eb2370c597fc29dbdc8aa6e06a2",
+  "pnpmShrinkwrapHash": "b3cfbd225a2425647bf5ca7739f1dce1a71410ea",
   "preferredVersionsHash": "ce857ea0536b894ec8f346aaea08cfd85a5af648"
 }

--- a/libraries/node-core-library/package.json
+++ b/libraries/node-core-library/package.json
@@ -16,7 +16,7 @@
     "_phase:test": "heft run --only test -- --clean"
   },
   "dependencies": {
-    "fs-extra": "~7.0.1",
+    "fs-extra": "~11.3.0",
     "import-lazy": "~4.0.0",
     "jju": "~1.4.0",
     "resolve": "~1.22.1",


### PR DESCRIPTION
## Summary
Update fs-extra to 11.3.0 to take advantage of more of the built-in capabilities of the NodeJS fs module and adopt various performance enhancements (such as removing unnecessary `lstat()` calls while deleting a folder).

## Details
Minimum NodeJS version for this version of fs-extra is 14.x, but node-core-library is already consuming typings for NodeJS 18.x, so this should not constitute a breaking change.

## How it was tested
Rebuilt and retested the repository. FileSystem api is exercised heavily throughout the build process.

## Impacted documentation
None