### PR TITLE
Use os.availableParallelism() instead of os.cpus().length

### DIFF
--- a/apps/heft/src/cli/HeftActionRunner.ts
+++ b/apps/heft/src/cli/HeftActionRunner.ts
@@ -195,7 +195,7 @@ export class HeftActionRunner {
     this._terminal = options.terminal;
     this._metricsCollector = options.metricsCollector;
 
-    const numberOfCores: number = os.cpus().length;
+    const numberOfCores: number = os.availableParallelism?.() ?? os.cpus().length;
 
     // If an explicit parallelism number wasn't provided, then choose a sensible
     // default.

--- a/apps/heft/src/metrics/MetricsCollector.ts
+++ b/apps/heft/src/metrics/MetricsCollector.ts
@@ -143,6 +143,8 @@ export class MetricsCollector {
 
     const { taskTotalExecutionMs } = filledPerformanceData;
 
+    const cpus: os.CpuInfo[] = os.cpus();
+
     const metricData: IMetricsData = {
       command: command,
       encounteredError: filledPerformanceData.encounteredError,
@@ -151,8 +153,8 @@ export class MetricsCollector {
       totalUptimeMs: process.uptime() * 1000,
       machineOs: process.platform,
       machineArch: process.arch,
-      machineCores: os.cpus().length,
-      machineProcessor: os.cpus()[0].model,
+      machineCores: cpus.length,
+      machineProcessor: cpus[0].model,
       machineTotalMemoryMB: os.totalmem(),
       commandParameters: parameters || {}
     };

--- a/apps/heft/src/metrics/MetricsCollector.ts
+++ b/apps/heft/src/metrics/MetricsCollector.ts
@@ -154,7 +154,9 @@ export class MetricsCollector {
       machineOs: process.platform,
       machineArch: process.arch,
       machineCores: cpus.length,
-      machineProcessor: cpus[0].model,
+      // The Node.js model is sometimes padded, for example:
+      // "AMD Ryzen 7 3700X 8-Core Processor
+      machineProcessor: cpus[0].model.trim(),
       machineTotalMemoryMB: os.totalmem(),
       commandParameters: parameters || {}
     };

--- a/common/changes/@microsoft/rush/available-parallelism_2025-01-30-01-01.json
+++ b/common/changes/@microsoft/rush/available-parallelism_2025-01-30-01-01.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Prefer `os.availableParallelism()` to `os.cpus().length`.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@rushstack/heft/available-parallelism_2025-01-30-01-01.json
+++ b/common/changes/@rushstack/heft/available-parallelism_2025-01-30-01-01.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Prefer `os.availableParallelism()` to `os.cpus().length`.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft"
+}

--- a/common/changes/@rushstack/module-minifier/available-parallelism_2025-01-30-01-01.json
+++ b/common/changes/@rushstack/module-minifier/available-parallelism_2025-01-30-01-01.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/module-minifier",
+      "comment": "Prefer `os.availableParallelism()` to `os.cpus().length`.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/module-minifier"
+}

--- a/common/changes/@rushstack/package-extractor/available-parallelism_2025-01-30-01-01.json
+++ b/common/changes/@rushstack/package-extractor/available-parallelism_2025-01-30-01-01.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/package-extractor",
+      "comment": "Prefer `os.availableParallelism()` to `os.cpus().length`.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/package-extractor"
+}

--- a/common/changes/@rushstack/webpack4-module-minifier-plugin/available-parallelism_2025-01-30-01-01.json
+++ b/common/changes/@rushstack/webpack4-module-minifier-plugin/available-parallelism_2025-01-30-01-01.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/webpack4-module-minifier-plugin",
+      "comment": "Prefer `os.availableParallelism()` to `os.cpus().length`.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/webpack4-module-minifier-plugin"
+}

--- a/libraries/module-minifier/src/WorkerPoolMinifier.ts
+++ b/libraries/module-minifier/src/WorkerPoolMinifier.ts
@@ -2,7 +2,7 @@
 // See LICENSE in the project root for license information.
 
 import { createHash } from 'crypto';
-import { cpus } from 'os';
+import os from 'os';
 import type { ResourceLimits } from 'worker_threads';
 
 import serialize from 'serialize-javascript';
@@ -24,7 +24,7 @@ import type {
 export interface IWorkerPoolMinifierOptions {
   /**
    * Maximum number of worker threads to use. Will never use more than there are modules to process.
-   * Defaults to os.cpus().length
+   * Defaults to os.availableParallelism()
    */
   maxThreads?: number;
   /**
@@ -62,7 +62,7 @@ export class WorkerPoolMinifier implements IModuleMinifier {
 
   public constructor(options: IWorkerPoolMinifierOptions) {
     const {
-      maxThreads = cpus().length,
+      maxThreads = os.availableParallelism?.() ?? os.cpus().length,
       terserOptions = {},
       verbose = false,
       workerResourceLimits

--- a/libraries/package-extractor/src/scripts/createLinks/utilities/constants.ts
+++ b/libraries/package-extractor/src/scripts/createLinks/utilities/constants.ts
@@ -8,7 +8,7 @@ import type { TARGET_ROOT_SCRIPT_RELATIVE_PATH_TEMPLATE_STRING as TargetRootScri
 /**
  * The maximum number of concurrent operations to perform.
  */
-export const MAX_CONCURRENCY: number = os.cpus().length * 2;
+export const MAX_CONCURRENCY: number = (os.availableParallelism?.() ?? os.cpus().length) * 2;
 
 /**
  * The name of the action to create symlinks.

--- a/libraries/rush-lib/src/cli/parsing/ParseParallelism.ts
+++ b/libraries/rush-lib/src/cli/parsing/ParseParallelism.ts
@@ -9,7 +9,7 @@ import * as os from 'os';
  */
 export function parseParallelism(
   rawParallelism: string | undefined,
-  numberOfCores: number = os.cpus().length
+  numberOfCores: number = os.availableParallelism?.() ?? os.cpus().length
 ): number {
   if (rawParallelism) {
     if (rawParallelism === 'max') {

--- a/libraries/rush-lib/src/logic/Telemetry.ts
+++ b/libraries/rush-lib/src/logic/Telemetry.ts
@@ -156,14 +156,15 @@ export class Telemetry {
     if (!this._enabled) {
       return;
     }
+    const cpus: os.CpuInfo[] = os.cpus();
     const data: ITelemetryData = {
       ...telemetryData,
       machineInfo: telemetryData.machineInfo || {
         machineArchitecture: os.arch(),
         // The Node.js model is sometimes padded, for example:
         // "AMD Ryzen 7 3700X 8-Core Processor             "
-        machineCpu: os.cpus()[0].model.trim(),
-        machineCores: os.cpus().length,
+        machineCpu: cpus[0].model.trim(),
+        machineCores: cpus.length,
         machineTotalMemoryMiB: Math.round(os.totalmem() / ONE_MEGABYTE_IN_BYTES),
         machineFreeMemoryMiB: Math.round(os.freemem() / ONE_MEGABYTE_IN_BYTES)
       },

--- a/webpack/webpack4-module-minifier-plugin/src/ParallelCompiler.ts
+++ b/webpack/webpack4-module-minifier-plugin/src/ParallelCompiler.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import { cpus } from 'os';
+import os from 'os';
 import { resolve } from 'path';
 import type { Worker } from 'worker_threads';
 
@@ -61,7 +61,7 @@ export async function runParallel(options: IParallelWebpackOptions): Promise<voi
   const configArray: Configuration[] = Array.isArray(rawConfig) ? rawConfig : [rawConfig];
   const configCount: number = configArray.length;
 
-  const totalCpus: number = cpus().length;
+  const totalCpus: number = os.availableParallelism?.() ?? os.cpus().length;
 
   // TODO: Use all cores if not minifying
   const {


### PR DESCRIPTION
## Summary
Prefer using [`os.availableParallelism()`](https://nodejs.org/docs/latest-v22.x/api/os.html#osavailableparallelism) to [`os.cpus().length`](https://nodejs.org/docs/latest-v22.x/api/os.html#oscpus)

The former API was introduced in NodeJS 18 and performs a lot less work than the latter.

## Details
In Node 22, `os.cpus()` opens several files to read info about each CPU on every invocation.

## How it was tested
Build, since this API is used to determine parallelism of Rush, as well as various unit tests.

## Impacted documentation
Only a few method comments where the default comes from this method.