### PR TITLE
[rush] Fix ensureConsistentVersions in common-versions

### DIFF
--- a/common/changes/@microsoft/rush/fix-ensure-consistent-versions_2025-01-29-22-15.json
+++ b/common/changes/@microsoft/rush/fix-ensure-consistent-versions_2025-01-29-22-15.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix support for \"ensureConsistentVersions\" in common-versions.json when subspaces features is not enabled.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/api/Subspace.ts
+++ b/libraries/rush-lib/src/api/Subspace.ts
@@ -326,16 +326,14 @@ export class Subspace {
    * @beta
    */
   public shouldEnsureConsistentVersions(variant?: string): boolean {
-    // If the subspaces feature is enabled, or the ensureConsistentVersions field is defined, return the value of the field
-    if (this._rushConfiguration.subspacesFeatureEnabled) {
-      const commonVersions: CommonVersionsConfiguration = this.getCommonVersions(variant);
-      if (commonVersions.ensureConsistentVersions !== undefined) {
-        return commonVersions.ensureConsistentVersions;
-      }
+    // If the ensureConsistentVersions field is defined, return the value of the field
+    const commonVersions: CommonVersionsConfiguration = this.getCommonVersions(variant);
+    if (commonVersions.ensureConsistentVersions !== undefined) {
+      return commonVersions.ensureConsistentVersions;
     }
 
-    // Fallback to ensureConsistentVersions in rush.json if subspaces is not enabled,
-    // or if the setting is not defined in the common-versions.json file
+    // Fallback to ensureConsistentVersions in rush.json if the setting is not defined in
+    // the common-versions.json file
     return this._rushConfiguration.ensureConsistentVersions;
   }
 


### PR DESCRIPTION
## Summary
Fixes #5086 

## Details
Always prefers `common-versions.json` as the source of truth for `ensureConsistentVersions`. Only falls back to `rush.json` if not defined in `common-versions.json`.

## How it was tested
- 

## Impacted documentation
New behavior matches the claimed specification, so no change.