### PR TITLE
[heft] Expose watchFs on IncrementalRunOptions

### DIFF
--- a/apps/heft/src/index.ts
+++ b/apps/heft/src/index.ts
@@ -45,7 +45,14 @@ export type { IRunScript, IRunScriptOptions } from './plugins/RunScriptPlugin';
 
 export type { IFileSelectionSpecifier, IGlobOptions, GlobFn, WatchGlobFn } from './plugins/FileGlobSpecifier';
 
-export type { IWatchedFileState } from './utilities/WatchFileSystemAdapter';
+export type {
+  IWatchedFileState,
+  IWatchFileSystem,
+  ReaddirDirentCallback,
+  ReaddirStringCallback,
+  StatCallback,
+  IReaddirOptions
+} from './utilities/WatchFileSystemAdapter';
 
 export {
   type IHeftRecordMetricsHookOptions,

--- a/apps/heft/src/operations/runners/TaskOperationRunner.ts
+++ b/apps/heft/src/operations/runners/TaskOperationRunner.ts
@@ -28,7 +28,11 @@ import type {
 import type { HeftPhaseSession } from '../../pluginFramework/HeftPhaseSession';
 import type { InternalHeftSession } from '../../pluginFramework/InternalHeftSession';
 import { watchGlobAsync, type IGlobOptions } from '../../plugins/FileGlobSpecifier';
-import { type IWatchedFileState, WatchFileSystemAdapter } from '../../utilities/WatchFileSystemAdapter';
+import {
+  type IWatchedFileState,
+  type IWatchFileSystem,
+  WatchFileSystemAdapter
+} from '../../utilities/WatchFileSystemAdapter';
 
 export interface ITaskOperationRunnerOptions {
   internalHeftSession: InternalHeftSession;
@@ -171,6 +175,9 @@ export class TaskOperationRunner implements IOperationRunner {
                       ...options,
                       fs: getWatchFileSystemAdapter()
                     });
+                  },
+                  get watchFs(): IWatchFileSystem {
+                    return getWatchFileSystemAdapter();
                   },
                   requestRun: requestRun!
                 };

--- a/apps/heft/src/pluginFramework/HeftTaskSession.ts
+++ b/apps/heft/src/pluginFramework/HeftTaskSession.ts
@@ -13,6 +13,7 @@ import type { ICopyOperation } from '../plugins/CopyFilesPlugin';
 import type { HeftPluginHost } from './HeftPluginHost';
 import type { WatchGlobFn } from '../plugins/FileGlobSpecifier';
 import { InternalError } from '@rushstack/node-core-library';
+import type { IWatchFileSystem } from '../utilities/WatchFileSystemAdapter';
 
 /**
  * The type of {@link IHeftTaskSession.parsedCommandLine}, which exposes details about the
@@ -189,6 +190,12 @@ export interface IHeftTaskRunIncrementalHookOptions extends IHeftTaskRunHookOpti
    * If a change to the monitored files is detected, the task will be scheduled for re-execution.
    */
   readonly watchGlobAsync: WatchGlobFn;
+
+  /**
+   * Access to the file system view that powers `watchGlobAsync`.
+   * This is useful for plugins that do their own file system operations but still want to leverage Heft for watching.
+   */
+  readonly watchFs: IWatchFileSystem;
 }
 
 /**

--- a/common/changes/@rushstack/heft/expose-watch-fs_2025-02-25-23-51.json
+++ b/common/changes/@rushstack/heft/expose-watch-fs_2025-02-25-23-51.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Expose `watchFs` on the incremental run options for tasks to give more flexibility when having Heft perform file watching than only invoking globs directly.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft"
+}

--- a/common/reviews/api/heft.api.md
+++ b/common/reviews/api/heft.api.md
@@ -16,6 +16,7 @@ import { CommandLineIntegerParameter } from '@rushstack/ts-command-line';
 import { CommandLineParameter } from '@rushstack/ts-command-line';
 import { CommandLineStringListParameter } from '@rushstack/ts-command-line';
 import { CommandLineStringParameter } from '@rushstack/ts-command-line';
+import * as fs from 'fs';
 import { IPackageJson } from '@rushstack/node-core-library';
 import { IRigConfig } from '@rushstack/rig-package';
 import { ITerminal } from '@rushstack/terminal';
@@ -192,6 +193,7 @@ export interface IHeftTaskRunHookOptions {
 // @public
 export interface IHeftTaskRunIncrementalHookOptions extends IHeftTaskRunHookOptions {
     readonly requestRun: () => void;
+    readonly watchFs: IWatchFileSystem;
     readonly watchGlobAsync: WatchGlobFn;
 }
 
@@ -235,6 +237,11 @@ export interface _IPerformanceData {
 }
 
 // @public
+export interface IReaddirOptions {
+    withFileTypes: true;
+}
+
+// @public
 export interface IRigPackageResolver {
     // (undocumented)
     resolvePackageAsync(packageName: string, terminal: ITerminal): Promise<string>;
@@ -272,6 +279,22 @@ export interface IWatchedFileState {
     changed: boolean;
 }
 
+// @public
+export interface IWatchFileSystem {
+    getStateAndTrack(filePath: string): IWatchedFileState;
+    getStateAndTrackAsync(filePath: string): Promise<IWatchedFileState>;
+    lstat(filePath: string, callback: StatCallback): void;
+    lstatSync(filePath: string): fs.Stats;
+    readdir(filePath: string, callback: ReaddirStringCallback): void;
+    // (undocumented)
+    readdir(filePath: string, options: IReaddirOptions, callback: ReaddirDirentCallback): void;
+    readdirSync(filePath: string): string[];
+    // (undocumented)
+    readdirSync(filePath: string, options: IReaddirOptions): fs.Dirent[];
+    stat(filePath: string, callback: StatCallback): void;
+    statSync(filePath: string): fs.Stats;
+}
+
 // @internal
 export class _MetricsCollector {
     recordAsync(command: string, performanceData?: Partial<_IPerformanceData>, parameters?: Record<string, string>): Promise<void>;
@@ -279,6 +302,15 @@ export class _MetricsCollector {
     readonly recordMetricsHook: AsyncParallelHook<IHeftRecordMetricsHookOptions>;
     setStartTime(): void;
 }
+
+// @public
+export type ReaddirDirentCallback = (error: NodeJS.ErrnoException | null, files: fs.Dirent[]) => void;
+
+// @public
+export type ReaddirStringCallback = (error: NodeJS.ErrnoException | null, files: string[]) => void;
+
+// @public
+export type StatCallback = (error: NodeJS.ErrnoException | null, stats: fs.Stats) => void;
 
 // @public
 export type WatchGlobFn = (pattern: string | string[], options?: IGlobOptions | undefined) => Promise<Map<string, IWatchedFileState>>;


### PR DESCRIPTION
## Summary
Allows plugins to more easily interact with Heft's file watcher layer, such that if they have their own way of reading files, they can still request that Heft watch them without having to build their own file watchers.

## Details
Exposes the `WatchFileSystem` that backs `watchGlobAsync` as `watchFs` on `IHeftTaskRunIncrementalHookOptions`.

## How it was tested
Surfaces an existing object that is already used in various plugins.

## Impacted documentation
API docs.