### PR TITLE
Bump TypeScript to 5.7.3

### DIFF
--- a/apps/cpu-profile-summarizer/package.json
+++ b/apps/cpu-profile-summarizer/package.json
@@ -24,6 +24,6 @@
   "devDependencies": {
     "@rushstack/heft": "workspace:*",
     "local-node-rig": "workspace:*",
-    "typescript": "~5.4.2"
+    "typescript": "~5.7.3"
   }
 }

--- a/apps/cpu-profile-summarizer/package.json
+++ b/apps/cpu-profile-summarizer/package.json
@@ -23,7 +23,6 @@
   },
   "devDependencies": {
     "@rushstack/heft": "workspace:*",
-    "local-node-rig": "workspace:*",
-    "typescript": "~5.7.3"
+    "local-node-rig": "workspace:*"
   }
 }

--- a/apps/heft/package.json
+++ b/apps/heft/package.json
@@ -55,6 +55,6 @@
     "@types/heft-jest": "1.0.1",
     "@types/node": "20.17.19",
     "@types/watchpack": "2.4.0",
-    "typescript": "~5.4.2"
+    "typescript": "~5.7.3"
   }
 }

--- a/apps/heft/src/index.ts
+++ b/apps/heft/src/index.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+/// <reference types="node" preserve="true" />
+
 /**
  * Heft is a config-driven toolchain that invokes other popular tools such
  * as TypeScript, ESLint, Jest, Webpack, and API Extractor. You can use it to build

--- a/apps/trace-import/package.json
+++ b/apps/trace-import/package.json
@@ -23,7 +23,7 @@
     "@rushstack/ts-command-line": "workspace:*",
     "resolve": "~1.22.1",
     "semver": "~7.5.4",
-    "typescript": "~5.4.2"
+    "typescript": "~5.7.3"
   },
   "devDependencies": {
     "@rushstack/heft": "workspace:*",

--- a/build-tests-samples/heft-node-basic-tutorial/package.json
+++ b/build-tests-samples/heft-node-basic-tutorial/package.json
@@ -19,6 +19,6 @@
     "@types/heft-jest": "1.0.1",
     "@types/node": "20.17.19",
     "eslint": "~8.57.0",
-    "typescript": "~5.4.2"
+    "typescript": "~5.7.3"
   }
 }

--- a/build-tests-samples/heft-node-jest-tutorial/package.json
+++ b/build-tests-samples/heft-node-jest-tutorial/package.json
@@ -18,6 +18,6 @@
     "@types/heft-jest": "1.0.1",
     "@types/node": "20.17.19",
     "eslint": "~8.57.0",
-    "typescript": "~5.4.2"
+    "typescript": "~5.7.3"
   }
 }

--- a/build-tests-samples/heft-serverless-stack-tutorial/package.json
+++ b/build-tests-samples/heft-serverless-stack-tutorial/package.json
@@ -30,6 +30,6 @@
     "constructs": "~10.0.98",
     "eslint": "~8.57.0",
     "local-eslint-config": "workspace:*",
-    "typescript": "~5.4.2"
+    "typescript": "~5.7.3"
   }
 }

--- a/build-tests-samples/heft-storybook-react-tutorial-storykit/package.json
+++ b/build-tests-samples/heft-storybook-react-tutorial-storykit/package.json
@@ -32,7 +32,7 @@
     "react": "~17.0.2",
     "style-loader": "~2.0.0",
     "terser-webpack-plugin": "~3.0.8",
-    "typescript": "~5.4.2",
+    "typescript": "~5.7.3",
     "webpack": "~4.47.0"
   }
 }

--- a/build-tests-samples/heft-storybook-react-tutorial/package.json
+++ b/build-tests-samples/heft-storybook-react-tutorial/package.json
@@ -38,7 +38,7 @@
     "html-webpack-plugin": "~4.5.2",
     "source-map-loader": "~1.1.3",
     "style-loader": "~2.0.0",
-    "typescript": "~5.4.2",
+    "typescript": "~5.7.3",
     "webpack": "~4.47.0"
   }
 }

--- a/build-tests-samples/heft-web-rig-app-tutorial/package.json
+++ b/build-tests-samples/heft-web-rig-app-tutorial/package.json
@@ -21,7 +21,6 @@
     "@rushstack/heft": "workspace:*",
     "@types/react-dom": "17.0.25",
     "@types/react": "17.0.74",
-    "@types/webpack-env": "1.18.8",
-    "typescript": "~5.7.3"
+    "@types/webpack-env": "1.18.8"
   }
 }

--- a/build-tests-samples/heft-web-rig-app-tutorial/package.json
+++ b/build-tests-samples/heft-web-rig-app-tutorial/package.json
@@ -22,6 +22,6 @@
     "@types/react-dom": "17.0.25",
     "@types/react": "17.0.74",
     "@types/webpack-env": "1.18.8",
-    "typescript": "~5.4.2"
+    "typescript": "~5.7.3"
   }
 }

--- a/build-tests-samples/heft-web-rig-library-tutorial/package.json
+++ b/build-tests-samples/heft-web-rig-library-tutorial/package.json
@@ -23,7 +23,6 @@
     "@rushstack/heft": "workspace:*",
     "@types/react-dom": "17.0.25",
     "@types/react": "17.0.74",
-    "@types/webpack-env": "1.18.8",
-    "typescript": "~5.7.3"
+    "@types/webpack-env": "1.18.8"
   }
 }

--- a/build-tests-samples/heft-web-rig-library-tutorial/package.json
+++ b/build-tests-samples/heft-web-rig-library-tutorial/package.json
@@ -24,6 +24,6 @@
     "@types/react-dom": "17.0.25",
     "@types/react": "17.0.74",
     "@types/webpack-env": "1.18.8",
-    "typescript": "~5.4.2"
+    "typescript": "~5.7.3"
   }
 }

--- a/build-tests-samples/heft-webpack-basic-tutorial/package.json
+++ b/build-tests-samples/heft-webpack-basic-tutorial/package.json
@@ -30,7 +30,7 @@
     "html-webpack-plugin": "~5.5.0",
     "source-map-loader": "~3.0.1",
     "style-loader": "~3.3.1",
-    "typescript": "~5.4.2",
+    "typescript": "~5.7.3",
     "webpack": "~5.95.0"
   }
 }

--- a/build-tests-samples/packlets-tutorial/package.json
+++ b/build-tests-samples/packlets-tutorial/package.json
@@ -16,6 +16,6 @@
     "@rushstack/heft-typescript-plugin": "workspace:*",
     "@types/node": "20.17.19",
     "eslint": "~8.57.0",
-    "typescript": "~5.4.2"
+    "typescript": "~5.7.3"
   }
 }

--- a/build-tests-subspace/rush-lib-test/package.json
+++ b/build-tests-subspace/rush-lib-test/package.json
@@ -14,12 +14,10 @@
     "@rushstack/terminal": "workspace:*"
   },
   "devDependencies": {
-    "@rushstack/eslint-config": "workspace:*",
     "@rushstack/heft": "workspace:*",
     "@types/node": "20.17.19",
     "eslint": "~8.57.0",
-    "local-node-rig": "workspace:*",
-    "typescript": "~5.7.3"
+    "local-node-rig": "workspace:*"
   },
   "dependenciesMeta": {
     "@microsoft/rush-lib": {

--- a/build-tests-subspace/rush-lib-test/package.json
+++ b/build-tests-subspace/rush-lib-test/package.json
@@ -19,7 +19,7 @@
     "@types/node": "20.17.19",
     "eslint": "~8.57.0",
     "local-node-rig": "workspace:*",
-    "typescript": "~5.4.2"
+    "typescript": "~5.7.3"
   },
   "dependenciesMeta": {
     "@microsoft/rush-lib": {

--- a/build-tests-subspace/rush-sdk-test/package.json
+++ b/build-tests-subspace/rush-sdk-test/package.json
@@ -14,12 +14,10 @@
   },
   "devDependencies": {
     "@microsoft/rush-lib": "workspace:*",
-    "@rushstack/eslint-config": "workspace:*",
     "@rushstack/heft": "workspace:*",
     "@types/node": "20.17.19",
     "eslint": "~8.57.0",
-    "local-node-rig": "workspace:*",
-    "typescript": "~5.7.3"
+    "local-node-rig": "workspace:*"
   },
   "dependenciesMeta": {
     "@microsoft/rush-lib": {

--- a/build-tests-subspace/rush-sdk-test/package.json
+++ b/build-tests-subspace/rush-sdk-test/package.json
@@ -19,7 +19,7 @@
     "@types/node": "20.17.19",
     "eslint": "~8.57.0",
     "local-node-rig": "workspace:*",
-    "typescript": "~5.4.2"
+    "typescript": "~5.7.3"
   },
   "dependenciesMeta": {
     "@microsoft/rush-lib": {

--- a/build-tests-subspace/typescript-newest-test/package.json
+++ b/build-tests-subspace/typescript-newest-test/package.json
@@ -14,7 +14,7 @@
     "@rushstack/heft": "workspace:*",
     "eslint": "~8.57.0",
     "local-node-rig": "workspace:*",
-    "typescript": "~5.4.2"
+    "typescript": "~5.7.3"
   },
   "dependenciesMeta": {
     "@rushstack/eslint-config": {

--- a/build-tests/api-extractor-scenarios/etc/mixinPattern/rollup.d.ts
+++ b/build-tests/api-extractor-scenarios/etc/mixinPattern/rollup.d.ts
@@ -9,7 +9,7 @@ export declare class B extends B_base {
 
 declare const B_base: {
     new (...args: any[]): {
-        mixinProp?: string | undefined;
+        mixinProp?: string;
     };
 } & typeof A;
 

--- a/build-tests/api-extractor-test-01/dist/api-extractor-test-01-alpha.d.ts
+++ b/build-tests/api-extractor-test-01/dist/api-extractor-test-01-alpha.d.ts
@@ -9,10 +9,6 @@
  * @packageDocumentation
  */
 
-/// <reference types="jest" />
-/// <reference lib="es2015.symbol.wellknown" />
-/// <reference lib="es2018.intl" />
-
 import { default as Long_2 } from 'long';
 import { MAX_UNSIGNED_VALUE } from 'long';
 

--- a/build-tests/api-extractor-test-01/dist/api-extractor-test-01-beta.d.ts
+++ b/build-tests/api-extractor-test-01/dist/api-extractor-test-01-beta.d.ts
@@ -9,10 +9,6 @@
  * @packageDocumentation
  */
 
-/// <reference types="jest" />
-/// <reference lib="es2015.symbol.wellknown" />
-/// <reference lib="es2018.intl" />
-
 import { default as Long_2 } from 'long';
 import { MAX_UNSIGNED_VALUE } from 'long';
 

--- a/build-tests/api-extractor-test-01/dist/api-extractor-test-01-public.d.ts
+++ b/build-tests/api-extractor-test-01/dist/api-extractor-test-01-public.d.ts
@@ -9,10 +9,6 @@
  * @packageDocumentation
  */
 
-/// <reference types="jest" />
-/// <reference lib="es2015.symbol.wellknown" />
-/// <reference lib="es2018.intl" />
-
 import { default as Long_2 } from 'long';
 import { MAX_UNSIGNED_VALUE } from 'long';
 

--- a/build-tests/api-extractor-test-01/dist/api-extractor-test-01.d.ts
+++ b/build-tests/api-extractor-test-01/dist/api-extractor-test-01.d.ts
@@ -9,10 +9,6 @@
  * @packageDocumentation
  */
 
-/// <reference types="jest" />
-/// <reference lib="es2015.symbol.wellknown" />
-/// <reference lib="es2018.intl" />
-
 import { default as Long_2 } from 'long';
 import { MAX_UNSIGNED_VALUE } from 'long';
 

--- a/build-tests/api-extractor-test-01/etc/api-extractor-test-01.api.md
+++ b/build-tests/api-extractor-test-01/etc/api-extractor-test-01.api.md
@@ -4,10 +4,6 @@
 
 ```ts
 
-/// <reference types="jest" />
-/// <reference lib="es2015.symbol.wellknown" />
-/// <reference lib="es2018.intl" />
-
 import { default as Long_2 } from 'long';
 import { MAX_UNSIGNED_VALUE } from 'long';
 

--- a/build-tests/api-extractor-test-02/package.json
+++ b/build-tests/api-extractor-test-02/package.json
@@ -18,6 +18,6 @@
   "devDependencies": {
     "@rushstack/heft": "workspace:*",
     "local-node-rig": "workspace:*",
-    "typescript": "5.7.3"
+    "typescript": "~5.7.3"
   }
 }

--- a/build-tests/api-extractor-test-02/package.json
+++ b/build-tests/api-extractor-test-02/package.json
@@ -17,7 +17,6 @@
   },
   "devDependencies": {
     "@rushstack/heft": "workspace:*",
-    "local-node-rig": "workspace:*",
-    "typescript": "~5.7.3"
+    "local-node-rig": "workspace:*"
   }
 }

--- a/build-tests/eslint-7-11-test/package.json
+++ b/build-tests/eslint-7-11-test/package.json
@@ -16,6 +16,6 @@
     "@typescript-eslint/parser": "~6.19.0",
     "eslint": "7.11.0",
     "local-node-rig": "workspace:*",
-    "typescript": "~5.4.2"
+    "typescript": "~5.7.3"
   }
 }

--- a/build-tests/eslint-7-7-test/package.json
+++ b/build-tests/eslint-7-7-test/package.json
@@ -16,6 +16,6 @@
     "@typescript-eslint/parser": "~6.19.0",
     "eslint": "7.7.0",
     "local-node-rig": "workspace:*",
-    "typescript": "~5.4.2"
+    "typescript": "~5.7.3"
   }
 }

--- a/build-tests/eslint-7-test/package.json
+++ b/build-tests/eslint-7-test/package.json
@@ -16,6 +16,6 @@
     "@typescript-eslint/parser": "~6.19.0",
     "eslint": "~7.30.0",
     "local-node-rig": "workspace:*",
-    "typescript": "~5.4.2"
+    "typescript": "~5.7.3"
   }
 }

--- a/build-tests/eslint-8-test/package.json
+++ b/build-tests/eslint-8-test/package.json
@@ -13,8 +13,8 @@
     "@rushstack/heft": "workspace:*",
     "local-node-rig": "workspace:*",
     "@types/node": "20.17.19",
-    "@typescript-eslint/parser": "~8.1.0",
+    "@typescript-eslint/parser": "~8.24.0",
     "eslint": "~8.57.0",
-    "typescript": "~5.4.2"
+    "typescript": "~5.7.3"
   }
 }

--- a/build-tests/eslint-bulk-suppressions-test-legacy/package.json
+++ b/build-tests/eslint-bulk-suppressions-test-legacy/package.json
@@ -12,11 +12,11 @@
     "@rushstack/eslint-patch": "workspace:*",
     "@rushstack/heft": "workspace:*",
     "@rushstack/node-core-library": "workspace:*",
-    "@typescript-eslint/parser": "~6.19.0",
+    "@typescript-eslint/parser": "~8.24.0",
     "eslint": "~8.57.0",
     "eslint-8.23": "npm:eslint@8.23.1",
     "eslint-oldest": "npm:eslint@8.6.0",
     "local-node-rig": "workspace:*",
-    "typescript": "~5.4.2"
+    "typescript": "~5.7.3"
   }
 }

--- a/build-tests/eslint-bulk-suppressions-test/package.json
+++ b/build-tests/eslint-bulk-suppressions-test/package.json
@@ -11,9 +11,9 @@
     "@rushstack/eslint-patch": "workspace:*",
     "@rushstack/heft": "workspace:*",
     "@rushstack/node-core-library": "workspace:*",
-    "@typescript-eslint/parser": "~8.1.0",
+    "@typescript-eslint/parser": "~8.24.0",
     "eslint": "~8.57.0",
     "local-node-rig": "workspace:*",
-    "typescript": "~5.4.2"
+    "typescript": "~5.7.3"
   }
 }

--- a/build-tests/hashed-folder-copy-plugin-webpack5-test/package.json
+++ b/build-tests/hashed-folder-copy-plugin-webpack5-test/package.json
@@ -16,7 +16,7 @@
     "@rushstack/heft-webpack5-plugin": "workspace:*",
     "@types/webpack-env": "1.18.8",
     "html-webpack-plugin": "~5.5.0",
-    "typescript": "~5.4.2",
+    "typescript": "~5.7.3",
     "webpack-bundle-analyzer": "~4.5.0",
     "webpack": "~5.95.0"
   }

--- a/build-tests/heft-example-plugin-01/package.json
+++ b/build-tests/heft-example-plugin-01/package.json
@@ -21,6 +21,6 @@
     "@types/node": "20.17.19",
     "@types/tapable": "1.0.6",
     "eslint": "~8.57.0",
-    "typescript": "~5.4.2"
+    "typescript": "~5.7.3"
   }
 }

--- a/build-tests/heft-example-plugin-02/package.json
+++ b/build-tests/heft-example-plugin-02/package.json
@@ -26,6 +26,6 @@
     "@types/node": "20.17.19",
     "eslint": "~8.57.0",
     "heft-example-plugin-01": "workspace:*",
-    "typescript": "~5.4.2"
+    "typescript": "~5.7.3"
   }
 }

--- a/build-tests/heft-fastify-test/package.json
+++ b/build-tests/heft-fastify-test/package.json
@@ -19,7 +19,7 @@
     "@types/heft-jest": "1.0.1",
     "@types/node": "20.17.19",
     "eslint": "~8.57.0",
-    "typescript": "~5.4.2"
+    "typescript": "~5.7.3"
   },
   "dependencies": {
     "fastify": "~3.16.1"

--- a/build-tests/heft-jest-preset-test/package.json
+++ b/build-tests/heft-jest-preset-test/package.json
@@ -18,6 +18,6 @@
     "@rushstack/heft-typescript-plugin": "workspace:*",
     "@types/heft-jest": "1.0.1",
     "eslint": "~8.57.0",
-    "typescript": "~5.4.2"
+    "typescript": "~5.7.3"
   }
 }

--- a/build-tests/heft-jest-reporters-test/package.json
+++ b/build-tests/heft-jest-reporters-test/package.json
@@ -20,6 +20,6 @@
     "@rushstack/heft-typescript-plugin": "workspace:*",
     "@types/heft-jest": "1.0.1",
     "eslint": "~8.57.0",
-    "typescript": "~5.4.2"
+    "typescript": "~5.7.3"
   }
 }

--- a/build-tests/heft-minimal-rig-test/package.json
+++ b/build-tests/heft-minimal-rig-test/package.json
@@ -9,7 +9,7 @@
     "_phase:build": ""
   },
   "dependencies": {
-    "typescript": "~5.4.2",
+    "typescript": "~5.7.3",
     "@microsoft/api-extractor": "workspace:*",
     "@rushstack/heft-api-extractor-plugin": "workspace:*",
     "@rushstack/heft-jest-plugin": "workspace:*",

--- a/build-tests/heft-node-everything-esm-module-test/package.json
+++ b/build-tests/heft-node-everything-esm-module-test/package.json
@@ -25,6 +25,6 @@
     "heft-example-plugin-01": "workspace:*",
     "heft-example-plugin-02": "workspace:*",
     "tslint": "~5.20.1",
-    "typescript": "~5.4.2"
+    "typescript": "~5.7.3"
   }
 }

--- a/build-tests/heft-node-everything-test/package.json
+++ b/build-tests/heft-node-everything-test/package.json
@@ -26,6 +26,6 @@
     "heft-example-plugin-01": "workspace:*",
     "heft-example-plugin-02": "workspace:*",
     "tslint": "~5.20.1",
-    "typescript": "~5.4.2"
+    "typescript": "~5.7.3"
   }
 }

--- a/build-tests/heft-parameter-plugin-test/package.json
+++ b/build-tests/heft-parameter-plugin-test/package.json
@@ -18,6 +18,6 @@
     "@types/heft-jest": "1.0.1",
     "@types/node": "20.17.19",
     "heft-parameter-plugin": "workspace:*",
-    "typescript": "~5.4.2"
+    "typescript": "~5.7.3"
   }
 }

--- a/build-tests/heft-parameter-plugin/package.json
+++ b/build-tests/heft-parameter-plugin/package.json
@@ -16,7 +16,7 @@
     "@rushstack/heft-typescript-plugin": "workspace:*",
     "@types/node": "20.17.19",
     "eslint": "~8.57.0",
-    "typescript": "~5.4.2"
+    "typescript": "~5.7.3"
   },
   "dependencies": {
     "@rushstack/node-core-library": "workspace:*"

--- a/build-tests/heft-sass-test/package.json
+++ b/build-tests/heft-sass-test/package.json
@@ -31,7 +31,7 @@
     "react-dom": "~17.0.2",
     "react": "~17.0.2",
     "style-loader": "~2.0.0",
-    "typescript": "~5.4.2",
+    "typescript": "~5.7.3",
     "webpack": "~4.47.0"
   },
   "dependencies": {

--- a/build-tests/heft-typescript-composite-test/package.json
+++ b/build-tests/heft-typescript-composite-test/package.json
@@ -20,6 +20,6 @@
     "@types/webpack-env": "1.18.8",
     "eslint": "~8.57.0",
     "tslint": "~5.20.1",
-    "typescript": "~5.4.2"
+    "typescript": "~5.7.3"
   }
 }

--- a/build-tests/heft-webpack4-everything-test/package.json
+++ b/build-tests/heft-webpack4-everything-test/package.json
@@ -27,7 +27,7 @@
     "local-eslint-config": "workspace:*",
     "source-map-loader": "~1.1.3",
     "tslint": "~5.20.1",
-    "typescript": "~5.4.2",
+    "typescript": "~5.7.3",
     "webpack": "~4.47.0"
   }
 }

--- a/build-tests/heft-webpack5-everything-test/package.json
+++ b/build-tests/heft-webpack5-everything-test/package.json
@@ -30,7 +30,7 @@
     "local-eslint-config": "workspace:*",
     "source-map-loader": "~3.0.1",
     "tslint": "~5.20.1",
-    "typescript": "~5.4.2",
+    "typescript": "~5.7.3",
     "webpack": "~5.95.0"
   }
 }

--- a/build-tests/localization-plugin-test-03/package.json
+++ b/build-tests/localization-plugin-test-03/package.json
@@ -19,7 +19,7 @@
     "html-webpack-plugin": "~4.5.2",
     "local-node-rig": "workspace:*",
     "ts-loader": "6.0.0",
-    "typescript": "~5.4.2",
+    "typescript": "~5.7.3",
     "webpack-bundle-analyzer": "~4.5.0",
     "webpack-dev-server": "~4.9.3",
     "webpack": "~4.47.0"

--- a/build-tests/rush-amazon-s3-build-cache-plugin-integration-test/package.json
+++ b/build-tests/rush-amazon-s3-build-cache-plugin-integration-test/package.json
@@ -18,9 +18,7 @@
     "@rushstack/terminal": "workspace:*",
     "@types/http-proxy": "~1.17.8",
     "@types/node": "20.17.19",
-    "eslint": "~8.57.0",
     "http-proxy": "~1.18.1",
-    "local-node-rig": "workspace:*",
-    "typescript": "~5.7.3"
+    "local-node-rig": "workspace:*"
   }
 }

--- a/build-tests/rush-amazon-s3-build-cache-plugin-integration-test/package.json
+++ b/build-tests/rush-amazon-s3-build-cache-plugin-integration-test/package.json
@@ -21,6 +21,6 @@
     "eslint": "~8.57.0",
     "http-proxy": "~1.18.1",
     "local-node-rig": "workspace:*",
-    "typescript": "~5.4.2"
+    "typescript": "~5.7.3"
   }
 }

--- a/build-tests/rush-redis-cobuild-plugin-integration-test/package.json
+++ b/build-tests/rush-redis-cobuild-plugin-integration-test/package.json
@@ -20,6 +20,6 @@
     "@types/node": "20.17.19",
     "eslint": "~8.57.0",
     "http-proxy": "~1.18.1",
-    "typescript": "~5.4.2"
+    "typescript": "~5.7.3"
   }
 }

--- a/build-tests/rush-redis-cobuild-plugin-integration-test/package.json
+++ b/build-tests/rush-redis-cobuild-plugin-integration-test/package.json
@@ -18,8 +18,6 @@
     "@rushstack/terminal": "workspace:*",
     "@types/http-proxy": "~1.17.8",
     "@types/node": "20.17.19",
-    "eslint": "~8.57.0",
-    "http-proxy": "~1.18.1",
-    "typescript": "~5.7.3"
+    "http-proxy": "~1.18.1"
   }
 }

--- a/build-tests/set-webpack-public-path-plugin-test/package.json
+++ b/build-tests/set-webpack-public-path-plugin-test/package.json
@@ -19,7 +19,7 @@
     "@types/webpack-env": "1.18.8",
     "eslint": "~8.57.0",
     "html-webpack-plugin": "~5.5.0",
-    "typescript": "~5.4.2",
+    "typescript": "~5.7.3",
     "webpack": "~5.95.0"
   }
 }

--- a/common/changes/@microsoft/api-extractor-model/bump-ts_2025-02-25-04-50.json
+++ b/common/changes/@microsoft/api-extractor-model/bump-ts_2025-02-25-04-50.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor-model",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor-model"
+}

--- a/common/changes/@microsoft/api-extractor/bump-ts_2025-02-19-19-31.json
+++ b/common/changes/@microsoft/api-extractor/bump-ts_2025-02-19-19-31.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Bump the `typescript` dependency to `~5.7.3`.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor"
+}

--- a/common/changes/@microsoft/api-extractor/bump-ts_2025-02-19-19-31.json
+++ b/common/changes/@microsoft/api-extractor/bump-ts_2025-02-19-19-31.json
@@ -2,8 +2,8 @@
   "changes": [
     {
       "packageName": "@microsoft/api-extractor",
-      "comment": "Bump the `typescript` dependency to `~5.7.3`.",
-      "type": "patch"
+      "comment": "",
+      "type": "none"
     }
   ],
   "packageName": "@microsoft/api-extractor"

--- a/common/changes/@microsoft/rush/bump-ts_2025-02-25-04-50.json
+++ b/common/changes/@microsoft/rush/bump-ts_2025-02-25-04-50.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@rushstack/cpu-profile-summarizer/bump-ts_2025-02-19-19-31.json
+++ b/common/changes/@rushstack/cpu-profile-summarizer/bump-ts_2025-02-19-19-31.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/cpu-profile-summarizer",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/cpu-profile-summarizer"
+}

--- a/common/changes/@rushstack/eslint-config/bump-ts_2025-02-19-19-31.json
+++ b/common/changes/@rushstack/eslint-config/bump-ts_2025-02-19-19-31.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-config",
+      "comment": "Bump the `@typescript-eslint/*` dependencies to `~8.24.0` to support newer versions of TypeScript.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/eslint-config"
+}

--- a/common/changes/@rushstack/eslint-patch/bump-ts_2025-02-19-19-31.json
+++ b/common/changes/@rushstack/eslint-patch/bump-ts_2025-02-19-19-31.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-patch",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/eslint-patch"
+}

--- a/common/changes/@rushstack/eslint-plugin-packlets/bump-ts_2025-02-19-19-31.json
+++ b/common/changes/@rushstack/eslint-plugin-packlets/bump-ts_2025-02-19-19-31.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-plugin-packlets",
+      "comment": "Bump the `@typescript-eslint/*` dependencies to `~8.24.0` to support newer",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/eslint-plugin-packlets"
+}

--- a/common/changes/@rushstack/eslint-plugin-packlets/bump-ts_2025-02-19-19-31.json
+++ b/common/changes/@rushstack/eslint-plugin-packlets/bump-ts_2025-02-19-19-31.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@rushstack/eslint-plugin-packlets",
-      "comment": "Bump the `@typescript-eslint/*` dependencies to `~8.24.0` to support newer",
+      "comment": "Bump the `@typescript-eslint/*` dependencies to `~8.24.0` to support newer versions of TypeScript.",
       "type": "minor"
     }
   ],

--- a/common/changes/@rushstack/eslint-plugin-security/bump-ts_2025-02-19-19-31.json
+++ b/common/changes/@rushstack/eslint-plugin-security/bump-ts_2025-02-19-19-31.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-plugin-security",
+      "comment": "Bump the `@typescript-eslint/*` dependencies to `~8.24.0` to support newer",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/eslint-plugin-security"
+}

--- a/common/changes/@rushstack/eslint-plugin-security/bump-ts_2025-02-19-19-31.json
+++ b/common/changes/@rushstack/eslint-plugin-security/bump-ts_2025-02-19-19-31.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@rushstack/eslint-plugin-security",
-      "comment": "Bump the `@typescript-eslint/*` dependencies to `~8.24.0` to support newer",
+      "comment": "Bump the `@typescript-eslint/*` dependencies to `~8.24.0` to support newer versions of TypeScript.",
       "type": "minor"
     }
   ],

--- a/common/changes/@rushstack/eslint-plugin/bump-ts_2025-02-19-19-31.json
+++ b/common/changes/@rushstack/eslint-plugin/bump-ts_2025-02-19-19-31.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@rushstack/eslint-plugin",
-      "comment": "Bump the `@typescript-eslint/*` dependencies to `~8.24.0` to support newer",
+      "comment": "Bump the `@typescript-eslint/*` dependencies to `~8.24.0` to support newer versions of TypeScript.",
       "type": "minor"
     }
   ],

--- a/common/changes/@rushstack/eslint-plugin/bump-ts_2025-02-19-19-31.json
+++ b/common/changes/@rushstack/eslint-plugin/bump-ts_2025-02-19-19-31.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-plugin",
+      "comment": "Bump the `@typescript-eslint/*` dependencies to `~8.24.0` to support newer",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/eslint-plugin"
+}

--- a/common/changes/@rushstack/heft-api-extractor-plugin/bump-ts_2025-02-19-19-31.json
+++ b/common/changes/@rushstack/heft-api-extractor-plugin/bump-ts_2025-02-19-19-31.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-api-extractor-plugin",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/heft-api-extractor-plugin"
+}

--- a/common/changes/@rushstack/heft-config-file/bump-ts_2025-02-25-04-50.json
+++ b/common/changes/@rushstack/heft-config-file/bump-ts_2025-02-25-04-50.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-config-file",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/heft-config-file"
+}

--- a/common/changes/@rushstack/heft-jest-plugin/bump-ts_2025-02-19-19-31.json
+++ b/common/changes/@rushstack/heft-jest-plugin/bump-ts_2025-02-19-19-31.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-jest-plugin",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/heft-jest-plugin"
+}

--- a/common/changes/@rushstack/heft-lint-plugin/bump-ts_2025-02-19-19-31.json
+++ b/common/changes/@rushstack/heft-lint-plugin/bump-ts_2025-02-19-19-31.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-lint-plugin",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/heft-lint-plugin"
+}

--- a/common/changes/@rushstack/heft-node-rig/bump-ts_2025-02-19-19-31.json
+++ b/common/changes/@rushstack/heft-node-rig/bump-ts_2025-02-19-19-31.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-node-rig",
+      "comment": "Bump the `typescript` dependency to `~5.7.3`.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft-node-rig"
+}

--- a/common/changes/@rushstack/heft-typescript-plugin/bump-ts_2025-02-19-19-31.json
+++ b/common/changes/@rushstack/heft-typescript-plugin/bump-ts_2025-02-19-19-31.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-typescript-plugin",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/heft-typescript-plugin"
+}

--- a/common/changes/@rushstack/heft-typescript-plugin/bump-ts_2025-02-25-00-08.json
+++ b/common/changes/@rushstack/heft-typescript-plugin/bump-ts_2025-02-25-00-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-typescript-plugin",
+      "comment": "Add support for TypeScript 5.7.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft-typescript-plugin"
+}

--- a/common/changes/@rushstack/heft-web-rig/bump-ts_2025-02-19-19-31.json
+++ b/common/changes/@rushstack/heft-web-rig/bump-ts_2025-02-19-19-31.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-web-rig",
+      "comment": "Bump the `typescript` dependency to `~5.7.3`.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft-web-rig"
+}

--- a/common/changes/@rushstack/heft/bump-ts_2025-02-19-19-31.json
+++ b/common/changes/@rushstack/heft/bump-ts_2025-02-19-19-31.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/heft"
+}

--- a/common/changes/@rushstack/module-minifier/bump-ts_2025-02-25-04-50.json
+++ b/common/changes/@rushstack/module-minifier/bump-ts_2025-02-25-04-50.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/module-minifier",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/module-minifier"
+}

--- a/common/changes/@rushstack/node-core-library/bump-ts_2025-02-25-04-50.json
+++ b/common/changes/@rushstack/node-core-library/bump-ts_2025-02-25-04-50.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/node-core-library",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/node-core-library"
+}

--- a/common/changes/@rushstack/operation-graph/bump-ts_2025-02-25-04-50.json
+++ b/common/changes/@rushstack/operation-graph/bump-ts_2025-02-25-04-50.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/operation-graph",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/operation-graph"
+}

--- a/common/changes/@rushstack/rig-package/bump-ts_2025-02-25-04-50.json
+++ b/common/changes/@rushstack/rig-package/bump-ts_2025-02-25-04-50.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/rig-package",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/rig-package"
+}

--- a/common/changes/@rushstack/set-webpack-public-path-plugin/bump-ts_2025-02-25-04-50.json
+++ b/common/changes/@rushstack/set-webpack-public-path-plugin/bump-ts_2025-02-25-04-50.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/set-webpack-public-path-plugin",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/set-webpack-public-path-plugin"
+}

--- a/common/changes/@rushstack/terminal/bump-ts_2025-02-25-04-50.json
+++ b/common/changes/@rushstack/terminal/bump-ts_2025-02-25-04-50.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/terminal",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/terminal"
+}

--- a/common/changes/@rushstack/trace-import/bump-ts_2025-02-19-19-31.json
+++ b/common/changes/@rushstack/trace-import/bump-ts_2025-02-19-19-31.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/trace-import",
+      "comment": "Bump the `typescript` dependency to `~5.7.3`.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/trace-import"
+}

--- a/common/changes/@rushstack/tree-pattern/bump-ts_2025-02-19-19-31.json
+++ b/common/changes/@rushstack/tree-pattern/bump-ts_2025-02-19-19-31.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/tree-pattern",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/tree-pattern"
+}

--- a/common/changes/@rushstack/ts-command-line/bump-ts_2025-02-25-04-50.json
+++ b/common/changes/@rushstack/ts-command-line/bump-ts_2025-02-25-04-50.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/ts-command-line",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/ts-command-line"
+}

--- a/common/changes/@rushstack/webpack-workspace-resolve-plugin/bump-ts_2025-02-25-04-50.json
+++ b/common/changes/@rushstack/webpack-workspace-resolve-plugin/bump-ts_2025-02-25-04-50.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/webpack-workspace-resolve-plugin",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/webpack-workspace-resolve-plugin"
+}

--- a/common/changes/@rushstack/webpack4-module-minifier-plugin/bump-ts_2025-02-25-04-50.json
+++ b/common/changes/@rushstack/webpack4-module-minifier-plugin/bump-ts_2025-02-25-04-50.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/webpack4-module-minifier-plugin",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/webpack4-module-minifier-plugin"
+}

--- a/common/changes/@rushstack/webpack5-localization-plugin/bump-ts_2025-02-25-04-50.json
+++ b/common/changes/@rushstack/webpack5-localization-plugin/bump-ts_2025-02-25-04-50.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/webpack5-localization-plugin",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/webpack5-localization-plugin"
+}

--- a/common/changes/@rushstack/webpack5-module-minifier-plugin/bump-ts_2025-02-25-04-50.json
+++ b/common/changes/@rushstack/webpack5-module-minifier-plugin/bump-ts_2025-02-25-04-50.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/webpack5-module-minifier-plugin",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/webpack5-module-minifier-plugin"
+}

--- a/common/changes/@rushstack/worker-pool/bump-ts_2025-02-25-04-50.json
+++ b/common/changes/@rushstack/worker-pool/bump-ts_2025-02-25-04-50.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/worker-pool",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/worker-pool"
+}

--- a/common/config/rush/pnpm-config.json
+++ b/common/config/rush/pnpm-config.json
@@ -410,6 +410,36 @@
           "optional": true
         }
       }
+    },
+
+    // TODO: Remove after an updated version of heft-node-rig is pulled in
+    "@rushstack/heft-node-rig@2.6.48": {
+      "dependencies": {
+        "typescript": "~5.7.3"
+      }
+    },
+    "@rushstack/eslint-config@4.1.1": {
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "~8.24.0",
+        "@typescript-eslint/utils": "~8.24.0",
+        "@typescript-eslint/parser": "~8.24.0",
+        "@typescript-eslint/typescript-estree": "~8.24.0"
+      }
+    },
+    "@rushstack/eslint-plugin@0.16.1": {
+      "dependencies": {
+        "@typescript-eslint/utils": "~8.24.0"
+      }
+    },
+    "@rushstack/eslint-plugin-packlets@0.9.2": {
+      "dependencies": {
+        "@typescript-eslint/utils": "~8.24.0"
+      }
+    },
+    "@rushstack/eslint-plugin-security@0.8.3": {
+      "dependencies": {
+        "@typescript-eslint/utils": "~8.24.0"
+      }
     }
   },
 

--- a/common/config/subspaces/build-tests-subspace/common-versions.json
+++ b/common/config/subspaces/build-tests-subspace/common-versions.json
@@ -29,7 +29,7 @@
     // Preferring it avoids errors for indirect dependencies that request it as a peer dependency.
     // It's also the newest supported compiler, used by most build tests and used as the bundled compiler
     // engine for API Extractor.
-    "typescript": "~5.4.2",
+    "typescript": "~5.7.3",
 
     // Workaround for https://github.com/microsoft/rushstack/issues/1466
     "eslint": "~8.57.0"
@@ -94,10 +94,7 @@
       // For testing Heft with TS V3
       "~3.9.10",
       // For testing Heft with TS V4
-      "~4.9.5",
-
-      // API Extractor bundles a specific TypeScript version because it calls internal APIs
-      "5.7.2"
+      "~4.9.5"
     ],
     "source-map": [
       "~0.6.1" // API Extractor is using an older version of source-map because newer versions are async

--- a/common/config/subspaces/build-tests-subspace/pnpm-lock.yaml
+++ b/common/config/subspaces/build-tests-subspace/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 overrides:
   package-json: ^7
 
-packageExtensionsChecksum: e59cfa9a35183eeeb6f2ac48c9ddd4b2
+packageExtensionsChecksum: 55f4ecaa9bc2eb3a2f471f725282aba9
 
 importers:
 
@@ -24,7 +24,7 @@ importers:
     devDependencies:
       '@rushstack/eslint-config':
         specifier: file:../../eslint/eslint-config
-        version: file:../../../eslint/eslint-config(eslint@8.57.1)(typescript@5.4.5)
+        version: file:../../../eslint/eslint-config(eslint@8.57.1)(typescript@5.7.3)
       '@rushstack/heft':
         specifier: file:../../apps/heft
         version: file:../../../apps/heft(@types/node@20.17.19)
@@ -38,8 +38,8 @@ importers:
         specifier: file:../../rigs/local-node-rig
         version: file:../../../rigs/local-node-rig
       typescript:
-        specifier: ~5.4.2
-        version: 5.4.5
+        specifier: ~5.7.3
+        version: 5.7.3
     dependenciesMeta:
       '@microsoft/rush-lib':
         injected: true
@@ -63,7 +63,7 @@ importers:
         version: file:../../../libraries/rush-lib(@types/node@20.17.19)
       '@rushstack/eslint-config':
         specifier: file:../../eslint/eslint-config
-        version: file:../../../eslint/eslint-config(eslint@8.57.1)(typescript@5.4.5)
+        version: file:../../../eslint/eslint-config(eslint@8.57.1)(typescript@5.7.3)
       '@rushstack/heft':
         specifier: file:../../apps/heft
         version: file:../../../apps/heft(@types/node@20.17.19)
@@ -77,8 +77,8 @@ importers:
         specifier: file:../../rigs/local-node-rig
         version: file:../../../rigs/local-node-rig
       typescript:
-        specifier: ~5.4.2
-        version: 5.4.5
+        specifier: ~5.7.3
+        version: 5.7.3
     dependenciesMeta:
       '@microsoft/rush-lib':
         injected: true
@@ -95,7 +95,7 @@ importers:
     devDependencies:
       '@rushstack/eslint-config':
         specifier: file:../../eslint/eslint-config
-        version: file:../../../eslint/eslint-config(eslint@8.57.1)(typescript@5.4.5)
+        version: file:../../../eslint/eslint-config(eslint@8.57.1)(typescript@5.7.3)
       '@rushstack/heft':
         specifier: file:../../apps/heft
         version: file:../../../apps/heft(@types/node@20.17.19)
@@ -106,8 +106,8 @@ importers:
         specifier: file:../../rigs/local-node-rig
         version: file:../../../rigs/local-node-rig
       typescript:
-        specifier: ~5.4.2
-        version: 5.4.5
+        specifier: ~5.7.3
+        version: 5.7.3
     dependenciesMeta:
       '@rushstack/eslint-config':
         injected: true
@@ -578,7 +578,7 @@ packages:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.5.0
       '@jest/test-result': 29.7.0(@types/node@20.17.19)
-      '@jest/transform': 29.5.0
+      '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@types/node': 20.17.19
       ansi-escapes: 4.3.2
@@ -591,11 +591,11 @@ packages:
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
-      jest-resolve: 29.5.0
+      jest-resolve: 29.7.0
       jest-resolve-dependencies: 29.7.0
       jest-runner: 29.7.0
       jest-runtime: 29.7.0
-      jest-snapshot: 29.5.0
+      jest-snapshot: 29.7.0
       jest-util: 29.7.0
       jest-validate: 29.7.0
       jest-watcher: 29.7.0
@@ -672,7 +672,7 @@ packages:
       '@bcoe/v8-coverage': 0.2.3
       '@jest/console': 29.7.0
       '@jest/test-result': 29.7.0(@types/node@20.17.19)
-      '@jest/transform': 29.5.0
+      '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.25
       '@types/istanbul-lib-coverage': 2.0.4
@@ -1183,74 +1183,65 @@ packages:
       '@types/yargs-parser': 21.0.3
     dev: true
 
-  /@typescript-eslint/eslint-plugin@8.1.0(@typescript-eslint/parser@8.1.0)(eslint@8.57.1)(typescript@4.9.5):
-    resolution: {integrity: sha512-LlNBaHFCEBPHyD4pZXb35mzjGkuGKXU5eeCA1SxvHfiRES0E82dOounfVpL4DCqYvJEKab0bZIA0gCRpdLKkCw==}
+  /@typescript-eslint/eslint-plugin@8.24.1(@typescript-eslint/parser@8.24.1)(eslint@8.57.1)(typescript@4.9.5):
+    resolution: {integrity: sha512-ll1StnKtBigWIGqvYDVuDmXJHVH4zLVot1yQ4fJtLpL7qacwkxJc1T0bptqw+miBQ/QfUbhl1TcQ4accW5KUyA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       '@typescript-eslint/parser': ^8.0.0 || ^8.0.0-alpha.0
       eslint: ^8.57.0 || ^9.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
+      typescript: '>=4.8.4 <5.8.0'
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.1.0(eslint@8.57.1)(typescript@4.9.5)
-      '@typescript-eslint/scope-manager': 8.1.0(typescript@4.9.5)
-      '@typescript-eslint/type-utils': 8.1.0(eslint@8.57.1)(typescript@4.9.5)
-      '@typescript-eslint/utils': 8.1.0(eslint@8.57.1)(typescript@4.9.5)
-      '@typescript-eslint/visitor-keys': 8.1.0(typescript@4.9.5)
+      '@typescript-eslint/parser': 8.24.1(eslint@8.57.1)(typescript@4.9.5)
+      '@typescript-eslint/scope-manager': 8.24.1(typescript@4.9.5)
+      '@typescript-eslint/type-utils': 8.24.1(eslint@8.57.1)(typescript@4.9.5)
+      '@typescript-eslint/utils': 8.24.1(eslint@8.57.1)(typescript@4.9.5)
+      '@typescript-eslint/visitor-keys': 8.24.1(typescript@4.9.5)
       eslint: 8.57.1
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
-      ts-api-utils: 1.4.3(typescript@4.9.5)
+      ts-api-utils: 2.0.1(typescript@4.9.5)
       typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/eslint-plugin@8.1.0(@typescript-eslint/parser@8.1.0)(eslint@8.57.1)(typescript@5.4.5):
-    resolution: {integrity: sha512-LlNBaHFCEBPHyD4pZXb35mzjGkuGKXU5eeCA1SxvHfiRES0E82dOounfVpL4DCqYvJEKab0bZIA0gCRpdLKkCw==}
+  /@typescript-eslint/eslint-plugin@8.24.1(@typescript-eslint/parser@8.24.1)(eslint@8.57.1)(typescript@5.7.3):
+    resolution: {integrity: sha512-ll1StnKtBigWIGqvYDVuDmXJHVH4zLVot1yQ4fJtLpL7qacwkxJc1T0bptqw+miBQ/QfUbhl1TcQ4accW5KUyA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       '@typescript-eslint/parser': ^8.0.0 || ^8.0.0-alpha.0
       eslint: ^8.57.0 || ^9.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
+      typescript: '>=4.8.4 <5.8.0'
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.1.0(eslint@8.57.1)(typescript@5.4.5)
-      '@typescript-eslint/scope-manager': 8.1.0(typescript@5.4.5)
-      '@typescript-eslint/type-utils': 8.1.0(eslint@8.57.1)(typescript@5.4.5)
-      '@typescript-eslint/utils': 8.1.0(eslint@8.57.1)(typescript@5.4.5)
-      '@typescript-eslint/visitor-keys': 8.1.0(typescript@5.4.5)
+      '@typescript-eslint/parser': 8.24.1(eslint@8.57.1)(typescript@5.7.3)
+      '@typescript-eslint/scope-manager': 8.24.1(typescript@5.7.3)
+      '@typescript-eslint/type-utils': 8.24.1(eslint@8.57.1)(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.24.1(eslint@8.57.1)(typescript@5.7.3)
+      '@typescript-eslint/visitor-keys': 8.24.1(typescript@5.7.3)
       eslint: 8.57.1
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
-      ts-api-utils: 1.4.3(typescript@5.4.5)
-      typescript: 5.4.5
+      ts-api-utils: 2.0.1(typescript@5.7.3)
+      typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@8.1.0(eslint@8.57.1)(typescript@4.9.5):
-    resolution: {integrity: sha512-U7iTAtGgJk6DPX9wIWPPOlt1gO57097G06gIcl0N0EEnNw8RGD62c+2/DiP/zL7KrkqnnqF7gtFGR7YgzPllTA==}
+  /@typescript-eslint/parser@8.24.1(eslint@8.57.1)(typescript@4.9.5):
+    resolution: {integrity: sha512-Tqoa05bu+t5s8CTZFaGpCH2ub3QeT9YDkXbPd3uQ4SfsLoh1/vv2GEYAioPoxCWJJNsenXlC88tRjwoHNts1oQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
+      typescript: '>=4.8.4 <5.8.0'
     dependencies:
-      '@typescript-eslint/scope-manager': 8.1.0(typescript@4.9.5)
-      '@typescript-eslint/types': 8.1.0(typescript@4.9.5)
-      '@typescript-eslint/typescript-estree': 8.1.0(typescript@4.9.5)
-      '@typescript-eslint/visitor-keys': 8.1.0(typescript@4.9.5)
+      '@typescript-eslint/scope-manager': 8.24.1(typescript@4.9.5)
+      '@typescript-eslint/types': 8.24.1(typescript@4.9.5)
+      '@typescript-eslint/typescript-estree': 8.24.1(typescript@4.9.5)
+      '@typescript-eslint/visitor-keys': 8.24.1(typescript@4.9.5)
       debug: 4.3.7
       eslint: 8.57.1
       typescript: 4.9.5
@@ -1258,106 +1249,99 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@8.1.0(eslint@8.57.1)(typescript@5.4.5):
-    resolution: {integrity: sha512-U7iTAtGgJk6DPX9wIWPPOlt1gO57097G06gIcl0N0EEnNw8RGD62c+2/DiP/zL7KrkqnnqF7gtFGR7YgzPllTA==}
+  /@typescript-eslint/parser@8.24.1(eslint@8.57.1)(typescript@5.7.3):
+    resolution: {integrity: sha512-Tqoa05bu+t5s8CTZFaGpCH2ub3QeT9YDkXbPd3uQ4SfsLoh1/vv2GEYAioPoxCWJJNsenXlC88tRjwoHNts1oQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
+      typescript: '>=4.8.4 <5.8.0'
     dependencies:
-      '@typescript-eslint/scope-manager': 8.1.0(typescript@5.4.5)
-      '@typescript-eslint/types': 8.1.0(typescript@5.4.5)
-      '@typescript-eslint/typescript-estree': 8.1.0(typescript@5.4.5)
-      '@typescript-eslint/visitor-keys': 8.1.0(typescript@5.4.5)
+      '@typescript-eslint/scope-manager': 8.24.1(typescript@5.7.3)
+      '@typescript-eslint/types': 8.24.1(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 8.24.1(typescript@5.7.3)
+      '@typescript-eslint/visitor-keys': 8.24.1(typescript@5.7.3)
       debug: 4.3.7
       eslint: 8.57.1
-      typescript: 5.4.5
+      typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/scope-manager@6.21.0(typescript@5.4.5):
+  /@typescript-eslint/scope-manager@6.21.0(typescript@5.7.3):
     resolution: {integrity: sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==}
     engines: {node: ^16.0.0 || >=18.0.0}
     dependencies:
-      '@typescript-eslint/types': 6.21.0(typescript@5.4.5)
-      '@typescript-eslint/visitor-keys': 6.21.0(typescript@5.4.5)
+      '@typescript-eslint/types': 6.21.0(typescript@5.7.3)
+      '@typescript-eslint/visitor-keys': 6.21.0(typescript@5.7.3)
     transitivePeerDependencies:
       - typescript
     dev: true
 
-  /@typescript-eslint/scope-manager@8.1.0(typescript@4.9.5):
-    resolution: {integrity: sha512-DsuOZQji687sQUjm4N6c9xABJa7fjvfIdjqpSIIVOgaENf2jFXiM9hIBZOL3hb6DHK9Nvd2d7zZnoMLf9e0OtQ==}
+  /@typescript-eslint/scope-manager@8.24.1(typescript@4.9.5):
+    resolution: {integrity: sha512-OdQr6BNBzwRjNEXMQyaGyZzgg7wzjYKfX2ZBV3E04hUCBDv3GQCHiz9RpqdUIiVrMgJGkXm3tcEh4vFSHreS2Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     dependencies:
-      '@typescript-eslint/types': 8.1.0(typescript@4.9.5)
-      '@typescript-eslint/visitor-keys': 8.1.0(typescript@4.9.5)
+      '@typescript-eslint/types': 8.24.1(typescript@4.9.5)
+      '@typescript-eslint/visitor-keys': 8.24.1(typescript@4.9.5)
     transitivePeerDependencies:
       - typescript
     dev: true
 
-  /@typescript-eslint/scope-manager@8.1.0(typescript@5.4.5):
-    resolution: {integrity: sha512-DsuOZQji687sQUjm4N6c9xABJa7fjvfIdjqpSIIVOgaENf2jFXiM9hIBZOL3hb6DHK9Nvd2d7zZnoMLf9e0OtQ==}
+  /@typescript-eslint/scope-manager@8.24.1(typescript@5.7.3):
+    resolution: {integrity: sha512-OdQr6BNBzwRjNEXMQyaGyZzgg7wzjYKfX2ZBV3E04hUCBDv3GQCHiz9RpqdUIiVrMgJGkXm3tcEh4vFSHreS2Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     dependencies:
-      '@typescript-eslint/types': 8.1.0(typescript@5.4.5)
-      '@typescript-eslint/visitor-keys': 8.1.0(typescript@5.4.5)
+      '@typescript-eslint/types': 8.24.1(typescript@5.7.3)
+      '@typescript-eslint/visitor-keys': 8.24.1(typescript@5.7.3)
     transitivePeerDependencies:
       - typescript
     dev: true
 
-  /@typescript-eslint/type-utils@8.1.0(eslint@8.57.1)(typescript@4.9.5):
-    resolution: {integrity: sha512-oLYvTxljVvsMnldfl6jIKxTaU7ok7km0KDrwOt1RHYu6nxlhN3TIx8k5Q52L6wR33nOwDgM7VwW1fT1qMNfFIA==}
+  /@typescript-eslint/type-utils@8.24.1(eslint@8.57.1)(typescript@4.9.5):
+    resolution: {integrity: sha512-/Do9fmNgCsQ+K4rCz0STI7lYB4phTtEXqqCAs3gZW0pnK7lWNkvWd5iW545GSmApm4AzmQXmSqXPO565B4WVrw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <5.8.0'
     dependencies:
-      '@typescript-eslint/typescript-estree': 8.1.0(typescript@4.9.5)
-      '@typescript-eslint/utils': 8.1.0(eslint@8.57.1)(typescript@4.9.5)
+      '@typescript-eslint/typescript-estree': 8.24.1(typescript@4.9.5)
+      '@typescript-eslint/utils': 8.24.1(eslint@8.57.1)(typescript@4.9.5)
       debug: 4.3.7
-      ts-api-utils: 1.4.3(typescript@4.9.5)
+      eslint: 8.57.1
+      ts-api-utils: 2.0.1(typescript@4.9.5)
       typescript: 4.9.5
     transitivePeerDependencies:
-      - eslint
       - supports-color
     dev: true
 
-  /@typescript-eslint/type-utils@8.1.0(eslint@8.57.1)(typescript@5.4.5):
-    resolution: {integrity: sha512-oLYvTxljVvsMnldfl6jIKxTaU7ok7km0KDrwOt1RHYu6nxlhN3TIx8k5Q52L6wR33nOwDgM7VwW1fT1qMNfFIA==}
+  /@typescript-eslint/type-utils@8.24.1(eslint@8.57.1)(typescript@5.7.3):
+    resolution: {integrity: sha512-/Do9fmNgCsQ+K4rCz0STI7lYB4phTtEXqqCAs3gZW0pnK7lWNkvWd5iW545GSmApm4AzmQXmSqXPO565B4WVrw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <5.8.0'
     dependencies:
-      '@typescript-eslint/typescript-estree': 8.1.0(typescript@5.4.5)
-      '@typescript-eslint/utils': 8.1.0(eslint@8.57.1)(typescript@5.4.5)
+      '@typescript-eslint/typescript-estree': 8.24.1(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.24.1(eslint@8.57.1)(typescript@5.7.3)
       debug: 4.3.7
-      ts-api-utils: 1.4.3(typescript@5.4.5)
-      typescript: 5.4.5
+      eslint: 8.57.1
+      ts-api-utils: 2.0.1(typescript@5.7.3)
+      typescript: 5.7.3
     transitivePeerDependencies:
-      - eslint
       - supports-color
     dev: true
 
-  /@typescript-eslint/types@6.21.0(typescript@5.4.5):
+  /@typescript-eslint/types@6.21.0(typescript@5.7.3):
     resolution: {integrity: sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
       typescript: '*'
     dependencies:
-      typescript: 5.4.5
+      typescript: 5.7.3
     dev: true
 
-  /@typescript-eslint/types@8.1.0(typescript@4.9.5):
-    resolution: {integrity: sha512-q2/Bxa0gMOu/2/AKALI0tCKbG2zppccnRIRCW6BaaTlRVaPKft4oVYPp7WOPpcnsgbr0qROAVCVKCvIQ0tbWog==}
+  /@typescript-eslint/types@8.24.1(typescript@4.9.5):
+    resolution: {integrity: sha512-9kqJ+2DkUXiuhoiYIUvIYjGcwle8pcPpdlfkemGvTObzgmYfJ5d0Qm6jwb4NBXP9W1I5tss0VIAnWFumz3mC5A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '*'
@@ -1365,16 +1349,16 @@ packages:
       typescript: 4.9.5
     dev: true
 
-  /@typescript-eslint/types@8.1.0(typescript@5.4.5):
-    resolution: {integrity: sha512-q2/Bxa0gMOu/2/AKALI0tCKbG2zppccnRIRCW6BaaTlRVaPKft4oVYPp7WOPpcnsgbr0qROAVCVKCvIQ0tbWog==}
+  /@typescript-eslint/types@8.24.1(typescript@5.7.3):
+    resolution: {integrity: sha512-9kqJ+2DkUXiuhoiYIUvIYjGcwle8pcPpdlfkemGvTObzgmYfJ5d0Qm6jwb4NBXP9W1I5tss0VIAnWFumz3mC5A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '*'
     dependencies:
-      typescript: 5.4.5
+      typescript: 5.7.3
     dev: true
 
-  /@typescript-eslint/typescript-estree@6.21.0(typescript@5.4.5):
+  /@typescript-eslint/typescript-estree@6.21.0(typescript@5.7.3):
     resolution: {integrity: sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -1383,64 +1367,58 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/types': 6.21.0(typescript@5.4.5)
-      '@typescript-eslint/visitor-keys': 6.21.0(typescript@5.4.5)
+      '@typescript-eslint/types': 6.21.0(typescript@5.7.3)
+      '@typescript-eslint/visitor-keys': 6.21.0(typescript@5.7.3)
       debug: 4.3.7
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.3
       semver: 7.6.3
-      ts-api-utils: 1.4.3(typescript@5.4.5)
-      typescript: 5.4.5
+      ts-api-utils: 1.4.3(typescript@5.7.3)
+      typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/typescript-estree@8.1.0(typescript@4.9.5):
-    resolution: {integrity: sha512-NTHhmufocEkMiAord/g++gWKb0Fr34e9AExBRdqgWdVBaKoei2dIyYKD9Q0jBnvfbEA5zaf8plUFMUH6kQ0vGg==}
+  /@typescript-eslint/typescript-estree@8.24.1(typescript@4.9.5):
+    resolution: {integrity: sha512-UPyy4MJ/0RE648DSKQe9g0VDSehPINiejjA6ElqnFaFIhI6ZEiZAkUI0D5MCk0bQcTf/LVqZStvQ6K4lPn/BRg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
+      typescript: '>=4.8.4 <5.8.0'
     dependencies:
-      '@typescript-eslint/types': 8.1.0(typescript@4.9.5)
-      '@typescript-eslint/visitor-keys': 8.1.0(typescript@4.9.5)
+      '@typescript-eslint/types': 8.24.1(typescript@4.9.5)
+      '@typescript-eslint/visitor-keys': 8.24.1(typescript@4.9.5)
       debug: 4.3.7
-      globby: 11.1.0
+      fast-glob: 3.3.2
       is-glob: 4.0.3
       minimatch: 9.0.5
       semver: 7.6.3
-      ts-api-utils: 1.4.3(typescript@4.9.5)
+      ts-api-utils: 2.0.1(typescript@4.9.5)
       typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/typescript-estree@8.1.0(typescript@5.4.5):
-    resolution: {integrity: sha512-NTHhmufocEkMiAord/g++gWKb0Fr34e9AExBRdqgWdVBaKoei2dIyYKD9Q0jBnvfbEA5zaf8plUFMUH6kQ0vGg==}
+  /@typescript-eslint/typescript-estree@8.24.1(typescript@5.7.3):
+    resolution: {integrity: sha512-UPyy4MJ/0RE648DSKQe9g0VDSehPINiejjA6ElqnFaFIhI6ZEiZAkUI0D5MCk0bQcTf/LVqZStvQ6K4lPn/BRg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
+      typescript: '>=4.8.4 <5.8.0'
     dependencies:
-      '@typescript-eslint/types': 8.1.0(typescript@5.4.5)
-      '@typescript-eslint/visitor-keys': 8.1.0(typescript@5.4.5)
+      '@typescript-eslint/types': 8.24.1(typescript@5.7.3)
+      '@typescript-eslint/visitor-keys': 8.24.1(typescript@5.7.3)
       debug: 4.3.7
-      globby: 11.1.0
+      fast-glob: 3.3.2
       is-glob: 4.0.3
       minimatch: 9.0.5
       semver: 7.6.3
-      ts-api-utils: 1.4.3(typescript@5.4.5)
-      typescript: 5.4.5
+      ts-api-utils: 2.0.1(typescript@5.7.3)
+      typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils@6.21.0(eslint@8.57.1)(typescript@5.4.5):
+  /@typescript-eslint/utils@6.21.0(eslint@8.57.1)(typescript@5.7.3):
     resolution: {integrity: sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -1449,9 +1427,9 @@ packages:
       '@eslint-community/eslint-utils': 4.4.1(eslint@8.57.1)
       '@types/json-schema': 7.0.15
       '@types/semver': 7.5.8
-      '@typescript-eslint/scope-manager': 6.21.0(typescript@5.4.5)
-      '@typescript-eslint/types': 6.21.0(typescript@5.4.5)
-      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.4.5)
+      '@typescript-eslint/scope-manager': 6.21.0(typescript@5.7.3)
+      '@typescript-eslint/types': 6.21.0(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.7.3)
       eslint: 8.57.1
       semver: 7.6.3
     transitivePeerDependencies:
@@ -1459,64 +1437,66 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/utils@8.1.0(eslint@8.57.1)(typescript@4.9.5):
-    resolution: {integrity: sha512-ypRueFNKTIFwqPeJBfeIpxZ895PQhNyH4YID6js0UoBImWYoSjBsahUn9KMiJXh94uOjVBgHD9AmkyPsPnFwJA==}
+  /@typescript-eslint/utils@8.24.1(eslint@8.57.1)(typescript@4.9.5):
+    resolution: {integrity: sha512-OOcg3PMMQx9EXspId5iktsI3eMaXVwlhC8BvNnX6B5w9a4dVgpkQZuU8Hy67TolKcl+iFWq0XX+jbDGN4xWxjQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <5.8.0'
     dependencies:
       '@eslint-community/eslint-utils': 4.4.1(eslint@8.57.1)
-      '@typescript-eslint/scope-manager': 8.1.0(typescript@4.9.5)
-      '@typescript-eslint/types': 8.1.0(typescript@4.9.5)
-      '@typescript-eslint/typescript-estree': 8.1.0(typescript@4.9.5)
+      '@typescript-eslint/scope-manager': 8.24.1(typescript@4.9.5)
+      '@typescript-eslint/types': 8.24.1(typescript@4.9.5)
+      '@typescript-eslint/typescript-estree': 8.24.1(typescript@4.9.5)
       eslint: 8.57.1
+      typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
-      - typescript
     dev: true
 
-  /@typescript-eslint/utils@8.1.0(eslint@8.57.1)(typescript@5.4.5):
-    resolution: {integrity: sha512-ypRueFNKTIFwqPeJBfeIpxZ895PQhNyH4YID6js0UoBImWYoSjBsahUn9KMiJXh94uOjVBgHD9AmkyPsPnFwJA==}
+  /@typescript-eslint/utils@8.24.1(eslint@8.57.1)(typescript@5.7.3):
+    resolution: {integrity: sha512-OOcg3PMMQx9EXspId5iktsI3eMaXVwlhC8BvNnX6B5w9a4dVgpkQZuU8Hy67TolKcl+iFWq0XX+jbDGN4xWxjQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <5.8.0'
     dependencies:
       '@eslint-community/eslint-utils': 4.4.1(eslint@8.57.1)
-      '@typescript-eslint/scope-manager': 8.1.0(typescript@5.4.5)
-      '@typescript-eslint/types': 8.1.0(typescript@5.4.5)
-      '@typescript-eslint/typescript-estree': 8.1.0(typescript@5.4.5)
+      '@typescript-eslint/scope-manager': 8.24.1(typescript@5.7.3)
+      '@typescript-eslint/types': 8.24.1(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 8.24.1(typescript@5.7.3)
       eslint: 8.57.1
+      typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
-      - typescript
     dev: true
 
-  /@typescript-eslint/visitor-keys@6.21.0(typescript@5.4.5):
+  /@typescript-eslint/visitor-keys@6.21.0(typescript@5.7.3):
     resolution: {integrity: sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==}
     engines: {node: ^16.0.0 || >=18.0.0}
     dependencies:
-      '@typescript-eslint/types': 6.21.0(typescript@5.4.5)
+      '@typescript-eslint/types': 6.21.0(typescript@5.7.3)
       eslint-visitor-keys: 3.4.3
     transitivePeerDependencies:
       - typescript
     dev: true
 
-  /@typescript-eslint/visitor-keys@8.1.0(typescript@4.9.5):
-    resolution: {integrity: sha512-ba0lNI19awqZ5ZNKh6wCModMwoZs457StTebQ0q1NP58zSi2F6MOZRXwfKZy+jB78JNJ/WH8GSh2IQNzXX8Nag==}
+  /@typescript-eslint/visitor-keys@8.24.1(typescript@4.9.5):
+    resolution: {integrity: sha512-EwVHlp5l+2vp8CoqJm9KikPZgi3gbdZAtabKT9KPShGeOcJhsv4Zdo3oc8T8I0uKEmYoU4ItyxbptjF08enaxg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     dependencies:
-      '@typescript-eslint/types': 8.1.0(typescript@4.9.5)
-      eslint-visitor-keys: 3.4.3
+      '@typescript-eslint/types': 8.24.1(typescript@4.9.5)
+      eslint-visitor-keys: 4.2.0
     transitivePeerDependencies:
       - typescript
     dev: true
 
-  /@typescript-eslint/visitor-keys@8.1.0(typescript@5.4.5):
-    resolution: {integrity: sha512-ba0lNI19awqZ5ZNKh6wCModMwoZs457StTebQ0q1NP58zSi2F6MOZRXwfKZy+jB78JNJ/WH8GSh2IQNzXX8Nag==}
+  /@typescript-eslint/visitor-keys@8.24.1(typescript@5.7.3):
+    resolution: {integrity: sha512-EwVHlp5l+2vp8CoqJm9KikPZgi3gbdZAtabKT9KPShGeOcJhsv4Zdo3oc8T8I0uKEmYoU4ItyxbptjF08enaxg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     dependencies:
-      '@typescript-eslint/types': 8.1.0(typescript@5.4.5)
-      eslint-visitor-keys: 3.4.3
+      '@typescript-eslint/types': 8.24.1(typescript@5.7.3)
+      eslint-visitor-keys: 4.2.0
     transitivePeerDependencies:
       - typescript
     dev: true
@@ -2337,7 +2317,7 @@ packages:
       '@pnpm/crypto.base32-hash': 1.0.1
       '@pnpm/types': 8.9.0
       encode-registry: 3.0.1
-      semver: 7.5.4
+      semver: 7.6.3
 
   /deps-regex@0.2.0:
     resolution: {integrity: sha512-PwuBojGMQAYbWkMXOY9Pd/NWCDNHVH12pnS7WHqZkTSeMESe4hwnKKRp0yR87g37113x4JPbo/oIvXY+s/f56Q==}
@@ -2588,17 +2568,17 @@ packages:
       eslint: 8.57.1
     dev: true
 
-  /eslint-plugin-deprecation@2.0.0(eslint@8.57.1)(typescript@5.4.5):
+  /eslint-plugin-deprecation@2.0.0(eslint@8.57.1)(typescript@5.7.3):
     resolution: {integrity: sha512-OAm9Ohzbj11/ZFyICyR5N6LbOIvQMp7ZU2zI7Ej0jIc8kiGUERXPNMfw2QqqHD1ZHtjMub3yPZILovYEYucgoQ==}
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0
       typescript: ^4.2.4 || ^5.0.0
     dependencies:
-      '@typescript-eslint/utils': 6.21.0(eslint@8.57.1)(typescript@5.4.5)
+      '@typescript-eslint/utils': 6.21.0(eslint@8.57.1)(typescript@5.7.3)
       eslint: 8.57.1
       tslib: 2.8.1
-      tsutils: 3.21.0(typescript@5.4.5)
-      typescript: 5.4.5
+      tsutils: 3.21.0(typescript@5.7.3)
+      typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2713,6 +2693,11 @@ packages:
   /eslint-visitor-keys@3.4.3:
     resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dev: true
+
+  /eslint-visitor-keys@4.2.0:
+    resolution: {integrity: sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     dev: true
 
   /eslint@8.57.1:
@@ -3741,10 +3726,10 @@ packages:
       glob: 7.2.3
       graceful-fs: 4.2.11
       jest-circus: 29.7.0
-      jest-environment-node: 29.5.0
+      jest-environment-node: 29.7.0
       jest-get-type: 29.6.3
       jest-regex-util: 29.6.3
-      jest-resolve: 29.5.0
+      jest-resolve: 29.7.0
       jest-runner: 29.7.0
       jest-util: 29.7.0
       jest-validate: 29.7.0
@@ -4025,7 +4010,7 @@ packages:
       '@babel/traverse': 7.25.9
       '@babel/types': 7.26.0
       '@jest/expect-utils': 29.7.0
-      '@jest/transform': 29.5.0
+      '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@types/babel__traverse': 7.20.6
       '@types/prettier': 2.7.3
@@ -4600,7 +4585,7 @@ packages:
       pkg-dir: 5.0.0
       preferred-pm: 3.1.4
       rc-config-loader: 4.1.3
-      semver: 7.5.4
+      semver: 7.6.3
       semver-diff: 3.1.1
       strip-ansi: 6.0.1
       text-table: 0.2.0
@@ -5602,22 +5587,31 @@ packages:
   /true-case-path@2.2.1:
     resolution: {integrity: sha512-0z3j8R7MCjy10kc/g+qg7Ln3alJTodw9aDuVWZa3uiWqfuBMKeAeP2ocWcxoyM3D73yz3Jt/Pu4qPr4wHSdB/Q==}
 
-  /ts-api-utils@1.4.3(typescript@4.9.5):
+  /ts-api-utils@1.4.3(typescript@5.7.3):
     resolution: {integrity: sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==}
     engines: {node: '>=16'}
     peerDependencies:
       typescript: '>=4.2.0'
+    dependencies:
+      typescript: 5.7.3
+    dev: true
+
+  /ts-api-utils@2.0.1(typescript@4.9.5):
+    resolution: {integrity: sha512-dnlgjFSVetynI8nzgJ+qF62efpglpWRk8isUEWZGWlJYySCTD6aKvbUDu+zbPeDakk3bg5H4XpitHukgfL1m9w==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
     dependencies:
       typescript: 4.9.5
     dev: true
 
-  /ts-api-utils@1.4.3(typescript@5.4.5):
-    resolution: {integrity: sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==}
-    engines: {node: '>=16'}
+  /ts-api-utils@2.0.1(typescript@5.7.3):
+    resolution: {integrity: sha512-dnlgjFSVetynI8nzgJ+qF62efpglpWRk8isUEWZGWlJYySCTD6aKvbUDu+zbPeDakk3bg5H4XpitHukgfL1m9w==}
+    engines: {node: '>=18.12'}
     peerDependencies:
-      typescript: '>=4.2.0'
+      typescript: '>=4.8.4'
     dependencies:
-      typescript: 5.4.5
+      typescript: 5.7.3
     dev: true
 
   /tsconfig-paths@3.15.0:
@@ -5668,14 +5662,14 @@ packages:
       typescript: 4.9.5
     dev: true
 
-  /tsutils@3.21.0(typescript@5.4.5):
+  /tsutils@3.21.0(typescript@5.7.3):
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
-      typescript: 5.4.5
+      typescript: 5.7.3
     dev: true
 
   /type-check@0.4.0:
@@ -5766,12 +5760,6 @@ packages:
     hasBin: true
     dev: true
 
-  /typescript@5.4.5:
-    resolution: {integrity: sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-    dev: true
-
   /typescript@5.7.3:
     resolution: {integrity: sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==}
     engines: {node: '>=14.17'}
@@ -5847,7 +5835,7 @@ packages:
     engines: {node: '>=10.12.0'}
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
-      '@types/istanbul-lib-coverage': 2.0.4
+      '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
     dev: true
 
@@ -6107,10 +6095,10 @@ packages:
       '@rushstack/eslint-plugin': file:../../../eslint/eslint-plugin(eslint@8.57.1)(typescript@4.9.5)
       '@rushstack/eslint-plugin-packlets': file:../../../eslint/eslint-plugin-packlets(eslint@8.57.1)(typescript@4.9.5)
       '@rushstack/eslint-plugin-security': file:../../../eslint/eslint-plugin-security(eslint@8.57.1)(typescript@4.9.5)
-      '@typescript-eslint/eslint-plugin': 8.1.0(@typescript-eslint/parser@8.1.0)(eslint@8.57.1)(typescript@4.9.5)
-      '@typescript-eslint/parser': 8.1.0(eslint@8.57.1)(typescript@4.9.5)
-      '@typescript-eslint/typescript-estree': 8.1.0(typescript@4.9.5)
-      '@typescript-eslint/utils': 8.1.0(eslint@8.57.1)(typescript@4.9.5)
+      '@typescript-eslint/eslint-plugin': 8.24.1(@typescript-eslint/parser@8.24.1)(eslint@8.57.1)(typescript@4.9.5)
+      '@typescript-eslint/parser': 8.24.1(eslint@8.57.1)(typescript@4.9.5)
+      '@typescript-eslint/typescript-estree': 8.24.1(typescript@4.9.5)
+      '@typescript-eslint/utils': 8.24.1(eslint@8.57.1)(typescript@4.9.5)
       eslint: 8.57.1
       eslint-plugin-promise: 6.1.1(eslint@8.57.1)
       eslint-plugin-react: 7.33.2(eslint@8.57.1)
@@ -6120,7 +6108,7 @@ packages:
       - supports-color
     dev: true
 
-  file:../../../eslint/eslint-config(eslint@8.57.1)(typescript@5.4.5):
+  file:../../../eslint/eslint-config(eslint@8.57.1)(typescript@5.7.3):
     resolution: {directory: ../../../eslint/eslint-config, type: directory}
     id: file:../../../eslint/eslint-config
     name: '@rushstack/eslint-config'
@@ -6129,18 +6117,18 @@ packages:
       typescript: '>=4.7.0'
     dependencies:
       '@rushstack/eslint-patch': file:../../../eslint/eslint-patch
-      '@rushstack/eslint-plugin': file:../../../eslint/eslint-plugin(eslint@8.57.1)(typescript@5.4.5)
-      '@rushstack/eslint-plugin-packlets': file:../../../eslint/eslint-plugin-packlets(eslint@8.57.1)(typescript@5.4.5)
-      '@rushstack/eslint-plugin-security': file:../../../eslint/eslint-plugin-security(eslint@8.57.1)(typescript@5.4.5)
-      '@typescript-eslint/eslint-plugin': 8.1.0(@typescript-eslint/parser@8.1.0)(eslint@8.57.1)(typescript@5.4.5)
-      '@typescript-eslint/parser': 8.1.0(eslint@8.57.1)(typescript@5.4.5)
-      '@typescript-eslint/typescript-estree': 8.1.0(typescript@5.4.5)
-      '@typescript-eslint/utils': 8.1.0(eslint@8.57.1)(typescript@5.4.5)
+      '@rushstack/eslint-plugin': file:../../../eslint/eslint-plugin(eslint@8.57.1)(typescript@5.7.3)
+      '@rushstack/eslint-plugin-packlets': file:../../../eslint/eslint-plugin-packlets(eslint@8.57.1)(typescript@5.7.3)
+      '@rushstack/eslint-plugin-security': file:../../../eslint/eslint-plugin-security(eslint@8.57.1)(typescript@5.7.3)
+      '@typescript-eslint/eslint-plugin': 8.24.1(@typescript-eslint/parser@8.24.1)(eslint@8.57.1)(typescript@5.7.3)
+      '@typescript-eslint/parser': 8.24.1(eslint@8.57.1)(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 8.24.1(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.24.1(eslint@8.57.1)(typescript@5.7.3)
       eslint: 8.57.1
       eslint-plugin-promise: 6.1.1(eslint@8.57.1)
       eslint-plugin-react: 7.33.2(eslint@8.57.1)
       eslint-plugin-tsdoc: 0.4.0
-      typescript: 5.4.5
+      typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6158,14 +6146,14 @@ packages:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       '@rushstack/tree-pattern': file:../../../libraries/tree-pattern
-      '@typescript-eslint/utils': 8.1.0(eslint@8.57.1)(typescript@4.9.5)
+      '@typescript-eslint/utils': 8.24.1(eslint@8.57.1)(typescript@4.9.5)
       eslint: 8.57.1
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  file:../../../eslint/eslint-plugin(eslint@8.57.1)(typescript@5.4.5):
+  file:../../../eslint/eslint-plugin(eslint@8.57.1)(typescript@5.7.3):
     resolution: {directory: ../../../eslint/eslint-plugin, type: directory}
     id: file:../../../eslint/eslint-plugin
     name: '@rushstack/eslint-plugin'
@@ -6173,7 +6161,7 @@ packages:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       '@rushstack/tree-pattern': file:../../../libraries/tree-pattern
-      '@typescript-eslint/utils': 8.1.0(eslint@8.57.1)(typescript@5.4.5)
+      '@typescript-eslint/utils': 8.24.1(eslint@8.57.1)(typescript@5.7.3)
       eslint: 8.57.1
     transitivePeerDependencies:
       - supports-color
@@ -6188,14 +6176,14 @@ packages:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       '@rushstack/tree-pattern': file:../../../libraries/tree-pattern
-      '@typescript-eslint/utils': 8.1.0(eslint@8.57.1)(typescript@4.9.5)
+      '@typescript-eslint/utils': 8.24.1(eslint@8.57.1)(typescript@4.9.5)
       eslint: 8.57.1
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  file:../../../eslint/eslint-plugin-packlets(eslint@8.57.1)(typescript@5.4.5):
+  file:../../../eslint/eslint-plugin-packlets(eslint@8.57.1)(typescript@5.7.3):
     resolution: {directory: ../../../eslint/eslint-plugin-packlets, type: directory}
     id: file:../../../eslint/eslint-plugin-packlets
     name: '@rushstack/eslint-plugin-packlets'
@@ -6203,7 +6191,7 @@ packages:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       '@rushstack/tree-pattern': file:../../../libraries/tree-pattern
-      '@typescript-eslint/utils': 8.1.0(eslint@8.57.1)(typescript@5.4.5)
+      '@typescript-eslint/utils': 8.24.1(eslint@8.57.1)(typescript@5.7.3)
       eslint: 8.57.1
     transitivePeerDependencies:
       - supports-color
@@ -6218,14 +6206,14 @@ packages:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       '@rushstack/tree-pattern': file:../../../libraries/tree-pattern
-      '@typescript-eslint/utils': 8.1.0(eslint@8.57.1)(typescript@4.9.5)
+      '@typescript-eslint/utils': 8.24.1(eslint@8.57.1)(typescript@4.9.5)
       eslint: 8.57.1
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  file:../../../eslint/eslint-plugin-security(eslint@8.57.1)(typescript@5.4.5):
+  file:../../../eslint/eslint-plugin-security(eslint@8.57.1)(typescript@5.7.3):
     resolution: {directory: ../../../eslint/eslint-plugin-security, type: directory}
     id: file:../../../eslint/eslint-plugin-security
     name: '@rushstack/eslint-plugin-security'
@@ -6233,22 +6221,22 @@ packages:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       '@rushstack/tree-pattern': file:../../../libraries/tree-pattern
-      '@typescript-eslint/utils': 8.1.0(eslint@8.57.1)(typescript@5.4.5)
+      '@typescript-eslint/utils': 8.24.1(eslint@8.57.1)(typescript@5.7.3)
       eslint: 8.57.1
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  file:../../../eslint/local-eslint-config(eslint@8.57.1)(typescript@5.4.5):
+  file:../../../eslint/local-eslint-config(eslint@8.57.1)(typescript@5.7.3):
     resolution: {directory: ../../../eslint/local-eslint-config, type: directory}
     id: file:../../../eslint/local-eslint-config
     name: local-eslint-config
     dependencies:
-      '@rushstack/eslint-config': file:../../../eslint/eslint-config(eslint@8.57.1)(typescript@5.4.5)
+      '@rushstack/eslint-config': file:../../../eslint/eslint-config(eslint@8.57.1)(typescript@5.7.3)
       '@rushstack/eslint-patch': file:../../../eslint/eslint-patch
-      '@typescript-eslint/parser': 8.1.0(eslint@8.57.1)(typescript@5.4.5)
-      eslint-plugin-deprecation: 2.0.0(eslint@8.57.1)(typescript@5.4.5)
+      '@typescript-eslint/parser': 8.24.1(eslint@8.57.1)(typescript@5.7.3)
+      eslint-plugin-deprecation: 2.0.0(eslint@8.57.1)(typescript@5.7.3)
       eslint-plugin-header: 3.1.1(eslint@8.57.1)
       eslint-plugin-import: 2.25.4(eslint@8.57.1)
       eslint-plugin-jsdoc: 37.6.1(eslint@8.57.1)
@@ -6555,7 +6543,7 @@ packages:
       '@rushstack/heft': '*'
     dependencies:
       '@microsoft/api-extractor': file:../../../apps/api-extractor(@types/node@20.17.19)
-      '@rushstack/eslint-config': file:../../../eslint/eslint-config(eslint@8.57.1)(typescript@5.4.5)
+      '@rushstack/eslint-config': file:../../../eslint/eslint-config(eslint@8.57.1)(typescript@5.7.3)
       '@rushstack/heft': file:../../../apps/heft(@types/node@20.17.19)
       '@rushstack/heft-api-extractor-plugin': file:../../../heft-plugins/heft-api-extractor-plugin(@rushstack/heft@0.69.2)(@types/node@20.17.19)
       '@rushstack/heft-jest-plugin': file:../../../heft-plugins/heft-jest-plugin(@rushstack/heft@0.69.2)(@types/node@20.17.19)(jest-environment-node@29.5.0)
@@ -6564,7 +6552,7 @@ packages:
       '@types/heft-jest': 1.0.1
       eslint: 8.57.1
       jest-environment-node: 29.5.0
-      typescript: 5.4.5
+      typescript: 5.7.3
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -6585,8 +6573,8 @@ packages:
       '@types/node': 20.17.19
       eslint: 8.57.1
       jest-junit: 12.3.0
-      local-eslint-config: file:../../../eslint/local-eslint-config(eslint@8.57.1)(typescript@5.4.5)
-      typescript: 5.4.5
+      local-eslint-config: file:../../../eslint/local-eslint-config(eslint@8.57.1)(typescript@5.7.3)
+      typescript: 5.7.3
     transitivePeerDependencies:
       - babel-plugin-macros
       - jest-environment-jsdom

--- a/common/config/subspaces/build-tests-subspace/pnpm-lock.yaml
+++ b/common/config/subspaces/build-tests-subspace/pnpm-lock.yaml
@@ -22,9 +22,6 @@ importers:
         specifier: file:../../libraries/terminal
         version: file:../../../libraries/terminal(@types/node@20.17.19)
     devDependencies:
-      '@rushstack/eslint-config':
-        specifier: file:../../eslint/eslint-config
-        version: file:../../../eslint/eslint-config(eslint@8.57.1)(typescript@5.7.3)
       '@rushstack/heft':
         specifier: file:../../apps/heft
         version: file:../../../apps/heft(@types/node@20.17.19)
@@ -37,9 +34,6 @@ importers:
       local-node-rig:
         specifier: file:../../rigs/local-node-rig
         version: file:../../../rigs/local-node-rig
-      typescript:
-        specifier: ~5.7.3
-        version: 5.7.3
     dependenciesMeta:
       '@microsoft/rush-lib':
         injected: true
@@ -61,9 +55,6 @@ importers:
       '@microsoft/rush-lib':
         specifier: file:../../libraries/rush-lib
         version: file:../../../libraries/rush-lib(@types/node@20.17.19)
-      '@rushstack/eslint-config':
-        specifier: file:../../eslint/eslint-config
-        version: file:../../../eslint/eslint-config(eslint@8.57.1)(typescript@5.7.3)
       '@rushstack/heft':
         specifier: file:../../apps/heft
         version: file:../../../apps/heft(@types/node@20.17.19)
@@ -76,9 +67,6 @@ importers:
       local-node-rig:
         specifier: file:../../rigs/local-node-rig
         version: file:../../../rigs/local-node-rig
-      typescript:
-        specifier: ~5.7.3
-        version: 5.7.3
     dependenciesMeta:
       '@microsoft/rush-lib':
         injected: true

--- a/common/config/subspaces/build-tests-subspace/repo-state.json
+++ b/common/config/subspaces/build-tests-subspace/repo-state.json
@@ -1,6 +1,6 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "45b904ad1ce0306ef6a551c0290435e6a8669c59",
-  "preferredVersionsHash": "ce857ea0536b894ec8f346aaea08cfd85a5af648",
-  "packageJsonInjectedDependenciesHash": "c4ec4896fb7415e2a36f0fd198f7c7420153371d"
+  "pnpmShrinkwrapHash": "e5d80b8cf111a9c4f3ae1e122504d8a8a8a10212",
+  "preferredVersionsHash": "7aee53abbca2f0cefac5a2a8c72ca7703b10dff2",
+  "packageJsonInjectedDependenciesHash": "e59d783ee1441f78fcac015b2650b856174f1d3d"
 }

--- a/common/config/subspaces/build-tests-subspace/repo-state.json
+++ b/common/config/subspaces/build-tests-subspace/repo-state.json
@@ -2,5 +2,5 @@
 {
   "pnpmShrinkwrapHash": "e5d80b8cf111a9c4f3ae1e122504d8a8a8a10212",
   "preferredVersionsHash": "7aee53abbca2f0cefac5a2a8c72ca7703b10dff2",
-  "packageJsonInjectedDependenciesHash": "e59d783ee1441f78fcac015b2650b856174f1d3d"
+  "packageJsonInjectedDependenciesHash": "c7802e383e0ceaf4141d6af590e4a965ef7ea0dc"
 }

--- a/common/config/subspaces/default/common-versions.json
+++ b/common/config/subspaces/default/common-versions.json
@@ -29,7 +29,7 @@
     // Preferring it avoids errors for indirect dependencies that request it as a peer dependency.
     // It's also the newest supported compiler, used by most build tests and used as the bundled compiler
     // engine for API Extractor.
-    "typescript": "~5.4.2",
+    "typescript": "~5.7.3",
 
     // Workaround for https://github.com/microsoft/rushstack/issues/1466
     "eslint": "~8.57.0"

--- a/common/config/subspaces/default/pnpm-lock.yaml
+++ b/common/config/subspaces/default/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 overrides:
   package-json: ^7
 
-packageExtensionsChecksum: e59cfa9a35183eeeb6f2ac48c9ddd4b2
+packageExtensionsChecksum: 55f4ecaa9bc2eb3a2f471f725282aba9
 
 importers:
 
@@ -136,8 +136,8 @@ importers:
         specifier: workspace:*
         version: link:../../rigs/local-node-rig
       typescript:
-        specifier: ~5.4.2
-        version: 5.4.2
+        specifier: ~5.7.3
+        version: 5.7.3
 
   ../../../apps/heft:
     dependencies:
@@ -200,8 +200,8 @@ importers:
         specifier: workspace:*
         version: link:../../eslint/local-eslint-config
       typescript:
-        specifier: ~5.4.2
-        version: 5.4.2
+        specifier: ~5.7.3
+        version: 5.7.3
 
   ../../../apps/lockfile-explorer:
     dependencies:
@@ -381,8 +381,8 @@ importers:
         specifier: ~7.5.4
         version: 7.5.4
       typescript:
-        specifier: ~5.4.2
-        version: 5.4.2
+        specifier: ~5.7.3
+        version: 5.7.3
     devDependencies:
       '@rushstack/heft':
         specifier: workspace:*
@@ -424,8 +424,8 @@ importers:
         specifier: workspace:*
         version: link:../../eslint/local-eslint-config
       typescript:
-        specifier: ~5.4.2
-        version: 5.4.2
+        specifier: ~5.7.3
+        version: 5.7.3
 
   ../../../build-tests-samples/heft-node-jest-tutorial:
     devDependencies:
@@ -454,8 +454,8 @@ importers:
         specifier: workspace:*
         version: link:../../eslint/local-eslint-config
       typescript:
-        specifier: ~5.4.2
-        version: 5.4.2
+        specifier: ~5.7.3
+        version: 5.7.3
 
   ../../../build-tests-samples/heft-node-rig-tutorial:
     devDependencies:
@@ -529,8 +529,8 @@ importers:
         specifier: workspace:*
         version: link:../../eslint/local-eslint-config
       typescript:
-        specifier: ~5.4.2
-        version: 5.4.2
+        specifier: ~5.7.3
+        version: 5.7.3
 
   ../../../build-tests-samples/heft-storybook-react-tutorial:
     dependencies:
@@ -570,7 +570,7 @@ importers:
         version: link:../../webpack/webpack4-module-minifier-plugin
       '@storybook/react':
         specifier: ~6.4.18
-        version: 6.4.22(@babel/core@7.20.12)(@types/node@20.17.19)(@types/react@17.0.74)(eslint@8.57.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.4.2)
+        version: 6.4.22(@babel/core@7.20.12)(@types/node@20.17.19)(@types/react@17.0.74)(eslint@8.57.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.7.3)
       '@types/heft-jest':
         specifier: 1.0.1
         version: 1.0.1
@@ -608,8 +608,8 @@ importers:
         specifier: ~2.0.0
         version: 2.0.0(webpack@4.47.0)
       typescript:
-        specifier: ~5.4.2
-        version: 5.4.2
+        specifier: ~5.7.3
+        version: 5.7.3
       webpack:
         specifier: ~4.47.0
         version: 4.47.0
@@ -640,13 +640,13 @@ importers:
         version: 6.4.22(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)
       '@storybook/addon-essentials':
         specifier: ~6.4.18
-        version: 6.4.22(@babel/core@7.20.12)(@storybook/react@6.4.22)(@types/react@17.0.74)(babel-loader@8.2.5)(react-dom@17.0.2)(react@17.0.2)(typescript@5.4.2)(webpack@4.47.0)
+        version: 6.4.22(@babel/core@7.20.12)(@storybook/react@6.4.22)(@types/react@17.0.74)(babel-loader@8.2.5)(react-dom@17.0.2)(react@17.0.2)(typescript@5.7.3)(webpack@4.47.0)
       '@storybook/addon-links':
         specifier: ~6.4.18
         version: 6.4.22(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)
       '@storybook/cli':
         specifier: ~6.4.18
-        version: 6.4.22(jest@29.3.1)(react-dom@17.0.2)(react@17.0.2)(typescript@5.4.2)
+        version: 6.4.22(jest@29.3.1)(react-dom@17.0.2)(react@17.0.2)(typescript@5.7.3)
       '@storybook/components':
         specifier: ~6.4.18
         version: 6.4.22(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)
@@ -655,7 +655,7 @@ importers:
         version: 6.4.22
       '@storybook/react':
         specifier: ~6.4.18
-        version: 6.4.22(@babel/core@7.20.12)(@types/node@20.17.19)(@types/react@17.0.74)(eslint@8.57.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.4.2)
+        version: 6.4.22(@babel/core@7.20.12)(@types/node@20.17.19)(@types/react@17.0.74)(eslint@8.57.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.7.3)
       '@storybook/theming':
         specifier: ~6.4.18
         version: 6.4.22(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)
@@ -696,8 +696,8 @@ importers:
         specifier: ~3.0.8
         version: 3.0.8(webpack@4.47.0)
       typescript:
-        specifier: ~5.4.2
-        version: 5.4.2
+        specifier: ~5.7.3
+        version: 5.7.3
       webpack:
         specifier: ~4.47.0
         version: 4.47.0
@@ -736,8 +736,8 @@ importers:
         specifier: workspace:*
         version: link:../../eslint/local-eslint-config
       typescript:
-        specifier: ~5.4.2
-        version: 5.4.2
+        specifier: ~5.7.3
+        version: 5.7.3
 
   ../../../build-tests-samples/heft-web-rig-library-tutorial:
     dependencies:
@@ -770,8 +770,8 @@ importers:
         specifier: workspace:*
         version: link:../../eslint/local-eslint-config
       typescript:
-        specifier: ~5.4.2
-        version: 5.4.2
+        specifier: ~5.7.3
+        version: 5.7.3
 
   ../../../build-tests-samples/heft-webpack-basic-tutorial:
     dependencies:
@@ -831,8 +831,8 @@ importers:
         specifier: ~3.3.1
         version: 3.3.4(webpack@5.95.0)
       typescript:
-        specifier: ~5.4.2
-        version: 5.4.2
+        specifier: ~5.7.3
+        version: 5.7.3
       webpack:
         specifier: ~5.95.0
         version: 5.95.0
@@ -858,8 +858,8 @@ importers:
         specifier: ~8.57.0
         version: 8.57.0(supports-color@8.1.1)
       typescript:
-        specifier: ~5.4.2
-        version: 5.4.2
+        specifier: ~5.7.3
+        version: 5.7.3
 
   ../../../build-tests/api-documenter-scenarios:
     devDependencies:
@@ -1051,7 +1051,7 @@ importers:
         specifier: workspace:*
         version: link:../../rigs/local-node-rig
       typescript:
-        specifier: 5.7.3
+        specifier: ~5.7.3
         version: 5.7.3
 
   ../../../build-tests/api-extractor-test-03:
@@ -1093,7 +1093,7 @@ importers:
     devDependencies:
       '@rushstack/eslint-config':
         specifier: 3.7.1
-        version: 3.7.1(eslint@7.11.0)(typescript@5.4.2)
+        version: 3.7.1(eslint@7.11.0)(typescript@5.7.3)
       '@rushstack/heft':
         specifier: workspace:*
         version: link:../../apps/heft
@@ -1102,7 +1102,7 @@ importers:
         version: 20.17.19
       '@typescript-eslint/parser':
         specifier: ~6.19.0
-        version: 6.19.1(eslint@7.11.0)(typescript@5.4.2)
+        version: 6.19.1(eslint@7.11.0)(typescript@5.7.3)
       eslint:
         specifier: 7.11.0
         version: 7.11.0
@@ -1110,14 +1110,14 @@ importers:
         specifier: workspace:*
         version: link:../../rigs/local-node-rig
       typescript:
-        specifier: ~5.4.2
-        version: 5.4.2
+        specifier: ~5.7.3
+        version: 5.7.3
 
   ../../../build-tests/eslint-7-7-test:
     devDependencies:
       '@rushstack/eslint-config':
         specifier: 3.7.1
-        version: 3.7.1(eslint@7.7.0)(typescript@5.4.2)
+        version: 3.7.1(eslint@7.7.0)(typescript@5.7.3)
       '@rushstack/heft':
         specifier: workspace:*
         version: link:../../apps/heft
@@ -1126,7 +1126,7 @@ importers:
         version: 20.17.19
       '@typescript-eslint/parser':
         specifier: ~6.19.0
-        version: 6.19.1(eslint@7.7.0)(typescript@5.4.2)
+        version: 6.19.1(eslint@7.7.0)(typescript@5.7.3)
       eslint:
         specifier: 7.7.0
         version: 7.7.0
@@ -1134,14 +1134,14 @@ importers:
         specifier: workspace:*
         version: link:../../rigs/local-node-rig
       typescript:
-        specifier: ~5.4.2
-        version: 5.4.2
+        specifier: ~5.7.3
+        version: 5.7.3
 
   ../../../build-tests/eslint-7-test:
     devDependencies:
       '@rushstack/eslint-config':
         specifier: 3.7.1
-        version: 3.7.1(eslint@7.30.0)(typescript@5.4.2)
+        version: 3.7.1(eslint@7.30.0)(typescript@5.7.3)
       '@rushstack/heft':
         specifier: workspace:*
         version: link:../../apps/heft
@@ -1150,7 +1150,7 @@ importers:
         version: 20.17.19
       '@typescript-eslint/parser':
         specifier: ~6.19.0
-        version: 6.19.1(eslint@7.30.0)(typescript@5.4.2)
+        version: 6.19.1(eslint@7.30.0)(typescript@5.7.3)
       eslint:
         specifier: ~7.30.0
         version: 7.30.0
@@ -1158,8 +1158,8 @@ importers:
         specifier: workspace:*
         version: link:../../rigs/local-node-rig
       typescript:
-        specifier: ~5.4.2
-        version: 5.4.2
+        specifier: ~5.7.3
+        version: 5.7.3
 
   ../../../build-tests/eslint-8-test:
     devDependencies:
@@ -1170,8 +1170,8 @@ importers:
         specifier: 20.17.19
         version: 20.17.19
       '@typescript-eslint/parser':
-        specifier: ~8.1.0
-        version: 8.1.0(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.4.2)
+        specifier: ~8.24.0
+        version: 8.24.0(eslint@8.57.0)(typescript@5.7.3)
       eslint:
         specifier: ~8.57.0
         version: 8.57.0(supports-color@8.1.1)
@@ -1179,8 +1179,8 @@ importers:
         specifier: workspace:*
         version: link:../../rigs/local-node-rig
       typescript:
-        specifier: ~5.4.2
-        version: 5.4.2
+        specifier: ~5.7.3
+        version: 5.7.3
 
   ../../../build-tests/eslint-bulk-suppressions-test:
     devDependencies:
@@ -1197,8 +1197,8 @@ importers:
         specifier: workspace:*
         version: link:../../libraries/node-core-library
       '@typescript-eslint/parser':
-        specifier: ~8.1.0
-        version: 8.1.0(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.4.2)
+        specifier: ~8.24.0
+        version: 8.24.0(eslint@8.57.0)(typescript@5.7.3)
       eslint:
         specifier: ~8.57.0
         version: 8.57.0(supports-color@8.1.1)
@@ -1206,8 +1206,8 @@ importers:
         specifier: workspace:*
         version: link:../../rigs/local-node-rig
       typescript:
-        specifier: ~5.4.2
-        version: 5.4.2
+        specifier: ~5.7.3
+        version: 5.7.3
 
   ../../../build-tests/eslint-bulk-suppressions-test-legacy:
     devDependencies:
@@ -1216,7 +1216,7 @@ importers:
         version: link:../../eslint/eslint-bulk
       '@rushstack/eslint-config':
         specifier: 3.7.1
-        version: 3.7.1(eslint@8.57.0)(typescript@5.4.2)
+        version: 3.7.1(eslint@8.57.0)(typescript@5.7.3)
       '@rushstack/eslint-patch':
         specifier: workspace:*
         version: link:../../eslint/eslint-patch
@@ -1227,8 +1227,8 @@ importers:
         specifier: workspace:*
         version: link:../../libraries/node-core-library
       '@typescript-eslint/parser':
-        specifier: ~6.19.0
-        version: 6.19.1(eslint@8.57.0)(typescript@5.4.2)
+        specifier: ~8.24.0
+        version: 8.24.0(eslint@8.57.0)(typescript@5.7.3)
       eslint:
         specifier: ~8.57.0
         version: 8.57.0(supports-color@8.1.1)
@@ -1242,8 +1242,8 @@ importers:
         specifier: workspace:*
         version: link:../../rigs/local-node-rig
       typescript:
-        specifier: ~5.4.2
-        version: 5.4.2
+        specifier: ~5.7.3
+        version: 5.7.3
 
   ../../../build-tests/hashed-folder-copy-plugin-webpack5-test:
     devDependencies:
@@ -1269,8 +1269,8 @@ importers:
         specifier: ~5.5.0
         version: 5.5.4(webpack@5.95.0)
       typescript:
-        specifier: ~5.4.2
-        version: 5.4.2
+        specifier: ~5.7.3
+        version: 5.7.3
       webpack:
         specifier: ~5.95.0
         version: 5.95.0
@@ -1312,8 +1312,8 @@ importers:
         specifier: workspace:*
         version: link:../../eslint/local-eslint-config
       typescript:
-        specifier: ~5.4.2
-        version: 5.4.2
+        specifier: ~5.7.3
+        version: 5.7.3
 
   ../../../build-tests/heft-example-plugin-02:
     devDependencies:
@@ -1339,8 +1339,8 @@ importers:
         specifier: workspace:*
         version: link:../../eslint/local-eslint-config
       typescript:
-        specifier: ~5.4.2
-        version: 5.4.2
+        specifier: ~5.7.3
+        version: 5.7.3
 
   ../../../build-tests/heft-fastify-test:
     dependencies:
@@ -1370,8 +1370,8 @@ importers:
         specifier: workspace:*
         version: link:../../eslint/local-eslint-config
       typescript:
-        specifier: ~5.4.2
-        version: 5.4.2
+        specifier: ~5.7.3
+        version: 5.7.3
 
   ../../../build-tests/heft-jest-preset-test:
     devDependencies:
@@ -1400,8 +1400,8 @@ importers:
         specifier: workspace:*
         version: link:../../eslint/local-eslint-config
       typescript:
-        specifier: ~5.4.2
-        version: 5.4.2
+        specifier: ~5.7.3
+        version: 5.7.3
 
   ../../../build-tests/heft-jest-reporters-test:
     devDependencies:
@@ -1436,8 +1436,8 @@ importers:
         specifier: workspace:*
         version: link:../../eslint/local-eslint-config
       typescript:
-        specifier: ~5.4.2
-        version: 5.4.2
+        specifier: ~5.7.3
+        version: 5.7.3
 
   ../../../build-tests/heft-minimal-rig-test:
     dependencies:
@@ -1457,8 +1457,8 @@ importers:
         specifier: workspace:*
         version: link:../../heft-plugins/heft-typescript-plugin
       typescript:
-        specifier: ~5.4.2
-        version: 5.4.2
+        specifier: ~5.7.3
+        version: 5.7.3
 
   ../../../build-tests/heft-minimal-rig-usage-test:
     devDependencies:
@@ -1518,10 +1518,10 @@ importers:
         version: link:../../eslint/local-eslint-config
       tslint:
         specifier: ~5.20.1
-        version: 5.20.1(typescript@5.4.2)
+        version: 5.20.1(typescript@5.7.3)
       typescript:
-        specifier: ~5.4.2
-        version: 5.4.2
+        specifier: ~5.7.3
+        version: 5.7.3
 
   ../../../build-tests/heft-node-everything-test:
     devDependencies:
@@ -1563,10 +1563,10 @@ importers:
         version: link:../../eslint/local-eslint-config
       tslint:
         specifier: ~5.20.1
-        version: 5.20.1(typescript@5.4.2)
+        version: 5.20.1(typescript@5.7.3)
       typescript:
-        specifier: ~5.4.2
-        version: 5.4.2
+        specifier: ~5.7.3
+        version: 5.7.3
 
   ../../../build-tests/heft-parameter-plugin:
     dependencies:
@@ -1593,8 +1593,8 @@ importers:
         specifier: workspace:*
         version: link:../../eslint/local-eslint-config
       typescript:
-        specifier: ~5.4.2
-        version: 5.4.2
+        specifier: ~5.7.3
+        version: 5.7.3
 
   ../../../build-tests/heft-parameter-plugin-test:
     devDependencies:
@@ -1623,8 +1623,8 @@ importers:
         specifier: workspace:*
         version: link:../heft-parameter-plugin
       typescript:
-        specifier: ~5.4.2
-        version: 5.4.2
+        specifier: ~5.7.3
+        version: 5.7.3
 
   ../../../build-tests/heft-sass-test:
     dependencies:
@@ -1696,8 +1696,8 @@ importers:
         specifier: ~2.0.0
         version: 2.0.0(webpack@4.47.0)
       typescript:
-        specifier: ~5.4.2
-        version: 5.4.2
+        specifier: ~5.7.3
+        version: 5.7.3
       webpack:
         specifier: ~4.47.0
         version: 4.47.0
@@ -1733,10 +1733,10 @@ importers:
         version: link:../../eslint/local-eslint-config
       tslint:
         specifier: ~5.20.1
-        version: 5.20.1(typescript@5.4.2)
+        version: 5.20.1(typescript@5.7.3)
       typescript:
-        specifier: ~5.4.2
-        version: 5.4.2
+        specifier: ~5.7.3
+        version: 5.7.3
 
   ../../../build-tests/heft-typescript-v2-test:
     devDependencies:
@@ -1907,10 +1907,10 @@ importers:
         version: 1.1.3(webpack@4.47.0)
       tslint:
         specifier: ~5.20.1
-        version: 5.20.1(typescript@5.4.2)
+        version: 5.20.1(typescript@5.7.3)
       typescript:
-        specifier: ~5.4.2
-        version: 5.4.2
+        specifier: ~5.7.3
+        version: 5.7.3
       webpack:
         specifier: ~4.47.0
         version: 4.47.0
@@ -1970,10 +1970,10 @@ importers:
         version: 3.0.2(webpack@5.95.0)
       tslint:
         specifier: ~5.20.1
-        version: 5.20.1(typescript@5.4.2)
+        version: 5.20.1(typescript@5.7.3)
       typescript:
-        specifier: ~5.4.2
-        version: 5.4.2
+        specifier: ~5.7.3
+        version: 5.7.3
       webpack:
         specifier: ~5.95.0
         version: 5.95.0
@@ -2090,10 +2090,10 @@ importers:
         version: link:../../rigs/local-node-rig
       ts-loader:
         specifier: 6.0.0
-        version: 6.0.0(typescript@5.4.2)
+        version: 6.0.0(typescript@5.7.3)
       typescript:
-        specifier: ~5.4.2
-        version: 5.4.2
+        specifier: ~5.7.3
+        version: 5.7.3
       webpack:
         specifier: ~4.47.0
         version: 4.47.0
@@ -2184,8 +2184,8 @@ importers:
         specifier: workspace:*
         version: link:../../rigs/local-node-rig
       typescript:
-        specifier: ~5.4.2
-        version: 5.4.2
+        specifier: ~5.7.3
+        version: 5.7.3
 
   ../../../build-tests/rush-lib-declaration-paths-test:
     dependencies:
@@ -2258,8 +2258,8 @@ importers:
         specifier: workspace:*
         version: link:../../rigs/local-node-rig
       typescript:
-        specifier: ~5.4.2
-        version: 5.4.2
+        specifier: ~5.7.3
+        version: 5.7.3
 
   ../../../build-tests/set-webpack-public-path-plugin-test:
     devDependencies:
@@ -2294,8 +2294,8 @@ importers:
         specifier: ~5.5.0
         version: 5.5.4(webpack@5.95.0)
       typescript:
-        specifier: ~5.4.2
-        version: 5.4.2
+        specifier: ~5.7.3
+        version: 5.7.3
       webpack:
         specifier: ~5.95.0
         version: 5.95.0
@@ -2327,17 +2327,17 @@ importers:
         specifier: workspace:*
         version: link:../eslint-plugin-security
       '@typescript-eslint/eslint-plugin':
-        specifier: ~8.1.0
-        version: 8.1.0(@typescript-eslint/parser@8.1.0)(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.4.2)
+        specifier: ~8.24.0
+        version: 8.24.0(@typescript-eslint/parser@8.24.0)(eslint@8.57.0)(typescript@5.7.3)
       '@typescript-eslint/parser':
-        specifier: ~8.1.0
-        version: 8.1.0(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.4.2)
+        specifier: ~8.24.0
+        version: 8.24.0(eslint@8.57.0)(typescript@5.7.3)
       '@typescript-eslint/typescript-estree':
-        specifier: ~8.1.0
-        version: 8.1.0(supports-color@8.1.1)(typescript@5.4.2)
+        specifier: ~8.24.0
+        version: 8.24.1(typescript@5.7.3)
       '@typescript-eslint/utils':
-        specifier: ~8.1.0
-        version: 8.1.0(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.4.2)
+        specifier: ~8.24.0
+        version: 8.24.1(eslint@8.57.0)(typescript@5.7.3)
       eslint-plugin-promise:
         specifier: ~6.1.1
         version: 6.1.1(eslint@8.57.0)
@@ -2352,8 +2352,8 @@ importers:
         specifier: ~8.57.0
         version: 8.57.0(supports-color@8.1.1)
       typescript:
-        specifier: ~5.4.2
-        version: 5.4.2
+        specifier: ~5.7.3
+        version: 5.7.3
 
   ../../../eslint/eslint-patch:
     devDependencies:
@@ -2370,8 +2370,8 @@ importers:
         specifier: 20.17.19
         version: 20.17.19
       '@typescript-eslint/types':
-        specifier: ~5.59.2
-        version: 5.59.11(typescript@5.4.2)
+        specifier: ~8.24.0
+        version: 8.24.1(typescript@5.7.3)
       eslint:
         specifier: ~8.57.0
         version: 8.57.0(supports-color@8.1.1)
@@ -2379,8 +2379,8 @@ importers:
         specifier: ~3.1.1
         version: 3.1.1(eslint@8.57.0)
       typescript:
-        specifier: ~5.4.2
-        version: 5.4.2
+        specifier: ~5.7.3
+        version: 5.7.3
 
   ../../../eslint/eslint-plugin:
     dependencies:
@@ -2388,8 +2388,8 @@ importers:
         specifier: workspace:*
         version: link:../../libraries/tree-pattern
       '@typescript-eslint/utils':
-        specifier: ~8.1.0
-        version: 8.1.0(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.4.2)
+        specifier: ~8.24.0
+        version: 8.24.1(eslint@8.57.0)(typescript@5.7.3)
     devDependencies:
       '@eslint/eslintrc':
         specifier: ~3.0.0
@@ -2413,14 +2413,14 @@ importers:
         specifier: 20.17.19
         version: 20.17.19
       '@typescript-eslint/parser':
-        specifier: ~8.1.0
-        version: 8.1.0(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.4.2)
+        specifier: ~8.24.0
+        version: 8.24.0(eslint@8.57.0)(typescript@5.7.3)
       '@typescript-eslint/rule-tester':
-        specifier: ~8.1.0
-        version: 8.1.0(@eslint/eslintrc@3.0.2)(eslint@8.57.0)(typescript@5.4.2)
+        specifier: ~8.24.0
+        version: 8.24.1(eslint@8.57.0)(typescript@5.7.3)
       '@typescript-eslint/typescript-estree':
-        specifier: ~8.1.0
-        version: 8.1.0(supports-color@8.1.1)(typescript@5.4.2)
+        specifier: ~8.24.0
+        version: 8.24.1(typescript@5.7.3)
       eslint:
         specifier: ~8.57.0
         version: 8.57.0(supports-color@8.1.1)
@@ -2428,8 +2428,8 @@ importers:
         specifier: ~3.1.1
         version: 3.1.1(eslint@8.57.0)
       typescript:
-        specifier: ~5.4.2
-        version: 5.4.2
+        specifier: ~5.7.3
+        version: 5.7.3
 
   ../../../eslint/eslint-plugin-packlets:
     dependencies:
@@ -2437,8 +2437,8 @@ importers:
         specifier: workspace:*
         version: link:../../libraries/tree-pattern
       '@typescript-eslint/utils':
-        specifier: ~8.1.0
-        version: 8.1.0(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.4.2)
+        specifier: ~8.24.0
+        version: 8.24.1(eslint@8.57.0)(typescript@5.7.3)
     devDependencies:
       '@rushstack/heft':
         specifier: 0.69.2
@@ -2459,11 +2459,11 @@ importers:
         specifier: 20.17.19
         version: 20.17.19
       '@typescript-eslint/parser':
-        specifier: ~8.1.0
-        version: 8.1.0(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.4.2)
+        specifier: ~8.24.0
+        version: 8.24.0(eslint@8.57.0)(typescript@5.7.3)
       '@typescript-eslint/typescript-estree':
-        specifier: ~8.1.0
-        version: 8.1.0(supports-color@8.1.1)(typescript@5.4.2)
+        specifier: ~8.24.0
+        version: 8.24.1(typescript@5.7.3)
       eslint:
         specifier: ~8.57.0
         version: 8.57.0(supports-color@8.1.1)
@@ -2471,8 +2471,8 @@ importers:
         specifier: ~3.1.1
         version: 3.1.1(eslint@8.57.0)
       typescript:
-        specifier: ~5.4.2
-        version: 5.4.2
+        specifier: ~5.7.3
+        version: 5.7.3
 
   ../../../eslint/eslint-plugin-security:
     dependencies:
@@ -2480,8 +2480,8 @@ importers:
         specifier: workspace:*
         version: link:../../libraries/tree-pattern
       '@typescript-eslint/utils':
-        specifier: ~8.1.0
-        version: 8.1.0(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.4.2)
+        specifier: ~8.24.0
+        version: 8.24.1(eslint@8.57.0)(typescript@5.7.3)
     devDependencies:
       '@eslint/eslintrc':
         specifier: ~3.0.0
@@ -2505,14 +2505,14 @@ importers:
         specifier: 20.17.19
         version: 20.17.19
       '@typescript-eslint/parser':
-        specifier: ~8.1.0
-        version: 8.1.0(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.4.2)
+        specifier: ~8.24.0
+        version: 8.24.0(eslint@8.57.0)(typescript@5.7.3)
       '@typescript-eslint/rule-tester':
-        specifier: ~8.1.0
-        version: 8.1.0(@eslint/eslintrc@3.0.2)(eslint@8.57.0)(typescript@5.4.2)
+        specifier: ~8.24.0
+        version: 8.24.1(eslint@8.57.0)(typescript@5.7.3)
       '@typescript-eslint/typescript-estree':
-        specifier: ~8.1.0
-        version: 8.1.0(supports-color@8.1.1)(typescript@5.4.2)
+        specifier: ~8.24.0
+        version: 8.24.1(typescript@5.7.3)
       eslint:
         specifier: ~8.57.0
         version: 8.57.0(supports-color@8.1.1)
@@ -2520,8 +2520,8 @@ importers:
         specifier: ~3.1.1
         version: 3.1.1(eslint@8.57.0)
       typescript:
-        specifier: ~5.4.2
-        version: 5.4.2
+        specifier: ~5.7.3
+        version: 5.7.3
 
   ../../../eslint/local-eslint-config:
     dependencies:
@@ -2532,11 +2532,11 @@ importers:
         specifier: workspace:*
         version: link:../eslint-patch
       '@typescript-eslint/parser':
-        specifier: ~8.1.0
-        version: 8.1.0(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.4.2)
+        specifier: ~8.24.0
+        version: 8.24.0(eslint@8.57.0)(typescript@5.7.3)
       eslint-plugin-deprecation:
         specifier: 2.0.0
-        version: 2.0.0(eslint@8.57.0)(typescript@5.4.2)
+        version: 2.0.0(eslint@8.57.0)(typescript@5.7.3)
       eslint-plugin-header:
         specifier: ~3.1.1
         version: 3.1.1(eslint@8.57.0)
@@ -2554,8 +2554,8 @@ importers:
         specifier: ~8.57.0
         version: 8.57.0(supports-color@8.1.1)
       typescript:
-        specifier: ~5.4.2
-        version: 5.4.2
+        specifier: ~5.7.3
+        version: 5.7.3
 
   ../../../heft-plugins/heft-api-extractor-plugin:
     dependencies:
@@ -2594,8 +2594,8 @@ importers:
         specifier: workspace:*
         version: link:../../eslint/local-eslint-config
       typescript:
-        specifier: ~5.4.2
-        version: 5.4.2
+        specifier: ~5.7.3
+        version: 5.7.3
 
   ../../../heft-plugins/heft-dev-cert-plugin:
     dependencies:
@@ -2686,8 +2686,8 @@ importers:
         specifier: workspace:*
         version: link:../../eslint/local-eslint-config
       typescript:
-        specifier: ~5.4.2
-        version: 5.4.2
+        specifier: ~5.7.3
+        version: 5.7.3
 
   ../../../heft-plugins/heft-lint-plugin:
     dependencies:
@@ -2730,10 +2730,10 @@ importers:
         version: link:../../eslint/local-eslint-config
       tslint:
         specifier: ~5.20.1
-        version: 5.20.1(typescript@5.4.2)
+        version: 5.20.1(typescript@5.7.3)
       typescript:
-        specifier: ~5.4.2
-        version: 5.4.2
+        specifier: ~5.7.3
+        version: 5.7.3
 
   ../../../heft-plugins/heft-localization-typings-plugin:
     dependencies:
@@ -2863,8 +2863,8 @@ importers:
         specifier: workspace:*
         version: link:../../eslint/local-eslint-config
       typescript:
-        specifier: ~5.4.2
-        version: 5.4.2
+        specifier: ~5.7.3
+        version: 5.7.3
 
   ../../../heft-plugins/heft-webpack4-plugin:
     dependencies:
@@ -2970,6 +2970,9 @@ importers:
       local-eslint-config:
         specifier: workspace:*
         version: link:../../eslint/local-eslint-config
+      typescript:
+        specifier: ~5.7.3
+        version: 5.7.3
 
   ../../../libraries/debug-certificate-manager:
     dependencies:
@@ -3026,6 +3029,9 @@ importers:
       local-eslint-config:
         specifier: workspace:*
         version: link:../../eslint/local-eslint-config
+      typescript:
+        specifier: ~5.7.3
+        version: 5.7.3
 
   ../../../libraries/load-themed-styles:
     devDependencies:
@@ -3091,6 +3097,9 @@ importers:
       '@rushstack/heft':
         specifier: workspace:*
         version: link:../../apps/heft
+      '@types/node':
+        specifier: 20.17.19
+        version: 20.17.19
       '@types/serialize-javascript':
         specifier: 5.0.2
         version: 5.0.2
@@ -3152,6 +3161,9 @@ importers:
       local-eslint-config:
         specifier: workspace:*
         version: link:../../eslint/local-eslint-config
+      typescript:
+        specifier: ~5.7.3
+        version: 5.7.3
 
   ../../../libraries/operation-graph:
     dependencies:
@@ -3177,6 +3189,9 @@ importers:
       local-eslint-config:
         specifier: workspace:*
         version: link:../../eslint/local-eslint-config
+      typescript:
+        specifier: ~5.7.3
+        version: 5.7.3
 
   ../../../libraries/package-deps-hash:
     dependencies:
@@ -3282,6 +3297,9 @@ importers:
       local-eslint-config:
         specifier: workspace:*
         version: link:../../eslint/local-eslint-config
+      typescript:
+        specifier: ~5.7.3
+        version: 5.7.3
 
   ../../../libraries/rush-lib:
     dependencies:
@@ -3600,12 +3618,15 @@ importers:
       local-eslint-config:
         specifier: workspace:*
         version: link:../../eslint/local-eslint-config
+      typescript:
+        specifier: ~5.7.3
+        version: 5.7.3
 
   ../../../libraries/tree-pattern:
     devDependencies:
       '@rushstack/eslint-config':
         specifier: 4.1.1
-        version: 4.1.1(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.4.2)
+        version: 4.1.1(eslint@8.57.0)(typescript@5.7.3)
       '@rushstack/heft':
         specifier: 0.69.2
         version: 0.69.2(@types/node@20.17.19)
@@ -3622,8 +3643,8 @@ importers:
         specifier: ~8.57.0
         version: 8.57.0(supports-color@8.1.1)
       typescript:
-        specifier: ~5.4.2
-        version: 5.4.2
+        specifier: ~5.7.3
+        version: 5.7.3
 
   ../../../libraries/ts-command-line:
     dependencies:
@@ -3785,8 +3806,8 @@ importers:
         specifier: ~29.5.0
         version: 29.5.0
       typescript:
-        specifier: ~5.4.2
-        version: 5.4.2
+        specifier: ~5.7.3
+        version: 5.7.3
     devDependencies:
       '@rushstack/heft':
         specifier: workspace:*
@@ -3864,8 +3885,8 @@ importers:
         specifier: ~5.3.1
         version: 5.3.10(webpack@5.95.0)
       typescript:
-        specifier: ~5.4.2
-        version: 5.4.2
+        specifier: ~5.7.3
+        version: 5.7.3
       url-loader:
         specifier: ~4.1.1
         version: 4.1.1(webpack@5.95.0)
@@ -3910,8 +3931,8 @@ importers:
         specifier: workspace:*
         version: link:../../eslint/local-eslint-config
       typescript:
-        specifier: ~5.4.2
-        version: 5.4.2
+        specifier: ~5.7.3
+        version: 5.7.3
 
   ../../../rigs/local-web-rig:
     dependencies:
@@ -3940,8 +3961,8 @@ importers:
         specifier: workspace:*
         version: link:../../eslint/local-eslint-config
       typescript:
-        specifier: ~5.4.2
-        version: 5.4.2
+        specifier: ~5.7.3
+        version: 5.7.3
 
   ../../../rush-plugins/rush-amazon-s3-build-cache-plugin:
     dependencies:
@@ -4389,8 +4410,8 @@ importers:
         specifier: workspace:*
         version: link:../../apps/heft
       '@types/node':
-        specifier: 18.17.15
-        version: 18.17.15
+        specifier: 20.17.19
+        version: 20.17.19
       local-node-rig:
         specifier: workspace:*
         version: link:../../rigs/local-node-rig
@@ -4470,6 +4491,9 @@ importers:
       '@rushstack/heft':
         specifier: workspace:*
         version: link:../../apps/heft
+      '@types/node':
+        specifier: 20.17.19
+        version: 20.17.19
       local-node-rig:
         specifier: workspace:*
         version: link:../../rigs/local-node-rig
@@ -4544,6 +4568,9 @@ importers:
       '@rushstack/heft':
         specifier: workspace:*
         version: link:../../apps/heft
+      '@types/node':
+        specifier: 20.17.19
+        version: 20.17.19
       '@types/webpack':
         specifier: 4.41.32
         version: 4.41.32
@@ -4599,6 +4626,9 @@ importers:
       '@rushstack/heft':
         specifier: workspace:*
         version: link:../../apps/heft
+      '@types/node':
+        specifier: 20.17.19
+        version: 20.17.19
       local-node-rig:
         specifier: workspace:*
         version: link:../../rigs/local-node-rig
@@ -4630,6 +4660,9 @@ importers:
       '@rushstack/module-minifier':
         specifier: workspace:*
         version: link:../../libraries/module-minifier
+      '@types/node':
+        specifier: 20.17.19
+        version: 20.17.19
       local-node-rig:
         specifier: workspace:*
         version: link:../../rigs/local-node-rig
@@ -10297,117 +10330,117 @@ packages:
     engines: {node: '>=14.0.0'}
     dev: true
 
-  /@rushstack/eslint-config@3.7.1(eslint@7.11.0)(typescript@5.4.2):
+  /@rushstack/eslint-config@3.7.1(eslint@7.11.0)(typescript@5.7.3):
     resolution: {integrity: sha512-LFoVMbvHj2WbfPjJixqHztCl6yMRSY2a1V2mqfQAjb49n7B06N+FZH5c0o6VmO+96fR1l0PC0DazLeHhRf+uug==}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
       typescript: '>=4.7.0'
     dependencies:
       '@rushstack/eslint-patch': 1.10.4
-      '@rushstack/eslint-plugin': 0.15.2(eslint@7.11.0)(typescript@5.4.2)
-      '@rushstack/eslint-plugin-packlets': 0.9.2(eslint@7.11.0)(typescript@5.4.2)
-      '@rushstack/eslint-plugin-security': 0.8.2(eslint@7.11.0)(typescript@5.4.2)
-      '@typescript-eslint/eslint-plugin': 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@7.11.0)(typescript@5.4.2)
-      '@typescript-eslint/parser': 6.19.1(eslint@7.11.0)(typescript@5.4.2)
-      '@typescript-eslint/typescript-estree': 6.19.1(supports-color@8.1.1)(typescript@5.4.2)
-      '@typescript-eslint/utils': 6.19.1(eslint@7.11.0)(typescript@5.4.2)
+      '@rushstack/eslint-plugin': 0.15.2(eslint@7.11.0)(typescript@5.7.3)
+      '@rushstack/eslint-plugin-packlets': 0.9.2(eslint@7.11.0)(typescript@5.7.3)
+      '@rushstack/eslint-plugin-security': 0.8.2(eslint@7.11.0)(typescript@5.7.3)
+      '@typescript-eslint/eslint-plugin': 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@7.11.0)(typescript@5.7.3)
+      '@typescript-eslint/parser': 6.19.1(eslint@7.11.0)(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 6.19.1(typescript@5.7.3)
+      '@typescript-eslint/utils': 6.19.1(eslint@7.11.0)(typescript@5.7.3)
       eslint: 7.11.0
       eslint-plugin-promise: 6.1.1(eslint@7.11.0)
       eslint-plugin-react: 7.33.2(eslint@7.11.0)
       eslint-plugin-tsdoc: 0.3.0
-      typescript: 5.4.2
+      typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@rushstack/eslint-config@3.7.1(eslint@7.30.0)(typescript@5.4.2):
+  /@rushstack/eslint-config@3.7.1(eslint@7.30.0)(typescript@5.7.3):
     resolution: {integrity: sha512-LFoVMbvHj2WbfPjJixqHztCl6yMRSY2a1V2mqfQAjb49n7B06N+FZH5c0o6VmO+96fR1l0PC0DazLeHhRf+uug==}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
       typescript: '>=4.7.0'
     dependencies:
       '@rushstack/eslint-patch': 1.10.4
-      '@rushstack/eslint-plugin': 0.15.2(eslint@7.30.0)(typescript@5.4.2)
-      '@rushstack/eslint-plugin-packlets': 0.9.2(eslint@7.30.0)(typescript@5.4.2)
-      '@rushstack/eslint-plugin-security': 0.8.2(eslint@7.30.0)(typescript@5.4.2)
-      '@typescript-eslint/eslint-plugin': 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@7.30.0)(typescript@5.4.2)
-      '@typescript-eslint/parser': 6.19.1(eslint@7.30.0)(typescript@5.4.2)
-      '@typescript-eslint/typescript-estree': 6.19.1(supports-color@8.1.1)(typescript@5.4.2)
-      '@typescript-eslint/utils': 6.19.1(eslint@7.30.0)(typescript@5.4.2)
+      '@rushstack/eslint-plugin': 0.15.2(eslint@7.30.0)(typescript@5.7.3)
+      '@rushstack/eslint-plugin-packlets': 0.9.2(eslint@7.30.0)(typescript@5.7.3)
+      '@rushstack/eslint-plugin-security': 0.8.2(eslint@7.30.0)(typescript@5.7.3)
+      '@typescript-eslint/eslint-plugin': 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@7.30.0)(typescript@5.7.3)
+      '@typescript-eslint/parser': 6.19.1(eslint@7.30.0)(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 6.19.1(typescript@5.7.3)
+      '@typescript-eslint/utils': 6.19.1(eslint@7.30.0)(typescript@5.7.3)
       eslint: 7.30.0
       eslint-plugin-promise: 6.1.1(eslint@7.30.0)
       eslint-plugin-react: 7.33.2(eslint@7.30.0)
       eslint-plugin-tsdoc: 0.3.0
-      typescript: 5.4.2
+      typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@rushstack/eslint-config@3.7.1(eslint@7.7.0)(typescript@5.4.2):
+  /@rushstack/eslint-config@3.7.1(eslint@7.7.0)(typescript@5.7.3):
     resolution: {integrity: sha512-LFoVMbvHj2WbfPjJixqHztCl6yMRSY2a1V2mqfQAjb49n7B06N+FZH5c0o6VmO+96fR1l0PC0DazLeHhRf+uug==}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
       typescript: '>=4.7.0'
     dependencies:
       '@rushstack/eslint-patch': 1.10.4
-      '@rushstack/eslint-plugin': 0.15.2(eslint@7.7.0)(typescript@5.4.2)
-      '@rushstack/eslint-plugin-packlets': 0.9.2(eslint@7.7.0)(typescript@5.4.2)
-      '@rushstack/eslint-plugin-security': 0.8.2(eslint@7.7.0)(typescript@5.4.2)
-      '@typescript-eslint/eslint-plugin': 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@7.7.0)(typescript@5.4.2)
-      '@typescript-eslint/parser': 6.19.1(eslint@7.7.0)(typescript@5.4.2)
-      '@typescript-eslint/typescript-estree': 6.19.1(supports-color@8.1.1)(typescript@5.4.2)
-      '@typescript-eslint/utils': 6.19.1(eslint@7.7.0)(typescript@5.4.2)
+      '@rushstack/eslint-plugin': 0.15.2(eslint@7.7.0)(typescript@5.7.3)
+      '@rushstack/eslint-plugin-packlets': 0.9.2(eslint@7.7.0)(typescript@5.7.3)
+      '@rushstack/eslint-plugin-security': 0.8.2(eslint@7.7.0)(typescript@5.7.3)
+      '@typescript-eslint/eslint-plugin': 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@7.7.0)(typescript@5.7.3)
+      '@typescript-eslint/parser': 6.19.1(eslint@7.7.0)(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 6.19.1(typescript@5.7.3)
+      '@typescript-eslint/utils': 6.19.1(eslint@7.7.0)(typescript@5.7.3)
       eslint: 7.7.0
       eslint-plugin-promise: 6.1.1(eslint@7.7.0)
       eslint-plugin-react: 7.33.2(eslint@7.7.0)
       eslint-plugin-tsdoc: 0.3.0
-      typescript: 5.4.2
+      typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@rushstack/eslint-config@3.7.1(eslint@8.57.0)(typescript@5.4.2):
+  /@rushstack/eslint-config@3.7.1(eslint@8.57.0)(typescript@5.7.3):
     resolution: {integrity: sha512-LFoVMbvHj2WbfPjJixqHztCl6yMRSY2a1V2mqfQAjb49n7B06N+FZH5c0o6VmO+96fR1l0PC0DazLeHhRf+uug==}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
       typescript: '>=4.7.0'
     dependencies:
       '@rushstack/eslint-patch': 1.10.4
-      '@rushstack/eslint-plugin': 0.15.2(eslint@8.57.0)(typescript@5.4.2)
-      '@rushstack/eslint-plugin-packlets': 0.9.2(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.4.2)
-      '@rushstack/eslint-plugin-security': 0.8.2(eslint@8.57.0)(typescript@5.4.2)
-      '@typescript-eslint/eslint-plugin': 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.57.0)(typescript@5.4.2)
-      '@typescript-eslint/parser': 6.19.1(eslint@8.57.0)(typescript@5.4.2)
-      '@typescript-eslint/typescript-estree': 6.19.1(supports-color@8.1.1)(typescript@5.4.2)
-      '@typescript-eslint/utils': 6.19.1(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.4.2)
+      '@rushstack/eslint-plugin': 0.15.2(eslint@8.57.0)(typescript@5.7.3)
+      '@rushstack/eslint-plugin-packlets': 0.9.2(eslint@8.57.0)(typescript@5.7.3)
+      '@rushstack/eslint-plugin-security': 0.8.2(eslint@8.57.0)(typescript@5.7.3)
+      '@typescript-eslint/eslint-plugin': 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.57.0)(typescript@5.7.3)
+      '@typescript-eslint/parser': 6.19.1(eslint@8.57.0)(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 6.19.1(typescript@5.7.3)
+      '@typescript-eslint/utils': 6.19.1(eslint@8.57.0)(typescript@5.7.3)
       eslint: 8.57.0(supports-color@8.1.1)
       eslint-plugin-promise: 6.1.1(eslint@8.57.0)
       eslint-plugin-react: 7.33.2(eslint@8.57.0)
       eslint-plugin-tsdoc: 0.3.0
-      typescript: 5.4.2
+      typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@rushstack/eslint-config@4.1.1(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.4.2):
+  /@rushstack/eslint-config@4.1.1(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.7.3):
     resolution: {integrity: sha512-fVL6mGv2pFEe8t8FRu6rKYRHpTIYrbY/Iqc/xQTa4u4bp6V+Y47teSWn1FeApgKk5tr34KmWqLPjzyNKEOTCig==}
     peerDependencies:
       eslint: ^8.57.0
       typescript: '>=4.7.0'
     dependencies:
       '@rushstack/eslint-patch': 1.10.5
-      '@rushstack/eslint-plugin': 0.16.1(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.4.2)
-      '@rushstack/eslint-plugin-packlets': 0.9.2(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.4.2)
-      '@rushstack/eslint-plugin-security': 0.8.3(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.4.2)
-      '@typescript-eslint/eslint-plugin': 8.1.0(@typescript-eslint/parser@8.1.0)(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.4.2)
-      '@typescript-eslint/parser': 8.1.0(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.4.2)
-      '@typescript-eslint/typescript-estree': 8.1.0(supports-color@8.1.1)(typescript@5.4.2)
-      '@typescript-eslint/utils': 8.1.0(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.4.2)
+      '@rushstack/eslint-plugin': 0.16.1(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.7.3)
+      '@rushstack/eslint-plugin-packlets': 0.9.2(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.7.3)
+      '@rushstack/eslint-plugin-security': 0.8.3(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.7.3)
+      '@typescript-eslint/eslint-plugin': 8.1.0(@typescript-eslint/parser@8.1.0)(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.7.3)
+      '@typescript-eslint/parser': 8.1.0(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 8.1.0(supports-color@8.1.1)(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.1.0(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.7.3)
       eslint: 8.57.0(supports-color@8.1.1)
       eslint-plugin-promise: 6.1.1(eslint@8.57.0)
       eslint-plugin-react: 7.33.2(eslint@8.57.0)
       eslint-plugin-tsdoc: 0.4.0
-      typescript: 5.4.2
+      typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -10435,6 +10468,29 @@ packages:
       - supports-color
     dev: true
 
+  /@rushstack/eslint-config@4.1.1(eslint@8.57.0)(typescript@5.7.3):
+    resolution: {integrity: sha512-fVL6mGv2pFEe8t8FRu6rKYRHpTIYrbY/Iqc/xQTa4u4bp6V+Y47teSWn1FeApgKk5tr34KmWqLPjzyNKEOTCig==}
+    peerDependencies:
+      eslint: ^8.57.0
+      typescript: '>=4.7.0'
+    dependencies:
+      '@rushstack/eslint-patch': 1.10.5
+      '@rushstack/eslint-plugin': 0.16.1(eslint@8.57.0)(typescript@5.7.3)
+      '@rushstack/eslint-plugin-packlets': 0.9.2(eslint@8.57.0)(typescript@5.7.3)
+      '@rushstack/eslint-plugin-security': 0.8.3(eslint@8.57.0)(typescript@5.7.3)
+      '@typescript-eslint/eslint-plugin': 8.1.0(@typescript-eslint/parser@8.1.0)(eslint@8.57.0)(typescript@5.7.3)
+      '@typescript-eslint/parser': 8.1.0(eslint@8.57.0)(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 8.1.0(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.1.0(eslint@8.57.0)(typescript@5.7.3)
+      eslint: 8.57.0(supports-color@8.1.1)
+      eslint-plugin-promise: 6.1.1(eslint@8.57.0)
+      eslint-plugin-react: 7.33.2(eslint@8.57.0)
+      eslint-plugin-tsdoc: 0.4.0
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@rushstack/eslint-patch@1.10.4:
     resolution: {integrity: sha512-WJgX9nzTqknM393q1QJDJmoW28kUfEnybeTfVNcNAPnIx210RXm2DiXiHzfNPJNIUUb1tJnz/l4QGtJ30PgWmA==}
     dev: true
@@ -10443,52 +10499,52 @@ packages:
     resolution: {integrity: sha512-kkKUDVlII2DQiKy7UstOR1ErJP8kUKAQ4oa+SQtM0K+lPdmmjj0YnnxBgtTVYH7mUKtbsxeFC9y0AmK7Yb78/A==}
     dev: true
 
-  /@rushstack/eslint-plugin-packlets@0.9.2(eslint@7.11.0)(typescript@5.4.2):
+  /@rushstack/eslint-plugin-packlets@0.9.2(eslint@7.11.0)(typescript@5.7.3):
     resolution: {integrity: sha512-rZofSLJpwyP7Xo6e4eKYkI7N4JM5PycvPuoX5IEK08PgxPDm/k5pdltH9DkIKnmWvLrxIMU+85VrB5xnjbK0RQ==}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       '@rushstack/tree-pattern': 0.3.4
-      '@typescript-eslint/utils': 6.19.1(eslint@7.11.0)(typescript@5.4.2)
+      '@typescript-eslint/utils': 6.19.1(eslint@7.11.0)(typescript@5.7.3)
       eslint: 7.11.0
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  /@rushstack/eslint-plugin-packlets@0.9.2(eslint@7.30.0)(typescript@5.4.2):
+  /@rushstack/eslint-plugin-packlets@0.9.2(eslint@7.30.0)(typescript@5.7.3):
     resolution: {integrity: sha512-rZofSLJpwyP7Xo6e4eKYkI7N4JM5PycvPuoX5IEK08PgxPDm/k5pdltH9DkIKnmWvLrxIMU+85VrB5xnjbK0RQ==}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       '@rushstack/tree-pattern': 0.3.4
-      '@typescript-eslint/utils': 6.19.1(eslint@7.30.0)(typescript@5.4.2)
+      '@typescript-eslint/utils': 6.19.1(eslint@7.30.0)(typescript@5.7.3)
       eslint: 7.30.0
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  /@rushstack/eslint-plugin-packlets@0.9.2(eslint@7.7.0)(typescript@5.4.2):
+  /@rushstack/eslint-plugin-packlets@0.9.2(eslint@7.7.0)(typescript@5.7.3):
     resolution: {integrity: sha512-rZofSLJpwyP7Xo6e4eKYkI7N4JM5PycvPuoX5IEK08PgxPDm/k5pdltH9DkIKnmWvLrxIMU+85VrB5xnjbK0RQ==}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       '@rushstack/tree-pattern': 0.3.4
-      '@typescript-eslint/utils': 6.19.1(eslint@7.7.0)(typescript@5.4.2)
+      '@typescript-eslint/utils': 6.19.1(eslint@7.7.0)(typescript@5.7.3)
       eslint: 7.7.0
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  /@rushstack/eslint-plugin-packlets@0.9.2(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.4.2):
+  /@rushstack/eslint-plugin-packlets@0.9.2(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.7.3):
     resolution: {integrity: sha512-rZofSLJpwyP7Xo6e4eKYkI7N4JM5PycvPuoX5IEK08PgxPDm/k5pdltH9DkIKnmWvLrxIMU+85VrB5xnjbK0RQ==}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       '@rushstack/tree-pattern': 0.3.4
-      '@typescript-eslint/utils': 6.19.1(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.4.2)
+      '@typescript-eslint/utils': 6.19.1(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.7.3)
       eslint: 8.57.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
@@ -10508,65 +10564,78 @@ packages:
       - typescript
     dev: true
 
-  /@rushstack/eslint-plugin-security@0.8.2(eslint@7.11.0)(typescript@5.4.2):
-    resolution: {integrity: sha512-AkY8BXanfV+RZLaifBglBpWYbR4vJNzYEj6C2m9TLDsRhZPW0h/rUHw6XDVpORhqJYCOXxoZcIwWnKenPbzDuQ==}
+  /@rushstack/eslint-plugin-packlets@0.9.2(eslint@8.57.0)(typescript@5.7.3):
+    resolution: {integrity: sha512-rZofSLJpwyP7Xo6e4eKYkI7N4JM5PycvPuoX5IEK08PgxPDm/k5pdltH9DkIKnmWvLrxIMU+85VrB5xnjbK0RQ==}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       '@rushstack/tree-pattern': 0.3.4
-      '@typescript-eslint/utils': 6.19.1(eslint@7.11.0)(typescript@5.4.2)
-      eslint: 7.11.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
-
-  /@rushstack/eslint-plugin-security@0.8.2(eslint@7.30.0)(typescript@5.4.2):
-    resolution: {integrity: sha512-AkY8BXanfV+RZLaifBglBpWYbR4vJNzYEj6C2m9TLDsRhZPW0h/rUHw6XDVpORhqJYCOXxoZcIwWnKenPbzDuQ==}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-    dependencies:
-      '@rushstack/tree-pattern': 0.3.4
-      '@typescript-eslint/utils': 6.19.1(eslint@7.30.0)(typescript@5.4.2)
-      eslint: 7.30.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
-
-  /@rushstack/eslint-plugin-security@0.8.2(eslint@7.7.0)(typescript@5.4.2):
-    resolution: {integrity: sha512-AkY8BXanfV+RZLaifBglBpWYbR4vJNzYEj6C2m9TLDsRhZPW0h/rUHw6XDVpORhqJYCOXxoZcIwWnKenPbzDuQ==}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-    dependencies:
-      '@rushstack/tree-pattern': 0.3.4
-      '@typescript-eslint/utils': 6.19.1(eslint@7.7.0)(typescript@5.4.2)
-      eslint: 7.7.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
-
-  /@rushstack/eslint-plugin-security@0.8.2(eslint@8.57.0)(typescript@5.4.2):
-    resolution: {integrity: sha512-AkY8BXanfV+RZLaifBglBpWYbR4vJNzYEj6C2m9TLDsRhZPW0h/rUHw6XDVpORhqJYCOXxoZcIwWnKenPbzDuQ==}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-    dependencies:
-      '@rushstack/tree-pattern': 0.3.4
-      '@typescript-eslint/utils': 6.19.1(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.4.2)
+      '@typescript-eslint/utils': 6.19.1(eslint@8.57.0)(typescript@5.7.3)
       eslint: 8.57.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  /@rushstack/eslint-plugin-security@0.8.3(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.4.2):
+  /@rushstack/eslint-plugin-security@0.8.2(eslint@7.11.0)(typescript@5.7.3):
+    resolution: {integrity: sha512-AkY8BXanfV+RZLaifBglBpWYbR4vJNzYEj6C2m9TLDsRhZPW0h/rUHw6XDVpORhqJYCOXxoZcIwWnKenPbzDuQ==}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      '@rushstack/tree-pattern': 0.3.4
+      '@typescript-eslint/utils': 6.19.1(eslint@7.11.0)(typescript@5.7.3)
+      eslint: 7.11.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
+  /@rushstack/eslint-plugin-security@0.8.2(eslint@7.30.0)(typescript@5.7.3):
+    resolution: {integrity: sha512-AkY8BXanfV+RZLaifBglBpWYbR4vJNzYEj6C2m9TLDsRhZPW0h/rUHw6XDVpORhqJYCOXxoZcIwWnKenPbzDuQ==}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      '@rushstack/tree-pattern': 0.3.4
+      '@typescript-eslint/utils': 6.19.1(eslint@7.30.0)(typescript@5.7.3)
+      eslint: 7.30.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
+  /@rushstack/eslint-plugin-security@0.8.2(eslint@7.7.0)(typescript@5.7.3):
+    resolution: {integrity: sha512-AkY8BXanfV+RZLaifBglBpWYbR4vJNzYEj6C2m9TLDsRhZPW0h/rUHw6XDVpORhqJYCOXxoZcIwWnKenPbzDuQ==}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      '@rushstack/tree-pattern': 0.3.4
+      '@typescript-eslint/utils': 6.19.1(eslint@7.7.0)(typescript@5.7.3)
+      eslint: 7.7.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
+  /@rushstack/eslint-plugin-security@0.8.2(eslint@8.57.0)(typescript@5.7.3):
+    resolution: {integrity: sha512-AkY8BXanfV+RZLaifBglBpWYbR4vJNzYEj6C2m9TLDsRhZPW0h/rUHw6XDVpORhqJYCOXxoZcIwWnKenPbzDuQ==}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      '@rushstack/tree-pattern': 0.3.4
+      '@typescript-eslint/utils': 6.19.1(eslint@8.57.0)(typescript@5.7.3)
+      eslint: 8.57.0(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
+  /@rushstack/eslint-plugin-security@0.8.3(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.7.3):
     resolution: {integrity: sha512-2l6bSIyTgaejiRPiFCsons/HA8sS7bKhmL/RHdAZo54jm/W/Xqb4zaFn4+OuMCNLASQhqXMc8FeYPF0V7t1Aow==}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       '@rushstack/tree-pattern': 0.3.4
-      '@typescript-eslint/utils': 8.1.0(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.4.2)
+      '@typescript-eslint/utils': 8.1.0(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.7.3)
       eslint: 8.57.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
@@ -10586,65 +10655,78 @@ packages:
       - typescript
     dev: true
 
-  /@rushstack/eslint-plugin@0.15.2(eslint@7.11.0)(typescript@5.4.2):
-    resolution: {integrity: sha512-oS3ENewjwEj+42jek1MQb2IETUd3On4tDgkuda2Mo7fbourygFZodhPDQYsj6aYFvwwn+FNLk4wjcghSQrCLqA==}
+  /@rushstack/eslint-plugin-security@0.8.3(eslint@8.57.0)(typescript@5.7.3):
+    resolution: {integrity: sha512-2l6bSIyTgaejiRPiFCsons/HA8sS7bKhmL/RHdAZo54jm/W/Xqb4zaFn4+OuMCNLASQhqXMc8FeYPF0V7t1Aow==}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       '@rushstack/tree-pattern': 0.3.4
-      '@typescript-eslint/utils': 6.19.1(eslint@7.11.0)(typescript@5.4.2)
-      eslint: 7.11.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
-
-  /@rushstack/eslint-plugin@0.15.2(eslint@7.30.0)(typescript@5.4.2):
-    resolution: {integrity: sha512-oS3ENewjwEj+42jek1MQb2IETUd3On4tDgkuda2Mo7fbourygFZodhPDQYsj6aYFvwwn+FNLk4wjcghSQrCLqA==}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-    dependencies:
-      '@rushstack/tree-pattern': 0.3.4
-      '@typescript-eslint/utils': 6.19.1(eslint@7.30.0)(typescript@5.4.2)
-      eslint: 7.30.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
-
-  /@rushstack/eslint-plugin@0.15.2(eslint@7.7.0)(typescript@5.4.2):
-    resolution: {integrity: sha512-oS3ENewjwEj+42jek1MQb2IETUd3On4tDgkuda2Mo7fbourygFZodhPDQYsj6aYFvwwn+FNLk4wjcghSQrCLqA==}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-    dependencies:
-      '@rushstack/tree-pattern': 0.3.4
-      '@typescript-eslint/utils': 6.19.1(eslint@7.7.0)(typescript@5.4.2)
-      eslint: 7.7.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
-
-  /@rushstack/eslint-plugin@0.15.2(eslint@8.57.0)(typescript@5.4.2):
-    resolution: {integrity: sha512-oS3ENewjwEj+42jek1MQb2IETUd3On4tDgkuda2Mo7fbourygFZodhPDQYsj6aYFvwwn+FNLk4wjcghSQrCLqA==}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-    dependencies:
-      '@rushstack/tree-pattern': 0.3.4
-      '@typescript-eslint/utils': 6.19.1(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.4.2)
+      '@typescript-eslint/utils': 8.1.0(eslint@8.57.0)(typescript@5.7.3)
       eslint: 8.57.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  /@rushstack/eslint-plugin@0.16.1(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.4.2):
+  /@rushstack/eslint-plugin@0.15.2(eslint@7.11.0)(typescript@5.7.3):
+    resolution: {integrity: sha512-oS3ENewjwEj+42jek1MQb2IETUd3On4tDgkuda2Mo7fbourygFZodhPDQYsj6aYFvwwn+FNLk4wjcghSQrCLqA==}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      '@rushstack/tree-pattern': 0.3.4
+      '@typescript-eslint/utils': 6.19.1(eslint@7.11.0)(typescript@5.7.3)
+      eslint: 7.11.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
+  /@rushstack/eslint-plugin@0.15.2(eslint@7.30.0)(typescript@5.7.3):
+    resolution: {integrity: sha512-oS3ENewjwEj+42jek1MQb2IETUd3On4tDgkuda2Mo7fbourygFZodhPDQYsj6aYFvwwn+FNLk4wjcghSQrCLqA==}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      '@rushstack/tree-pattern': 0.3.4
+      '@typescript-eslint/utils': 6.19.1(eslint@7.30.0)(typescript@5.7.3)
+      eslint: 7.30.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
+  /@rushstack/eslint-plugin@0.15.2(eslint@7.7.0)(typescript@5.7.3):
+    resolution: {integrity: sha512-oS3ENewjwEj+42jek1MQb2IETUd3On4tDgkuda2Mo7fbourygFZodhPDQYsj6aYFvwwn+FNLk4wjcghSQrCLqA==}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      '@rushstack/tree-pattern': 0.3.4
+      '@typescript-eslint/utils': 6.19.1(eslint@7.7.0)(typescript@5.7.3)
+      eslint: 7.7.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
+  /@rushstack/eslint-plugin@0.15.2(eslint@8.57.0)(typescript@5.7.3):
+    resolution: {integrity: sha512-oS3ENewjwEj+42jek1MQb2IETUd3On4tDgkuda2Mo7fbourygFZodhPDQYsj6aYFvwwn+FNLk4wjcghSQrCLqA==}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      '@rushstack/tree-pattern': 0.3.4
+      '@typescript-eslint/utils': 6.19.1(eslint@8.57.0)(typescript@5.7.3)
+      eslint: 8.57.0(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
+  /@rushstack/eslint-plugin@0.16.1(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.7.3):
     resolution: {integrity: sha512-e+VVtwBvuGqvVCcXUDTireQFfaIncmlD6rOBils0BeGkrLbP1r330/AFcRoYQEZUZpdhVxFtJrIq48HIlWBFzA==}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       '@rushstack/tree-pattern': 0.3.4
-      '@typescript-eslint/utils': 8.1.0(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.4.2)
+      '@typescript-eslint/utils': 8.1.0(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.7.3)
       eslint: 8.57.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
@@ -10658,6 +10740,19 @@ packages:
     dependencies:
       '@rushstack/tree-pattern': 0.3.4
       '@typescript-eslint/utils': 8.1.0(eslint@8.57.0)(typescript@4.9.5)
+      eslint: 8.57.0(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
+  /@rushstack/eslint-plugin@0.16.1(eslint@8.57.0)(typescript@5.7.3):
+    resolution: {integrity: sha512-e+VVtwBvuGqvVCcXUDTireQFfaIncmlD6rOBils0BeGkrLbP1r330/AFcRoYQEZUZpdhVxFtJrIq48HIlWBFzA==}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      '@rushstack/tree-pattern': 0.3.4
+      '@typescript-eslint/utils': 8.1.0(eslint@8.57.0)(typescript@5.7.3)
       eslint: 8.57.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
@@ -10799,7 +10894,7 @@ packages:
       '@rushstack/heft': '*'
     dependencies:
       '@microsoft/api-extractor': 7.51.1(@types/node@20.17.19)
-      '@rushstack/eslint-config': 4.1.1(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.4.2)
+      '@rushstack/eslint-config': 4.1.1(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.7.3)
       '@rushstack/heft': link:../../../apps/heft
       '@rushstack/heft-api-extractor-plugin': 0.3.71(@rushstack/heft@..+..+apps+heft)(@types/node@20.17.19)
       '@rushstack/heft-jest-plugin': 0.14.12(@rushstack/heft@..+..+apps+heft)(@types/node@20.17.19)(jest-environment-jsdom@29.5.0)(jest-environment-node@29.5.0)
@@ -10808,7 +10903,7 @@ packages:
       '@types/heft-jest': 1.0.1
       eslint: 8.57.0(supports-color@8.1.1)
       jest-environment-node: 29.5.0
-      typescript: 5.4.2
+      typescript: 5.7.3
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -10824,7 +10919,7 @@ packages:
       '@rushstack/heft': '*'
     dependencies:
       '@microsoft/api-extractor': 7.51.1(@types/node@20.17.19)
-      '@rushstack/eslint-config': 4.1.1(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.4.2)
+      '@rushstack/eslint-config': 4.1.1(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.7.3)
       '@rushstack/heft': 0.69.2(@types/node@20.17.19)
       '@rushstack/heft-api-extractor-plugin': 0.3.71(@rushstack/heft@0.69.2)(@types/node@20.17.19)
       '@rushstack/heft-jest-plugin': 0.14.12(@rushstack/heft@0.69.2)(@types/node@20.17.19)(jest-environment-node@29.5.0)(supports-color@8.1.1)
@@ -10833,7 +10928,7 @@ packages:
       '@types/heft-jest': 1.0.1
       eslint: 8.57.0(supports-color@8.1.1)
       jest-environment-node: 29.5.0
-      typescript: 5.4.2
+      typescript: 5.7.3
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -11583,7 +11678,7 @@ packages:
       - '@types/react'
     dev: true
 
-  /@storybook/addon-controls@6.4.22(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)(typescript@5.4.2):
+  /@storybook/addon-controls@6.4.22(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)(typescript@5.7.3):
     resolution: {integrity: sha512-f/M/W+7UTEUnr/L6scBMvksq+ZA8GTfh3bomE5FtWyOyaFppq9k8daKAvdYNlzXAOrUUsoZVJDgpb20Z2VBiSQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -11598,7 +11693,7 @@ packages:
       '@storybook/api': 6.4.22(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)
       '@storybook/client-logger': 6.4.22
       '@storybook/components': 6.4.22(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)
-      '@storybook/core-common': 6.4.22(eslint@8.57.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.4.2)
+      '@storybook/core-common': 6.4.22(eslint@8.57.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.7.3)
       '@storybook/csf': 0.0.2--canary.87bc651.0
       '@storybook/node-logger': 6.4.22
       '@storybook/store': 6.4.22(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)
@@ -11618,7 +11713,7 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/addon-docs@6.4.22(@storybook/react@6.4.22)(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)(typescript@5.4.2)(webpack@4.47.0):
+  /@storybook/addon-docs@6.4.22(@storybook/react@6.4.22)(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)(typescript@5.7.3)(webpack@4.47.0):
     resolution: {integrity: sha512-9j+i+W+BGHJuRe4jUrqk6ubCzP4fc1xgFS2o8pakRiZgPn5kUQPdkticmsyh1XeEJifwhqjKJvkEDrcsleytDA==}
     peerDependencies:
       '@storybook/angular': 6.4.22
@@ -11676,17 +11771,17 @@ packages:
       '@mdx-js/react': 1.6.22(react@17.0.2)
       '@storybook/addons': 6.4.22(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)
       '@storybook/api': 6.4.22(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)
-      '@storybook/builder-webpack4': 6.4.22(@types/react@17.0.74)(eslint@8.57.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.4.2)
+      '@storybook/builder-webpack4': 6.4.22(@types/react@17.0.74)(eslint@8.57.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.7.3)
       '@storybook/client-logger': 6.4.22
       '@storybook/components': 6.4.22(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)
-      '@storybook/core': 6.4.22(@types/react@17.0.74)(eslint@8.57.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.4.2)(webpack@4.47.0)
+      '@storybook/core': 6.4.22(@types/react@17.0.74)(eslint@8.57.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.7.3)(webpack@4.47.0)
       '@storybook/core-events': 6.4.22
       '@storybook/csf': 0.0.2--canary.87bc651.0
       '@storybook/csf-tools': 6.4.22
       '@storybook/node-logger': 6.4.22
       '@storybook/postinstall': 6.4.22
       '@storybook/preview-web': 6.4.22(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)
-      '@storybook/react': 6.4.22(@babel/core@7.20.12)(@types/node@20.17.19)(@types/react@17.0.74)(eslint@8.57.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.4.2)
+      '@storybook/react': 6.4.22(@babel/core@7.20.12)(@types/node@20.17.19)(@types/react@17.0.74)(eslint@8.57.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.7.3)
       '@storybook/source-loader': 6.4.22(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)
       '@storybook/store': 6.4.22(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)
       '@storybook/theming': 6.4.22(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)
@@ -11730,7 +11825,7 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/addon-essentials@6.4.22(@babel/core@7.20.12)(@storybook/react@6.4.22)(@types/react@17.0.74)(babel-loader@8.2.5)(react-dom@17.0.2)(react@17.0.2)(typescript@5.4.2)(webpack@4.47.0):
+  /@storybook/addon-essentials@6.4.22(@babel/core@7.20.12)(@storybook/react@6.4.22)(@types/react@17.0.74)(babel-loader@8.2.5)(react-dom@17.0.2)(react@17.0.2)(typescript@5.7.3)(webpack@4.47.0):
     resolution: {integrity: sha512-GTv291fqvWq2wzm7MruBvCGuWaCUiuf7Ca3kzbQ/WqWtve7Y/1PDsqRNQLGZrQxkXU0clXCqY1XtkTrtA3WGFQ==}
     peerDependencies:
       '@babel/core': ^7.9.6
@@ -11758,8 +11853,8 @@ packages:
       '@babel/core': 7.20.12(supports-color@8.1.1)
       '@storybook/addon-actions': 6.4.22(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)
       '@storybook/addon-backgrounds': 6.4.22(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)
-      '@storybook/addon-controls': 6.4.22(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)(typescript@5.4.2)
-      '@storybook/addon-docs': 6.4.22(@storybook/react@6.4.22)(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)(typescript@5.4.2)(webpack@4.47.0)
+      '@storybook/addon-controls': 6.4.22(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)(typescript@5.7.3)
+      '@storybook/addon-docs': 6.4.22(@storybook/react@6.4.22)(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)(typescript@5.7.3)(webpack@4.47.0)
       '@storybook/addon-measure': 6.4.22(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)
       '@storybook/addon-outline': 6.4.22(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)
       '@storybook/addon-toolbars': 6.4.22(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)
@@ -11981,7 +12076,7 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /@storybook/builder-webpack4@6.4.22(@types/react@17.0.74)(eslint@8.57.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.4.2):
+  /@storybook/builder-webpack4@6.4.22(@types/react@17.0.74)(eslint@8.57.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.7.3):
     resolution: {integrity: sha512-A+GgGtKGnBneRFSFkDarUIgUTI8pYFdLmUVKEAGdh2hL+vLXAz9A46sEY7C8LQ85XWa8TKy3OTDxqR4+4iWj3A==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -12019,7 +12114,7 @@ packages:
       '@storybook/client-api': 6.4.22(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)
       '@storybook/client-logger': 6.4.22
       '@storybook/components': 6.4.22(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)
-      '@storybook/core-common': 6.4.22(eslint@8.57.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.4.2)
+      '@storybook/core-common': 6.4.22(eslint@8.57.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.7.3)
       '@storybook/core-events': 6.4.22
       '@storybook/node-logger': 6.4.22
       '@storybook/preview-web': 6.4.22(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)
@@ -12044,7 +12139,7 @@ packages:
       glob-promise: 3.4.0(glob@7.2.3)
       global: 4.4.0
       html-webpack-plugin: 4.5.2(webpack@4.47.0)
-      pnp-webpack-plugin: 1.6.4(typescript@5.4.2)
+      pnp-webpack-plugin: 1.6.4(typescript@5.7.3)
       postcss: 7.0.39
       postcss-flexbugs-fixes: 4.2.1
       postcss-loader: 4.3.0(postcss@7.0.39)(webpack@4.47.0)
@@ -12055,7 +12150,7 @@ packages:
       style-loader: 1.3.0(webpack@4.47.0)
       terser-webpack-plugin: 4.2.3(webpack@4.47.0)
       ts-dedent: 2.2.0
-      typescript: 5.4.2
+      typescript: 5.7.3
       url-loader: 4.1.1(file-loader@6.2.0)(webpack@4.47.0)
       util-deprecate: 1.0.2
       webpack: 4.47.0
@@ -12102,7 +12197,7 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
-  /@storybook/cli@6.4.22(jest@29.3.1)(react-dom@17.0.2)(react@17.0.2)(typescript@5.4.2):
+  /@storybook/cli@6.4.22(jest@29.3.1)(react-dom@17.0.2)(react@17.0.2)(typescript@5.7.3):
     resolution: {integrity: sha512-Paj5JtiYG6HjYYEiLm0SGg6GJ+ebJSvfbbYx5W+MNiojyMwrzkof+G2VEGk5AbE2JSkXvDQJ/9B8/SuS94yqvA==}
     hasBin: true
     peerDependencies:
@@ -12111,7 +12206,7 @@ packages:
       '@babel/core': 7.20.12(supports-color@8.1.1)
       '@babel/preset-env': 7.24.0(@babel/core@7.20.12)
       '@storybook/codemod': 6.4.22(@babel/preset-env@7.24.0)
-      '@storybook/core-common': 6.4.22(eslint@8.57.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.4.2)
+      '@storybook/core-common': 6.4.22(eslint@8.57.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.7.3)
       '@storybook/csf-tools': 6.4.22
       '@storybook/node-logger': 6.4.22
       '@storybook/semver': 7.3.2
@@ -12244,7 +12339,7 @@ packages:
       - '@types/react'
     dev: true
 
-  /@storybook/core-client@6.4.22(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)(typescript@5.4.2)(webpack@4.47.0):
+  /@storybook/core-client@6.4.22(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)(typescript@5.7.3)(webpack@4.47.0):
     resolution: {integrity: sha512-uHg4yfCBeM6eASSVxStWRVTZrAnb4FT6X6v/xDqr4uXCpCttZLlBzrSDwPBLNNLtCa7ntRicHM8eGKIOD5lMYQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -12275,7 +12370,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
       regenerator-runtime: 0.13.11
       ts-dedent: 2.2.0
-      typescript: 5.4.2
+      typescript: 5.7.3
       unfetch: 4.2.0
       util-deprecate: 1.0.2
       webpack: 4.47.0
@@ -12283,7 +12378,7 @@ packages:
       - '@types/react'
     dev: true
 
-  /@storybook/core-common@6.4.22(eslint@8.57.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.4.2):
+  /@storybook/core-common@6.4.22(eslint@8.57.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.7.3):
     resolution: {integrity: sha512-PD3N/FJXPNRHeQS2zdgzYFtqPLdi3MLwAicbnw+U3SokcsspfsAuyYHZOYZgwO8IAEKy6iCc7TpBdiSJZ/vAKQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -12326,7 +12421,7 @@ packages:
       express: 4.20.0
       file-system-cache: 1.1.0
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.3(eslint@8.57.0)(typescript@5.4.2)(webpack@4.47.0)
+      fork-ts-checker-webpack-plugin: 6.5.3(eslint@8.57.0)(typescript@5.7.3)(webpack@4.47.0)
       fs-extra: 9.1.0
       glob: 7.2.3
       handlebars: 4.7.8
@@ -12342,7 +12437,7 @@ packages:
       slash: 3.0.0
       telejson: 5.3.3
       ts-dedent: 2.2.0
-      typescript: 5.4.2
+      typescript: 5.7.3
       util-deprecate: 1.0.2
       webpack: 4.47.0
     transitivePeerDependencies:
@@ -12359,7 +12454,7 @@ packages:
       core-js: 3.36.0
     dev: true
 
-  /@storybook/core-server@6.4.22(@types/react@17.0.74)(eslint@8.57.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.4.2):
+  /@storybook/core-server@6.4.22(@types/react@17.0.74)(eslint@8.57.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.7.3):
     resolution: {integrity: sha512-wFh3e2fa0un1d4+BJP+nd3FVWUO7uHTqv3OGBfOmzQMKp4NU1zaBNdSQG7Hz6mw0fYPBPZgBjPfsJRwIYLLZyw==}
     peerDependencies:
       '@storybook/builder-webpack5': 6.4.22
@@ -12376,13 +12471,13 @@ packages:
         optional: true
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@storybook/builder-webpack4': 6.4.22(@types/react@17.0.74)(eslint@8.57.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.4.2)
-      '@storybook/core-client': 6.4.22(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)(typescript@5.4.2)(webpack@4.47.0)
-      '@storybook/core-common': 6.4.22(eslint@8.57.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.4.2)
+      '@storybook/builder-webpack4': 6.4.22(@types/react@17.0.74)(eslint@8.57.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.7.3)
+      '@storybook/core-client': 6.4.22(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)(typescript@5.7.3)(webpack@4.47.0)
+      '@storybook/core-common': 6.4.22(eslint@8.57.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.7.3)
       '@storybook/core-events': 6.4.22
       '@storybook/csf': 0.0.2--canary.87bc651.0
       '@storybook/csf-tools': 6.4.22
-      '@storybook/manager-webpack4': 6.4.22(@types/react@17.0.74)(eslint@8.57.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.4.2)
+      '@storybook/manager-webpack4': 6.4.22(@types/react@17.0.74)(eslint@8.57.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.7.3)
       '@storybook/node-logger': 6.4.22
       '@storybook/semver': 7.3.2
       '@storybook/store': 6.4.22(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)
@@ -12415,7 +12510,7 @@ packages:
       slash: 3.0.0
       telejson: 5.3.3
       ts-dedent: 2.2.0
-      typescript: 5.4.2
+      typescript: 5.7.3
       util-deprecate: 1.0.2
       watchpack: 2.4.0
       webpack: 4.47.0
@@ -12432,7 +12527,7 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/core@6.4.22(@types/react@17.0.74)(eslint@8.57.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.4.2)(webpack@4.47.0):
+  /@storybook/core@6.4.22(@types/react@17.0.74)(eslint@8.57.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.7.3)(webpack@4.47.0):
     resolution: {integrity: sha512-KZYJt7GM5NgKFXbPRZZZPEONZ5u/tE/cRbMdkn/zWN3He8+VP+65/tz8hbriI/6m91AWVWkBKrODSkeq59NgRA==}
     peerDependencies:
       '@storybook/builder-webpack5': 6.4.22
@@ -12446,11 +12541,11 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@storybook/core-client': 6.4.22(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)(typescript@5.4.2)(webpack@4.47.0)
-      '@storybook/core-server': 6.4.22(@types/react@17.0.74)(eslint@8.57.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.4.2)
+      '@storybook/core-client': 6.4.22(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)(typescript@5.7.3)(webpack@4.47.0)
+      '@storybook/core-server': 6.4.22(@types/react@17.0.74)(eslint@8.57.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.7.3)
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
-      typescript: 5.4.2
+      typescript: 5.7.3
       webpack: 4.47.0
     transitivePeerDependencies:
       - '@storybook/manager-webpack5'
@@ -12495,7 +12590,7 @@ packages:
       lodash: 4.17.21
     dev: true
 
-  /@storybook/manager-webpack4@6.4.22(@types/react@17.0.74)(eslint@8.57.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.4.2):
+  /@storybook/manager-webpack4@6.4.22(@types/react@17.0.74)(eslint@8.57.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.7.3):
     resolution: {integrity: sha512-nzhDMJYg0vXdcG0ctwE6YFZBX71+5NYaTGkxg3xT7gbgnP1YFXn9gVODvgq3tPb3gcRapjyOIxUa20rV+r8edA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -12509,8 +12604,8 @@ packages:
       '@babel/plugin-transform-template-literals': 7.23.3(@babel/core@7.20.12)
       '@babel/preset-react': 7.23.3(@babel/core@7.20.12)
       '@storybook/addons': 6.4.22(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)
-      '@storybook/core-client': 6.4.22(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)(typescript@5.4.2)(webpack@4.47.0)
-      '@storybook/core-common': 6.4.22(eslint@8.57.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.4.2)
+      '@storybook/core-client': 6.4.22(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)(typescript@5.7.3)(webpack@4.47.0)
+      '@storybook/core-common': 6.4.22(eslint@8.57.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.7.3)
       '@storybook/node-logger': 6.4.22
       '@storybook/theming': 6.4.22(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)
       '@storybook/ui': 6.4.22(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)
@@ -12528,7 +12623,7 @@ packages:
       fs-extra: 9.1.0
       html-webpack-plugin: 4.5.2(webpack@4.47.0)
       node-fetch: 2.6.7
-      pnp-webpack-plugin: 1.6.4(typescript@5.4.2)
+      pnp-webpack-plugin: 1.6.4(typescript@5.7.3)
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
       read-pkg-up: 7.0.1
@@ -12538,7 +12633,7 @@ packages:
       telejson: 5.3.3
       terser-webpack-plugin: 4.2.3(webpack@4.47.0)
       ts-dedent: 2.2.0
-      typescript: 5.4.2
+      typescript: 5.7.3
       url-loader: 4.1.1(file-loader@6.2.0)(webpack@4.47.0)
       util-deprecate: 1.0.2
       webpack: 4.47.0
@@ -12598,7 +12693,7 @@ packages:
       - '@types/react'
     dev: true
 
-  /@storybook/react-docgen-typescript-plugin@1.0.2-canary.253f8c1.0(typescript@5.4.2)(webpack@4.47.0):
+  /@storybook/react-docgen-typescript-plugin@1.0.2-canary.253f8c1.0(typescript@5.7.3)(webpack@4.47.0):
     resolution: {integrity: sha512-mmoRG/rNzAiTbh+vGP8d57dfcR2aP+5/Ll03KKFyfy5FqWFm/Gh7u27ikx1I3LmVMI8n6jh5SdWMkMKon7/tDw==}
     peerDependencies:
       typescript: '>= 3.x'
@@ -12609,15 +12704,15 @@ packages:
       find-cache-dir: 3.3.2
       flat-cache: 3.2.0
       micromatch: 4.0.5
-      react-docgen-typescript: 2.2.2(typescript@5.4.2)
+      react-docgen-typescript: 2.2.2(typescript@5.7.3)
       tslib: 2.3.1
-      typescript: 5.4.2
+      typescript: 5.7.3
       webpack: 4.47.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@storybook/react@6.4.22(@babel/core@7.20.12)(@types/node@20.17.19)(@types/react@17.0.74)(eslint@8.57.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.4.2):
+  /@storybook/react@6.4.22(@babel/core@7.20.12)(@types/node@20.17.19)(@types/react@17.0.74)(eslint@8.57.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.7.3):
     resolution: {integrity: sha512-5BFxtiguOcePS5Ty/UoH7C6odmvBYIZutfiy4R3Ua6FYmtxac5vP9r5KjCz1IzZKT8mCf4X+PuK1YvDrPPROgQ==}
     engines: {node: '>=10.13.0'}
     hasBin: true
@@ -12639,11 +12734,11 @@ packages:
       '@babel/preset-react': 7.23.3(@babel/core@7.20.12)
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.11(react-refresh@0.11.0)(webpack@4.47.0)
       '@storybook/addons': 6.4.22(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)
-      '@storybook/core': 6.4.22(@types/react@17.0.74)(eslint@8.57.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.4.2)(webpack@4.47.0)
-      '@storybook/core-common': 6.4.22(eslint@8.57.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.4.2)
+      '@storybook/core': 6.4.22(@types/react@17.0.74)(eslint@8.57.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.7.3)(webpack@4.47.0)
+      '@storybook/core-common': 6.4.22(eslint@8.57.0)(react-dom@17.0.2)(react@17.0.2)(typescript@5.7.3)
       '@storybook/csf': 0.0.2--canary.87bc651.0
       '@storybook/node-logger': 6.4.22
-      '@storybook/react-docgen-typescript-plugin': 1.0.2-canary.253f8c1.0(typescript@5.4.2)(webpack@4.47.0)
+      '@storybook/react-docgen-typescript-plugin': 1.0.2-canary.253f8c1.0(typescript@5.7.3)(webpack@4.47.0)
       '@storybook/semver': 7.3.2
       '@storybook/store': 6.4.22(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)
       '@types/node': 20.17.19
@@ -12662,7 +12757,7 @@ packages:
       read-pkg-up: 7.0.1
       regenerator-runtime: 0.13.11
       ts-dedent: 2.2.0
-      typescript: 5.4.2
+      typescript: 5.7.3
       webpack: 4.47.0
     transitivePeerDependencies:
       - '@storybook/builder-webpack5'
@@ -13466,7 +13561,7 @@ packages:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  /@typescript-eslint/eslint-plugin@6.19.1(@typescript-eslint/parser@6.19.1)(eslint@7.11.0)(typescript@5.4.2):
+  /@typescript-eslint/eslint-plugin@6.19.1(@typescript-eslint/parser@6.19.1)(eslint@7.11.0)(typescript@5.7.3):
     resolution: {integrity: sha512-roQScUGFruWod9CEyoV5KlCYrubC/fvG8/1zXuT0WTcxX87GnMMmnksMwSg99lo1xiKrBzw2icsJPMAw1OtKxg==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -13478,24 +13573,24 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.10.0
-      '@typescript-eslint/parser': 6.19.1(eslint@7.11.0)(typescript@5.4.2)
-      '@typescript-eslint/scope-manager': 6.19.1(typescript@5.4.2)
-      '@typescript-eslint/type-utils': 6.19.1(eslint@7.11.0)(typescript@5.4.2)
-      '@typescript-eslint/utils': 6.19.1(eslint@7.11.0)(typescript@5.4.2)
-      '@typescript-eslint/visitor-keys': 6.19.1(typescript@5.4.2)
+      '@typescript-eslint/parser': 6.19.1(eslint@7.11.0)(typescript@5.7.3)
+      '@typescript-eslint/scope-manager': 6.19.1(typescript@5.7.3)
+      '@typescript-eslint/type-utils': 6.19.1(eslint@7.11.0)(typescript@5.7.3)
+      '@typescript-eslint/utils': 6.19.1(eslint@7.11.0)(typescript@5.7.3)
+      '@typescript-eslint/visitor-keys': 6.19.1(typescript@5.7.3)
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 7.11.0
       graphemer: 1.4.0
       ignore: 5.3.1
       natural-compare: 1.4.0
       semver: 7.5.4
-      ts-api-utils: 1.3.0(typescript@5.4.2)
-      typescript: 5.4.2
+      ts-api-utils: 1.3.0(typescript@5.7.3)
+      typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/eslint-plugin@6.19.1(@typescript-eslint/parser@6.19.1)(eslint@7.30.0)(typescript@5.4.2):
+  /@typescript-eslint/eslint-plugin@6.19.1(@typescript-eslint/parser@6.19.1)(eslint@7.30.0)(typescript@5.7.3):
     resolution: {integrity: sha512-roQScUGFruWod9CEyoV5KlCYrubC/fvG8/1zXuT0WTcxX87GnMMmnksMwSg99lo1xiKrBzw2icsJPMAw1OtKxg==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -13507,24 +13602,24 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.10.0
-      '@typescript-eslint/parser': 6.19.1(eslint@7.30.0)(typescript@5.4.2)
-      '@typescript-eslint/scope-manager': 6.19.1(typescript@5.4.2)
-      '@typescript-eslint/type-utils': 6.19.1(eslint@7.30.0)(typescript@5.4.2)
-      '@typescript-eslint/utils': 6.19.1(eslint@7.30.0)(typescript@5.4.2)
-      '@typescript-eslint/visitor-keys': 6.19.1(typescript@5.4.2)
+      '@typescript-eslint/parser': 6.19.1(eslint@7.30.0)(typescript@5.7.3)
+      '@typescript-eslint/scope-manager': 6.19.1(typescript@5.7.3)
+      '@typescript-eslint/type-utils': 6.19.1(eslint@7.30.0)(typescript@5.7.3)
+      '@typescript-eslint/utils': 6.19.1(eslint@7.30.0)(typescript@5.7.3)
+      '@typescript-eslint/visitor-keys': 6.19.1(typescript@5.7.3)
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 7.30.0
       graphemer: 1.4.0
       ignore: 5.3.1
       natural-compare: 1.4.0
       semver: 7.5.4
-      ts-api-utils: 1.3.0(typescript@5.4.2)
-      typescript: 5.4.2
+      ts-api-utils: 1.3.0(typescript@5.7.3)
+      typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/eslint-plugin@6.19.1(@typescript-eslint/parser@6.19.1)(eslint@7.7.0)(typescript@5.4.2):
+  /@typescript-eslint/eslint-plugin@6.19.1(@typescript-eslint/parser@6.19.1)(eslint@7.7.0)(typescript@5.7.3):
     resolution: {integrity: sha512-roQScUGFruWod9CEyoV5KlCYrubC/fvG8/1zXuT0WTcxX87GnMMmnksMwSg99lo1xiKrBzw2icsJPMAw1OtKxg==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -13536,24 +13631,24 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.10.0
-      '@typescript-eslint/parser': 6.19.1(eslint@7.7.0)(typescript@5.4.2)
-      '@typescript-eslint/scope-manager': 6.19.1(typescript@5.4.2)
-      '@typescript-eslint/type-utils': 6.19.1(eslint@7.7.0)(typescript@5.4.2)
-      '@typescript-eslint/utils': 6.19.1(eslint@7.7.0)(typescript@5.4.2)
-      '@typescript-eslint/visitor-keys': 6.19.1(typescript@5.4.2)
+      '@typescript-eslint/parser': 6.19.1(eslint@7.7.0)(typescript@5.7.3)
+      '@typescript-eslint/scope-manager': 6.19.1(typescript@5.7.3)
+      '@typescript-eslint/type-utils': 6.19.1(eslint@7.7.0)(typescript@5.7.3)
+      '@typescript-eslint/utils': 6.19.1(eslint@7.7.0)(typescript@5.7.3)
+      '@typescript-eslint/visitor-keys': 6.19.1(typescript@5.7.3)
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 7.7.0
       graphemer: 1.4.0
       ignore: 5.3.1
       natural-compare: 1.4.0
       semver: 7.5.4
-      ts-api-utils: 1.3.0(typescript@5.4.2)
-      typescript: 5.4.2
+      ts-api-utils: 1.3.0(typescript@5.7.3)
+      typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/eslint-plugin@6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.57.0)(typescript@5.4.2):
+  /@typescript-eslint/eslint-plugin@6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.57.0)(typescript@5.7.3):
     resolution: {integrity: sha512-roQScUGFruWod9CEyoV5KlCYrubC/fvG8/1zXuT0WTcxX87GnMMmnksMwSg99lo1xiKrBzw2icsJPMAw1OtKxg==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -13565,24 +13660,24 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.10.0
-      '@typescript-eslint/parser': 6.19.1(eslint@8.57.0)(typescript@5.4.2)
-      '@typescript-eslint/scope-manager': 6.19.1(typescript@5.4.2)
-      '@typescript-eslint/type-utils': 6.19.1(eslint@8.57.0)(typescript@5.4.2)
-      '@typescript-eslint/utils': 6.19.1(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.4.2)
-      '@typescript-eslint/visitor-keys': 6.19.1(typescript@5.4.2)
+      '@typescript-eslint/parser': 6.19.1(eslint@8.57.0)(typescript@5.7.3)
+      '@typescript-eslint/scope-manager': 6.19.1(typescript@5.7.3)
+      '@typescript-eslint/type-utils': 6.19.1(eslint@8.57.0)(typescript@5.7.3)
+      '@typescript-eslint/utils': 6.19.1(eslint@8.57.0)(typescript@5.7.3)
+      '@typescript-eslint/visitor-keys': 6.19.1(typescript@5.7.3)
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.57.0(supports-color@8.1.1)
       graphemer: 1.4.0
       ignore: 5.3.1
       natural-compare: 1.4.0
       semver: 7.5.4
-      ts-api-utils: 1.3.0(typescript@5.4.2)
-      typescript: 5.4.2
+      ts-api-utils: 1.3.0(typescript@5.7.3)
+      typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/eslint-plugin@8.1.0(@typescript-eslint/parser@8.1.0)(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.4.2):
+  /@typescript-eslint/eslint-plugin@8.1.0(@typescript-eslint/parser@8.1.0)(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.7.3):
     resolution: {integrity: sha512-LlNBaHFCEBPHyD4pZXb35mzjGkuGKXU5eeCA1SxvHfiRES0E82dOounfVpL4DCqYvJEKab0bZIA0gCRpdLKkCw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
@@ -13594,19 +13689,20 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.10.0
-      '@typescript-eslint/parser': 8.1.0(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.4.2)
-      '@typescript-eslint/scope-manager': 8.1.0(typescript@5.4.2)
-      '@typescript-eslint/type-utils': 8.1.0(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.4.2)
-      '@typescript-eslint/utils': 8.1.0(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.4.2)
-      '@typescript-eslint/visitor-keys': 8.1.0(typescript@5.4.2)
+      '@typescript-eslint/parser': 8.1.0(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.7.3)
+      '@typescript-eslint/scope-manager': 8.1.0(typescript@5.7.3)
+      '@typescript-eslint/type-utils': 8.1.0(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.1.0(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.7.3)
+      '@typescript-eslint/visitor-keys': 8.1.0(typescript@5.7.3)
       eslint: 8.57.0(supports-color@8.1.1)
       graphemer: 1.4.0
       ignore: 5.3.1
       natural-compare: 1.4.0
-      ts-api-utils: 1.3.0(typescript@5.4.2)
-      typescript: 5.4.2
+      ts-api-utils: 1.3.0(typescript@5.7.3)
+      typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@typescript-eslint/eslint-plugin@8.1.0(@typescript-eslint/parser@8.1.0)(eslint@8.57.0)(typescript@4.9.5):
     resolution: {integrity: sha512-LlNBaHFCEBPHyD4pZXb35mzjGkuGKXU5eeCA1SxvHfiRES0E82dOounfVpL4DCqYvJEKab0bZIA0gCRpdLKkCw==}
@@ -13635,7 +13731,58 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@6.19.1(eslint@7.11.0)(typescript@5.4.2):
+  /@typescript-eslint/eslint-plugin@8.1.0(@typescript-eslint/parser@8.1.0)(eslint@8.57.0)(typescript@5.7.3):
+    resolution: {integrity: sha512-LlNBaHFCEBPHyD4pZXb35mzjGkuGKXU5eeCA1SxvHfiRES0E82dOounfVpL4DCqYvJEKab0bZIA0gCRpdLKkCw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^8.0.0 || ^8.0.0-alpha.0
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@eslint-community/regexpp': 4.10.0
+      '@typescript-eslint/parser': 8.1.0(eslint@8.57.0)(typescript@5.7.3)
+      '@typescript-eslint/scope-manager': 8.1.0(typescript@5.7.3)
+      '@typescript-eslint/type-utils': 8.1.0(eslint@8.57.0)(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.1.0(eslint@8.57.0)(typescript@5.7.3)
+      '@typescript-eslint/visitor-keys': 8.1.0(typescript@5.7.3)
+      eslint: 8.57.0(supports-color@8.1.1)
+      graphemer: 1.4.0
+      ignore: 5.3.1
+      natural-compare: 1.4.0
+      ts-api-utils: 1.3.0(typescript@5.7.3)
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/eslint-plugin@8.24.0(@typescript-eslint/parser@8.24.0)(eslint@8.57.0)(typescript@5.7.3):
+    resolution: {integrity: sha512-aFcXEJJCI4gUdXgoo/j9udUYIHgF23MFkg09LFz2dzEmU0+1Plk4rQWv/IYKvPHAtlkkGoB3m5e6oUp+JPsNaQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^8.0.0 || ^8.0.0-alpha.0
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <5.8.0'
+    dependencies:
+      '@eslint-community/regexpp': 4.10.0
+      '@typescript-eslint/parser': 8.24.0(eslint@8.57.0)(typescript@5.7.3)
+      '@typescript-eslint/scope-manager': 8.24.0(typescript@5.7.3)
+      '@typescript-eslint/type-utils': 8.24.0(eslint@8.57.0)(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.24.0(eslint@8.57.0)(typescript@5.7.3)
+      '@typescript-eslint/visitor-keys': 8.24.0(typescript@5.7.3)
+      eslint: 8.57.0(supports-color@8.1.1)
+      graphemer: 1.4.0
+      ignore: 5.3.1
+      natural-compare: 1.4.0
+      ts-api-utils: 2.0.1(typescript@5.7.3)
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@typescript-eslint/parser@6.19.1(eslint@7.11.0)(typescript@5.7.3):
     resolution: {integrity: sha512-WEfX22ziAh6pRE9jnbkkLGp/4RhTpffr2ZK5bJ18M8mIfA8A+k97U9ZyaXCEJRlmMHh7R9MJZWXp/r73DzINVQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -13645,18 +13792,18 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/scope-manager': 6.19.1(typescript@5.4.2)
-      '@typescript-eslint/types': 6.19.1(typescript@5.4.2)
-      '@typescript-eslint/typescript-estree': 6.19.1(supports-color@8.1.1)(typescript@5.4.2)
-      '@typescript-eslint/visitor-keys': 6.19.1(typescript@5.4.2)
+      '@typescript-eslint/scope-manager': 6.19.1(typescript@5.7.3)
+      '@typescript-eslint/types': 6.19.1(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 6.19.1(typescript@5.7.3)
+      '@typescript-eslint/visitor-keys': 6.19.1(typescript@5.7.3)
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 7.11.0
-      typescript: 5.4.2
+      typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@6.19.1(eslint@7.30.0)(typescript@5.4.2):
+  /@typescript-eslint/parser@6.19.1(eslint@7.30.0)(typescript@5.7.3):
     resolution: {integrity: sha512-WEfX22ziAh6pRE9jnbkkLGp/4RhTpffr2ZK5bJ18M8mIfA8A+k97U9ZyaXCEJRlmMHh7R9MJZWXp/r73DzINVQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -13666,18 +13813,18 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/scope-manager': 6.19.1(typescript@5.4.2)
-      '@typescript-eslint/types': 6.19.1(typescript@5.4.2)
-      '@typescript-eslint/typescript-estree': 6.19.1(supports-color@8.1.1)(typescript@5.4.2)
-      '@typescript-eslint/visitor-keys': 6.19.1(typescript@5.4.2)
+      '@typescript-eslint/scope-manager': 6.19.1(typescript@5.7.3)
+      '@typescript-eslint/types': 6.19.1(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 6.19.1(typescript@5.7.3)
+      '@typescript-eslint/visitor-keys': 6.19.1(typescript@5.7.3)
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 7.30.0
-      typescript: 5.4.2
+      typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@6.19.1(eslint@7.7.0)(typescript@5.4.2):
+  /@typescript-eslint/parser@6.19.1(eslint@7.7.0)(typescript@5.7.3):
     resolution: {integrity: sha512-WEfX22ziAh6pRE9jnbkkLGp/4RhTpffr2ZK5bJ18M8mIfA8A+k97U9ZyaXCEJRlmMHh7R9MJZWXp/r73DzINVQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -13687,18 +13834,18 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/scope-manager': 6.19.1(typescript@5.4.2)
-      '@typescript-eslint/types': 6.19.1(typescript@5.4.2)
-      '@typescript-eslint/typescript-estree': 6.19.1(supports-color@8.1.1)(typescript@5.4.2)
-      '@typescript-eslint/visitor-keys': 6.19.1(typescript@5.4.2)
+      '@typescript-eslint/scope-manager': 6.19.1(typescript@5.7.3)
+      '@typescript-eslint/types': 6.19.1(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 6.19.1(typescript@5.7.3)
+      '@typescript-eslint/visitor-keys': 6.19.1(typescript@5.7.3)
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 7.7.0
-      typescript: 5.4.2
+      typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@6.19.1(eslint@8.57.0)(typescript@5.4.2):
+  /@typescript-eslint/parser@6.19.1(eslint@8.57.0)(typescript@5.7.3):
     resolution: {integrity: sha512-WEfX22ziAh6pRE9jnbkkLGp/4RhTpffr2ZK5bJ18M8mIfA8A+k97U9ZyaXCEJRlmMHh7R9MJZWXp/r73DzINVQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -13708,18 +13855,18 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/scope-manager': 6.19.1(typescript@5.4.2)
-      '@typescript-eslint/types': 6.19.1(typescript@5.4.2)
-      '@typescript-eslint/typescript-estree': 6.19.1(supports-color@8.1.1)(typescript@5.4.2)
-      '@typescript-eslint/visitor-keys': 6.19.1(typescript@5.4.2)
+      '@typescript-eslint/scope-manager': 6.19.1(typescript@5.7.3)
+      '@typescript-eslint/types': 6.19.1(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 6.19.1(typescript@5.7.3)
+      '@typescript-eslint/visitor-keys': 6.19.1(typescript@5.7.3)
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.57.0(supports-color@8.1.1)
-      typescript: 5.4.2
+      typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@8.1.0(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.4.2):
+  /@typescript-eslint/parser@8.1.0(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.7.3):
     resolution: {integrity: sha512-U7iTAtGgJk6DPX9wIWPPOlt1gO57097G06gIcl0N0EEnNw8RGD62c+2/DiP/zL7KrkqnnqF7gtFGR7YgzPllTA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
@@ -13729,15 +13876,16 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/scope-manager': 8.1.0(typescript@5.4.2)
-      '@typescript-eslint/types': 8.1.0(typescript@5.4.2)
-      '@typescript-eslint/typescript-estree': 8.1.0(supports-color@8.1.1)(typescript@5.4.2)
-      '@typescript-eslint/visitor-keys': 8.1.0(typescript@5.4.2)
+      '@typescript-eslint/scope-manager': 8.1.0(typescript@5.7.3)
+      '@typescript-eslint/types': 8.1.0(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 8.1.0(supports-color@8.1.1)(typescript@5.7.3)
+      '@typescript-eslint/visitor-keys': 8.1.0(typescript@5.7.3)
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.57.0(supports-color@8.1.1)
-      typescript: 5.4.2
+      typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@typescript-eslint/parser@8.1.0(eslint@8.57.0)(typescript@4.9.5):
     resolution: {integrity: sha512-U7iTAtGgJk6DPX9wIWPPOlt1gO57097G06gIcl0N0EEnNw8RGD62c+2/DiP/zL7KrkqnnqF7gtFGR7YgzPllTA==}
@@ -13760,18 +13908,72 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/rule-tester@8.1.0(@eslint/eslintrc@3.0.2)(eslint@8.57.0)(typescript@5.4.2):
-    resolution: {integrity: sha512-shzRkkwKoCUCV1lttzqMFsKnbsOWQ0vjfxe1q3kDjrqdhKkQ/t3t3GwHk0QqjYQd7NUjKk2EB+nNaNI//0IL7Q==}
+  /@typescript-eslint/parser@8.1.0(eslint@8.57.0)(typescript@5.7.3):
+    resolution: {integrity: sha512-U7iTAtGgJk6DPX9wIWPPOlt1gO57097G06gIcl0N0EEnNw8RGD62c+2/DiP/zL7KrkqnnqF7gtFGR7YgzPllTA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      '@eslint/eslintrc': '>=2'
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.1.0(typescript@5.7.3)
+      '@typescript-eslint/types': 8.1.0(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 8.1.0(typescript@5.7.3)
+      '@typescript-eslint/visitor-keys': 8.1.0(typescript@5.7.3)
+      debug: 4.3.4(supports-color@8.1.1)
+      eslint: 8.57.0(supports-color@8.1.1)
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/parser@8.24.0(eslint@8.57.0)(typescript@5.7.3):
+    resolution: {integrity: sha512-MFDaO9CYiard9j9VepMNa9MTcqVvSny2N4hkY6roquzj8pdCBRENhErrteaQuu7Yjn1ppk0v1/ZF9CG3KIlrTA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <5.8.0'
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.24.0(typescript@5.7.3)
+      '@typescript-eslint/types': 8.24.0(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 8.24.0(typescript@5.7.3)
+      '@typescript-eslint/visitor-keys': 8.24.0(typescript@5.7.3)
+      debug: 4.3.4(supports-color@8.1.1)
+      eslint: 8.57.0(supports-color@8.1.1)
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+
+  /@typescript-eslint/parser@8.24.1(eslint@8.57.0)(typescript@5.7.3):
+    resolution: {integrity: sha512-Tqoa05bu+t5s8CTZFaGpCH2ub3QeT9YDkXbPd3uQ4SfsLoh1/vv2GEYAioPoxCWJJNsenXlC88tRjwoHNts1oQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <5.8.0'
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.24.1(typescript@5.7.3)
+      '@typescript-eslint/types': 8.24.1(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 8.24.1(typescript@5.7.3)
+      '@typescript-eslint/visitor-keys': 8.24.1(typescript@5.7.3)
+      debug: 4.3.4(supports-color@8.1.1)
+      eslint: 8.57.0(supports-color@8.1.1)
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/rule-tester@8.24.1(eslint@8.57.0)(typescript@5.7.3):
+    resolution: {integrity: sha512-9d9cceSuljUx0nJ//bAg8g0UUzz/EOjhR9K2u0btfM8C9uVIR73KgUm87kZnzcDxm9tK/LcWSG2jG5SQfQvNHA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
     dependencies:
-      '@eslint/eslintrc': 3.0.2
       '@types/semver': 7.5.0
-      '@typescript-eslint/parser': 8.1.0(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.4.2)
-      '@typescript-eslint/typescript-estree': 8.1.0(supports-color@8.1.1)(typescript@5.4.2)
-      '@typescript-eslint/utils': 8.1.0(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.4.2)
+      '@typescript-eslint/parser': 8.24.1(eslint@8.57.0)(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 8.24.1(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.24.1(eslint@8.57.0)(typescript@5.7.3)
       ajv: 6.12.6
       eslint: 8.57.0(supports-color@8.1.1)
       json-stable-stringify-without-jsonify: 1.0.1
@@ -13792,12 +13994,12 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/scope-manager@6.19.1(typescript@5.4.2):
+  /@typescript-eslint/scope-manager@6.19.1(typescript@5.7.3):
     resolution: {integrity: sha512-4CdXYjKf6/6aKNMSly/BP4iCSOpvMmqtDzRtqFyyAae3z5kkqEjKndR5vDHL8rSuMIIWP8u4Mw4VxLyxZW6D5w==}
     engines: {node: ^16.0.0 || >=18.0.0}
     dependencies:
-      '@typescript-eslint/types': 6.19.1(typescript@5.4.2)
-      '@typescript-eslint/visitor-keys': 6.19.1(typescript@5.4.2)
+      '@typescript-eslint/types': 6.19.1(typescript@5.7.3)
+      '@typescript-eslint/visitor-keys': 6.19.1(typescript@5.7.3)
     transitivePeerDependencies:
       - typescript
 
@@ -13811,16 +14013,35 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/scope-manager@8.1.0(typescript@5.4.2):
+  /@typescript-eslint/scope-manager@8.1.0(typescript@5.7.3):
     resolution: {integrity: sha512-DsuOZQji687sQUjm4N6c9xABJa7fjvfIdjqpSIIVOgaENf2jFXiM9hIBZOL3hb6DHK9Nvd2d7zZnoMLf9e0OtQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     dependencies:
-      '@typescript-eslint/types': 8.1.0(typescript@5.4.2)
-      '@typescript-eslint/visitor-keys': 8.1.0(typescript@5.4.2)
+      '@typescript-eslint/types': 8.1.0(typescript@5.7.3)
+      '@typescript-eslint/visitor-keys': 8.1.0(typescript@5.7.3)
+    transitivePeerDependencies:
+      - typescript
+    dev: true
+
+  /@typescript-eslint/scope-manager@8.24.0(typescript@5.7.3):
+    resolution: {integrity: sha512-HZIX0UByphEtdVBKaQBgTDdn9z16l4aTUz8e8zPQnyxwHBtf5vtl1L+OhH+m1FGV9DrRmoDuYKqzVrvWDcDozw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    dependencies:
+      '@typescript-eslint/types': 8.24.0(typescript@5.7.3)
+      '@typescript-eslint/visitor-keys': 8.24.0(typescript@5.7.3)
     transitivePeerDependencies:
       - typescript
 
-  /@typescript-eslint/type-utils@6.19.1(eslint@7.11.0)(typescript@5.4.2):
+  /@typescript-eslint/scope-manager@8.24.1(typescript@5.7.3):
+    resolution: {integrity: sha512-OdQr6BNBzwRjNEXMQyaGyZzgg7wzjYKfX2ZBV3E04hUCBDv3GQCHiz9RpqdUIiVrMgJGkXm3tcEh4vFSHreS2Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    dependencies:
+      '@typescript-eslint/types': 8.24.1(typescript@5.7.3)
+      '@typescript-eslint/visitor-keys': 8.24.1(typescript@5.7.3)
+    transitivePeerDependencies:
+      - typescript
+
+  /@typescript-eslint/type-utils@6.19.1(eslint@7.11.0)(typescript@5.7.3):
     resolution: {integrity: sha512-0vdyld3ecfxJuddDjACUvlAeYNrHP/pDeQk2pWBR2ESeEzQhg52DF53AbI9QCBkYE23lgkhLCZNkHn2hEXXYIg==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -13830,17 +14051,17 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 6.19.1(supports-color@8.1.1)(typescript@5.4.2)
-      '@typescript-eslint/utils': 6.19.1(eslint@7.11.0)(typescript@5.4.2)
+      '@typescript-eslint/typescript-estree': 6.19.1(typescript@5.7.3)
+      '@typescript-eslint/utils': 6.19.1(eslint@7.11.0)(typescript@5.7.3)
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 7.11.0
-      ts-api-utils: 1.3.0(typescript@5.4.2)
-      typescript: 5.4.2
+      ts-api-utils: 1.3.0(typescript@5.7.3)
+      typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/type-utils@6.19.1(eslint@7.30.0)(typescript@5.4.2):
+  /@typescript-eslint/type-utils@6.19.1(eslint@7.30.0)(typescript@5.7.3):
     resolution: {integrity: sha512-0vdyld3ecfxJuddDjACUvlAeYNrHP/pDeQk2pWBR2ESeEzQhg52DF53AbI9QCBkYE23lgkhLCZNkHn2hEXXYIg==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -13850,17 +14071,17 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 6.19.1(supports-color@8.1.1)(typescript@5.4.2)
-      '@typescript-eslint/utils': 6.19.1(eslint@7.30.0)(typescript@5.4.2)
+      '@typescript-eslint/typescript-estree': 6.19.1(typescript@5.7.3)
+      '@typescript-eslint/utils': 6.19.1(eslint@7.30.0)(typescript@5.7.3)
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 7.30.0
-      ts-api-utils: 1.3.0(typescript@5.4.2)
-      typescript: 5.4.2
+      ts-api-utils: 1.3.0(typescript@5.7.3)
+      typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/type-utils@6.19.1(eslint@7.7.0)(typescript@5.4.2):
+  /@typescript-eslint/type-utils@6.19.1(eslint@7.7.0)(typescript@5.7.3):
     resolution: {integrity: sha512-0vdyld3ecfxJuddDjACUvlAeYNrHP/pDeQk2pWBR2ESeEzQhg52DF53AbI9QCBkYE23lgkhLCZNkHn2hEXXYIg==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -13870,17 +14091,17 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 6.19.1(supports-color@8.1.1)(typescript@5.4.2)
-      '@typescript-eslint/utils': 6.19.1(eslint@7.7.0)(typescript@5.4.2)
+      '@typescript-eslint/typescript-estree': 6.19.1(typescript@5.7.3)
+      '@typescript-eslint/utils': 6.19.1(eslint@7.7.0)(typescript@5.7.3)
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 7.7.0
-      ts-api-utils: 1.3.0(typescript@5.4.2)
-      typescript: 5.4.2
+      ts-api-utils: 1.3.0(typescript@5.7.3)
+      typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/type-utils@6.19.1(eslint@8.57.0)(typescript@5.4.2):
+  /@typescript-eslint/type-utils@6.19.1(eslint@8.57.0)(typescript@5.7.3):
     resolution: {integrity: sha512-0vdyld3ecfxJuddDjACUvlAeYNrHP/pDeQk2pWBR2ESeEzQhg52DF53AbI9QCBkYE23lgkhLCZNkHn2hEXXYIg==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -13890,17 +14111,17 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 6.19.1(supports-color@8.1.1)(typescript@5.4.2)
-      '@typescript-eslint/utils': 6.19.1(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.4.2)
+      '@typescript-eslint/typescript-estree': 6.19.1(typescript@5.7.3)
+      '@typescript-eslint/utils': 6.19.1(eslint@8.57.0)(typescript@5.7.3)
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.57.0(supports-color@8.1.1)
-      ts-api-utils: 1.3.0(typescript@5.4.2)
-      typescript: 5.4.2
+      ts-api-utils: 1.3.0(typescript@5.7.3)
+      typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/type-utils@8.1.0(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.4.2):
+  /@typescript-eslint/type-utils@8.1.0(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.7.3):
     resolution: {integrity: sha512-oLYvTxljVvsMnldfl6jIKxTaU7ok7km0KDrwOt1RHYu6nxlhN3TIx8k5Q52L6wR33nOwDgM7VwW1fT1qMNfFIA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
@@ -13909,14 +14130,15 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 8.1.0(supports-color@8.1.1)(typescript@5.4.2)
-      '@typescript-eslint/utils': 8.1.0(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.4.2)
+      '@typescript-eslint/typescript-estree': 8.1.0(supports-color@8.1.1)(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.1.0(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.7.3)
       debug: 4.3.4(supports-color@8.1.1)
-      ts-api-utils: 1.3.0(typescript@5.4.2)
-      typescript: 5.4.2
+      ts-api-utils: 1.3.0(typescript@5.7.3)
+      typescript: 5.7.3
     transitivePeerDependencies:
       - eslint
       - supports-color
+    dev: true
 
   /@typescript-eslint/type-utils@8.1.0(eslint@8.57.0)(typescript@4.9.5):
     resolution: {integrity: sha512-oLYvTxljVvsMnldfl6jIKxTaU7ok7km0KDrwOt1RHYu6nxlhN3TIx8k5Q52L6wR33nOwDgM7VwW1fT1qMNfFIA==}
@@ -13937,14 +14159,41 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/types@5.59.11(typescript@5.4.2):
-    resolution: {integrity: sha512-epoN6R6tkvBYSc+cllrz+c2sOFWkbisJZWkOE+y3xHtvYaOE6Wk6B8e114McRJwFRjGvYdJwLXQH5c9osME/AA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+  /@typescript-eslint/type-utils@8.1.0(eslint@8.57.0)(typescript@5.7.3):
+    resolution: {integrity: sha512-oLYvTxljVvsMnldfl6jIKxTaU7ok7km0KDrwOt1RHYu6nxlhN3TIx8k5Q52L6wR33nOwDgM7VwW1fT1qMNfFIA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
     dependencies:
-      typescript: 5.4.2
+      '@typescript-eslint/typescript-estree': 8.1.0(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.1.0(eslint@8.57.0)(typescript@5.7.3)
+      debug: 4.3.4(supports-color@8.1.1)
+      ts-api-utils: 1.3.0(typescript@5.7.3)
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - eslint
+      - supports-color
     dev: true
+
+  /@typescript-eslint/type-utils@8.24.0(eslint@8.57.0)(typescript@5.7.3):
+    resolution: {integrity: sha512-8fitJudrnY8aq0F1wMiPM1UUgiXQRJ5i8tFjq9kGfRajU+dbPyOuHbl0qRopLEidy0MwqgTHDt6CnSeXanNIwA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <5.8.0'
+    dependencies:
+      '@typescript-eslint/typescript-estree': 8.24.0(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.24.0(eslint@8.57.0)(typescript@5.7.3)
+      debug: 4.3.4(supports-color@8.1.1)
+      eslint: 8.57.0(supports-color@8.1.1)
+      ts-api-utils: 2.0.1(typescript@5.7.3)
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /@typescript-eslint/types@6.19.1(typescript@4.9.5):
     resolution: {integrity: sha512-6+bk6FEtBhvfYvpHsDgAL3uo4BfvnTnoge5LrrCj2eJN8g3IJdLTD4B/jK3Q6vo4Ql/Hoip9I8aB6fF+6RfDqg==}
@@ -13955,13 +14204,13 @@ packages:
       typescript: 4.9.5
     dev: true
 
-  /@typescript-eslint/types@6.19.1(typescript@5.4.2):
+  /@typescript-eslint/types@6.19.1(typescript@5.7.3):
     resolution: {integrity: sha512-6+bk6FEtBhvfYvpHsDgAL3uo4BfvnTnoge5LrrCj2eJN8g3IJdLTD4B/jK3Q6vo4Ql/Hoip9I8aB6fF+6RfDqg==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
       typescript: '*'
     dependencies:
-      typescript: 5.4.2
+      typescript: 5.7.3
 
   /@typescript-eslint/types@8.1.0(typescript@4.9.5):
     resolution: {integrity: sha512-q2/Bxa0gMOu/2/AKALI0tCKbG2zppccnRIRCW6BaaTlRVaPKft4oVYPp7WOPpcnsgbr0qROAVCVKCvIQ0tbWog==}
@@ -13972,15 +14221,32 @@ packages:
       typescript: 4.9.5
     dev: true
 
-  /@typescript-eslint/types@8.1.0(typescript@5.4.2):
+  /@typescript-eslint/types@8.1.0(typescript@5.7.3):
     resolution: {integrity: sha512-q2/Bxa0gMOu/2/AKALI0tCKbG2zppccnRIRCW6BaaTlRVaPKft4oVYPp7WOPpcnsgbr0qROAVCVKCvIQ0tbWog==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '*'
     dependencies:
-      typescript: 5.4.2
+      typescript: 5.7.3
+    dev: true
 
-  /@typescript-eslint/typescript-estree@6.19.1(supports-color@8.1.1)(typescript@5.4.2):
+  /@typescript-eslint/types@8.24.0(typescript@5.7.3):
+    resolution: {integrity: sha512-VacJCBTyje7HGAw7xp11q439A+zeGG0p0/p2zsZwpnMzjPB5WteaWqt4g2iysgGFafrqvyLWqq6ZPZAOCoefCw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '*'
+    dependencies:
+      typescript: 5.7.3
+
+  /@typescript-eslint/types@8.24.1(typescript@5.7.3):
+    resolution: {integrity: sha512-9kqJ+2DkUXiuhoiYIUvIYjGcwle8pcPpdlfkemGvTObzgmYfJ5d0Qm6jwb4NBXP9W1I5tss0VIAnWFumz3mC5A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '*'
+    dependencies:
+      typescript: 5.7.3
+
+  /@typescript-eslint/typescript-estree@6.19.1(supports-color@8.1.1)(typescript@5.7.3):
     resolution: {integrity: sha512-aFdAxuhzBFRWhy+H20nYu19+Km+gFfwNO4TEqyszkMcgBDYQjmPJ61erHxuT2ESJXhlhrO7I5EFIlZ+qGR8oVA==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -13989,17 +14255,18 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/types': 6.19.1(typescript@5.4.2)
-      '@typescript-eslint/visitor-keys': 6.19.1(typescript@5.4.2)
+      '@typescript-eslint/types': 6.19.1(typescript@5.7.3)
+      '@typescript-eslint/visitor-keys': 6.19.1(typescript@5.7.3)
       debug: 4.3.4(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.3
       semver: 7.5.4
-      ts-api-utils: 1.3.0(typescript@5.4.2)
-      typescript: 5.4.2
+      ts-api-utils: 1.3.0(typescript@5.7.3)
+      typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@typescript-eslint/typescript-estree@6.19.1(typescript@4.9.5):
     resolution: {integrity: sha512-aFdAxuhzBFRWhy+H20nYu19+Km+gFfwNO4TEqyszkMcgBDYQjmPJ61erHxuT2ESJXhlhrO7I5EFIlZ+qGR8oVA==}
@@ -14023,7 +14290,28 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/typescript-estree@8.1.0(supports-color@8.1.1)(typescript@5.4.2):
+  /@typescript-eslint/typescript-estree@6.19.1(typescript@5.7.3):
+    resolution: {integrity: sha512-aFdAxuhzBFRWhy+H20nYu19+Km+gFfwNO4TEqyszkMcgBDYQjmPJ61erHxuT2ESJXhlhrO7I5EFIlZ+qGR8oVA==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 6.19.1(typescript@5.7.3)
+      '@typescript-eslint/visitor-keys': 6.19.1(typescript@5.7.3)
+      debug: 4.3.4(supports-color@8.1.1)
+      globby: 11.1.0
+      is-glob: 4.0.3
+      minimatch: 9.0.3
+      semver: 7.5.4
+      ts-api-utils: 1.3.0(typescript@5.7.3)
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+
+  /@typescript-eslint/typescript-estree@8.1.0(supports-color@8.1.1)(typescript@5.7.3):
     resolution: {integrity: sha512-NTHhmufocEkMiAord/g++gWKb0Fr34e9AExBRdqgWdVBaKoei2dIyYKD9Q0jBnvfbEA5zaf8plUFMUH6kQ0vGg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
@@ -14032,17 +14320,18 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/types': 8.1.0(typescript@5.4.2)
-      '@typescript-eslint/visitor-keys': 8.1.0(typescript@5.4.2)
+      '@typescript-eslint/types': 8.1.0(typescript@5.7.3)
+      '@typescript-eslint/visitor-keys': 8.1.0(typescript@5.7.3)
       debug: 4.3.4(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.5
       semver: 7.6.3
-      ts-api-utils: 1.3.0(typescript@5.4.2)
-      typescript: 5.4.2
+      ts-api-utils: 1.3.0(typescript@5.7.3)
+      typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@typescript-eslint/typescript-estree@8.1.0(typescript@4.9.5):
     resolution: {integrity: sha512-NTHhmufocEkMiAord/g++gWKb0Fr34e9AExBRdqgWdVBaKoei2dIyYKD9Q0jBnvfbEA5zaf8plUFMUH6kQ0vGg==}
@@ -14066,7 +14355,65 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils@6.19.1(eslint@7.11.0)(typescript@5.4.2):
+  /@typescript-eslint/typescript-estree@8.1.0(typescript@5.7.3):
+    resolution: {integrity: sha512-NTHhmufocEkMiAord/g++gWKb0Fr34e9AExBRdqgWdVBaKoei2dIyYKD9Q0jBnvfbEA5zaf8plUFMUH6kQ0vGg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 8.1.0(typescript@5.7.3)
+      '@typescript-eslint/visitor-keys': 8.1.0(typescript@5.7.3)
+      debug: 4.3.4(supports-color@8.1.1)
+      globby: 11.1.0
+      is-glob: 4.0.3
+      minimatch: 9.0.5
+      semver: 7.6.3
+      ts-api-utils: 1.3.0(typescript@5.7.3)
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/typescript-estree@8.24.0(typescript@5.7.3):
+    resolution: {integrity: sha512-ITjYcP0+8kbsvT9bysygfIfb+hBj6koDsu37JZG7xrCiy3fPJyNmfVtaGsgTUSEuTzcvME5YI5uyL5LD1EV5ZQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <5.8.0'
+    dependencies:
+      '@typescript-eslint/types': 8.24.0(typescript@5.7.3)
+      '@typescript-eslint/visitor-keys': 8.24.0(typescript@5.7.3)
+      debug: 4.3.4(supports-color@8.1.1)
+      fast-glob: 3.3.2
+      is-glob: 4.0.3
+      minimatch: 9.0.5
+      semver: 7.6.3
+      ts-api-utils: 2.0.1(typescript@5.7.3)
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+
+  /@typescript-eslint/typescript-estree@8.24.1(typescript@5.7.3):
+    resolution: {integrity: sha512-UPyy4MJ/0RE648DSKQe9g0VDSehPINiejjA6ElqnFaFIhI6ZEiZAkUI0D5MCk0bQcTf/LVqZStvQ6K4lPn/BRg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <5.8.0'
+    dependencies:
+      '@typescript-eslint/types': 8.24.1(typescript@5.7.3)
+      '@typescript-eslint/visitor-keys': 8.24.1(typescript@5.7.3)
+      debug: 4.3.4(supports-color@8.1.1)
+      fast-glob: 3.3.2
+      is-glob: 4.0.3
+      minimatch: 9.0.5
+      semver: 7.6.3
+      ts-api-utils: 2.0.1(typescript@5.7.3)
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+
+  /@typescript-eslint/utils@6.19.1(eslint@7.11.0)(typescript@5.7.3):
     resolution: {integrity: sha512-JvjfEZuP5WoMqwh9SPAPDSHSg9FBHHGhjPugSRxu5jMfjvBpq5/sGTD+9M9aQ5sh6iJ8AY/Kk/oUYVEMAPwi7w==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -14075,9 +14422,9 @@ packages:
       '@eslint-community/eslint-utils': 4.4.0(eslint@7.11.0)
       '@types/json-schema': 7.0.15
       '@types/semver': 7.5.0
-      '@typescript-eslint/scope-manager': 6.19.1(typescript@5.4.2)
-      '@typescript-eslint/types': 6.19.1(typescript@5.4.2)
-      '@typescript-eslint/typescript-estree': 6.19.1(supports-color@8.1.1)(typescript@5.4.2)
+      '@typescript-eslint/scope-manager': 6.19.1(typescript@5.7.3)
+      '@typescript-eslint/types': 6.19.1(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 6.19.1(typescript@5.7.3)
       eslint: 7.11.0
       semver: 7.5.4
     transitivePeerDependencies:
@@ -14085,7 +14432,7 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/utils@6.19.1(eslint@7.30.0)(typescript@5.4.2):
+  /@typescript-eslint/utils@6.19.1(eslint@7.30.0)(typescript@5.7.3):
     resolution: {integrity: sha512-JvjfEZuP5WoMqwh9SPAPDSHSg9FBHHGhjPugSRxu5jMfjvBpq5/sGTD+9M9aQ5sh6iJ8AY/Kk/oUYVEMAPwi7w==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -14094,9 +14441,9 @@ packages:
       '@eslint-community/eslint-utils': 4.4.0(eslint@7.30.0)
       '@types/json-schema': 7.0.15
       '@types/semver': 7.5.0
-      '@typescript-eslint/scope-manager': 6.19.1(typescript@5.4.2)
-      '@typescript-eslint/types': 6.19.1(typescript@5.4.2)
-      '@typescript-eslint/typescript-estree': 6.19.1(supports-color@8.1.1)(typescript@5.4.2)
+      '@typescript-eslint/scope-manager': 6.19.1(typescript@5.7.3)
+      '@typescript-eslint/types': 6.19.1(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 6.19.1(typescript@5.7.3)
       eslint: 7.30.0
       semver: 7.5.4
     transitivePeerDependencies:
@@ -14104,7 +14451,7 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/utils@6.19.1(eslint@7.7.0)(typescript@5.4.2):
+  /@typescript-eslint/utils@6.19.1(eslint@7.7.0)(typescript@5.7.3):
     resolution: {integrity: sha512-JvjfEZuP5WoMqwh9SPAPDSHSg9FBHHGhjPugSRxu5jMfjvBpq5/sGTD+9M9aQ5sh6iJ8AY/Kk/oUYVEMAPwi7w==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -14113,9 +14460,9 @@ packages:
       '@eslint-community/eslint-utils': 4.4.0(eslint@7.7.0)
       '@types/json-schema': 7.0.15
       '@types/semver': 7.5.0
-      '@typescript-eslint/scope-manager': 6.19.1(typescript@5.4.2)
-      '@typescript-eslint/types': 6.19.1(typescript@5.4.2)
-      '@typescript-eslint/typescript-estree': 6.19.1(supports-color@8.1.1)(typescript@5.4.2)
+      '@typescript-eslint/scope-manager': 6.19.1(typescript@5.7.3)
+      '@typescript-eslint/types': 6.19.1(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 6.19.1(typescript@5.7.3)
       eslint: 7.7.0
       semver: 7.5.4
     transitivePeerDependencies:
@@ -14123,7 +14470,7 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/utils@6.19.1(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.4.2):
+  /@typescript-eslint/utils@6.19.1(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.7.3):
     resolution: {integrity: sha512-JvjfEZuP5WoMqwh9SPAPDSHSg9FBHHGhjPugSRxu5jMfjvBpq5/sGTD+9M9aQ5sh6iJ8AY/Kk/oUYVEMAPwi7w==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -14132,14 +14479,15 @@ packages:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
       '@types/json-schema': 7.0.15
       '@types/semver': 7.5.0
-      '@typescript-eslint/scope-manager': 6.19.1(typescript@5.4.2)
-      '@typescript-eslint/types': 6.19.1(typescript@5.4.2)
-      '@typescript-eslint/typescript-estree': 6.19.1(supports-color@8.1.1)(typescript@5.4.2)
+      '@typescript-eslint/scope-manager': 6.19.1(typescript@5.7.3)
+      '@typescript-eslint/types': 6.19.1(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 6.19.1(supports-color@8.1.1)(typescript@5.7.3)
       eslint: 8.57.0(supports-color@8.1.1)
       semver: 7.5.4
     transitivePeerDependencies:
       - supports-color
       - typescript
+    dev: true
 
   /@typescript-eslint/utils@6.19.1(eslint@8.57.0)(typescript@4.9.5):
     resolution: {integrity: sha512-JvjfEZuP5WoMqwh9SPAPDSHSg9FBHHGhjPugSRxu5jMfjvBpq5/sGTD+9M9aQ5sh6iJ8AY/Kk/oUYVEMAPwi7w==}
@@ -14160,20 +14508,39 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/utils@8.1.0(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.4.2):
+  /@typescript-eslint/utils@6.19.1(eslint@8.57.0)(typescript@5.7.3):
+    resolution: {integrity: sha512-JvjfEZuP5WoMqwh9SPAPDSHSg9FBHHGhjPugSRxu5jMfjvBpq5/sGTD+9M9aQ5sh6iJ8AY/Kk/oUYVEMAPwi7w==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    peerDependencies:
+      eslint: ^7.0.0 || ^8.0.0
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
+      '@types/json-schema': 7.0.15
+      '@types/semver': 7.5.0
+      '@typescript-eslint/scope-manager': 6.19.1(typescript@5.7.3)
+      '@typescript-eslint/types': 6.19.1(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 6.19.1(typescript@5.7.3)
+      eslint: 8.57.0(supports-color@8.1.1)
+      semver: 7.5.4
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  /@typescript-eslint/utils@8.1.0(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.7.3):
     resolution: {integrity: sha512-ypRueFNKTIFwqPeJBfeIpxZ895PQhNyH4YID6js0UoBImWYoSjBsahUn9KMiJXh94uOjVBgHD9AmkyPsPnFwJA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
-      '@typescript-eslint/scope-manager': 8.1.0(typescript@5.4.2)
-      '@typescript-eslint/types': 8.1.0(typescript@5.4.2)
-      '@typescript-eslint/typescript-estree': 8.1.0(supports-color@8.1.1)(typescript@5.4.2)
+      '@typescript-eslint/scope-manager': 8.1.0(typescript@5.7.3)
+      '@typescript-eslint/types': 8.1.0(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 8.1.0(supports-color@8.1.1)(typescript@5.7.3)
       eslint: 8.57.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
       - typescript
+    dev: true
 
   /@typescript-eslint/utils@8.1.0(eslint@8.57.0)(typescript@4.9.5):
     resolution: {integrity: sha512-ypRueFNKTIFwqPeJBfeIpxZ895PQhNyH4YID6js0UoBImWYoSjBsahUn9KMiJXh94uOjVBgHD9AmkyPsPnFwJA==}
@@ -14191,6 +14558,55 @@ packages:
       - typescript
     dev: true
 
+  /@typescript-eslint/utils@8.1.0(eslint@8.57.0)(typescript@5.7.3):
+    resolution: {integrity: sha512-ypRueFNKTIFwqPeJBfeIpxZ895PQhNyH4YID6js0UoBImWYoSjBsahUn9KMiJXh94uOjVBgHD9AmkyPsPnFwJA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
+      '@typescript-eslint/scope-manager': 8.1.0(typescript@5.7.3)
+      '@typescript-eslint/types': 8.1.0(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 8.1.0(typescript@5.7.3)
+      eslint: 8.57.0(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
+  /@typescript-eslint/utils@8.24.0(eslint@8.57.0)(typescript@5.7.3):
+    resolution: {integrity: sha512-07rLuUBElvvEb1ICnafYWr4hk8/U7X9RDCOqd9JcAMtjh/9oRmcfN4yGzbPVirgMR0+HLVHehmu19CWeh7fsmQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <5.8.0'
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
+      '@typescript-eslint/scope-manager': 8.24.0(typescript@5.7.3)
+      '@typescript-eslint/types': 8.24.0(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 8.24.0(typescript@5.7.3)
+      eslint: 8.57.0(supports-color@8.1.1)
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@typescript-eslint/utils@8.24.1(eslint@8.57.0)(typescript@5.7.3):
+    resolution: {integrity: sha512-OOcg3PMMQx9EXspId5iktsI3eMaXVwlhC8BvNnX6B5w9a4dVgpkQZuU8Hy67TolKcl+iFWq0XX+jbDGN4xWxjQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <5.8.0'
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
+      '@typescript-eslint/scope-manager': 8.24.1(typescript@5.7.3)
+      '@typescript-eslint/types': 8.24.1(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 8.24.1(typescript@5.7.3)
+      eslint: 8.57.0(supports-color@8.1.1)
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - supports-color
+
   /@typescript-eslint/visitor-keys@6.19.1(typescript@4.9.5):
     resolution: {integrity: sha512-gkdtIO+xSO/SmI0W68DBg4u1KElmIUo3vXzgHyGPs6cxgB0sa3TlptRAAE0hUY1hM6FcDKEv7aIwiTGm76cXfQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
@@ -14201,14 +14617,15 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/visitor-keys@6.19.1(typescript@5.4.2):
+  /@typescript-eslint/visitor-keys@6.19.1(typescript@5.7.3):
     resolution: {integrity: sha512-gkdtIO+xSO/SmI0W68DBg4u1KElmIUo3vXzgHyGPs6cxgB0sa3TlptRAAE0hUY1hM6FcDKEv7aIwiTGm76cXfQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
     dependencies:
-      '@typescript-eslint/types': 6.19.1(typescript@5.4.2)
+      '@typescript-eslint/types': 6.19.1(typescript@5.7.3)
       eslint-visitor-keys: 3.4.3
     transitivePeerDependencies:
       - typescript
+    dev: true
 
   /@typescript-eslint/visitor-keys@8.1.0(typescript@4.9.5):
     resolution: {integrity: sha512-ba0lNI19awqZ5ZNKh6wCModMwoZs457StTebQ0q1NP58zSi2F6MOZRXwfKZy+jB78JNJ/WH8GSh2IQNzXX8Nag==}
@@ -14220,12 +14637,31 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/visitor-keys@8.1.0(typescript@5.4.2):
+  /@typescript-eslint/visitor-keys@8.1.0(typescript@5.7.3):
     resolution: {integrity: sha512-ba0lNI19awqZ5ZNKh6wCModMwoZs457StTebQ0q1NP58zSi2F6MOZRXwfKZy+jB78JNJ/WH8GSh2IQNzXX8Nag==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     dependencies:
-      '@typescript-eslint/types': 8.1.0(typescript@5.4.2)
+      '@typescript-eslint/types': 8.1.0(typescript@5.7.3)
       eslint-visitor-keys: 3.4.3
+    transitivePeerDependencies:
+      - typescript
+    dev: true
+
+  /@typescript-eslint/visitor-keys@8.24.0(typescript@5.7.3):
+    resolution: {integrity: sha512-kArLq83QxGLbuHrTMoOEWO+l2MwsNS2TGISEdx8xgqpkbytB07XmlQyQdNDrCc1ecSqx0cnmhGvpX+VBwqqSkg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    dependencies:
+      '@typescript-eslint/types': 8.24.0(typescript@5.7.3)
+      eslint-visitor-keys: 4.2.0
+    transitivePeerDependencies:
+      - typescript
+
+  /@typescript-eslint/visitor-keys@8.24.1(typescript@5.7.3):
+    resolution: {integrity: sha512-EwVHlp5l+2vp8CoqJm9KikPZgi3gbdZAtabKT9KPShGeOcJhsv4Zdo3oc8T8I0uKEmYoU4ItyxbptjF08enaxg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    dependencies:
+      '@typescript-eslint/types': 8.24.1(typescript@5.7.3)
+      eslint-visitor-keys: 4.2.0
     transitivePeerDependencies:
       - typescript
 
@@ -18104,17 +18540,17 @@ packages:
       eslint: 8.57.0(supports-color@8.1.1)
     dev: false
 
-  /eslint-plugin-deprecation@2.0.0(eslint@8.57.0)(typescript@5.4.2):
+  /eslint-plugin-deprecation@2.0.0(eslint@8.57.0)(typescript@5.7.3):
     resolution: {integrity: sha512-OAm9Ohzbj11/ZFyICyR5N6LbOIvQMp7ZU2zI7Ej0jIc8kiGUERXPNMfw2QqqHD1ZHtjMub3yPZILovYEYucgoQ==}
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0
       typescript: ^4.2.4 || ^5.0.0
     dependencies:
-      '@typescript-eslint/utils': 6.19.1(eslint@8.57.0)(supports-color@8.1.1)(typescript@5.4.2)
+      '@typescript-eslint/utils': 6.19.1(eslint@8.57.0)(typescript@5.7.3)
       eslint: 8.57.0(supports-color@8.1.1)
       tslib: 2.3.1
-      tsutils: 3.21.0(typescript@5.4.2)
-      typescript: 5.4.2
+      tsutils: 3.21.0(typescript@5.7.3)
+      typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -18379,6 +18815,10 @@ packages:
     resolution: {integrity: sha512-OtIRv/2GyiF6o/d8K7MYKKbXrOUBIK6SfkIRM4Z0dY3w+LiQ0vy3F57m0Z71bjbyeiWFiHJ8brqnmE6H6/jEuw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     dev: true
+
+  /eslint-visitor-keys@4.2.0:
+    resolution: {integrity: sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   /eslint@7.11.0:
     resolution: {integrity: sha512-G9+qtYVCHaDi1ZuWzBsOWo2wSwd70TXnU6UHA3cTYHp7gCTXZcpggWFoUVAMRarg68qtPoNfFbzPh+VdOgmwmw==}
@@ -19276,7 +19716,7 @@ packages:
       worker-rpc: 0.1.1
     dev: true
 
-  /fork-ts-checker-webpack-plugin@6.5.3(eslint@8.57.0)(typescript@5.4.2)(webpack@4.47.0):
+  /fork-ts-checker-webpack-plugin@6.5.3(eslint@8.57.0)(typescript@5.7.3)(webpack@4.47.0):
     resolution: {integrity: sha512-SbH/l9ikmMWycd5puHJKTkZJKddF4iRLyW3DeZ08HTI7NGyLS38MXd/KGgeWumQO7YNQbW2u/NtPT2YowbPaGQ==}
     engines: {node: '>=10', yarn: '>=1.0.0'}
     peerDependencies:
@@ -19304,7 +19744,7 @@ packages:
       schema-utils: 2.7.0
       semver: 7.5.4
       tapable: 1.1.3
-      typescript: 5.4.2
+      typescript: 5.7.3
       webpack: 4.47.0
     dev: true
 
@@ -23850,11 +24290,11 @@ packages:
       semver-compare: 1.0.0
     dev: false
 
-  /pnp-webpack-plugin@1.6.4(typescript@5.4.2):
+  /pnp-webpack-plugin@1.6.4(typescript@5.7.3):
     resolution: {integrity: sha512-7Wjy+9E3WwLOEL30D+m8TSTF7qJJUJLONBnwQp0518siuMxUQUbgZwssaFX+QKlZkjHZcw/IpZCt/H0srrntSg==}
     engines: {node: '>=6'}
     dependencies:
-      ts-pnp: 1.2.0(typescript@5.4.2)
+      ts-pnp: 1.2.0(typescript@5.7.3)
     transitivePeerDependencies:
       - typescript
     dev: true
@@ -24700,12 +25140,12 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     dev: true
 
-  /react-docgen-typescript@2.2.2(typescript@5.4.2):
+  /react-docgen-typescript@2.2.2(typescript@5.7.3):
     resolution: {integrity: sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==}
     peerDependencies:
       typescript: '>= 4.3.x'
     dependencies:
-      typescript: 5.4.2
+      typescript: 5.7.3
     dev: true
 
   /react-docgen@5.4.3:
@@ -27177,20 +27617,29 @@ packages:
       typescript: 4.9.5
     dev: true
 
-  /ts-api-utils@1.3.0(typescript@5.4.2):
+  /ts-api-utils@1.3.0(typescript@5.7.3):
     resolution: {integrity: sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==}
     engines: {node: '>=16'}
     peerDependencies:
       typescript: '>=4.2.0'
     dependencies:
-      typescript: 5.4.2
+      typescript: 5.7.3
+    dev: true
+
+  /ts-api-utils@2.0.1(typescript@5.7.3):
+    resolution: {integrity: sha512-dnlgjFSVetynI8nzgJ+qF62efpglpWRk8isUEWZGWlJYySCTD6aKvbUDu+zbPeDakk3bg5H4XpitHukgfL1m9w==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
+    dependencies:
+      typescript: 5.7.3
 
   /ts-dedent@2.2.0:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
     engines: {node: '>=6.10'}
     dev: true
 
-  /ts-loader@6.0.0(typescript@5.4.2):
+  /ts-loader@6.0.0(typescript@5.7.3):
     resolution: {integrity: sha512-lszy+D41R0Te2+loZxADWS+E1+Z55A+i3dFfFie1AZHL++65JRKVDBPQgeWgRrlv5tbxdU3zOtXp8b7AFR6KEg==}
     engines: {node: '>=8.6'}
     peerDependencies:
@@ -27201,10 +27650,10 @@ packages:
       loader-utils: 1.4.2
       micromatch: 4.0.5
       semver: 6.3.1
-      typescript: 5.4.2
+      typescript: 5.7.3
     dev: false
 
-  /ts-pnp@1.2.0(typescript@5.4.2):
+  /ts-pnp@1.2.0(typescript@5.7.3):
     resolution: {integrity: sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==}
     engines: {node: '>=6'}
     peerDependencies:
@@ -27213,7 +27662,7 @@ packages:
       typescript:
         optional: true
     dependencies:
-      typescript: 5.4.2
+      typescript: 5.7.3
     dev: true
 
   /tsconfig-paths@3.15.0:
@@ -27307,7 +27756,7 @@ packages:
       typescript: 4.9.5
     dev: true
 
-  /tslint@5.20.1(typescript@5.4.2):
+  /tslint@5.20.1(typescript@5.7.3):
     resolution: {integrity: sha512-EcMxhzCFt8k+/UP5r8waCf/lzmeSyVlqxqMEDQE7rWYiQky8KpIBz1JAoYXfROHrPZ1XXd43q8yQnULOLiBRQg==}
     engines: {node: '>=4.8.0'}
     hasBin: true
@@ -27326,8 +27775,8 @@ packages:
       resolve: 1.22.8
       semver: 5.7.2
       tslib: 1.14.1
-      tsutils: 2.29.0(typescript@5.4.2)
-      typescript: 5.4.2
+      tsutils: 2.29.0(typescript@5.7.3)
+      typescript: 5.7.3
     dev: true
 
   /tsutils@2.29.0(typescript@2.9.2):
@@ -27357,23 +27806,23 @@ packages:
       typescript: 4.9.5
     dev: true
 
-  /tsutils@2.29.0(typescript@5.4.2):
+  /tsutils@2.29.0(typescript@5.7.3):
     resolution: {integrity: sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==}
     peerDependencies:
       typescript: '>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >= 3.0.0-dev || >= 3.1.0-dev'
     dependencies:
       tslib: 1.14.1
-      typescript: 5.4.2
+      typescript: 5.7.3
     dev: true
 
-  /tsutils@3.21.0(typescript@5.4.2):
+  /tsutils@3.21.0(typescript@5.7.3):
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
-      typescript: 5.4.2
+      typescript: 5.7.3
     dev: false
 
   /tty-browserify@0.0.0:
@@ -27506,11 +27955,6 @@ packages:
     engines: {node: '>=4.2.0'}
     hasBin: true
     dev: true
-
-  /typescript@5.4.2:
-    resolution: {integrity: sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==}
-    engines: {node: '>=14.17'}
-    hasBin: true
 
   /typescript@5.7.3:
     resolution: {integrity: sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==}

--- a/common/config/subspaces/default/pnpm-lock.yaml
+++ b/common/config/subspaces/default/pnpm-lock.yaml
@@ -135,9 +135,6 @@ importers:
       local-node-rig:
         specifier: workspace:*
         version: link:../../rigs/local-node-rig
-      typescript:
-        specifier: ~5.7.3
-        version: 5.7.3
 
   ../../../apps/heft:
     dependencies:
@@ -735,9 +732,6 @@ importers:
       local-eslint-config:
         specifier: workspace:*
         version: link:../../eslint/local-eslint-config
-      typescript:
-        specifier: ~5.7.3
-        version: 5.7.3
 
   ../../../build-tests-samples/heft-web-rig-library-tutorial:
     dependencies:
@@ -769,9 +763,6 @@ importers:
       local-eslint-config:
         specifier: workspace:*
         version: link:../../eslint/local-eslint-config
-      typescript:
-        specifier: ~5.7.3
-        version: 5.7.3
 
   ../../../build-tests-samples/heft-webpack-basic-tutorial:
     dependencies:
@@ -1050,9 +1041,6 @@ importers:
       local-node-rig:
         specifier: workspace:*
         version: link:../../rigs/local-node-rig
-      typescript:
-        specifier: ~5.7.3
-        version: 5.7.3
 
   ../../../build-tests/api-extractor-test-03:
     dependencies:
@@ -2174,18 +2162,12 @@ importers:
       '@types/node':
         specifier: 20.17.19
         version: 20.17.19
-      eslint:
-        specifier: ~8.57.0
-        version: 8.57.0(supports-color@8.1.1)
       http-proxy:
         specifier: ~1.18.1
         version: 1.18.1
       local-node-rig:
         specifier: workspace:*
         version: link:../../rigs/local-node-rig
-      typescript:
-        specifier: ~5.7.3
-        version: 5.7.3
 
   ../../../build-tests/rush-lib-declaration-paths-test:
     dependencies:
@@ -2248,18 +2230,12 @@ importers:
       '@types/node':
         specifier: 20.17.19
         version: 20.17.19
-      eslint:
-        specifier: ~8.57.0
-        version: 8.57.0(supports-color@8.1.1)
       http-proxy:
         specifier: ~1.18.1
         version: 1.18.1
       local-node-rig:
         specifier: workspace:*
         version: link:../../rigs/local-node-rig
-      typescript:
-        specifier: ~5.7.3
-        version: 5.7.3
 
   ../../../build-tests/set-webpack-public-path-plugin-test:
     devDependencies:

--- a/common/config/subspaces/default/pnpm-lock.yaml
+++ b/common/config/subspaces/default/pnpm-lock.yaml
@@ -4388,6 +4388,9 @@ importers:
       '@rushstack/heft':
         specifier: workspace:*
         version: link:../../apps/heft
+      '@types/node':
+        specifier: 18.17.15
+        version: 18.17.15
       local-node-rig:
         specifier: workspace:*
         version: link:../../rigs/local-node-rig

--- a/common/config/subspaces/default/repo-state.json
+++ b/common/config/subspaces/default/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "2a95a770d2c21f58265c08eea5af11b933e7f4ee",
-  "preferredVersionsHash": "ce857ea0536b894ec8f346aaea08cfd85a5af648"
+  "pnpmShrinkwrapHash": "8b7c136deba4689ee5e7e9448da1659e5495855e",
+  "preferredVersionsHash": "7aee53abbca2f0cefac5a2a8c72ca7703b10dff2"
 }

--- a/eslint/eslint-config/package.json
+++ b/eslint/eslint-config/package.json
@@ -31,16 +31,16 @@
     "@rushstack/eslint-plugin": "workspace:*",
     "@rushstack/eslint-plugin-packlets": "workspace:*",
     "@rushstack/eslint-plugin-security": "workspace:*",
-    "@typescript-eslint/eslint-plugin": "~8.1.0",
-    "@typescript-eslint/utils": "~8.1.0",
-    "@typescript-eslint/parser": "~8.1.0",
-    "@typescript-eslint/typescript-estree": "~8.1.0",
+    "@typescript-eslint/eslint-plugin": "~8.24.0",
+    "@typescript-eslint/utils": "~8.24.0",
+    "@typescript-eslint/parser": "~8.24.0",
+    "@typescript-eslint/typescript-estree": "~8.24.0",
     "eslint-plugin-promise": "~6.1.1",
     "eslint-plugin-react": "~7.33.2",
     "eslint-plugin-tsdoc": "~0.4.0"
   },
   "devDependencies": {
     "eslint": "~8.57.0",
-    "typescript": "~5.4.2"
+    "typescript": "~5.7.3"
   }
 }

--- a/eslint/eslint-patch/package.json
+++ b/eslint/eslint-patch/package.json
@@ -34,9 +34,9 @@
     "@rushstack/heft-node-rig": "2.6.59",
     "@types/eslint": "8.56.10",
     "@types/node": "20.17.19",
-    "@typescript-eslint/types": "~5.59.2",
+    "@typescript-eslint/types": "~8.24.0",
     "eslint": "~8.57.0",
     "eslint-plugin-header": "~3.1.1",
-    "typescript": "~5.4.2"
+    "typescript": "~5.7.3"
   }
 }

--- a/eslint/eslint-patch/src/eslint-bulk-suppressions/ast-guards.ts
+++ b/eslint/eslint-patch/src/eslint-bulk-suppressions/ast-guards.ts
@@ -190,10 +190,10 @@ export function isNormalObjectProperty(node: TSESTree.Node): node is INormalObje
   return isProperty(node) && (isIdentifier(node.key) || isPrivateIdentifier(node.key));
 }
 
-export interface INormalVariableDeclarator extends TSESTree.VariableDeclarator {
+export type INormalVariableDeclarator = TSESTree.LetOrConstOrVarDeclaration & {
   id: TSESTree.Identifier;
   init: TSESTree.Expression;
-}
+};
 
 export function isNormalVariableDeclarator(node: TSESTree.Node): node is INormalVariableDeclarator {
   return isVariableDeclarator(node) && isIdentifier(node.id) && node.init !== null;
@@ -209,9 +209,9 @@ export function isNormalAssignmentPatternWithAnonymousExpressionAssigned(
   return isNormalAssignmentPattern(node) && isNormalAnonymousExpression(node.right);
 }
 
-export interface INormalVariableDeclaratorWithAnonymousExpressionAssigned extends INormalVariableDeclarator {
+export type INormalVariableDeclaratorWithAnonymousExpressionAssigned = INormalVariableDeclarator & {
   init: NormalAnonymousExpression;
-}
+};
 
 export function isNormalVariableDeclaratorWithAnonymousExpressionAssigned(
   node: TSESTree.Node

--- a/eslint/eslint-plugin-packlets/package.json
+++ b/eslint/eslint-plugin-packlets/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@rushstack/tree-pattern": "workspace:*",
-    "@typescript-eslint/utils": "~8.1.0"
+    "@typescript-eslint/utils": "~8.24.0"
   },
   "peerDependencies": {
     "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -36,10 +36,10 @@
     "@types/estree": "1.0.5",
     "@types/heft-jest": "1.0.1",
     "@types/node": "20.17.19",
-    "@typescript-eslint/parser": "~8.1.0",
-    "@typescript-eslint/typescript-estree": "~8.1.0",
+    "@typescript-eslint/parser": "~8.24.0",
+    "@typescript-eslint/typescript-estree": "~8.24.0",
     "eslint": "~8.57.0",
     "eslint-plugin-header": "~3.1.1",
-    "typescript": "~5.4.2"
+    "typescript": "~5.7.3"
   }
 }

--- a/eslint/eslint-plugin-security/package.json
+++ b/eslint/eslint-plugin-security/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@rushstack/tree-pattern": "workspace:*",
-    "@typescript-eslint/utils": "~8.1.0"
+    "@typescript-eslint/utils": "~8.24.0"
   },
   "peerDependencies": {
     "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -36,11 +36,11 @@
     "@types/estree": "1.0.5",
     "@types/heft-jest": "1.0.1",
     "@types/node": "20.17.19",
-    "@typescript-eslint/parser": "~8.1.0",
-    "@typescript-eslint/rule-tester": "~8.1.0",
-    "@typescript-eslint/typescript-estree": "~8.1.0",
+    "@typescript-eslint/parser": "~8.24.0",
+    "@typescript-eslint/rule-tester": "~8.24.0",
+    "@typescript-eslint/typescript-estree": "~8.24.0",
     "eslint": "~8.57.0",
     "eslint-plugin-header": "~3.1.1",
-    "typescript": "~5.4.2"
+    "typescript": "~5.7.3"
   }
 }

--- a/eslint/eslint-plugin/package.json
+++ b/eslint/eslint-plugin/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@rushstack/tree-pattern": "workspace:*",
-    "@typescript-eslint/utils": "~8.1.0"
+    "@typescript-eslint/utils": "~8.24.0"
   },
   "peerDependencies": {
     "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -40,11 +40,11 @@
     "@types/estree": "1.0.5",
     "@types/heft-jest": "1.0.1",
     "@types/node": "20.17.19",
-    "@typescript-eslint/parser": "~8.1.0",
-    "@typescript-eslint/rule-tester": "~8.1.0",
-    "@typescript-eslint/typescript-estree": "~8.1.0",
+    "@typescript-eslint/parser": "~8.24.0",
+    "@typescript-eslint/rule-tester": "~8.24.0",
+    "@typescript-eslint/typescript-estree": "~8.24.0",
     "eslint": "~8.57.0",
     "eslint-plugin-header": "~3.1.1",
-    "typescript": "~5.4.2"
+    "typescript": "~5.7.3"
   }
 }

--- a/eslint/local-eslint-config/package.json
+++ b/eslint/local-eslint-config/package.json
@@ -9,12 +9,12 @@
   },
   "devDependencies": {
     "eslint": "~8.57.0",
-    "typescript": "~5.4.2"
+    "typescript": "~5.7.3"
   },
   "dependencies": {
     "@rushstack/eslint-config": "workspace:*",
     "@rushstack/eslint-patch": "workspace:*",
-    "@typescript-eslint/parser": "~8.1.0",
+    "@typescript-eslint/parser": "~8.24.0",
     "eslint-plugin-deprecation": "2.0.0",
     "eslint-plugin-header": "~3.1.1",
     "eslint-plugin-import": "2.25.4",

--- a/heft-plugins/heft-api-extractor-plugin/package.json
+++ b/heft-plugins/heft-api-extractor-plugin/package.json
@@ -31,6 +31,6 @@
     "@types/heft-jest": "1.0.1",
     "@types/node": "20.17.19",
     "@types/semver": "7.5.0",
-    "typescript": "~5.4.2"
+    "typescript": "~5.7.3"
   }
 }

--- a/heft-plugins/heft-jest-plugin/package.json
+++ b/heft-plugins/heft-jest-plugin/package.json
@@ -53,6 +53,6 @@
     "jest-environment-node": "~29.5.0",
     "jest-watch-select-projects": "2.0.0",
     "local-eslint-config": "workspace:*",
-    "typescript": "~5.4.2"
+    "typescript": "~5.7.3"
   }
 }

--- a/heft-plugins/heft-jest-plugin/tsconfig.json
+++ b/heft-plugins/heft-jest-plugin/tsconfig.json
@@ -4,6 +4,7 @@
   "compilerOptions": {
     "isolatedModules": true,
     "types": ["node", "heft-jest"],
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "target": "es2018"
   }
 }

--- a/heft-plugins/heft-lint-plugin/package.json
+++ b/heft-plugins/heft-lint-plugin/package.json
@@ -33,6 +33,6 @@
     "@types/semver": "7.5.0",
     "eslint": "~8.57.0",
     "tslint": "~5.20.1",
-    "typescript": "~5.4.2"
+    "typescript": "~5.7.3"
   }
 }

--- a/heft-plugins/heft-typescript-plugin/package.json
+++ b/heft-plugins/heft-typescript-plugin/package.json
@@ -33,6 +33,6 @@
     "@rushstack/terminal": "workspace:*",
     "@types/node": "20.17.19",
     "@types/semver": "7.5.0",
-    "typescript": "~5.4.2"
+    "typescript": "~5.7.3"
   }
 }

--- a/heft-plugins/heft-typescript-plugin/src/TypeScriptBuilder.ts
+++ b/heft-plugins/heft-typescript-plugin/src/TypeScriptBuilder.ts
@@ -122,7 +122,7 @@ const OLDEST_SUPPORTED_TS_MAJOR_VERSION: number = 2;
 const OLDEST_SUPPORTED_TS_MINOR_VERSION: number = 9;
 
 const NEWEST_SUPPORTED_TS_MAJOR_VERSION: number = 5;
-const NEWEST_SUPPORTED_TS_MINOR_VERSION: number = 6;
+const NEWEST_SUPPORTED_TS_MINOR_VERSION: number = 7;
 
 interface ITypeScriptTool {
   ts: ExtendedTypeScript;

--- a/libraries/api-extractor-model/package.json
+++ b/libraries/api-extractor-model/package.json
@@ -26,6 +26,7 @@
     "@rushstack/heft": "0.69.2",
     "@rushstack/heft-node-rig": "2.6.59",
     "@types/heft-jest": "1.0.1",
-    "@types/node": "20.17.19"
+    "@types/node": "20.17.19",
+    "typescript": "~5.7.3"
   }
 }

--- a/libraries/heft-config-file/package.json
+++ b/libraries/heft-config-file/package.json
@@ -31,6 +31,7 @@
     "@rushstack/heft": "0.69.2",
     "@rushstack/heft-node-rig": "2.6.59",
     "@types/heft-jest": "1.0.1",
-    "@types/node": "20.17.19"
+    "@types/node": "20.17.19",
+    "typescript": "~5.7.3"
   }
 }

--- a/libraries/module-minifier/package.json
+++ b/libraries/module-minifier/package.json
@@ -23,8 +23,9 @@
   },
   "devDependencies": {
     "@rushstack/heft": "workspace:*",
-    "local-node-rig": "workspace:*",
-    "@types/serialize-javascript": "5.0.2"
+    "@types/node": "20.17.19",
+    "@types/serialize-javascript": "5.0.2",
+    "local-node-rig": "workspace:*"
   },
   "peerDependencies": {
     "@types/node": "*"

--- a/libraries/module-minifier/src/index.ts
+++ b/libraries/module-minifier/src/index.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+/// <reference types="node" preserve="true" />
+
 /**
  * This library wraps terser in convenient handles for parallelization.
  * It powers `@rushstack/webpack4-module-minifier-plugin` and `@rushstack/webpack5-module-minifier-plugin`

--- a/libraries/node-core-library/package.json
+++ b/libraries/node-core-library/package.json
@@ -34,7 +34,8 @@
     "@types/jju": "1.4.1",
     "@types/node": "20.17.19",
     "@types/resolve": "1.20.2",
-    "@types/semver": "7.5.0"
+    "@types/semver": "7.5.0",
+    "typescript": "~5.7.3"
   },
   "peerDependencies": {
     "@types/node": "*"

--- a/libraries/node-core-library/src/index.ts
+++ b/libraries/node-core-library/src/index.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+/// <reference types="node" preserve="true" />
+
 /**
  * Core libraries that every NodeJS toolchain project should use.
  *

--- a/libraries/operation-graph/package.json
+++ b/libraries/operation-graph/package.json
@@ -24,7 +24,8 @@
     "@rushstack/heft": "0.69.2",
     "@rushstack/heft-node-rig": "2.6.59",
     "@types/heft-jest": "1.0.1",
-    "@types/node": "20.17.19"
+    "@types/node": "20.17.19",
+    "typescript": "~5.7.3"
   },
   "peerDependencies": {
     "@types/node": "*"

--- a/libraries/operation-graph/src/index.ts
+++ b/libraries/operation-graph/src/index.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+/// <reference types="node" preserve="true" />
+
 export type {
   IOperationRunner,
   IOperationRunnerContext,

--- a/libraries/rig-package/package.json
+++ b/libraries/rig-package/package.json
@@ -27,6 +27,7 @@
     "@types/node": "20.17.19",
     "@types/resolve": "1.20.2",
     "ajv": "~8.13.0",
-    "resolve": "~1.22.1"
+    "resolve": "~1.22.1",
+    "typescript": "~5.7.3"
   }
 }

--- a/libraries/rush-lib/src/api/EventHooks.ts
+++ b/libraries/rush-lib/src/api/EventHooks.ts
@@ -52,7 +52,7 @@ export class EventHooks {
     for (const [name, eventHooks] of Object.entries(eventHooksJson)) {
       const eventName: Event | undefined = Enum.tryGetValueByKey(Event, name);
       if (eventName) {
-        this._hooks.set(eventName, [...eventHooks] || []);
+        this._hooks.set(eventName, [...eventHooks]);
       }
     }
   }

--- a/libraries/rush-lib/src/index.ts
+++ b/libraries/rush-lib/src/index.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+/// <reference types="node" preserve="true" />
+
 /**
  * A library for writing scripts that interact with the {@link https://rushjs.io/ | Rush} tool.
  * @packageDocumentation

--- a/libraries/rush-lib/src/logic/InteractiveUpgrader.ts
+++ b/libraries/rush-lib/src/logic/InteractiveUpgrader.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+/// <reference path="../npm-check-typings.d.ts" preserve="true" />
+
 import npmCheck from 'npm-check';
 import type * as NpmCheck from 'npm-check';
 import { Colorize } from '@rushstack/terminal';

--- a/libraries/rush-lib/src/logic/PackageJsonUpdater.ts
+++ b/libraries/rush-lib/src/logic/PackageJsonUpdater.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+/// <reference path="../npm-check-typings.d.ts" preserve="true" />
+
 import * as semver from 'semver';
 import type * as NpmCheck from 'npm-check';
 import { ConsoleTerminalProvider, Terminal, type ITerminalProvider, Colorize } from '@rushstack/terminal';

--- a/libraries/rush-lib/src/logic/operations/test/OperationExecutionManager.test.ts
+++ b/libraries/rush-lib/src/logic/operations/test/OperationExecutionManager.test.ts
@@ -91,8 +91,10 @@ describe(OperationExecutionManager.name, () => {
       _printOperationStatus(mockTerminal, result);
       expect(result.status).toEqual(OperationStatus.Failure);
       expect(result.operationResults.size).toEqual(1);
-      const firstResult: IOperationExecutionResult = result.operationResults.values().next().value;
-      expect(firstResult.status).toEqual(OperationStatus.Failure);
+      const firstResult: IOperationExecutionResult | undefined = result.operationResults
+        .values()
+        .next().value;
+      expect(firstResult?.status).toEqual(OperationStatus.Failure);
 
       const allMessages: string = mockWritable.getAllOutput();
       expect(allMessages).toContain('Error: step 1 failed');
@@ -113,8 +115,10 @@ describe(OperationExecutionManager.name, () => {
       _printOperationStatus(mockTerminal, result);
       expect(result.status).toEqual(OperationStatus.Failure);
       expect(result.operationResults.size).toEqual(1);
-      const firstResult: IOperationExecutionResult = result.operationResults.values().next().value;
-      expect(firstResult.status).toEqual(OperationStatus.Failure);
+      const firstResult: IOperationExecutionResult | undefined = result.operationResults
+        .values()
+        .next().value;
+      expect(firstResult?.status).toEqual(OperationStatus.Failure);
 
       const allOutput: string = mockWritable.getAllOutput();
       expect(allOutput).toMatch(/Build step 1/);
@@ -187,8 +191,10 @@ describe(OperationExecutionManager.name, () => {
         _printOperationStatus(mockTerminal, result);
         expect(result.status).toEqual(OperationStatus.SuccessWithWarning);
         expect(result.operationResults.size).toEqual(1);
-        const firstResult: IOperationExecutionResult = result.operationResults.values().next().value;
-        expect(firstResult.status).toEqual(OperationStatus.SuccessWithWarning);
+        const firstResult: IOperationExecutionResult | undefined = result.operationResults
+          .values()
+          .next().value;
+        expect(firstResult?.status).toEqual(OperationStatus.SuccessWithWarning);
 
         const allMessages: string = mockWritable.getAllOutput();
         expect(allMessages).toContain('Build step 1');
@@ -226,8 +232,10 @@ describe(OperationExecutionManager.name, () => {
         _printOperationStatus(mockTerminal, result);
         expect(result.status).toEqual(OperationStatus.Success);
         expect(result.operationResults.size).toEqual(1);
-        const firstResult: IOperationExecutionResult = result.operationResults.values().next().value;
-        expect(firstResult.status).toEqual(OperationStatus.SuccessWithWarning);
+        const firstResult: IOperationExecutionResult | undefined = result.operationResults
+          .values()
+          .next().value;
+        expect(firstResult?.status).toEqual(OperationStatus.SuccessWithWarning);
         const allMessages: string = mockWritable.getAllOutput();
         expect(allMessages).toContain('Build step 1');
         expect(allMessages).toContain('Warning: step 1 succeeded with warnings');

--- a/libraries/rush-lib/src/utilities/InteractiveUpgradeUI.ts
+++ b/libraries/rush-lib/src/utilities/InteractiveUpgradeUI.ts
@@ -5,6 +5,8 @@
 // https://github.com/dylang/npm-check/blob/master/lib/out/interactive-update.js
 // Extended to use one type of text table
 
+/// <reference path="../npm-check-typings.d.ts" preserve="true" />
+
 import inquirer from 'inquirer';
 import CliTable from 'cli-table';
 import type Separator from 'inquirer/lib/objects/separator';

--- a/libraries/rush-sdk/src/loader.ts
+++ b/libraries/rush-sdk/src/loader.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+/// <reference types="node" preserve="true" />
+
 import * as path from 'path';
 import type { SpawnSyncReturns } from 'child_process';
 import { JsonFile, type JsonObject, Executable } from '@rushstack/node-core-library';

--- a/libraries/terminal/package.json
+++ b/libraries/terminal/package.json
@@ -25,7 +25,8 @@
     "@types/heft-jest": "1.0.1",
     "@types/node": "20.17.19",
     "@types/supports-color": "8.1.3",
-    "local-eslint-config": "workspace:*"
+    "local-eslint-config": "workspace:*",
+    "typescript": "~5.7.3"
   },
   "peerDependencies": {
     "@types/node": "*"

--- a/libraries/terminal/src/index.ts
+++ b/libraries/terminal/src/index.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+/// <reference types="node" preserve="true" />
+
 /**
  * This library implements a system for processing human readable text that
  * will be output by console applications.

--- a/libraries/tree-pattern/package.json
+++ b/libraries/tree-pattern/package.json
@@ -22,6 +22,6 @@
     "@types/heft-jest": "1.0.1",
     "@types/node": "20.17.19",
     "eslint": "~8.57.0",
-    "typescript": "~5.4.2"
+    "typescript": "~5.7.3"
   }
 }

--- a/libraries/ts-command-line/tsconfig.json
+++ b/libraries/ts-command-line/tsconfig.json
@@ -3,6 +3,7 @@
 
   "compilerOptions": {
     "isolatedModules": true,
-    "types": ["heft-jest", "node"]
+    "types": ["heft-jest", "node"],
+    "target": "es2018"
   }
 }

--- a/libraries/worker-pool/src/index.ts
+++ b/libraries/worker-pool/src/index.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+/// <reference types="node" preserve="true" />
+
 /**
  * A lightweight worker pool implementation using the NodeJS `worker_threads` API.
  *

--- a/rigs/heft-node-rig/package.json
+++ b/rigs/heft-node-rig/package.json
@@ -25,7 +25,7 @@
     "@types/heft-jest": "1.0.1",
     "eslint": "~8.57.0",
     "jest-environment-node": "~29.5.0",
-    "typescript": "~5.4.2"
+    "typescript": "~5.7.3"
   },
   "devDependencies": {
     "@rushstack/heft": "workspace:*"

--- a/rigs/heft-web-rig/package.json
+++ b/rigs/heft-web-rig/package.json
@@ -39,7 +39,7 @@
     "source-map-loader": "~3.0.1",
     "style-loader": "~3.3.1",
     "terser-webpack-plugin": "~5.3.1",
-    "typescript": "~5.4.2",
+    "typescript": "~5.7.3",
     "url-loader": "~4.1.1",
     "webpack-bundle-analyzer": "~4.5.0",
     "webpack-merge": "~5.8.0",

--- a/rigs/local-node-rig/package.json
+++ b/rigs/local-node-rig/package.json
@@ -17,6 +17,6 @@
     "local-eslint-config": "workspace:*",
     "eslint": "~8.57.0",
     "jest-junit": "12.3.0",
-    "typescript": "~5.4.2"
+    "typescript": "~5.7.3"
   }
 }

--- a/rigs/local-node-rig/profiles/default/tsconfig-base.json
+++ b/rigs/local-node-rig/profiles/default/tsconfig-base.json
@@ -6,6 +6,7 @@
   "compilerOptions": {
     "resolveJsonModule": true,
     "isolatedModules": true,
+    "target": "es2018",
 
     "outDir": "../../../../lib",
     "rootDir": "../../../../src",

--- a/rigs/local-web-rig/package.json
+++ b/rigs/local-web-rig/package.json
@@ -17,6 +17,6 @@
     "local-eslint-config": "workspace:*",
     "eslint": "~8.57.0",
     "jest-junit": "12.3.0",
-    "typescript": "~5.4.2"
+    "typescript": "~5.7.3"
   }
 }

--- a/rush-plugins/rush-amazon-s3-build-cache-plugin/src/index.ts
+++ b/rush-plugins/rush-amazon-s3-build-cache-plugin/src/index.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+/// <reference types="node" preserve="true" />
+
 import { RushAmazonS3BuildCachePlugin } from './RushAmazonS3BuildCachePlugin';
 
 export { type IAmazonS3Credentials } from './AmazonS3Credentials';

--- a/rush-plugins/rush-redis-cobuild-plugin/src/index.ts
+++ b/rush-plugins/rush-redis-cobuild-plugin/src/index.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+/// <reference types="node" preserve="true" />
+
 export {
   RushRedisCobuildPlugin as default,
   type IRushRedisCobuildPluginOptions

--- a/webpack/set-webpack-public-path-plugin/package.json
+++ b/webpack/set-webpack-public-path-plugin/package.json
@@ -29,8 +29,9 @@
   },
   "devDependencies": {
     "@rushstack/heft": "workspace:*",
+    "@types/node": "18.17.15",
     "local-node-rig": "workspace:*",
-    "webpack": "~5.95.0",
-    "memfs": "4.12.0"
+    "memfs": "4.12.0",
+    "webpack": "~5.95.0"
   }
 }

--- a/webpack/set-webpack-public-path-plugin/package.json
+++ b/webpack/set-webpack-public-path-plugin/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@rushstack/heft": "workspace:*",
-    "@types/node": "18.17.15",
+    "@types/node": "20.17.19",
     "local-node-rig": "workspace:*",
     "memfs": "4.12.0",
     "webpack": "~5.95.0"

--- a/webpack/webpack-workspace-resolve-plugin/package.json
+++ b/webpack/webpack-workspace-resolve-plugin/package.json
@@ -27,6 +27,7 @@
   },
   "devDependencies": {
     "@rushstack/heft": "workspace:*",
+    "@types/node": "18.17.15",
     "local-node-rig": "workspace:*",
     "memfs": "4.12.0",
     "webpack": "~5.95.0"

--- a/webpack/webpack-workspace-resolve-plugin/package.json
+++ b/webpack/webpack-workspace-resolve-plugin/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@rushstack/heft": "workspace:*",
-    "@types/node": "18.17.15",
+    "@types/node": "20.17.19",
     "local-node-rig": "workspace:*",
     "memfs": "4.12.0",
     "webpack": "~5.95.0"

--- a/webpack/webpack4-module-minifier-plugin/package.json
+++ b/webpack/webpack4-module-minifier-plugin/package.json
@@ -44,11 +44,12 @@
   },
   "devDependencies": {
     "@rushstack/heft": "workspace:*",
-    "local-node-rig": "workspace:*",
-    "@types/webpack": "4.41.32",
+    "@types/node": "20.17.19",
     "@types/webpack-sources": "1.4.2",
-    "webpack": "~4.47.0",
-    "webpack-sources": "~1.4.3"
+    "@types/webpack": "4.41.32",
+    "local-node-rig": "workspace:*",
+    "webpack-sources": "~1.4.3",
+    "webpack": "~4.47.0"
   },
   "sideEffects": [
     "./lib/OverrideWebpackIdentifierAllocation"

--- a/webpack/webpack5-localization-plugin/package.json
+++ b/webpack/webpack5-localization-plugin/package.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "@rushstack/heft": "workspace:*",
+    "@types/node": "18.17.15",
     "local-node-rig": "workspace:*",
     "memfs": "4.12.0",
     "webpack": "~5.95.0"

--- a/webpack/webpack5-localization-plugin/package.json
+++ b/webpack/webpack5-localization-plugin/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@rushstack/heft": "workspace:*",
-    "@types/node": "18.17.15",
+    "@types/node": "20.17.19",
     "local-node-rig": "workspace:*",
     "memfs": "4.12.0",
     "webpack": "~5.95.0"

--- a/webpack/webpack5-localization-plugin/src/index.ts
+++ b/webpack/webpack5-localization-plugin/src/index.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+/// <reference types="node" preserve="true" />
+
 export { LocalizationPlugin, type IStringPlaceholder as _IStringPlaceholder } from './LocalizationPlugin';
 export { TrueHashPlugin, type ITrueHashPluginOptions } from './TrueHashPlugin';
 

--- a/webpack/webpack5-module-minifier-plugin/package.json
+++ b/webpack/webpack5-module-minifier-plugin/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@rushstack/heft": "workspace:*",
     "@rushstack/module-minifier": "workspace:*",
-    "@types/node": "18.17.15",
+    "@types/node": "20.17.19",
     "local-node-rig": "workspace:*",
     "memfs": "4.12.0",
     "webpack": "~5.95.0"

--- a/webpack/webpack5-module-minifier-plugin/package.json
+++ b/webpack/webpack5-module-minifier-plugin/package.json
@@ -31,8 +31,9 @@
   },
   "devDependencies": {
     "@rushstack/heft": "workspace:*",
-    "local-node-rig": "workspace:*",
     "@rushstack/module-minifier": "workspace:*",
+    "@types/node": "18.17.15",
+    "local-node-rig": "workspace:*",
     "memfs": "4.12.0",
     "webpack": "~5.95.0"
   },


### PR DESCRIPTION
## Summary

Bumps TypeScript to `~5.7.3` and the `@typescript-eslint/*` dependencies to be compatible with the new version of TypeScript.

Note that this PR currently includes https://github.com/microsoft/rushstack/pull/5131. Once that goes in, I'll rebase this PR.

## How it was tested

Built.

## Impacted documentation

None.