### PR TITLE
[rush] Fix bug including unnecessary operations

### DIFF
--- a/common/changes/@microsoft/rush/bugfix-include-deps_2025-02-28-22-54.json
+++ b/common/changes/@microsoft/rush/bugfix-include-deps_2025-02-28-22-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix a bug that included excess operations during watch mode builds in response to changes and when using `--include-phase-deps`.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/bugfix-include-deps_2025-02-28-22-54.json
+++ b/common/changes/@microsoft/rush/bugfix-include-deps_2025-02-28-22-54.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Fix a bug that included excess operations during watch mode builds in response to changes and when using `--include-phase-deps`.",
+      "comment": "Fix an issue where `--include-phase-deps` and watch mode sometimes included operations that were not required",
       "type": "none"
     }
   ],

--- a/libraries/rush-lib/src/logic/operations/test/PhasedOperationPlugin.test.ts
+++ b/libraries/rush-lib/src/logic/operations/test/PhasedOperationPlugin.test.ts
@@ -5,6 +5,7 @@ import path from 'path';
 import { JsonFile } from '@rushstack/node-core-library';
 
 import { RushConfiguration } from '../../../api/RushConfiguration';
+import type { RushConfigurationProject } from '../../../api/RushConfigurationProject';
 import {
   CommandLineConfiguration,
   type IPhase,
@@ -19,7 +20,6 @@ import {
   type ICreateOperationsContext,
   PhasedCommandHooks
 } from '../../../pluginFramework/PhasedCommandHooks';
-import type { RushConfigurationProject } from '../../..';
 
 interface ISerializedOperation {
   name: string;


### PR DESCRIPTION
## Summary
Fixes an issue where `--include-phase-deps` and watch mode rebuilds were both scheduling more operations than necessary.

## Details
The new calculation for what is in scope is:
1. Let `All` be the set of operations necessary to form a complete graph that contains the originally requested phases and originally selected projects, including their dependencies.
1. Let `ToExecute` be the set of operations that are in a project with changes and are one of the originally requested phases.
1. Additionally include in `ToExecute` all operations in `All` that depend on any operation in `ToExecute`
2. If `--include-phase-deps` is true and it is not a watch-mode rebuild, additionally include in `ToExecute` all operations that are dependencies of the operations in `ToExecute`.
3. Configure the `enabled` state of all operations in `All` based on their membership in `ToExecute`, with an additional filter for the explicit selection (if `--include-phase-deps` is not set), to facilitate unsafe selections.

## How it was tested
`rush test --include-phase-deps -o rush-lib -o rush` ran `_phase:build` in all dependencies, but only invoked `_phase:test` for `rush-lib` and `rush`.
`rush start --to heft-webpack5-everything-test`, then manually altering `webpack5-module-minifier-plugin` ran `_phase:build` and `_phase:test` in `webpack5-module-minifier-plugin` and `heft-webpack5-everything-test`, but no other operations.
 
## Impacted documentation
Makes the command do what it says it does, so none.