### PR TITLE
Update localization tooling to support emitting trimmed JSON files for runtime

### DIFF
--- a/build-tests/localization-plugin-test-02/config/heft.json
+++ b/build-tests/localization-plugin-test-02/config/heft.json
@@ -24,7 +24,9 @@
                 "interfaceDocumentationComment": "This interface represents a JSON object that has been loaded from a localization file.",
                 "valueDocumentationComment": "@public",
                 "inferInterfaceNameFromFilename": true
-              }
+              },
+              "stringNamesToIgnore": ["__IGNORED_STRING__"],
+              "trimmedJsonOutputFolders": ["temp/loc-raw"]
             }
           }
         },

--- a/common/changes/@rushstack/heft-localization-typings-plugin/loc-loader-ignore-string_2025-02-27-02-42.json
+++ b/common/changes/@rushstack/heft-localization-typings-plugin/loc-loader-ignore-string_2025-02-27-02-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-localization-typings-plugin",
+      "comment": "Add option \"trimmedJsonOutputFolders\" to allow the plugin to output an object mapping the string names to untranslated strings as JSON in the specified folders. This allows bundlers and unit tests to operate on those strings without special handling.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft-localization-typings-plugin"
+}

--- a/common/changes/@rushstack/localization-utilities/loc-loader-ignore-string_2025-02-27-02-42.json
+++ b/common/changes/@rushstack/localization-utilities/loc-loader-ignore-string_2025-02-27-02-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/localization-utilities",
+      "comment": "Update `loc.json` format to allow keys to be mapped to raw strings. This is useful so that the file name can be preserved for a strings file that can be directly imported at runtime.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/localization-utilities"
+}

--- a/common/changes/@rushstack/webpack5-localization-plugin/loc-loader-ignore-string_2025-02-27-02-08.json
+++ b/common/changes/@rushstack/webpack5-localization-plugin/loc-loader-ignore-string_2025-02-27-02-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/webpack5-localization-plugin",
+      "comment": "Support passing the `ignoreString` option to all loaders.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/webpack5-localization-plugin"
+}

--- a/common/reviews/api/localization-utilities.api.md
+++ b/common/reviews/api/localization-utilities.api.md
@@ -84,16 +84,12 @@ export interface IPseudolocaleOptions {
 
 // @public (undocumented)
 export interface ITypingsGeneratorOptions extends ITypingsGeneratorBaseOptions {
-    // (undocumented)
     exportAsDefault?: boolean | IExportAsDefaultOptions | IInferInterfaceNameExportAsDefaultOptions;
-    // (undocumented)
     ignoreMissingResxComments?: boolean | undefined;
-    // (undocumented)
     ignoreString?: IgnoreStringFunction;
-    // (undocumented)
     processComment?: (comment: string | undefined, relativeFilePath: string, stringName: string) => string | undefined;
-    // (undocumented)
     resxNewlineNormalization?: NewlineKind | undefined;
+    trimmedJsonOutputFolders?: string[] | undefined;
 }
 
 // @public (undocumented)

--- a/heft-plugins/heft-localization-typings-plugin/src/LocalizationTypingsPlugin.ts
+++ b/heft-plugins/heft-localization-typings-plugin/src/LocalizationTypingsPlugin.ts
@@ -25,6 +25,13 @@ export interface ILocalizationTypingsPluginOptions {
   generatedTsFolder?: string;
 
   /**
+   * Folders, relative to the project root, where JSON files containing only the key/string pairs should be emitted to.
+   * These files will be emitted as `.resx.json`, `.loc.json`, or `.resjson`, depending on the input file extension.
+   * The intent is that bundlers can find these files and load them to receive the original untranslated strings.
+   */
+  trimmedJsonOutputFolders?: string[];
+
+  /**
    * Additional folders, relative to the project root, where the generated typings should be emitted to.
    */
   secondaryGeneratedTsFolders?: string[];
@@ -49,7 +56,8 @@ export default class LocalizationTypingsPlugin implements IHeftTaskPlugin<ILocal
       srcFolder,
       generatedTsFolder,
       stringNamesToIgnore,
-      secondaryGeneratedTsFolders: secondaryGeneratedTsFoldersFromOptions
+      secondaryGeneratedTsFolders: secondaryGeneratedTsFoldersFromOptions,
+      trimmedJsonOutputFolders: trimmedJsonOutputFoldersFromOptions
     } = options ?? {};
 
     let secondaryGeneratedTsFolders: string[] | undefined;
@@ -57,6 +65,14 @@ export default class LocalizationTypingsPlugin implements IHeftTaskPlugin<ILocal
       secondaryGeneratedTsFolders = [];
       for (const secondaryGeneratedTsFolder of secondaryGeneratedTsFoldersFromOptions) {
         secondaryGeneratedTsFolders.push(`${slashNormalizedBuildFolderPath}/${secondaryGeneratedTsFolder}`);
+      }
+    }
+
+    let trimmedJsonOutputFolders: string[] | undefined;
+    if (trimmedJsonOutputFoldersFromOptions) {
+      trimmedJsonOutputFolders = [];
+      for (const trimmedJsonOutputFolder of trimmedJsonOutputFoldersFromOptions) {
+        trimmedJsonOutputFolders.push(`${slashNormalizedBuildFolderPath}/${trimmedJsonOutputFolder}`);
       }
     }
 

--- a/heft-plugins/heft-localization-typings-plugin/src/schemas/options.schema.json
+++ b/heft-plugins/heft-localization-typings-plugin/src/schemas/options.schema.json
@@ -53,6 +53,14 @@
       "description": "Source code root directory. Defaults to \"src/\"."
     },
 
+    "trimmedJsonOutputFolders": {
+      "type": "array",
+      "description": "Output folders, relative to the project root, where JSON files that have had comments and any ignored strings discarded should be emitted to.",
+      "items": {
+        "type": "string"
+      }
+    },
+
     "generatedTsFolder": {
       "type": "string",
       "description": "Output directory for generated typings. Defaults to \"temp/loc-ts/\"."

--- a/libraries/localization-utilities/src/parsers/parseLocJson.ts
+++ b/libraries/localization-utilities/src/parsers/parseLocJson.ts
@@ -19,16 +19,15 @@ export function parseLocJson({ content, filePath, ignoreString }: IParseFileOpti
     throw new Error(`The loc file is invalid. Error: ${e}`);
   }
 
-  if (ignoreString) {
-    const newParsedFile: ILocalizationFile = {};
-    for (const [key, stringData] of Object.entries(parsedFile)) {
-      if (!ignoreString(filePath, key)) {
-        newParsedFile[key] = stringData;
-      }
+  // Normalize file shape and possibly filter
+  const newParsedFile: ILocalizationFile = {};
+  for (const [key, stringData] of Object.entries(parsedFile)) {
+    if (!ignoreString?.(filePath, key)) {
+      // Normalize entry shape. We allow the values to be plain strings as a format that can be handed
+      // off to webpack builds that don't understand the comment syntax.
+      newParsedFile[key] = typeof stringData === 'string' ? { value: stringData } : stringData;
     }
-
-    return newParsedFile;
-  } else {
-    return parsedFile;
   }
+
+  return newParsedFile;
 }

--- a/libraries/localization-utilities/src/parsers/test/__snapshots__/parseLocJson.test.ts.snap
+++ b/libraries/localization-utilities/src/parsers/test/__snapshots__/parseLocJson.test.ts.snap
@@ -22,6 +22,17 @@ Array [
 ]
 `;
 
+exports[`parseLocJson parses a file with raw strings 1`] = `
+Object {
+  "bar": Object {
+    "value": "Bar",
+  },
+  "foo": Object {
+    "value": "Foo",
+  },
+}
+`;
+
 exports[`parseLocJson parses a valid file 1`] = `
 Object {
   "bar": Object {
@@ -40,5 +51,9 @@ exports[`parseLocJson throws on invalid file 1`] = `
 test.loc.json
 
 Error: #/foo
-       must NOT have additional properties: baz"
+       must NOT have additional properties: baz
+Error: #/foo
+       must be string
+Error: #/foo
+       must match exactly one schema in oneOf"
 `;

--- a/libraries/localization-utilities/src/parsers/test/parseLocJson.test.ts
+++ b/libraries/localization-utilities/src/parsers/test/parseLocJson.test.ts
@@ -25,6 +25,20 @@ describe(parseLocJson.name, () => {
     ).toMatchSnapshot();
   });
 
+  it('parses a file with raw strings', () => {
+    const content: string = JSON.stringify({
+      foo: 'Foo',
+      bar: 'Bar'
+    });
+
+    expect(
+      parseLocJson({
+        content,
+        filePath: 'test.loc.json'
+      })
+    ).toMatchSnapshot();
+  });
+
   it('throws on invalid file', () => {
     const content: string = JSON.stringify({
       foo: {

--- a/libraries/localization-utilities/src/schemas/locJson.schema.json
+++ b/libraries/localization-utilities/src/schemas/locJson.schema.json
@@ -4,17 +4,24 @@
 
   "patternProperties": {
     "^[A-Za-z_$][0-9A-Za-z_$]*$": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "string"
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "value": {
+              "type": "string"
+            },
+            "comment": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "required": ["value"]
         },
-        "comment": {
+        {
           "type": "string"
         }
-      },
-      "additionalProperties": false,
-      "required": ["value"]
+      ]
     }
   },
   "additionalProperties": false,

--- a/webpack/webpack5-localization-plugin/src/loaders/LoaderFactory.ts
+++ b/webpack/webpack5-localization-plugin/src/loaders/LoaderFactory.ts
@@ -8,7 +8,7 @@ import type { ILocalizationFile } from '@rushstack/localization-utilities';
 import { getPluginInstance, type LocalizationPlugin } from '../LocalizationPlugin';
 
 export interface IBaseLocLoaderOptions {
-  // Nothing
+  ignoreString?: (key: string) => boolean;
 }
 
 export function createLoader<T extends IBaseLocLoaderOptions>(

--- a/webpack/webpack5-localization-plugin/src/loaders/locjson-loader.ts
+++ b/webpack/webpack5-localization-plugin/src/loaders/locjson-loader.ts
@@ -10,7 +10,8 @@ const loader: LoaderDefinitionFunction<IBaseLocLoaderOptions> = createLoader(
   (content: string, filePath: string, context: LoaderContext<IBaseLocLoaderOptions>) => {
     return parseLocJson({
       content,
-      filePath
+      filePath,
+      ignoreString: context.getOptions().ignoreString
     });
   }
 );

--- a/webpack/webpack5-localization-plugin/src/loaders/resjson-loader.ts
+++ b/webpack/webpack5-localization-plugin/src/loaders/resjson-loader.ts
@@ -10,7 +10,8 @@ const loader: LoaderDefinitionFunction<IBaseLocLoaderOptions> = createLoader(
   (content: string, filePath: string, context: LoaderContext<IBaseLocLoaderOptions>) => {
     return parseResJson({
       content,
-      filePath
+      filePath,
+      ignoreString: context.getOptions().ignoreString
     });
   }
 );

--- a/webpack/webpack5-localization-plugin/src/loaders/resx-loader.ts
+++ b/webpack/webpack5-localization-plugin/src/loaders/resx-loader.ts
@@ -19,7 +19,8 @@ const loader: LoaderDefinitionFunction<IResxLocLoaderOptions> = createLoader(
       filePath,
       terminal,
       resxNewlineNormalization: options.resxNewlineNormalization,
-      ignoreMissingResxComments: !options.ignoreMissingResxComments
+      ignoreMissingResxComments: !options.ignoreMissingResxComments,
+      ignoreString: options.ignoreString
     });
   }
 );


### PR DESCRIPTION
## Summary
Modifies the localization toolchain to support emitting processed localization files into the JS output folders. These files are structured such that tools with default extension guessing will find them, and so that they match the schema that the generated typings claim they have.

## Details
Files will be emitted with the following extensions depending on input:
```
{
  '.loc.json': '.loc.json',
  '.resjson': '.resjson',
  '.resx': '.resx.json',
  '.resx.json': '.resx.json'
}
```

## How it was tested
Added unit tests for the `.loc.json` parser and enabled the `trimmedJsonOutputFolders` setting in a build test project.

## Impacted documentation
Plugin documentation for `heft-localization-typings-plugin`.