### PR TITLE
[rush-lib]: Support access parameter for each project configuration

### DIFF
--- a/common/changes/@microsoft/rush/pedrogomes-support-access-restrictions_2025-02-10-07-04.json
+++ b/common/changes/@microsoft/rush/pedrogomes-support-access-restrictions_2025-02-10-07-04.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "provides access parameter to restrict packages to be installed",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -1304,6 +1304,8 @@ export class RushConfigurationProject {
     //
     // @internal
     constructor(options: IRushConfigurationProjectOptions);
+    // Warning: (ae-forgotten-export) The symbol "PackageAccessType" needs to be exported by the entry point index.d.ts
+    readonly access: PackageAccessType;
     // @beta
     readonly configuredSubspaceName: string | undefined;
     get consumingProjects(): ReadonlySet<RushConfigurationProject>;
@@ -1335,6 +1337,7 @@ export class RushConfigurationProject {
     readonly tags: ReadonlySet<string>;
     readonly tempProjectName: string;
     readonly unscopedTempProjectName: string;
+    validateAccess(): void;
     // @beta
     get versionPolicy(): VersionPolicy | undefined;
     // @beta

--- a/libraries/rush-lib/src/api/RushConfiguration.ts
+++ b/libraries/rush-lib/src/api/RushConfiguration.ts
@@ -960,8 +960,11 @@ export class RushConfiguration {
         allowedProjectTags,
         subspace
       });
-      subspace._addProject(project);
 
+      // Validates project according to its access restrictions
+      project.validateAccess();
+
+      subspace._addProject(project);
       this._projects.push(project);
       if (this._projectsByName.has(project.packageName)) {
         throw new Error(

--- a/libraries/rush-lib/src/api/RushConfigurationProject.ts
+++ b/libraries/rush-lib/src/api/RushConfigurationProject.ts
@@ -29,6 +29,16 @@ export interface IRushConfigurationProjectJson {
   publishFolder?: string;
   tags?: string[];
   subspaceName?: string;
+  access?: PackageAccessType;
+}
+
+/**
+ * The type of package access restrictions
+ */
+export enum PackageAccessType {
+  Private = 'private',
+  Protected = 'protected',
+  Public = 'public'
 }
 
 /**
@@ -206,13 +216,23 @@ export class RushConfigurationProject {
    */
   public readonly configuredSubspaceName: string | undefined;
 
+  /**
+   * Access restrictions
+   */
+  public readonly access: PackageAccessType;
+
   /** @internal */
   public constructor(options: IRushConfigurationProjectOptions) {
     const { projectJson, rushConfiguration, tempProjectName, allowedProjectTags } = options;
-    const { packageName, projectFolder: projectRelativeFolder } = projectJson;
+    const {
+      packageName,
+      projectFolder: projectRelativeFolder,
+      access = PackageAccessType.Public
+    } = projectJson;
     this.rushConfiguration = rushConfiguration;
     this.packageName = packageName;
     this.projectRelativeFolder = projectRelativeFolder;
+    this.access = access;
 
     validateRelativePathField(projectRelativeFolder, 'projectFolder', rushConfiguration.rushJsonFile);
 
@@ -513,6 +533,31 @@ export class RushConfigurationProject {
       }
     }
     return isMain;
+  }
+
+  /**
+   * Validates if this project can access its local dependencies.
+   *
+   */
+  public validateAccess(): void {
+    const invalidDeps: string[] = [];
+    for (const project of this.dependencyProjects) {
+      if (project.access === PackageAccessType.Public) {
+        continue;
+      } else if (project.access === PackageAccessType.Private) {
+        invalidDeps.push(project.packageName);
+      } else if (this.subspace.subspaceName !== project.subspace.subspaceName) {
+        invalidDeps.push(project.packageName);
+      }
+    }
+
+    if (invalidDeps.length > 0) {
+      throw new Error(
+        `${this.packageName} doesn't have permissions to access ${invalidDeps.join(
+          ', '
+        )}.\nPlease remove this dependency or update the ${RushConstants.rushJsonFilename} access rights.`
+      );
+    }
   }
 }
 

--- a/libraries/rush-lib/src/schemas/rush.schema.json
+++ b/libraries/rush-lib/src/schemas/rush.schema.json
@@ -315,6 +315,12 @@
           "subspaceName": {
             "description": "(EXPERIMENTAL) An optional entry for specifying which subspace this project belongs to if the subspaces feature is enabled.",
             "type": "string"
+          },
+          "access": {
+            "description": "Restricts the project to be accessed by others. There are three possible values:\n\n\"public\" - any package can install this project.\n\"protected\" - only packages from the same subspace can install this project.\n\"private\" - no packages can install this project.\n\nThe default value is \"public\".",
+            "enum": ["public", "private", "protected"],
+            "type": "string",
+            "default": "public"
           }
         },
         "additionalProperties": false,


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

Restricts a package to be installed according to its access policy.

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

## Details

Package maintainers require to have more control and visibility over their project. Supporting a new rush project parameter called `access`, will help developers to restrict their project's visibility when intended (e.g. an application should NOT be accessed by any other project).

Currently the parameter provides 3 values:
* public: project can be accessed by any local package (e.g. core arch libraries). Default value.
* protected: project can only be accessed by the same subspace local package (e.g. team libraries)
* private: project cannot be accessed by others (e.g. standard application)

### Example

![CleanShot 2025-02-10 at 15 21 06@2x](https://github.com/user-attachments/assets/af1d9f2d-00ec-4bbe-85ac-9510e1798329)

P1 has **protected** access policy and depends on P2 and P3. P1 and P2 belongs to the same subspace S1, while P3 belongs to the subspace S2. Since P1 is restricted to only be installed by packages from S1, `rush install` will fail during S2 installation.

```
// rush.json
{
  ...,
  "projects": [
     {
       "packageName": "P1",
       "projectFolder": "packages/p1",
       "subspaceName": "S1",
       "access": "protected"
     },
     {
       "packageName": "P2",
       "projectFolder": "packages/p2",
       "subspaceName": "S1"
     },
     {
       "packageName": "P3",
       "projectFolder": "packages/p3",
       "subspaceName": "S2"
     },
  ]
}
```

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested

* Create a repository with subspaces enabled: https://rushjs.io/pages/advanced/subspaces/
* Create 2 subspaces (e.g. default, S1)
* Create 2 projects (e.g. P1 and P2) inside of default subspace and 1 project (e.g. P3) inside of S1
* Add P2 and P3 as a local dependencies of P1
* Update rush.json with `{ "access": "protected" }` for P1 configuration (or any other value) 
* Run `rush install --subspace default`

The error message will appear and the installation will fail:
```
ERROR: P1 cannot be accessed by P3.

Please remove the dependency P1 or update the "access" parameter on the rush.json configuration.
```

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

## Impacted documentation

https://rushjs.io/pages/configs/rush_json

<!--------------------------------------------------------------------------
👉 STEP 7: Does your PR affect anything that is discussed in the website docs?
     If so, please paste the URL of each affected web page, so we will
     remember to update the documentation after your PR is merged.
     (Updating the website is appreciated but not required.)
     If no docs are impacted, delete the "Impacted documentation" section.

     If you modified a JSON schema, remember to update init templates such as:
     rush-lib/assets/rush-init/*.json
     api-extractor/src/schemas/api-extractor-template.json
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 8: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
