### PR TITLE
[load-themed-styles] Support using CSS variables instead

### DIFF
--- a/common/changes/@microsoft/load-themed-styles/load-styles-variables_2025-02-27-19-34.json
+++ b/common/changes/@microsoft/load-themed-styles/load-styles-variables_2025-02-27-19-34.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/load-themed-styles",
+      "comment": "Set css variables on `body` corresponding to all theme tokens in `loadTheme`. Add a new function `replaceTokensWithVariables` that will convert theme tokens in CSS to CSS variable references. Combined these allow callers to completely stop using `loadStyles` and export their CSS as external stylesheets.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/load-themed-styles"
+}

--- a/libraries/load-themed-styles/src/index.ts
+++ b/libraries/load-themed-styles/src/index.ts
@@ -251,8 +251,31 @@ function applyThemableStyles(stylesArray: ThemableArray, styleRecord?: IStyleRec
 export function loadTheme(theme: ITheme | undefined): void {
   _themeState.theme = theme;
 
+  try {
+    const { style } = document.body;
+    for (const key in theme) {
+      if (theme.hasOwnProperty(key)) {
+        style.setProperty(`--${key}`, theme[key]);
+      }
+    }
+  } catch (e) {
+    // Log but suppress error
+    console.error(e);
+  }
+
   // reload styles.
   reloadStyles();
+}
+
+/**
+ * Replaces theme tokens with CSS variable references.
+ * @param styles - Raw css text with theme tokens
+ * @returns A css string with theme tokens replaced with css variable references
+ */
+export function replaceTokensWithVariables(styles: string): string {
+  return styles.replace(_themeTokenRegex, (match: string, themeSlot: string, defaultValue: string) => {
+    return typeof defaultValue === 'string' ? `var(--${themeSlot}, ${defaultValue})` : `var(--${themeSlot})`;
+  });
 }
 
 /**


### PR DESCRIPTION
## Summary
Adds functionality to support converting code based on `load-themed-styles` to externalize their stylesheets instead of calling `loadStyles`.

## Details
Two pieces:
1. `loadTheme` will now define CSS variables on `document.body` corresponding to all keys in the theme.
2. Added a new function `replaceTokensWithVariables(cssText)` that can be applied at build time to convert CSS that contains theme tokens to CSS with variable references (with defaults, if provided) that will match the variables injected in `loadTheme`.

## How it was tested
Pending...

## Impacted documentation
Docs for the feature.