### PR TITLE
Rename the subspace pnpmfileSettings file to globalPnpmfileSettings.json to avoid overwriting the original pnpmfileSettings.json

### DIFF
--- a/common/changes/@microsoft/rush/bugfix-rename-subspace-pnpmfileShimSettings_2025-02-25-05-03.json
+++ b/common/changes/@microsoft/rush/bugfix-rename-subspace-pnpmfileShimSettings_2025-02-25-05-03.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Rename the subspace pnpmfileSettings file to globalPnpmfileSettings.json to avoid overwriting the original pnpmfileSettings.json",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/logic/pnpm/SubspaceGlobalPnpmfileShim.ts
+++ b/libraries/rush-lib/src/logic/pnpm/SubspaceGlobalPnpmfileShim.ts
@@ -44,7 +44,7 @@ function init(context: IPnpmfileContext | any): IPnpmfileContext {
   if (!settings) {
     // Initialize the settings from file
     if (!context.splitWorkspacePnpmfileShimSettings) {
-      context.splitWorkspacePnpmfileShimSettings = __non_webpack_require__('./pnpmfileSettings.json');
+      context.splitWorkspacePnpmfileShimSettings = __non_webpack_require__('./globalPnpmfileSettings.json');
     }
     settings = context.splitWorkspacePnpmfileShimSettings!;
   } else if (!context.splitWorkspacePnpmfileShimSettings) {

--- a/libraries/rush-lib/src/logic/pnpm/SubspacePnpmfileConfiguration.ts
+++ b/libraries/rush-lib/src/logic/pnpm/SubspacePnpmfileConfiguration.ts
@@ -49,7 +49,7 @@ export class SubspacePnpmfileConfiguration {
     // Write the settings file used by the shim
     await JsonFile.saveAsync(
       subspaceGlobalPnpmfileShimSettings,
-      path.join(targetDir, 'pnpmfileSettings.json'),
+      path.join(targetDir, 'globalPnpmfileSettings.json'),
       {
         ensureFolderExists: true
       }


### PR DESCRIPTION

<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

This MR rename subspace pnpmfileSettings file to globalPnpmfileSettings.json, because subspace pnpmfileSettings overrides original pnpmfileSettings and they have different data structures.

subspace pnpmfileSettings
https://github.com/microsoft/rushstack/blob/e64a1e51976626f95250205cbb9d21b5fc805769/libraries/rush-lib/src/logic/pnpm/IPnpmfile.ts#L34-L39

original pnpmfileSettings
https://github.com/microsoft/rushstack/blob/e64a1e51976626f95250205cbb9d21b5fc805769/libraries/rush-lib/src/logic/pnpm/IPnpmfile.ts#L13-L22

Due to the missing preferredVersion information in subspace pnpmfileSettings file, the preferredVersion does not take effect when the subspace is enabled.

Fixes #5118

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

## Details

After debugging rush-lib, I found that pnpmfileSettings.json will be written twice.

First time:
https://github.com/microsoft/rushstack/blob/438525caf08bcbdb75d33f6747cc34e050837d46/libraries/rush-lib/src/logic/pnpm/PnpmfileConfiguration.ts#L80-L83

Second time:
https://github.com/microsoft/rushstack/blob/438525caf08bcbdb75d33f6747cc34e050837d46/libraries/rush-lib/src/logic/pnpm/SubspacePnpmfileConfiguration.ts#L50-L56

The second write operation will overwrite the first write content. And pnpmfileSettings.json is read once by global-pnpmfile.cjs and pnpmfile.cjs respectively.

Maybe we should distinguish the file names written twice, one is named pnpmfileSettings.json and the other named is globalPnpmfileSettings.json.

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

## Impacted documentation

<!--------------------------------------------------------------------------
👉 STEP 7: Does your PR affect anything that is discussed in the website docs?
     If so, please paste the URL of each affected web page, so we will
     remember to update the documentation after your PR is merged.
     (Updating the website is appreciated but not required.)
     If no docs are impacted, delete the "Impacted documentation" section.

     If you modified a JSON schema, remember to update init templates such as:
     rush-lib/assets/rush-init/*.json
     api-extractor/src/schemas/api-extractor-template.json
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 8: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
