### PR TITLE
[heft-lint-plugin] fix: eslint doesn't cache output correctly

### DIFF
--- a/heft-plugins/heft-lint-plugin/src/Eslint.ts
+++ b/heft-plugins/heft-lint-plugin/src/Eslint.ts
@@ -176,7 +176,14 @@ export class Eslint extends LinterBase<TEslint.ESLint.LintResult> {
           return lintResult.fixableErrorCount + lintResult.fixableWarningCount > 0;
         }));
 
-    return lintResults;
+    const transformedLintResults: TEslint.ESLint.LintResult[] = [];
+    for (const lintResult of lintResults) {
+      if (lintResult.messages.length > 0 || lintResult.warningCount > 0 || lintResult.errorCount > 0) {
+        transformedLintResults.push(lintResult);
+      }
+    }
+
+    return transformedLintResults;
   }
 
   protected async lintingFinishedAsync(lintResults: TEslint.ESLint.LintResult[]): Promise<void> {

--- a/heft-plugins/heft-lint-plugin/src/LinterBase.ts
+++ b/heft-plugins/heft-lint-plugin/src/LinterBase.ts
@@ -139,7 +139,9 @@ export abstract class LinterBase<TLintResult> {
       }
 
       // Compute the version from the source file content
-      const version: string = sourceFile.version || '';
+      const sourceCodeHash: Hash = createHash('sha1');
+      sourceCodeHash.update(sourceFile.text);
+      const version: string = sourceCodeHash.digest('base64');
       const cachedVersion: string = cachedNoFailureFileVersions.get(relative) || '';
       if (
         cachedVersion === '' ||


### PR DESCRIPTION
## Summary

context: https://rushstack.zulipchat.com/#narrow/channel/262522-heft/topic/heft-lint-plugin.20blocking/near/499305386

It looks like the ESLint part of the heft-lint-plugin hasn't been caching correctly. This should significantly speed up rebuilds with the cache still set up.

## Details

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested

Tested against `rush-lib`, with a cache file the build time was ~2.2s and without the cache file it was ~7s. Before this change, it was a consistent 7s. Also verified that the cache file now has content.
