### PR TITLE
[rush] Make `associatedProject` and `associatedPhase` required

### DIFF
--- a/common/changes/@microsoft/rush/require-phase-project_2025-03-01-00-12.json
+++ b/common/changes/@microsoft/rush/require-phase-project_2025-03-01-00-12.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "(plugin-api) Guaranteed `operation.associatedPhase` and `operation.associatedProject` are not undefined.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -645,7 +645,7 @@ export interface IOperationRunnerContext {
     environment: IEnvironment | undefined;
     error?: Error;
     // @internal
-    _operationMetadataManager?: _OperationMetadataManager;
+    _operationMetadataManager: _OperationMetadataManager;
     quietMode: boolean;
     runWithTerminalAsync<T>(callback: (terminal: ITerminal, terminalProvider: ITerminalProvider) => Promise<T>, options: {
         createLogFile: boolean;

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -937,7 +937,7 @@ export class Operation {
     enabled: boolean;
     get isNoOp(): boolean;
     logFilenameIdentifier: string;
-    get name(): string | undefined;
+    get name(): string;
     runner: IOperationRunner | undefined;
     settings: IOperationSettings | undefined;
     weight: number;

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -615,17 +615,13 @@ export interface _IOperationMetadata {
 export interface _IOperationMetadataManagerOptions {
     // (undocumented)
     operation: Operation;
-    // (undocumented)
-    phase: IPhase;
-    // (undocumented)
-    rushProject: RushConfigurationProject;
 }
 
 // @alpha
 export interface IOperationOptions {
     logFilenameIdentifier: string;
-    phase?: IPhase | undefined;
-    project?: RushConfigurationProject | undefined;
+    phase: IPhase;
+    project: RushConfigurationProject;
     runner?: IOperationRunner | undefined;
     settings?: IOperationSettings | undefined;
 }
@@ -933,8 +929,8 @@ export class NpmOptionsConfiguration extends PackageManagerOptionsConfigurationB
 export class Operation {
     constructor(options: IOperationOptions);
     addDependency(dependency: Operation): void;
-    readonly associatedPhase: IPhase | undefined;
-    readonly associatedProject: RushConfigurationProject | undefined;
+    readonly associatedPhase: IPhase;
+    readonly associatedProject: RushConfigurationProject;
     readonly consumers: ReadonlySet<Operation>;
     deleteDependency(dependency: Operation): void;
     readonly dependencies: ReadonlySet<Operation>;

--- a/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
+++ b/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
@@ -759,11 +759,9 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
 
     function invalidateOperation(operation: Operation, reason: string): void {
       const { associatedProject } = operation;
-      if (associatedProject) {
-        // Since ProjectWatcher only tracks entire projects, widen the operation to its project
-        // Revisit when migrating to @rushstack/operation-graph and we have a long-lived operation graph
-        projectWatcher.invalidateProject(associatedProject, `${operation.name!} (${reason})`);
-      }
+      // Since ProjectWatcher only tracks entire projects, widen the operation to its project
+      // Revisit when migrating to @rushstack/operation-graph and we have a long-lived operation graph
+      projectWatcher.invalidateProject(associatedProject, `${operation.name!} (${reason})`);
     }
 
     // Loop until Ctrl+C

--- a/libraries/rush-lib/src/logic/buildCache/ProjectBuildCache.ts
+++ b/libraries/rush-lib/src/logic/buildCache/ProjectBuildCache.ts
@@ -102,18 +102,13 @@ export class ProjectBuildCache {
     operation: OperationExecutionRecord,
     options: IOperationBuildCacheOptions
   ): ProjectBuildCache {
-    if (!operation.associatedProject) {
-      throw new InternalError('Operation must have an associated project');
-    }
-    if (!operation.associatedPhase) {
-      throw new InternalError('Operation must have an associated phase');
-    }
     const outputFolders: string[] = [...(operation.operation.settings?.outputFolderNames ?? [])];
     if (operation.metadataFolderPath) {
       outputFolders.push(operation.metadataFolderPath);
     }
     const buildCacheOptions: IProjectBuildCacheOptions = {
-      ...options,
+      buildCacheConfiguration: options.buildCacheConfiguration,
+      terminal: options.terminal,
       project: operation.associatedProject,
       phaseName: operation.associatedPhase.name,
       projectOutputFolderNames: outputFolders,

--- a/libraries/rush-lib/src/logic/operations/BuildPlanPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/BuildPlanPlugin.ts
@@ -59,23 +59,22 @@ export class BuildPlanPlugin implements IPhasedCommandPlugin {
 
       for (const operation of operations) {
         const { associatedProject, associatedPhase } = operation;
-        if (associatedProject && associatedPhase) {
-          const projectConfiguration: RushProjectConfiguration | undefined =
-            projectConfigurations.get(associatedProject);
-          const fileHashes: ReadonlyMap<string, string> | undefined =
-            inputsSnapshot?.getTrackedFileHashesForOperation(associatedProject, associatedPhase.name);
-          if (!fileHashes) {
-            continue;
-          }
-          const cacheDisabledReason: string | undefined =
-            RushProjectConfiguration.getCacheDisabledReasonForProject({
-              projectConfiguration,
-              trackedFileNames: fileHashes.keys(),
-              isNoOp: operation.isNoOp,
-              phaseName: associatedPhase.name
-            });
-          buildCacheByOperation.set(operation, { cacheDisabledReason });
+
+        const projectConfiguration: RushProjectConfiguration | undefined =
+          projectConfigurations.get(associatedProject);
+        const fileHashes: ReadonlyMap<string, string> | undefined =
+          inputsSnapshot?.getTrackedFileHashesForOperation(associatedProject, associatedPhase.name);
+        if (!fileHashes) {
+          continue;
         }
+        const cacheDisabledReason: string | undefined =
+          RushProjectConfiguration.getCacheDisabledReasonForProject({
+            projectConfiguration,
+            trackedFileNames: fileHashes.keys(),
+            isNoOp: operation.isNoOp,
+            phaseName: associatedPhase.name
+          });
+        buildCacheByOperation.set(operation, { cacheDisabledReason });
       }
       clusterOperations(disjointSet, buildCacheByOperation);
       const buildPlan: ICobuildPlan = createCobuildPlan(disjointSet, terminal, buildCacheByOperation);
@@ -323,7 +322,7 @@ function logCobuildBuildPlan(buildPlan: ICobuildPlan, terminal: ITerminal): void
     const dedupedOperations: Set<string> = new Set<string>();
     for (const operation of ops) {
       dedupedOperations.add(
-        `${operation.associatedProject?.packageName ?? ''} (${operation.associatedPhase?.name})`
+        `${operation.associatedProject.packageName ?? ''} (${operation.associatedPhase.name})`
       );
     }
     return [...dedupedOperations];

--- a/libraries/rush-lib/src/logic/operations/BuildPlanPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/BuildPlanPlugin.ts
@@ -211,8 +211,8 @@ function generateCobuildPlanSummary(operations: Operation[], terminal: ITerminal
       `Plan @ Depth ${operationDepth} has ${numberOfNodes[operationDepth]} nodes and ${numberOfDependents} dependents:`
     );
     for (const operation of operationsAtDepth) {
-      if (!operation.runner?.isNoOp) {
-        terminal.writeLine(`- ${operation.runner?.name ?? 'unknown'}`);
+      if (operation.isNoOp !== true) {
+        terminal.writeLine(`- ${operation.name}`);
       }
     }
   }
@@ -225,7 +225,7 @@ function generateCobuildPlanSummary(operations: Operation[], terminal: ITerminal
 }
 
 function getName(op: Operation): string {
-  return op.runner?.name ?? 'unknown';
+  return op.name;
 }
 
 /**
@@ -321,9 +321,7 @@ function logCobuildBuildPlan(buildPlan: ICobuildPlan, terminal: ITerminal): void
   function dedupeShards(ops: Set<Operation>): string[] {
     const dedupedOperations: Set<string> = new Set<string>();
     for (const operation of ops) {
-      dedupedOperations.add(
-        `${operation.associatedProject.packageName ?? ''} (${operation.associatedPhase.name})`
-      );
+      dedupedOperations.add(`${operation.associatedProject.packageName} (${operation.associatedPhase.name})`);
     }
     return [...dedupedOperations];
   }
@@ -342,15 +340,12 @@ function logCobuildBuildPlan(buildPlan: ICobuildPlan, terminal: ITerminal): void
       terminal.writeLine(
         `- Clustered by: \n${[...allClusterDependencies]
           .filter((e) => buildCacheByOperation.get(e)?.cacheDisabledReason)
-          .map((e) => `  - (${e.runner?.name}) "${buildCacheByOperation.get(e)?.cacheDisabledReason ?? ''}"`)
+          .map((e) => `  - (${e.name}) "${buildCacheByOperation.get(e)?.cacheDisabledReason ?? ''}"`)
           .join('\n')}`
       );
     }
     terminal.writeLine(
-      `- Operations: ${Array.from(
-        cluster,
-        (e) => `${getName(e)}${e.runner?.isNoOp ? ' [SKIPPED]' : ''}`
-      ).join(', ')}`
+      `- Operations: ${Array.from(cluster, (e) => `${getName(e)}${e.isNoOp ? ' [SKIPPED]' : ''}`).join(', ')}`
     );
     terminal.writeLine('--------------------------------------------------');
   }

--- a/libraries/rush-lib/src/logic/operations/ConsoleTimelinePlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/ConsoleTimelinePlugin.ts
@@ -181,9 +181,7 @@ export function _printTimeline({ terminal, result, cobuildConfiguration }: IPrin
 
       const { associatedPhase } = operation;
 
-      if (associatedPhase) {
-        durationByPhase.set(associatedPhase, (durationByPhase.get(associatedPhase) || 0) + duration);
-      }
+      durationByPhase.set(associatedPhase, (durationByPhase.get(associatedPhase) || 0) + duration);
 
       data.push({
         startTime,

--- a/libraries/rush-lib/src/logic/operations/ConsoleTimelinePlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/ConsoleTimelinePlugin.ts
@@ -187,7 +187,7 @@ export function _printTimeline({ terminal, result, cobuildConfiguration }: IPrin
         startTime,
         endTime,
         durationString,
-        name: operation.name!,
+        name: operation.name,
         status: operationResult.status,
         isExecuteByOtherCobuildRunner:
           !!operationResult.cobuildRunnerId &&

--- a/libraries/rush-lib/src/logic/operations/IOperationRunner.ts
+++ b/libraries/rush-lib/src/logic/operations/IOperationRunner.ts
@@ -32,7 +32,7 @@ export interface IOperationRunnerContext {
    *
    * @internal
    */
-  _operationMetadataManager?: OperationMetadataManager;
+  _operationMetadataManager: OperationMetadataManager;
   /**
    * Object used to track elapsed time.
    */

--- a/libraries/rush-lib/src/logic/operations/IPCOperationRunnerPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/IPCOperationRunnerPlugin.ts
@@ -51,7 +51,7 @@ export class IPCOperationRunnerPlugin implements IPhasedCommandPlugin {
         for (const operation of operations) {
           const { associatedPhase: phase, associatedProject: project, runner } = operation;
 
-          if (runner || !phase || !project) {
+          if (runner) {
             continue;
           }
 

--- a/libraries/rush-lib/src/logic/operations/LegacySkipPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/LegacySkipPlugin.ts
@@ -77,8 +77,8 @@ export class LegacySkipPlugin implements IPhasedCommandPlugin {
 
         for (const record of operations.values()) {
           const { operation } = record;
-          const { associatedProject, runner, logFilenameIdentifier } = operation;
-          if (!associatedProject || !runner) {
+          const { associatedProject, associatedPhase, runner, logFilenameIdentifier } = operation;
+          if (!runner) {
             continue;
           }
 
@@ -102,10 +102,7 @@ export class LegacySkipPlugin implements IPhasedCommandPlugin {
 
           try {
             const fileHashes: ReadonlyMap<string, string> | undefined =
-              inputsSnapshot?.getTrackedFileHashesForOperation(
-                associatedProject,
-                operation.associatedPhase?.name
-              );
+              inputsSnapshot?.getTrackedFileHashesForOperation(associatedProject, associatedPhase.name);
 
             if (!fileHashes) {
               logGitWarning = true;
@@ -205,7 +202,7 @@ export class LegacySkipPlugin implements IPhasedCommandPlugin {
         }
 
         // TODO: Remove legacyDepsPath with the next major release of Rush
-        const legacyDepsPath: string = path.join(associatedProject!.projectFolder, 'package-deps.json');
+        const legacyDepsPath: string = path.join(associatedProject.projectFolder, 'package-deps.json');
 
         await Promise.all([
           // Delete the legacy package-deps.json

--- a/libraries/rush-lib/src/logic/operations/NodeDiagnosticDirPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/NodeDiagnosticDirPlugin.ts
@@ -30,10 +30,6 @@ export class NodeDiagnosticDirPlugin implements IPhasedCommandPlugin {
     const getDiagnosticDir = (operation: Operation): string | undefined => {
       const { associatedProject } = operation;
 
-      if (!associatedProject) {
-        return;
-      }
-
       const diagnosticDir: string = path.resolve(
         this._diagnosticsDir,
         associatedProject.packageName,

--- a/libraries/rush-lib/src/logic/operations/Operation.ts
+++ b/libraries/rush-lib/src/logic/operations/Operation.ts
@@ -120,15 +120,23 @@ export class Operation {
   /**
    * The name of this operation, for logging.
    */
-  public get name(): string | undefined {
-    return this.runner?.name;
+  public get name(): string {
+    const { runner } = this;
+    if (!runner) {
+      throw new Error(`Cannot get name of an Operation that does not yet have a runner.`);
+    }
+    return runner.name;
   }
 
   /**
    * If set to true, this operation is considered a no-op and can be considered always skipped for analysis purposes.
    */
   public get isNoOp(): boolean {
-    return !!this.runner?.isNoOp;
+    const { runner } = this;
+    if (!runner) {
+      throw new Error(`Cannot get isNoOp of an Operation that does not yet have a runner.`);
+    }
+    return !!runner.isNoOp;
   }
 
   /**

--- a/libraries/rush-lib/src/logic/operations/Operation.ts
+++ b/libraries/rush-lib/src/logic/operations/Operation.ts
@@ -12,14 +12,14 @@ import type { IOperationSettings } from '../../api/RushProjectConfiguration';
  */
 export interface IOperationOptions {
   /**
-   * The Rush phase associated with this Operation, if any
+   * The Rush phase associated with this Operation
    */
-  phase?: IPhase | undefined;
+  phase: IPhase;
 
   /**
-   * The Rush project associated with this Operation, if any
+   * The Rush project associated with this Operation
    */
-  project?: RushConfigurationProject | undefined;
+  project: RushConfigurationProject;
 
   /**
    * When the scheduler is ready to process this `Operation`, the `runner` implements the actual work of
@@ -51,12 +51,12 @@ export class Operation {
   /**
    * The Rush phase associated with this Operation, if any
    */
-  public readonly associatedPhase: IPhase | undefined;
+  public readonly associatedPhase: IPhase;
 
   /**
    * The Rush project associated with this Operation, if any
    */
-  public readonly associatedProject: RushConfigurationProject | undefined;
+  public readonly associatedProject: RushConfigurationProject;
 
   /**
    * A set of all operations which depend on this operation.

--- a/libraries/rush-lib/src/logic/operations/Operation.ts
+++ b/libraries/rush-lib/src/logic/operations/Operation.ts
@@ -49,12 +49,12 @@ export interface IOperationOptions {
  */
 export class Operation {
   /**
-   * The Rush phase associated with this Operation, if any
+   * The Rush phase associated with this Operation
    */
   public readonly associatedPhase: IPhase;
 
   /**
-   * The Rush project associated with this Operation, if any
+   * The Rush project associated with this Operation
    */
   public readonly associatedProject: RushConfigurationProject;
 

--- a/libraries/rush-lib/src/logic/operations/OperationMetadataManager.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationMetadataManager.ts
@@ -14,8 +14,6 @@ import {
 import { OperationStateFile } from './OperationStateFile';
 import { RushConstants } from '../RushConstants';
 
-import type { IPhase } from '../../api/CommandLineConfiguration';
-import type { RushConfigurationProject } from '../../api/RushConfigurationProject';
 import type { IOperationStateJson } from './OperationStateFile';
 import type { Operation } from './Operation';
 
@@ -23,8 +21,6 @@ import type { Operation } from './Operation';
  * @internal
  */
 export interface IOperationMetadataManagerOptions {
-  rushProject: RushConfigurationProject;
-  phase: IPhase;
   operation: Operation;
 }
 
@@ -59,10 +55,9 @@ export class OperationMetadataManager {
 
   public constructor(options: IOperationMetadataManagerOptions) {
     const {
-      rushProject,
-      operation: { logFilenameIdentifier }
+      operation: { logFilenameIdentifier, associatedProject }
     } = options;
-    const { projectFolder } = rushProject;
+    const { projectFolder } = associatedProject;
 
     this.logFilenameIdentifier = logFilenameIdentifier;
 

--- a/libraries/rush-lib/src/logic/operations/OperationResultSummarizerPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationResultSummarizerPlugin.ts
@@ -172,7 +172,7 @@ function writeCondensedSummary(
 
   let longestTaskName: number = 0;
   for (const [operation] of operations) {
-    const nameLength: number = (operation.name || '').length;
+    const nameLength: number = operation.name.length;
     if (nameLength > longestTaskName) {
       longestTaskName = nameLength;
     }
@@ -185,7 +185,7 @@ function writeCondensedSummary(
       operationResult.status !== OperationStatus.Skipped
     ) {
       const time: string = operationResult.stopwatch.toString();
-      const padding: string = ' '.repeat(longestTaskName - (operation.name || '').length);
+      const padding: string = ' '.repeat(longestTaskName - operation.name.length);
       terminal.writeLine(`  ${operation.name}${padding}    ${time}`);
     } else {
       terminal.writeLine(`  ${operation.name}`);

--- a/libraries/rush-lib/src/logic/operations/PnpmSyncCopyOperationPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/PnpmSyncCopyOperationPlugin.ts
@@ -38,22 +38,20 @@ export class PnpmSyncCopyOperationPlugin implements IPhasedCommandPlugin {
           return;
         }
 
-        if (project) {
-          const pnpmSyncJsonPath: string = `${project.projectFolder}/node_modules/.pnpm-sync.json`;
-          if (await FileSystem.exists(pnpmSyncJsonPath)) {
-            const { PackageExtractor } = await import(
-              /* webpackChunkName: 'PackageExtractor' */
-              '@rushstack/package-extractor'
-            );
-            await pnpmSyncCopyAsync({
-              pnpmSyncJsonPath,
-              ensureFolderAsync: FileSystem.ensureFolderAsync,
-              forEachAsyncWithConcurrency: Async.forEachAsync,
-              getPackageIncludedFiles: PackageExtractor.getPackageIncludedFilesAsync,
-              logMessageCallback: (logMessageOptions: ILogMessageCallbackOptions) =>
-                PnpmSyncUtilities.processLogMessage(logMessageOptions, this._terminal)
-            });
-          }
+        const pnpmSyncJsonPath: string = `${project.projectFolder}/node_modules/.pnpm-sync.json`;
+        if (await FileSystem.exists(pnpmSyncJsonPath)) {
+          const { PackageExtractor } = await import(
+            /* webpackChunkName: 'PackageExtractor' */
+            '@rushstack/package-extractor'
+          );
+          await pnpmSyncCopyAsync({
+            pnpmSyncJsonPath,
+            ensureFolderAsync: FileSystem.ensureFolderAsync,
+            forEachAsyncWithConcurrency: Async.forEachAsync,
+            getPackageIncludedFiles: PackageExtractor.getPackageIncludedFilesAsync,
+            logMessageCallback: (logMessageOptions: ILogMessageCallbackOptions) =>
+              PnpmSyncUtilities.processLogMessage(logMessageOptions, this._terminal)
+          });
         }
       }
     );

--- a/libraries/rush-lib/src/logic/operations/ShardedPhaseOperationPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/ShardedPhaseOperationPlugin.ts
@@ -56,7 +56,7 @@ function spliceShards(existingOperations: Set<Operation>, context: ICreateOperat
       settings: operationSettings,
       logFilenameIdentifier: baseLogFilenameIdentifier
     } = operation;
-    if (phase && project && operationSettings?.sharding && !operation.runner) {
+    if (operationSettings?.sharding && !operation.runner) {
       const { count: shards } = operationSettings.sharding;
 
       /**

--- a/libraries/rush-lib/src/logic/operations/ShellOperationRunner.ts
+++ b/libraries/rush-lib/src/logic/operations/ShellOperationRunner.ts
@@ -23,7 +23,7 @@ export interface IShellOperationRunnerOptions {
 }
 
 /**
- * An `IOperationRunner` subclass that performs an operation via a shell command.
+ * An `IOperationRunner` implementation that performs an operation via a shell command.
  * Currently contains the build cache logic, pending extraction as separate operations.
  * Supports skipping an operation if allowed and it is already up-to-date.
  */
@@ -35,6 +35,10 @@ export class ShellOperationRunner implements IOperationRunner {
   public readonly cacheable: boolean = true;
   public readonly warningsAreAllowed: boolean;
   public readonly commandToRun: string;
+  /**
+   * The creator is expected to use a different runner if the command is known to be a noop.
+   */
+  public readonly isNoOp: boolean = false;
 
   private readonly _commandForHash: string;
 

--- a/libraries/rush-lib/src/logic/operations/ShellOperationRunnerPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/ShellOperationRunnerPlugin.ts
@@ -36,7 +36,7 @@ export class ShellOperationRunnerPlugin implements IPhasedCommandPlugin {
         for (const operation of operations) {
           const { associatedPhase: phase, associatedProject: project } = operation;
 
-          if (phase && project && !operation.runner) {
+          if (!operation.runner) {
             // This is a shell command. In the future, may consider having a property on the initial operation
             // to specify a runner type requested in rush-project.json
             const customParameterValues: ReadonlyArray<string> = getCustomParameterValuesForPhase(phase);

--- a/libraries/rush-lib/src/logic/operations/ValidateOperationsPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/ValidateOperationsPlugin.ts
@@ -36,7 +36,7 @@ export class ValidateOperationsPlugin implements IPhasedCommandPlugin {
   ): void {
     const phasesByProject: Map<RushConfigurationProject, Set<IPhase>> = new Map();
     for (const { associatedPhase, associatedProject, runner } of records.keys()) {
-      if (associatedProject && associatedPhase && !runner?.isNoOp) {
+      if (!runner?.isNoOp) {
         // Ignore operations that aren't associated with a project or phase, or that
         // use the NullOperationRunner (i.e. - the phase doesn't do anything)
         let projectPhases: Set<IPhase> | undefined = phasesByProject.get(associatedProject);

--- a/libraries/rush-lib/src/logic/operations/WeightedOperationPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/WeightedOperationPlugin.ts
@@ -36,7 +36,7 @@ function weightOperations(
     const { associatedProject: project, associatedPhase: phase } = operation;
     if (runner!.isNoOp) {
       operation.weight = 0;
-    } else if (project && phase) {
+    } else {
       const projectConfiguration: RushProjectConfiguration | undefined = projectConfigurations.get(project);
       const operationSettings: IOperationSettings | undefined =
         operation.settings ?? projectConfiguration?.operationSettingsByOperationName.get(phase.name);

--- a/libraries/rush-lib/src/logic/operations/test/BuildPlanPlugin.test.ts
+++ b/libraries/rush-lib/src/logic/operations/test/BuildPlanPlugin.test.ts
@@ -54,7 +54,7 @@ describe(BuildPlanPlugin.name, () => {
     for (const operation of operations) {
       const { associatedPhase, associatedProject } = operation;
 
-      if (associatedPhase && associatedProject && !operation.runner) {
+      if (!operation.runner) {
         const name: string = `${associatedProject.packageName} (${associatedPhase.name.slice(
           RushConstants.phaseNamePrefix.length
         )})`;

--- a/libraries/rush-lib/src/logic/operations/test/OperationExecutionManager.test.ts
+++ b/libraries/rush-lib/src/logic/operations/test/OperationExecutionManager.test.ts
@@ -19,6 +19,8 @@ import { Terminal } from '@rushstack/terminal';
 import { CollatedTerminal } from '@rushstack/stream-collator';
 import { MockWritable, PrintUtilities } from '@rushstack/terminal';
 
+import type { IPhase } from '../../../api/CommandLineConfiguration';
+import type { RushConfigurationProject } from '../../../api/RushConfigurationProject';
 import {
   OperationExecutionManager,
   type IOperationExecutionManagerOptions
@@ -45,13 +47,39 @@ mockGetTimeInMs.mockImplementation(() => {
 const mockWritable: MockWritable = new MockWritable();
 const mockTerminal: Terminal = new Terminal(new CollatedTerminalProvider(new CollatedTerminal(mockWritable)));
 
+const mockPhase: IPhase = {
+  name: 'phase',
+  allowWarningsOnSuccess: false,
+  associatedParameters: new Set(),
+  dependencies: {
+    self: new Set(),
+    upstream: new Set()
+  },
+  isSynthetic: false,
+  logFilenameIdentifier: 'phase',
+  missingScriptBehavior: 'silent'
+};
+const projectsByName: Map<string, RushConfigurationProject> = new Map();
+function getOrCreateProject(name: string): RushConfigurationProject {
+  let project: RushConfigurationProject | undefined = projectsByName.get(name);
+  if (!project) {
+    project = {
+      packageName: name
+    } as unknown as RushConfigurationProject;
+    projectsByName.set(name, project);
+  }
+  return project;
+}
+
 function createExecutionManager(
   executionManagerOptions: IOperationExecutionManagerOptions,
   operationRunner: IOperationRunner
 ): OperationExecutionManager {
   const operation: Operation = new Operation({
     runner: operationRunner,
-    logFilenameIdentifier: 'operation'
+    logFilenameIdentifier: 'operation',
+    phase: mockPhase,
+    project: getOrCreateProject('project')
   });
 
   return new OperationExecutionManager(new Set([operation]), executionManagerOptions);
@@ -129,6 +157,8 @@ describe(OperationExecutionManager.name, () => {
         runner: new MockOperationRunner('fail', async () => {
           return OperationStatus.Failure;
         }),
+        phase: mockPhase,
+        project: getOrCreateProject('fail'),
         logFilenameIdentifier: 'fail'
       });
 
@@ -136,6 +166,8 @@ describe(OperationExecutionManager.name, () => {
 
       const blockedOperation = new Operation({
         runner: new MockOperationRunner('blocked', blockedRunFn),
+        phase: mockPhase,
+        project: getOrCreateProject('blocked'),
         logFilenameIdentifier: 'blocked'
       });
 

--- a/libraries/rush-lib/src/logic/operations/test/OperationMetadataManager.test.ts
+++ b/libraries/rush-lib/src/logic/operations/test/OperationMetadataManager.test.ts
@@ -19,16 +19,16 @@ const mockWritable: MockWritable = new MockWritable();
 const mockTerminal: Terminal = new Terminal(new CollatedTerminalProvider(new CollatedTerminal(mockWritable)));
 
 const operation = new Operation({
-  logFilenameIdentifier: 'identifier'
-});
-
-const manager: OperationMetadataManager = new OperationMetadataManager({
-  rushProject: {
+  logFilenameIdentifier: 'identifier',
+  project: {
     projectFolder: '/path/to/project'
   } as unknown as RushConfigurationProject,
   phase: {
     logFilenameIdentifier: 'identifier'
-  } as unknown as IPhase,
+  } as unknown as IPhase
+});
+
+const manager: OperationMetadataManager = new OperationMetadataManager({
   operation
 });
 

--- a/libraries/rush-lib/src/logic/operations/test/PhasedOperationPlugin.test.ts
+++ b/libraries/rush-lib/src/logic/operations/test/PhasedOperationPlugin.test.ts
@@ -46,7 +46,7 @@ describe(PhasedOperationPlugin.name, () => {
     for (const operation of operations) {
       const { associatedPhase, associatedProject } = operation;
 
-      if (associatedPhase && associatedProject && !operation.runner) {
+      if (!operation.runner) {
         const name: string = `${associatedProject.packageName} (${associatedPhase.name.slice(
           RushConstants.phaseNamePrefix.length
         )})`;

--- a/libraries/rush-lib/src/logic/operations/test/PhasedOperationPlugin.test.ts
+++ b/libraries/rush-lib/src/logic/operations/test/PhasedOperationPlugin.test.ts
@@ -29,9 +29,9 @@ interface ISerializedOperation {
 
 function serializeOperation(operation: Operation): ISerializedOperation {
   return {
-    name: operation.name!,
+    name: operation.name,
     silent: !operation.enabled || operation.runner!.silent,
-    dependencies: Array.from(operation.dependencies, (dep: Operation) => dep.name!)
+    dependencies: Array.from(operation.dependencies, (dep: Operation) => dep.name)
   };
 }
 

--- a/libraries/rush-lib/src/logic/operations/test/ShellOperationRunnerPlugin.test.ts
+++ b/libraries/rush-lib/src/logic/operations/test/ShellOperationRunnerPlugin.test.ts
@@ -22,7 +22,7 @@ interface ISerializedOperation {
 
 function serializeOperation(operation: Operation): ISerializedOperation {
   return {
-    name: operation.name!,
+    name: operation.name,
     commandToRun: operation.runner!.getConfigHash()
   };
 }

--- a/libraries/rush-lib/src/logic/operations/test/__snapshots__/OperationExecutionManager.test.ts.snap
+++ b/libraries/rush-lib/src/logic/operations/test/__snapshots__/OperationExecutionManager.test.ts.snap
@@ -438,6 +438,16 @@ Array [
   },
   Object {
     "kind": "O",
+    "text": "BY PHASE:
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "  [cyan]           phase[default] 0.2s
+",
+  },
+  Object {
+    "kind": "O",
     "text": "
 ",
   },

--- a/rush-plugins/rush-buildxl-graph-plugin/src/GraphProcessor.ts
+++ b/rush-plugins/rush-buildxl-graph-plugin/src/GraphProcessor.ts
@@ -94,9 +94,11 @@ const REQUIRED_FIELDS: Array<keyof IGraphNodeInternal> = [
 /*
  * Try to get the operation id, return undefined if it fails
  */
-export function tryGetOperationId(operation: Partial<Operation>): string | undefined {
-  const task: string | undefined = operation.associatedPhase?.name;
-  const project: string | undefined = operation.associatedProject?.packageName;
+export function tryGetOperationId(
+  operation: Pick<Operation, 'associatedPhase' | 'associatedProject'>
+): string | undefined {
+  const task: string | undefined = operation.associatedPhase.name;
+  const project: string | undefined = operation.associatedProject.packageName;
   return task && project ? `${project}#${task}` : undefined;
 }
 

--- a/rush-plugins/rush-buildxl-graph-plugin/src/debugGraphFiltering.ts
+++ b/rush-plugins/rush-buildxl-graph-plugin/src/debugGraphFiltering.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import { tryGetOperationId } from './GraphProcessor';
+import { getOperationId } from './GraphProcessor';
 
 const BANNED_KEYS: ReadonlySet<string> = new Set([
   'packageJsonEditor',
@@ -53,7 +53,7 @@ export function filterObjectForDebug(obj: object, depth: number = 10, simplify: 
       }
 
       if (simplify) {
-        const operationId: string | undefined = tryGetOperationId(value);
+        const operationId: string | undefined = getOperationId(value);
         if (operationId) {
           output[key] = operationId;
           continue;

--- a/rush-plugins/rush-buildxl-graph-plugin/src/test/GraphProcessor.test.ts
+++ b/rush-plugins/rush-buildxl-graph-plugin/src/test/GraphProcessor.test.ts
@@ -1,8 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import type { IOperationRunner, Operation } from '@rushstack/rush-sdk';
-import type { ShellOperationRunner } from '@rushstack/rush-sdk/lib/logic/operations/ShellOperationRunner';
+import { type IOperationRunner, Operation } from '@rushstack/rush-sdk';
 import { Terminal, NoOpTerminalProvider } from '@rushstack/terminal';
 
 import { GraphProcessor, type IGraphNode } from '../GraphProcessor';
@@ -14,6 +13,16 @@ import debugGraph from '../examples/debug-graph.json';
 
 function sortGraphNodes(graphNodes: IGraphNode[]): IGraphNode[] {
   return graphNodes.sort((a, b) => (a.id === b.id ? 0 : a.id < b.id ? -1 : 1));
+}
+
+function getDebugOperationMap(): Operation[] {
+  const cloned: typeof debugGraph.OperationMap = JSON.parse(JSON.stringify(debugGraph.OperationMap));
+
+  return cloned.map((op) => {
+    // Operation has getters
+    Object.setPrototypeOf(op, Operation.prototype);
+    return op as unknown as Operation;
+  });
 }
 
 describe(GraphProcessor.name, () => {
@@ -39,9 +48,7 @@ describe(GraphProcessor.name, () => {
   });
 
   it('should process debug-graph.json into graph.json', () => {
-    let prunedGraph: IGraphNode[] = graphParser.processOperations(
-      new Set<Operation>(debugGraph.OperationMap as unknown as Operation[])
-    );
+    let prunedGraph: IGraphNode[] = graphParser.processOperations(new Set<Operation>(getDebugOperationMap()));
 
     prunedGraph = sortGraphNodes(prunedGraph);
     expect(prunedGraph).toEqual(exampleGraph);
@@ -50,7 +57,7 @@ describe(GraphProcessor.name, () => {
   });
 
   it('should fail if the input schema is invalid', () => {
-    const clonedOperationMap: Operation[] = JSON.parse(JSON.stringify(debugGraph.OperationMap));
+    const clonedOperationMap: Operation[] = getDebugOperationMap();
     (clonedOperationMap[0].dependencies as unknown as Operation[]).push({
       incorrectPhase: { name: 'incorrectPhase' },
       incorrectProject: { packageName: 'incorrectProject' }
@@ -62,10 +69,13 @@ describe(GraphProcessor.name, () => {
   });
 
   it('should fail if isNoOp mismatches a command', () => {
-    const clonedOperationMap: Operation[] = JSON.parse(JSON.stringify(debugGraph.OperationMap));
-    (clonedOperationMap[0].runner as IOperationRunner & { isNoOp: boolean }).isNoOp = true;
-    (clonedOperationMap[0].runner as ShellOperationRunner & { commandToRun: string }).commandToRun =
-      'echo "hello world"';
+    const clonedOperationMap: Operation[] = getDebugOperationMap();
+    const runner: IOperationRunner | undefined = clonedOperationMap[0].runner;
+    if (!runner) {
+      throw new Error('runner is undefined');
+    }
+    (runner as IOperationRunner & { isNoOp: boolean }).isNoOp = true;
+    (runner as IOperationRunner & { commandToRun?: string }).commandToRun = 'echo "hello world"';
     const operations: Set<Operation> = new Set(clonedOperationMap);
     graphParser.processOperations(operations);
     expect(emittedErrors).not.toEqual([]);

--- a/rush-plugins/rush-buildxl-graph-plugin/src/test/__snapshots__/GraphProcessor.test.ts.snap
+++ b/rush-plugins/rush-buildxl-graph-plugin/src/test/__snapshots__/GraphProcessor.test.ts.snap
@@ -1,15 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`GraphProcessor should fail if the input schema is invalid 1`] = `
-"Operation does not have a name: {
-  \\"incorrectPhase\\": {
-    \\"name\\": \\"incorrectPhase\\"
-  },
-  \\"incorrectProject\\": {
-    \\"packageName\\": \\"incorrectProject\\"
-  }
-}"
-`;
+exports[`GraphProcessor should fail if the input schema is invalid 1`] = `"Cannot read properties of undefined (reading 'name')"`;
 
 exports[`GraphProcessor validateGraph should fail to validate when command is empty 1`] = `
 Array [

--- a/rush-plugins/rush-serve-plugin/src/phasedCommandHandler.ts
+++ b/rush-plugins/rush-serve-plugin/src/phasedCommandHandler.ts
@@ -325,7 +325,7 @@ function tryEnableBuildStatusWebSocketServer(
     const { operation } = record;
     const { name, associatedPhase, associatedProject, runner, enabled } = operation;
 
-    if (!name || !associatedPhase || !associatedProject || !runner) {
+    if (!name || !runner) {
       return;
     }
 


### PR DESCRIPTION
## Summary
Removes a legacy behavior where the `associatedProject` and `associatedPhase` properties on `Operation` were allowed to be undefined.

## Details
Any plugins that instantiate `Operation` instances are now required to provide `project` and `phase`. In exchange, plugins that read these values can now expect them not to be `undefined`.

## How it was tested
Local invocation. This PR's build policy, which runs multiple plugins that interact with the operation graph.

## Impacted documentation
The API docs for `Operation`, `IOperationRunnerContext`.