### PR TITLE
[heft] Add `heftConfiguration.wellKnownConfigurationFiles` API

### DIFF
--- a/apps/heft/src/configuration/wellKnown/JavaScriptEmitKinds.ts
+++ b/apps/heft/src/configuration/wellKnown/JavaScriptEmitKinds.ts
@@ -1,0 +1,93 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import {
+  InheritanceType,
+  PathResolutionMethod,
+  type IConfigurationFileOptions,
+  type IProjectConfigurationFileOptions
+} from '@rushstack/heft-config-file';
+import type { ITerminal } from '@rushstack/terminal';
+
+import javascriptEmitKindsSchema from '../../schemas/javascript-emit-kinds.schema.json';
+
+/**
+ * The JavaScript module kind to emit.
+ * @public
+ */
+export type JavaScriptModuleKind = 'amd' | 'commonjs' | 'es2015' | 'esnext' | 'system' | 'umd';
+/**
+ * The script target to emit.
+ * @public
+ */
+export type JavaScriptTarget =
+  | 'es3'
+  | 'es5'
+  | 'es6'
+  | 'es2015'
+  | 'es2016'
+  | 'es2017'
+  | 'es2018'
+  | 'es2019'
+  | 'es2020'
+  | 'es2021'
+  | 'es2022'
+  | 'esnext';
+
+/**
+ * Description of an emit kind.
+ * Plugins that emit multiple kinds should use this interface to describe the kinds they emit.
+ * @public
+ */
+export interface IJavaScriptEmitKind {
+  outputFolder: string;
+  moduleKind: JavaScriptModuleKind;
+  target: JavaScriptTarget;
+}
+
+/**
+ * Options for the JsEmitKindsPlugin.
+ * @public
+ */
+export interface IJavaScriptEmitKindsConfigurationJson {
+  emitKinds: IJavaScriptEmitKind[];
+}
+
+export const JavaScriptEmitKinds: IConfigurationFileOptions<
+  IJavaScriptEmitKindsConfigurationJson,
+  IProjectConfigurationFileOptions
+> = {
+  projectRelativeFilePath: 'config/javascript-emit-kinds.json',
+  jsonSchemaObject: javascriptEmitKindsSchema,
+  propertyInheritance: {
+    emitKinds: {
+      inheritanceType: InheritanceType.append
+    }
+  },
+  jsonPathMetadata: {
+    'emitKinds.*.outputFolder': {
+      pathResolutionMethod: PathResolutionMethod.resolvePathRelativeToProjectRoot
+    }
+  },
+  customValidationFunction: (
+    jsonObject: IJavaScriptEmitKindsConfigurationJson,
+    resolvedConfigurationFilePathForLogging: string,
+    terminal: ITerminal
+  ): boolean => {
+    let valid: boolean = true;
+    const emitKindByOutputFolder: Map<string, IJavaScriptEmitKind> = new Map();
+    for (const emitKind of jsonObject.emitKinds) {
+      const existingEmitKind: IJavaScriptEmitKind | undefined = emitKindByOutputFolder.get(
+        emitKind.outputFolder
+      );
+      if (existingEmitKind) {
+        valid = false;
+        terminal.writeError(
+          `Output folder "${emitKindByOutputFolder}" in "${resolvedConfigurationFilePathForLogging}" is specified multiple times.`
+        );
+      }
+      emitKindByOutputFolder.set(emitKind.outputFolder, emitKind);
+    }
+    return valid;
+  }
+};

--- a/apps/heft/src/configuration/wellKnown/index.ts
+++ b/apps/heft/src/configuration/wellKnown/index.ts
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+export { JavaScriptEmitKinds } from './JavaScriptEmitKinds';

--- a/apps/heft/src/index.ts
+++ b/apps/heft/src/index.ts
@@ -11,10 +11,22 @@
  * @packageDocumentation
  */
 
+export type {
+  ProjectConfigurationFile,
+  IProjectConfigurationFileSpecification
+} from '@rushstack/heft-config-file';
+
 export {
   HeftConfiguration,
   type IHeftConfigurationInitializationOptions as _IHeftConfigurationInitializationOptions
 } from './configuration/HeftConfiguration';
+
+export type {
+  IJavaScriptEmitKind,
+  IJavaScriptEmitKindsConfigurationJson,
+  JavaScriptModuleKind,
+  JavaScriptTarget
+} from './configuration/wellKnown/JavaScriptEmitKinds';
 
 export type { IRigPackageResolver } from './configuration/RigPackageResolver';
 

--- a/apps/heft/src/schemas/javascript-emit-kinds.schema.json
+++ b/apps/heft/src/schemas/javascript-emit-kinds.schema.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "JavaScript Emit Kinds Configuration",
+  "description": "Defines a configuration for emitting multiple formats of ECMAScript to separate folders.",
+  "type": "object",
+
+  "additionalProperties": false,
+  "required": ["emitKinds"],
+
+  "properties": {
+    "$schema": {
+      "description": "Part of the JSON Schema standard, this optional keyword declares the URL of the schema that the file conforms to. Editors may download the schema and use it to perform syntax highlighting.",
+      "type": "string"
+    },
+
+    "extends": {
+      "description": "Optionally specifies another JSON config file that this file extends from.  This provides a way for standard settings to be shared across multiple projects.",
+      "type": "string"
+    },
+
+    "emitKinds": {
+      "type": "array",
+      "description": "An mapping from the relative output folder to emit kind that other plugins will use to determine where to write outputs.",
+
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["outputFolder", "moduleKind"],
+        "properties": {
+          "outputFolder": {
+            "title": "Output Folder",
+            "type": "string",
+            "description": "The folder to output to, relative to the project root.",
+            "pattern": "[^\\\\]"
+          },
+
+          "moduleKind": {
+            "title": "Module Kind",
+            "type": "string",
+            "description": "The module kind that files will conform to. Tells tools how imports and exports are handled.",
+            "enum": ["commonjs", "amd", "umd", "system", "es2015", "esnext"]
+          },
+
+          "target": {
+            "title": "Target",
+            "type": "string",
+            "description": "The ECMAScript specification level that files will conform to. Tells tools what syntax is available. Defaults to \"ES5\".",
+            "enum": [
+              "es3",
+              "es5",
+              "es6",
+              "es2015",
+              "es2016",
+              "es2017",
+              "es2018",
+              "es2019",
+              "es2020",
+              "es2021",
+              "es2022",
+              "esnext"
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/common/changes/@rushstack/heft-config-file/multi-emit-plugin_2025-03-04-01-02.json
+++ b/common/changes/@rushstack/heft-config-file/multi-emit-plugin_2025-03-04-01-02.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-config-file",
+      "comment": "Add a new `customValidationFunction` option for custom validation logic on loaded configuration files.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft-config-file"
+}

--- a/common/changes/@rushstack/heft-typescript-plugin/multi-emit-plugin_2025-03-01-03-11.json
+++ b/common/changes/@rushstack/heft-typescript-plugin/multi-emit-plugin_2025-03-01-03-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-typescript-plugin",
+      "comment": "Add logic to compare the plugin's configuration with that of a `config/javascript-emit-kinds.json` configuration file and report any mismatch if both are configured.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft-typescript-plugin"
+}

--- a/common/changes/@rushstack/heft/multi-emit-plugin_2025-03-01-03-11.json
+++ b/common/changes/@rushstack/heft/multi-emit-plugin_2025-03-01-03-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Add a method `tryLoadProjectConfigurationFileAsync<TConfigFile>(options, terminal)` to `HeftConfiguration`. Add a property `wellKnownConfigurationFiles` to provide access to configuration files that may be used across many plugins, the first example of which is `JavaScriptEmitKinds`, describing a file at `config/javascript-emit-kinds.json` that specifies one or more output folders for compiled JavaScript in differing formats.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft"
+}

--- a/common/reviews/api/heft-config-file.api.md
+++ b/common/reviews/api/heft-config-file.api.md
@@ -30,11 +30,15 @@ export abstract class ConfigurationFileBase<TConfigurationFile, TExtraOptions ex
     protected abstract _tryLoadConfigurationFileInRigAsync(terminal: ITerminal, rigConfig: IRigConfig, visitedConfigurationFilePaths: Set<string>): Promise<TConfigurationFile | undefined>;
 }
 
+// @beta
+export type CustomValidationFunction<TConfigurationFile> = (configurationFile: TConfigurationFile, resolvedConfigurationFilePathForLogging: string, terminal: ITerminal) => boolean;
+
 // @beta (undocumented)
 export type IConfigurationFileOptions<TConfigurationFile, TExtraOptions extends object> = IConfigurationFileOptionsWithJsonSchemaFilePath<TConfigurationFile, TExtraOptions> | IConfigurationFileOptionsWithJsonSchemaObject<TConfigurationFile, TExtraOptions>;
 
 // @beta (undocumented)
 export interface IConfigurationFileOptionsBase<TConfigurationFile> {
+    customValidationFunction?: CustomValidationFunction<TConfigurationFile>;
     jsonPathMetadata?: IJsonPathsMetadata<TConfigurationFile>;
     propertyInheritance?: IPropertiesInheritance<TConfigurationFile>;
     propertyInheritanceDefaults?: IPropertyInheritanceDefaults;
@@ -106,6 +110,9 @@ export interface IProjectConfigurationFileOptions {
     projectRelativeFilePath: string;
 }
 
+// @beta
+export type IProjectConfigurationFileSpecification<TConfigFile> = IConfigurationFileOptions<TConfigFile, IProjectConfigurationFileOptions>;
+
 // @beta (undocumented)
 export type IPropertiesInheritance<TConfigurationFile> = {
     [propertyName in keyof TConfigurationFile]?: IPropertyInheritance<InheritanceType.append | InheritanceType.merge | InheritanceType.replace> | ICustomPropertyInheritance<TConfigurationFile[propertyName]>;
@@ -149,7 +156,7 @@ export enum PathResolutionMethod {
 
 // @beta (undocumented)
 export class ProjectConfigurationFile<TConfigurationFile> extends ConfigurationFileBase<TConfigurationFile, IProjectConfigurationFileOptions> {
-    constructor(options: IConfigurationFileOptions<TConfigurationFile, IProjectConfigurationFileOptions>);
+    constructor(options: IProjectConfigurationFileSpecification<TConfigurationFile>);
     loadConfigurationFileForProject(terminal: ITerminal, projectPath: string, rigConfig?: IRigConfig): TConfigurationFile;
     loadConfigurationFileForProjectAsync(terminal: ITerminal, projectPath: string, rigConfig?: IRigConfig): Promise<TConfigurationFile>;
     readonly projectRelativeFilePath: string;

--- a/common/reviews/api/heft-typescript-plugin.api.md
+++ b/common/reviews/api/heft-typescript-plugin.api.md
@@ -36,7 +36,11 @@ export interface IPartialTsconfig {
 // @beta (undocumented)
 export interface IPartialTsconfigCompilerOptions {
     // (undocumented)
+    module?: keyof TTypescript.ModuleKind;
+    // (undocumented)
     outDir?: string;
+    // (undocumented)
+    target?: keyof TTypescript.ScriptTarget;
 }
 
 // @beta (undocumented)

--- a/common/reviews/api/heft.api.md
+++ b/common/reviews/api/heft.api.md
@@ -17,10 +17,14 @@ import { CommandLineParameter } from '@rushstack/ts-command-line';
 import { CommandLineStringListParameter } from '@rushstack/ts-command-line';
 import { CommandLineStringParameter } from '@rushstack/ts-command-line';
 import * as fs from 'fs';
+import { IConfigurationFileOptions } from '@rushstack/heft-config-file';
 import { IPackageJson } from '@rushstack/node-core-library';
+import { IProjectConfigurationFileOptions } from '@rushstack/heft-config-file';
+import { IProjectConfigurationFileSpecification } from '@rushstack/heft-config-file';
 import { IRigConfig } from '@rushstack/rig-package';
 import { ITerminal } from '@rushstack/terminal';
 import { ITerminalProvider } from '@rushstack/terminal';
+import { ProjectConfigurationFile } from '@rushstack/heft-config-file';
 
 export { CommandLineChoiceListParameter }
 
@@ -57,6 +61,9 @@ export class HeftConfiguration {
     get slashNormalizedBuildFolderPath(): string;
     get tempFolderPath(): string;
     get terminalProvider(): ITerminalProvider;
+    tryLoadProjectConfigurationFileAsync<TConfigFile>(options: IProjectConfigurationFileSpecification<TConfigFile>, terminal: ITerminal): Promise<TConfigFile | undefined>;
+    // Warning: (ae-forgotten-export) The symbol "wellKnown" needs to be exported by the entry point index.d.ts
+    get wellKnownConfigurationFiles(): Readonly<typeof wellKnown>;
 }
 
 // @public
@@ -213,6 +220,22 @@ export interface IIncrementalCopyOperation extends ICopyOperation {
     onlyIfChanged?: boolean;
 }
 
+// @public
+export interface IJavaScriptEmitKind {
+    // (undocumented)
+    moduleKind: JavaScriptModuleKind;
+    // (undocumented)
+    outputFolder: string;
+    // (undocumented)
+    target: JavaScriptTarget;
+}
+
+// @public
+export interface IJavaScriptEmitKindsConfigurationJson {
+    // (undocumented)
+    emitKinds: IJavaScriptEmitKind[];
+}
+
 // @public (undocumented)
 export interface IMetricsData {
     bootDurationMs: number;
@@ -235,6 +258,8 @@ export interface _IPerformanceData {
     // (undocumented)
     taskTotalExecutionMs: number;
 }
+
+export { IProjectConfigurationFileSpecification }
 
 // @public
 export interface IReaddirOptions {
@@ -295,6 +320,12 @@ export interface IWatchFileSystem {
     statSync(filePath: string): fs.Stats;
 }
 
+// @public
+export type JavaScriptModuleKind = 'amd' | 'commonjs' | 'es2015' | 'esnext' | 'system' | 'umd';
+
+// @public
+export type JavaScriptTarget = 'es3' | 'es5' | 'es6' | 'es2015' | 'es2016' | 'es2017' | 'es2018' | 'es2019' | 'es2020' | 'es2021' | 'es2022' | 'esnext';
+
 // @internal
 export class _MetricsCollector {
     recordAsync(command: string, performanceData?: Partial<_IPerformanceData>, parameters?: Record<string, string>): Promise<void>;
@@ -302,6 +333,8 @@ export class _MetricsCollector {
     readonly recordMetricsHook: AsyncParallelHook<IHeftRecordMetricsHookOptions>;
     setStartTime(): void;
 }
+
+export { ProjectConfigurationFile }
 
 // @public
 export type ReaddirDirentCallback = (error: NodeJS.ErrnoException | null, files: fs.Dirent[]) => void;

--- a/libraries/heft-config-file/src/ProjectConfigurationFile.ts
+++ b/libraries/heft-config-file/src/ProjectConfigurationFile.ts
@@ -19,6 +19,15 @@ export interface IProjectConfigurationFileOptions {
 }
 
 /**
+ * Alias for the constructor type for {@link ProjectConfigurationFile}.
+ * @beta
+ */
+export type IProjectConfigurationFileSpecification<TConfigFile> = IConfigurationFileOptions<
+  TConfigFile,
+  IProjectConfigurationFileOptions
+>;
+
+/**
  * @beta
  */
 export class ProjectConfigurationFile<TConfigurationFile> extends ConfigurationFileBase<
@@ -28,9 +37,7 @@ export class ProjectConfigurationFile<TConfigurationFile> extends ConfigurationF
   /** {@inheritDoc IProjectConfigurationFileOptions.projectRelativeFilePath} */
   public readonly projectRelativeFilePath: string;
 
-  public constructor(
-    options: IConfigurationFileOptions<TConfigurationFile, IProjectConfigurationFileOptions>
-  ) {
+  public constructor(options: IProjectConfigurationFileSpecification<TConfigurationFile>) {
     super(options);
     this.projectRelativeFilePath = options.projectRelativeFilePath;
   }

--- a/libraries/heft-config-file/src/index.ts
+++ b/libraries/heft-config-file/src/index.ts
@@ -10,6 +10,7 @@
 
 export {
   ConfigurationFileBase,
+  type CustomValidationFunction,
   type IConfigurationFileOptionsBase,
   type IConfigurationFileOptionsWithJsonSchemaFilePath,
   type IConfigurationFileOptionsWithJsonSchemaObject,
@@ -44,7 +45,11 @@ export const ConfigurationFile: typeof ProjectConfigurationFile = ProjectConfigu
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export type ConfigurationFile<TConfigurationFile> = ProjectConfigurationFile<TConfigurationFile>;
 
-export { ProjectConfigurationFile, type IProjectConfigurationFileOptions } from './ProjectConfigurationFile';
+export {
+  ProjectConfigurationFile,
+  type IProjectConfigurationFileOptions,
+  type IProjectConfigurationFileSpecification
+} from './ProjectConfigurationFile';
 export { NonProjectConfigurationFile } from './NonProjectConfigurationFile';
 
 export * as TestUtilities from './TestUtilities';


### PR DESCRIPTION
## Summary
Exposes functionality for loading riggable configuration files directly on `HeftConfiguration`. Provides an entry point for well-known shared configuration files that may be used by plugins in the ecosystem without requiring their information to be part of `heft.json` itself.

## Details
Rigs or heft projects can define a configuration file at `config/javascript-emit-kinds.json` to declare the expected output layout for a JavaScript project.

Plugins can access this configuration file by invoking
```ts
const IJavaScriptEmitKindsConfigurationJson | undefined = await heftConfiguration.tryLoadProjectConfigurationFileAsync(heftConfiguration.wellKnownConfigurationFiles.javascriptEmitKinds, terminal);
```

### Example javascript-emit-kinds.json
```json
{
  "emitKinds": [
    {
      "outputFolder": "lib-esm",
      "moduleKind": "esnext",
      "target": "esnext"
    },
    {
      "outputFolder": "lib-commonjs",
      "moduleKind": "commonjs",
      "target": "es2020"
    }
  ]
}
```

If you have this file configured alongside `heft-typescript-plugin`, and the configurations do not match, warnings will be printed.

## How it was tested
Enabled in `heft-webpack5-everything-test`.

With some mismatched configuration, sample errors:
`javascript-emit-kinds.json` contained the config in the "details" section above.

vs.

typescript.json
```json
  "additionalModuleKindsToEmit": [
    {
      "moduleKind": "commonjs",
      "outFolderName": "lib-commonjs"
    }
  ],
```

`tsconfig.json` was configured to emit `esnext`, `es5` output to `lib/`.

```
[build:typescript] Warning: The configuration at "config/javascript-emit-kinds.json" says to emit "esnext" modules targeting "esnext" to the "/workspaces/rushstack-2/build-tests/heft-webpack5-everything-test/lib-esm" folder, but this folder is not configured in the TypeScript plugin. Please add the entry to "config/typescript.json" if it should be emitted or remove it from "config/javascript-emit-kinds.json" if it should not.

[build:typescript] Warning: The TypeScript plugin is emitting "esnext" modules targeting "es5" to the "/workspaces/rushstack-2/build-tests/heft-webpack5-everything-test/lib" folder, but this folder has not been registered in the global config at "config/javascript-emit-kinds.json". Please remove the entry from "config/typescript.json" task if it should not be emitted or add it to "config/javascript-emit-kinds.json" if it should.

[build:typescript] Warning: The TypeScript plugin is emitting "commonjs" modules targeting "es5" to the "/workspaces/rushstack-2/build-tests/heft-webpack5-everything-test/lib-commonjs" folder, but this folder has been registered for emitting "commonjs" modules targeting "es2020" in "config/javascript-emit-kinds.json". Please update one of the config files.
```

Note that the mismatch warnings only show up if `config/javascript-emit-kinds.json` exists.

## Impacted documentation
Needs more information in the core Heft documentation.