### PR TITLE
Extend Heft-Jest-Plugin schema to match with configuration options

### DIFF
--- a/common/changes/@rushstack/heft-jest-plugin/bugfix-IncorrectHeftJsonPluginSchema_2025-02-06-21-03.json
+++ b/common/changes/@rushstack/heft-jest-plugin/bugfix-IncorrectHeftJsonPluginSchema_2025-02-06-21-03.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-jest-plugin",
+      "comment": "Extend heft-jest-plugin json schema to match HeftJestConfiguration",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft-jest-plugin"
+}

--- a/heft-plugins/heft-jest-plugin/src/schemas/heft-jest-plugin.schema.json
+++ b/heft-plugins/heft-jest-plugin/src/schemas/heft-jest-plugin.schema.json
@@ -9,7 +9,7 @@
   "properties": {
     "configurationPath": {
       "title": "Path to Jest configuration file",
-      "description": "If provided, this path will be used to load Jest configuration. Otherwise, Jest configuration will be loaded from \"jest.config.json\".",
+      "description": "If provided, this path will be used to load Jest configuration. Otherwise, Jest configuration will be loaded from \"<projectDir>/config/jest.config.json\".",
       "type": "string"
     },
     "disableCodeCoverage": {
@@ -20,56 +20,6 @@
     "disableConfigurationModuleResolution": {
       "title": "Disable Configuration Module Resolution",
       "description": "If set to true, modules specified in the Jest configuration will be resolved using Jest default (rootDir-relative) resolution. Otherwise, modules will be resolved using Node module resolution.",
-      "type": "boolean"
-    },
-    "enableNodeEnvManagement": {
-      "title": "Enable management of the NODE_ENV variable",
-      "description": "If set to false, heft-jest-plugin will not set or unset the NODE_ENV variable. Otherwise, NODE_ENV will be set to `test` before execution and cleared after. If the NODE_ENV value is already set to a value that is not `test`, warning message appears.",
-      "type": "boolean"
-    },
-    "findRelatedTests": {
-      "title": "Find tests related to file",
-      "description": "Find and run the tests that cover the source file that is specified. This corresponds to the \"--findRelatedTests\" parameter in Jest\"s documentation. This parameter is not compatible with watch mode.",
-      "type": "string"
-    },
-    "maxWorkers": {
-      "title": "Maximum number of worker processes",
-      "description": "Use this parameter to control maximum number of worker processes tests are allowed to use. This parameter is similar to the parameter noted in the Jest documentation, and can either be an integer representing the number of workers to spawn when running tests, or can be a string representing a percentage of the available CPUs on the machine to utilize. Example values: \"3\", \"25%\"",
-      "type": "string"
-    },
-    "passWithNoTests": {
-      "title": "Pass with no tests",
-      "description": "If set to false, Jest will fail if no tests are found.",
-      "type": "boolean"
-    },
-    "silent": {
-      "title": "Disable console output",
-      "description": "Prevent tests from printing messages through the console. This corresponds to the \"--silent\" parameter in Jest\"s documentation.",
-      "type": "boolean"
-    },
-    "testNamePattern": {
-      "title": "Test Name Pattern",
-      "description": "Run only tests with a name that matches a regular expression. On Windows you will need to use \"/\" instead of \"\\\". This corresponds to the \"--testNamePattern\" parameter in Jest\"s documentation.",
-      "type": "string"
-    },
-    "testPathIgnorePatterns": {
-      "title": "Test Path Ignore Patterns",
-      "description": "Avoid running tests with a source file path that matches one ore more regular expressions. On Windows you will need to use \"/\" instead of \"\\\". This corresponds to the \"--testPathIgnorePatterns\" parameter in Jest\"s documentation.",
-      "type": "string"
-    },
-    "testPathPattern": {
-      "title": "Test Path Pattern",
-      "description": "Run only tests with a source file path that matches a regular expression. On Windows you will need to use \"/\" instead of \"\\\". This corresponds to the \"--testPathPattern\" parameter in Jest\"s documentation.",
-      "type": "string"
-    },
-    "testTimeout": {
-      "title": "Test Timeout",
-      "description": "Change the default timeout for tests; if a test doesn\"t complete within this many milliseconds, it will fail. Individual tests can override the default. If unspecified, the default is normally 5000 ms. This corresponds to the \"--testTimeout\" parameter in Jest\"s documentation.",
-      "type": "number"
-    },
-    "updateSnapshots": {
-      "title": "Update Snapshots",
-      "description": "Update Jest snapshots while running the tests. This corresponds to the \"--updateSnapshots\" parameter in Jest.",
       "type": "boolean"
     }
   }

--- a/heft-plugins/heft-jest-plugin/src/schemas/heft-jest-plugin.schema.json
+++ b/heft-plugins/heft-jest-plugin/src/schemas/heft-jest-plugin.schema.json
@@ -7,6 +7,16 @@
   "additionalProperties": false,
 
   "properties": {
+    "configurationPath": {
+      "title": "Path to Jest configuration file",
+      "description": "If provided, this path will be used to load Jest configuration. Otherwise, Jest configuration will be loaded from \"jest.config.json\".",
+      "type": "string"
+    },
+    "disableCodeCoverage": {
+      "title": "Disable Code Coverage",
+      "description": "Disable any configured code coverage. If code coverage is not configured, this parameter has no effect.",
+      "type": "boolean"
+    },
     "disableConfigurationModuleResolution": {
       "title": "Disable Configuration Module Resolution",
       "description": "If set to true, modules specified in the Jest configuration will be resolved using Jest default (rootDir-relative) resolution. Otherwise, modules will be resolved using Node module resolution.",
@@ -15,6 +25,51 @@
     "enableNodeEnvManagement": {
       "title": "Enable management of the NODE_ENV variable",
       "description": "If set to false, heft-jest-plugin will not set or unset the NODE_ENV variable. Otherwise, NODE_ENV will be set to `test` before execution and cleared after. If the NODE_ENV value is already set to a value that is not `test`, warning message appears.",
+      "type": "boolean"
+    },
+    "findRelatedTests": {
+      "title": "Find tests related to file",
+      "description": "Find and run the tests that cover the source file that is specified. This corresponds to the \"--findRelatedTests\" parameter in Jest\"s documentation. This parameter is not compatible with watch mode.",
+      "type": "string"
+    },
+    "maxWorkers": {
+      "title": "Maximum number of worker processes",
+      "description": "Use this parameter to control maximum number of worker processes tests are allowed to use. This parameter is similar to the parameter noted in the Jest documentation, and can either be an integer representing the number of workers to spawn when running tests, or can be a string representing a percentage of the available CPUs on the machine to utilize. Example values: \"3\", \"25%\"",
+      "type": "string"
+    },
+    "passWithNoTests": {
+      "title": "Pass with no tests",
+      "description": "If set to false, Jest will fail if no tests are found.",
+      "type": "boolean"
+    },
+    "silent": {
+      "title": "Disable console output",
+      "description": "Prevent tests from printing messages through the console. This corresponds to the \"--silent\" parameter in Jest\"s documentation.",
+      "type": "boolean"
+    },
+    "testNamePattern": {
+      "title": "Test Name Pattern",
+      "description": "Run only tests with a name that matches a regular expression. On Windows you will need to use \"/\" instead of \"\\\". This corresponds to the \"--testNamePattern\" parameter in Jest\"s documentation.",
+      "type": "string"
+    },
+    "testPathIgnorePatterns": {
+      "title": "Test Path Ignore Patterns",
+      "description": "Avoid running tests with a source file path that matches one ore more regular expressions. On Windows you will need to use \"/\" instead of \"\\\". This corresponds to the \"--testPathIgnorePatterns\" parameter in Jest\"s documentation.",
+      "type": "string"
+    },
+    "testPathPattern": {
+      "title": "Test Path Pattern",
+      "description": "Run only tests with a source file path that matches a regular expression. On Windows you will need to use \"/\" instead of \"\\\". This corresponds to the \"--testPathPattern\" parameter in Jest\"s documentation.",
+      "type": "string"
+    },
+    "testTimeout": {
+      "title": "Test Timeout",
+      "description": "Change the default timeout for tests; if a test doesn\"t complete within this many milliseconds, it will fail. Individual tests can override the default. If unspecified, the default is normally 5000 ms. This corresponds to the \"--testTimeout\" parameter in Jest\"s documentation.",
+      "type": "number"
+    },
+    "updateSnapshots": {
+      "title": "Update Snapshots",
+      "description": "Update Jest snapshots while running the tests. This corresponds to the \"--updateSnapshots\" parameter in Jest.",
       "type": "boolean"
     }
   }

--- a/heft-plugins/heft-jest-plugin/src/schemas/heft-jest-plugin.schema.json
+++ b/heft-plugins/heft-jest-plugin/src/schemas/heft-jest-plugin.schema.json
@@ -12,14 +12,14 @@
       "description": "If provided, this path will be used to load Jest configuration. Otherwise, Jest configuration will be loaded from \"<projectDir>/config/jest.config.json\".",
       "type": "string"
     },
-    "disableCodeCoverage": {
-      "title": "Disable Code Coverage",
-      "description": "Disable any configured code coverage. If code coverage is not configured, this parameter has no effect.",
-      "type": "boolean"
-    },
     "disableConfigurationModuleResolution": {
       "title": "Disable Configuration Module Resolution",
       "description": "If set to true, modules specified in the Jest configuration will be resolved using Jest default (rootDir-relative) resolution. Otherwise, modules will be resolved using Node module resolution.",
+      "type": "boolean"
+    },
+    "enableNodeEnvManagement": {
+      "title": "Enable management of the NODE_ENV variable",
+      "description": "If set to false, heft-jest-plugin will not set or unset the NODE_ENV variable. Otherwise, NODE_ENV will be set to `test` before execution and cleared after. If the NODE_ENV value is already set to a value that is not `test`, warning message appears.",
       "type": "boolean"
     }
   }


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

There is a mismatch between the [schema](https://github.com/microsoft/rushstack/blob/main/heft-plugins/heft-jest-plugin/src/schemas/heft-jest-plugin.schema.json) and the possible configuration documented [here](https://heft.rushstack.io/pages/plugins/jest/#heftjson-plugin-options).
This PR extends the schema to match the plugin options.

## Details

Extended the schema, mostly with information already available in the documentation.
Note that both `debugHeftReporter` and `detectOpenHandles` were _not_ added to the schema on purpose, since IMO they do not belong in something that is set up statically (but should only be passed from the command line)
Happy to adjust that, if wanted.

## How it was tested

I modified the schema json in one of my projects consuming rush (within node_modules) and verified the behaviour.

## Impacted documentation

None; This PR aligns the code _to_ the documentation.
<!--------------------------------------------------------------------------
👉 STEP 7: Does your PR affect anything that is discussed in the website docs?
     If so, please paste the URL of each affected web page, so we will
     remember to update the documentation after your PR is merged.
     (Updating the website is appreciated but not required.)
     If no docs are impacted, delete the "Impacted documentation" section.

     If you modified a JSON schema, remember to update init templates such as:
     rush-lib/assets/rush-init/*.json
     api-extractor/src/schemas/api-extractor-template.json
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 8: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
