### PR TITLE
[heft] Add `tryLoadProjectConfigurationFileAsync` API and use in plugins

### DIFF
--- a/apps/heft/src/configuration/HeftConfiguration.ts
+++ b/apps/heft/src/configuration/HeftConfiguration.ts
@@ -183,7 +183,7 @@ export class HeftConfiguration {
     terminal: ITerminal
   ): TConfigFile | undefined {
     const loader: ProjectConfigurationFile<TConfigFile> = this._getConfigFileLoader(options);
-    return loader.tryLoadConfigurationFileForProject(terminal, this._buildFolderPath, this._rigConfig);
+    return loader.tryLoadConfigurationFileForProject(terminal, this.buildFolderPath, this._rigConfig);
   }
 
   /**
@@ -197,7 +197,7 @@ export class HeftConfiguration {
     terminal: ITerminal
   ): Promise<TConfigFile | undefined> {
     const loader: ProjectConfigurationFile<TConfigFile> = this._getConfigFileLoader(options);
-    return loader.tryLoadConfigurationFileForProjectAsync(terminal, this._buildFolderPath, this._rigConfig);
+    return loader.tryLoadConfigurationFileForProjectAsync(terminal, this.buildFolderPath, this._rigConfig);
   }
 
   /**

--- a/apps/heft/src/configuration/types.ts
+++ b/apps/heft/src/configuration/types.ts
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+export type {
+  CustomValidationFunction,
+  ICustomJsonPathMetadata,
+  ICustomPropertyInheritance,
+  IJsonPathMetadata,
+  IJsonPathMetadataResolverOptions,
+  IJsonPathsMetadata,
+  INonCustomJsonPathMetadata,
+  IOriginalValueOptions,
+  IProjectConfigurationFileSpecification,
+  IPropertiesInheritance,
+  IPropertyInheritance,
+  IPropertyInheritanceDefaults,
+  InheritanceType,
+  PathResolutionMethod,
+  PropertyInheritanceCustomFunction
+} from '@rushstack/heft-config-file';

--- a/apps/heft/src/index.ts
+++ b/apps/heft/src/index.ts
@@ -11,6 +11,9 @@
  * @packageDocumentation
  */
 
+import type * as ConfigurationFile from './configuration/types';
+export type { ConfigurationFile };
+
 export {
   HeftConfiguration,
   type IHeftConfigurationInitializationOptions as _IHeftConfigurationInitializationOptions

--- a/common/changes/@rushstack/heft-api-extractor-plugin/heft-config-api_2025-03-04-23-15.json
+++ b/common/changes/@rushstack/heft-api-extractor-plugin/heft-config-api_2025-03-04-23-15.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-api-extractor-plugin",
+      "comment": "Use `tryLoadProjectConfigurationFileAsync` Heft API to remove direct dependency on `@rushstack/heft-config-file`.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft-api-extractor-plugin"
+}

--- a/common/changes/@rushstack/heft-config-file/heft-config-api_2025-03-04-23-13.json
+++ b/common/changes/@rushstack/heft-config-file/heft-config-api_2025-03-04-23-13.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-config-file",
+      "comment": "Fix an issue with `PathResolutionMethod.resolvePathRelativeToProjectRoot` when extending files across packages.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft-config-file"
+}

--- a/common/changes/@rushstack/heft-config-file/multi-emit-plugin_2025-03-04-01-02.json
+++ b/common/changes/@rushstack/heft-config-file/multi-emit-plugin_2025-03-04-01-02.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-config-file",
+      "comment": "Add a new `customValidationFunction` option for custom validation logic on loaded configuration files.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft-config-file"
+}

--- a/common/changes/@rushstack/heft-sass-plugin/heft-config-api_2025-03-05-00-29.json
+++ b/common/changes/@rushstack/heft-sass-plugin/heft-config-api_2025-03-05-00-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-sass-plugin",
+      "comment": "Use `tryLoadProjectConfigurationFileAsync` API to remove direct dependency on `@rushstack/heft-config-file`.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft-sass-plugin"
+}

--- a/common/changes/@rushstack/heft/multi-emit-plugin_2025-03-01-03-11.json
+++ b/common/changes/@rushstack/heft/multi-emit-plugin_2025-03-01-03-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Add a method `tryLoadProjectConfigurationFileAsync<TConfigFile>(options, terminal)` to `HeftConfiguration`.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft"
+}

--- a/common/changes/@rushstack/rig-package/multi-emit-plugin_2025-03-01-03-11.json
+++ b/common/changes/@rushstack/rig-package/multi-emit-plugin_2025-03-01-03-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-typescript-plugin",
+      "comment": "Leverage Heft's new `tryLoadProjectConfigurationFileAsync` method.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft-typescript-plugin"
+}

--- a/common/config/subspaces/build-tests-subspace/repo-state.json
+++ b/common/config/subspaces/build-tests-subspace/repo-state.json
@@ -2,5 +2,5 @@
 {
   "pnpmShrinkwrapHash": "d9e805ea30f80e290b5d5ea83856c8b5d7302941",
   "preferredVersionsHash": "54149ea3f01558a859c96dee2052b797d4defe68",
-  "packageJsonInjectedDependenciesHash": "8982ce433cee12f925dfe4d72638fad18cbf641c"
+  "packageJsonInjectedDependenciesHash": "949bb6038c34cb0580b82a6f728b26a66fff3177"
 }

--- a/common/config/subspaces/default/pnpm-lock.yaml
+++ b/common/config/subspaces/default/pnpm-lock.yaml
@@ -2496,9 +2496,6 @@ importers:
 
   ../../../heft-plugins/heft-api-extractor-plugin:
     dependencies:
-      '@rushstack/heft-config-file':
-        specifier: workspace:*
-        version: link:../../libraries/heft-config-file
       '@rushstack/node-core-library':
         specifier: workspace:*
         version: link:../../libraries/node-core-library
@@ -2685,9 +2682,6 @@ importers:
 
   ../../../heft-plugins/heft-sass-plugin:
     dependencies:
-      '@rushstack/heft-config-file':
-        specifier: workspace:*
-        version: link:../../libraries/heft-config-file
       '@rushstack/node-core-library':
         specifier: workspace:*
         version: link:../../libraries/node-core-library

--- a/common/reviews/api/heft.api.md
+++ b/common/reviews/api/heft.api.md
@@ -16,11 +16,26 @@ import { CommandLineIntegerParameter } from '@rushstack/ts-command-line';
 import { CommandLineParameter } from '@rushstack/ts-command-line';
 import { CommandLineStringListParameter } from '@rushstack/ts-command-line';
 import { CommandLineStringParameter } from '@rushstack/ts-command-line';
+import { CustomValidationFunction } from '@rushstack/heft-config-file';
 import * as fs from 'fs';
+import { ICustomJsonPathMetadata } from '@rushstack/heft-config-file';
+import { ICustomPropertyInheritance } from '@rushstack/heft-config-file';
+import { IJsonPathMetadata } from '@rushstack/heft-config-file';
+import { IJsonPathMetadataResolverOptions } from '@rushstack/heft-config-file';
+import { IJsonPathsMetadata } from '@rushstack/heft-config-file';
+import { InheritanceType } from '@rushstack/heft-config-file';
+import { INonCustomJsonPathMetadata } from '@rushstack/heft-config-file';
+import { IOriginalValueOptions } from '@rushstack/heft-config-file';
 import { IPackageJson } from '@rushstack/node-core-library';
+import { IProjectConfigurationFileSpecification } from '@rushstack/heft-config-file';
+import { IPropertiesInheritance } from '@rushstack/heft-config-file';
+import { IPropertyInheritance } from '@rushstack/heft-config-file';
+import { IPropertyInheritanceDefaults } from '@rushstack/heft-config-file';
 import { IRigConfig } from '@rushstack/rig-package';
 import { ITerminal } from '@rushstack/terminal';
 import { ITerminalProvider } from '@rushstack/terminal';
+import { PathResolutionMethod } from '@rushstack/heft-config-file';
+import { PropertyInheritanceCustomFunction } from '@rushstack/heft-config-file';
 
 export { CommandLineChoiceListParameter }
 
@@ -37,6 +52,27 @@ export { CommandLineParameter }
 export { CommandLineStringListParameter }
 
 export { CommandLineStringParameter }
+
+declare namespace ConfigurationFile {
+    export {
+        CustomValidationFunction,
+        ICustomJsonPathMetadata,
+        ICustomPropertyInheritance,
+        IJsonPathMetadata,
+        IJsonPathMetadataResolverOptions,
+        IJsonPathsMetadata,
+        INonCustomJsonPathMetadata,
+        IOriginalValueOptions,
+        IProjectConfigurationFileSpecification,
+        IPropertiesInheritance,
+        IPropertyInheritance,
+        IPropertyInheritanceDefaults,
+        InheritanceType,
+        PathResolutionMethod,
+        PropertyInheritanceCustomFunction
+    }
+}
+export { ConfigurationFile }
 
 // @public
 export type GlobFn = (pattern: string | string[], options?: IGlobOptions | undefined) => Promise<string[]>;
@@ -58,6 +94,8 @@ export class HeftConfiguration {
     get slashNormalizedBuildFolderPath(): string;
     get tempFolderPath(): string;
     readonly terminalProvider: ITerminalProvider;
+    tryLoadProjectConfigurationFile<TConfigFile>(options: IProjectConfigurationFileSpecification<TConfigFile>, terminal: ITerminal): TConfigFile | undefined;
+    tryLoadProjectConfigurationFileAsync<TConfigFile>(options: IProjectConfigurationFileSpecification<TConfigFile>, terminal: ITerminal): Promise<TConfigFile | undefined>;
 }
 
 // @public

--- a/heft-plugins/heft-api-extractor-plugin/package.json
+++ b/heft-plugins/heft-api-extractor-plugin/package.json
@@ -18,7 +18,6 @@
     "@rushstack/heft": "0.71.2"
   },
   "dependencies": {
-    "@rushstack/heft-config-file": "workspace:*",
     "@rushstack/node-core-library": "workspace:*",
     "semver": "~7.5.4"
   },

--- a/heft-plugins/heft-sass-plugin/package.json
+++ b/heft-plugins/heft-sass-plugin/package.json
@@ -19,7 +19,6 @@
     "@rushstack/heft": "^0.71.2"
   },
   "dependencies": {
-    "@rushstack/heft-config-file": "workspace:*",
     "@rushstack/node-core-library": "workspace:*",
     "@rushstack/typings-generator": "workspace:*",
     "sass-embedded": "~1.77.8",

--- a/heft-plugins/heft-typescript-plugin/src/TypeScriptPlugin.ts
+++ b/heft-plugins/heft-typescript-plugin/src/TypeScriptPlugin.ts
@@ -324,8 +324,6 @@ export default class TypeScriptPlugin implements IHeftTaskPlugin {
     taskSession: IHeftTaskSession,
     heftConfiguration: HeftConfiguration
   ): Promise<TypeScriptBuilder | false> {
-    const terminal: ITerminal = taskSession.logger.terminal;
-
     const { typeScriptConfigurationJson, partialTsconfigFile } = await this._loadConfigAsync(
       taskSession,
       heftConfiguration

--- a/libraries/heft-config-file/src/ConfigurationFileBase.ts
+++ b/libraries/heft-config-file/src/ConfigurationFileBase.ts
@@ -3,75 +3,152 @@
 
 import * as nodeJsPath from 'path';
 import { JSONPath } from 'jsonpath-plus';
-import { JsonSchema, JsonFile, PackageJsonLookup, Import, FileSystem } from '@rushstack/node-core-library';
+import { JsonSchema, JsonFile, Import, FileSystem } from '@rushstack/node-core-library';
 import type { ITerminal } from '@rushstack/terminal';
-import type { IRigConfig } from '@rushstack/rig-package';
 
 interface IConfigurationJson {
   extends?: string;
 }
 
+/* eslint-disable @typescript-eslint/typedef,@typescript-eslint/no-redeclare,@typescript-eslint/no-namespace,@typescript-eslint/naming-convention */
+// This structure is used so that consumers can pass raw string literals and have it typecheck, without breaking existing callers.
 /**
  * @beta
+ *
+ * The set of possible mechanisms for merging properties from parent configuration files.
  */
-export enum InheritanceType {
+const InheritanceType = {
   /**
    * Append additional elements after elements from the parent file's property. Only applicable
    * for arrays.
    */
-  append = 'append',
+  append: 'append',
 
   /**
    * Perform a shallow merge of additional elements after elements from the parent file's property.
    * Only applicable for objects.
    */
-  merge = 'merge',
+  merge: 'merge',
 
   /**
    * Discard elements from the parent file's property
    */
-  replace = 'replace',
+  replace: 'replace',
 
   /**
    * Custom inheritance functionality
    */
-  custom = 'custom'
-}
-
+  custom: 'custom'
+} as const;
 /**
  * @beta
  */
-export enum PathResolutionMethod {
+type InheritanceType = (typeof InheritanceType)[keyof typeof InheritanceType];
+/**
+ * @beta
+ */
+declare namespace InheritanceType {
+  /**
+   * Append additional elements after elements from the parent file's property. Only applicable
+   * for arrays.
+   */
+  export type append = typeof InheritanceType.append;
+
+  /**
+   * Perform a shallow merge of additional elements after elements from the parent file's property.
+   * Only applicable for objects.
+   */
+  export type merge = typeof InheritanceType.merge;
+
+  /**
+   * Discard elements from the parent file's property
+   */
+  export type replace = typeof InheritanceType.replace;
+
+  /**
+   * Custom inheritance functionality
+   */
+  export type custom = typeof InheritanceType.custom;
+}
+export { InheritanceType };
+
+/**
+ * @beta
+ *
+ * The set of possible resolution methods for fields that refer to paths.
+ */
+const PathResolutionMethod = {
   /**
    * Resolve a path relative to the configuration file
    */
-  resolvePathRelativeToConfigurationFile = 'resolvePathRelativeToConfigurationFile',
+  resolvePathRelativeToConfigurationFile: 'resolvePathRelativeToConfigurationFile',
 
   /**
    * Resolve a path relative to the root of the project containing the configuration file
    */
-  resolvePathRelativeToProjectRoot = 'resolvePathRelativeToProjectRoot',
+  resolvePathRelativeToProjectRoot: 'resolvePathRelativeToProjectRoot',
 
   /**
    * Treat the property as a NodeJS-style require/import reference and resolve using standard
    * NodeJS filesystem resolution
    *
    * @deprecated
-   * Use {@link PathResolutionMethod.nodeResolve} instead
+   * Use {@link (PathResolutionMethod:variable).nodeResolve} instead
    */
-  NodeResolve = 'NodeResolve',
+  NodeResolve: 'NodeResolve',
 
   /**
    * Treat the property as a NodeJS-style require/import reference and resolve using standard
    * NodeJS filesystem resolution
    */
-  nodeResolve = 'nodeResolve',
+  nodeResolve: 'nodeResolve',
 
   /**
    * Resolve the property using a custom resolver.
    */
-  custom = 'custom'
+  custom: 'custom'
+} as const;
+/**
+ * @beta
+ */
+type PathResolutionMethod = (typeof PathResolutionMethod)[keyof typeof PathResolutionMethod];
+/**
+ * @beta
+ */
+declare namespace PathResolutionMethod {
+  /**
+   * Resolve a path relative to the configuration file
+   */
+  export type resolvePathRelativeToConfigurationFile =
+    typeof PathResolutionMethod.resolvePathRelativeToConfigurationFile;
+
+  /**
+   * Resolve a path relative to the root of the project containing the configuration file
+   */
+  export type resolvePathRelativeToProjectRoot = typeof PathResolutionMethod.resolvePathRelativeToProjectRoot;
+
+  /**
+   * Treat the property as a NodeJS-style require/import reference and resolve using standard
+   * NodeJS filesystem resolution
+   *
+   * @deprecated
+   * Use {@link (PathResolutionMethod:namespace).nodeResolve} instead
+   */
+  export type NodeResolve = typeof PathResolutionMethod.NodeResolve;
+
+  /**
+   * Treat the property as a NodeJS-style require/import reference and resolve using standard
+   * NodeJS filesystem resolution
+   */
+  export type nodeResolve = typeof PathResolutionMethod.nodeResolve;
+
+  /**
+   * Resolve the property using a custom resolver.
+   */
+  export type custom = typeof PathResolutionMethod.custom;
 }
+export { PathResolutionMethod };
+/* eslint-enable @typescript-eslint/typedef,@typescript-eslint/no-redeclare,@typescript-eslint/no-namespace,@typescript-eslint/naming-convention */
 
 const CONFIGURATION_FILE_MERGE_BEHAVIOR_FIELD_REGEX: RegExp = /^\$([^\.]+)\.inheritanceType$/;
 export const CONFIGURATION_FILE_FIELD_ANNOTATION: unique symbol = Symbol(
@@ -109,6 +186,10 @@ export interface IJsonPathMetadataResolverOptions<TConfigurationFile> {
    * The configuration file the property was obtained from.
    */
   configurationFile: Partial<TConfigurationFile>;
+  /**
+   * If this is a project configuration file, the root folder of the project.
+   */
+  projectFolderPath?: string;
 }
 
 /**
@@ -207,6 +288,20 @@ export interface IJsonPathsMetadata<TConfigurationFile> {
 }
 
 /**
+ * A function to invoke after schema validation to validate the configuration file.
+ * If this function returns any value other than `true`, the configuration file API
+ * will throw an error indicating that custom validation failed. If the function wishes
+ * to provide its own error message, it may use any combination of the terminal and throwing
+ * its own error.
+ * @beta
+ */
+export type CustomValidationFunction<TConfigurationFile> = (
+  configurationFile: TConfigurationFile,
+  resolvedConfigurationFilePathForLogging: string,
+  terminal: ITerminal
+) => boolean;
+
+/**
  * @beta
  */
 export interface IConfigurationFileOptionsBase<TConfigurationFile> {
@@ -226,6 +321,15 @@ export interface IConfigurationFileOptionsBase<TConfigurationFile> {
    * configuration files.
    */
   propertyInheritanceDefaults?: IPropertyInheritanceDefaults;
+
+  /**
+   * Use this property if you need to validate the configuration file in ways beyond what JSON schema can handle.
+   * This function will be invoked after JSON schema validation.
+   *
+   * If the file is valid, this function should return `true`, otherwise `ConfigurationFile` will throw an error
+   * indicating that custom validation failed. To suppress this error, the function may itself choose to throw.
+   */
+  customValidationFunction?: CustomValidationFunction<TConfigurationFile>;
 }
 
 /**
@@ -280,15 +384,31 @@ export interface IOriginalValueOptions<TParentProperty> {
   propertyName: keyof TParentProperty;
 }
 
+interface IConfigurationFileCacheEntry<TConfigFile> {
+  resolvedConfigurationFilePath: string;
+  resolvedConfigurationFilePathForLogging: string;
+  parent?: IConfigurationFileCacheEntry<TConfigFile>;
+  configurationFile: TConfigFile & IConfigurationJson;
+}
+
+/**
+ * Callback that returns a fallback configuration file path if the original configuration file was not found.
+ * @beta
+ */
+export type IOnConfigurationFileNotFoundCallback = (
+  resolvedConfigurationFilePathForLogging: string
+) => string | undefined;
+
 /**
  * @beta
  */
 export abstract class ConfigurationFileBase<TConfigurationFile, TExtraOptions extends {}> {
   private readonly _getSchema: () => JsonSchema;
 
-  private readonly _jsonPathMetadata: IJsonPathsMetadata<TConfigurationFile>;
+  private readonly _jsonPathMetadata: readonly [string, IJsonPathMetadata<TConfigurationFile>][];
   private readonly _propertyInheritanceTypes: IPropertiesInheritance<TConfigurationFile>;
   private readonly _defaultPropertyInheritance: IPropertyInheritanceDefaults;
+  private readonly _customValidationFunction: CustomValidationFunction<TConfigurationFile> | undefined;
   private __schema: JsonSchema | undefined;
   private get _schema(): JsonSchema {
     if (!this.__schema) {
@@ -298,9 +418,11 @@ export abstract class ConfigurationFileBase<TConfigurationFile, TExtraOptions ex
     return this.__schema;
   }
 
-  private readonly _configCache: Map<string, TConfigurationFile> = new Map();
-  private readonly _configPromiseCache: Map<string, Promise<TConfigurationFile>> = new Map();
-  private readonly _packageJsonLookup: PackageJsonLookup = new PackageJsonLookup();
+  private readonly _configCache: Map<string, IConfigurationFileCacheEntry<TConfigurationFile>> = new Map();
+  private readonly _configPromiseCache: Map<
+    string,
+    Promise<IConfigurationFileCacheEntry<TConfigurationFile>>
+  > = new Map();
 
   public constructor(options: IConfigurationFileOptions<TConfigurationFile, TExtraOptions>) {
     if (options.jsonSchemaObject) {
@@ -309,9 +431,10 @@ export abstract class ConfigurationFileBase<TConfigurationFile, TExtraOptions ex
       this._getSchema = () => JsonSchema.fromFile(options.jsonSchemaPath);
     }
 
-    this._jsonPathMetadata = options.jsonPathMetadata || {};
+    this._jsonPathMetadata = Object.entries(options.jsonPathMetadata || {});
     this._propertyInheritanceTypes = options.propertyInheritance || {};
     this._defaultPropertyInheritance = options.propertyInheritanceDefaults || {};
+    this._customValidationFunction = options.customValidationFunction;
   }
 
   /**
@@ -342,22 +465,69 @@ export abstract class ConfigurationFileBase<TConfigurationFile, TExtraOptions ex
   public getPropertyOriginalValue<TParentProperty extends object, TValue>(
     options: IOriginalValueOptions<TParentProperty>
   ): TValue | undefined {
-    const annotation: IConfigurationFileFieldAnnotation<TParentProperty> | undefined =
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (options.parentObject as any)[CONFIGURATION_FILE_FIELD_ANNOTATION];
-    if (annotation && annotation.originalValues.hasOwnProperty(options.propertyName)) {
+    const {
+      [CONFIGURATION_FILE_FIELD_ANNOTATION]: annotation
+    }: { [CONFIGURATION_FILE_FIELD_ANNOTATION]?: IConfigurationFileFieldAnnotation<TParentProperty> } =
+      options.parentObject;
+    if (annotation?.originalValues.hasOwnProperty(options.propertyName)) {
       return annotation.originalValues[options.propertyName] as TValue;
-    } else {
-      return undefined;
     }
   }
 
   protected _loadConfigurationFileInnerWithCache(
     terminal: ITerminal,
     resolvedConfigurationFilePath: string,
-    visitedConfigurationFilePaths: Set<string>,
-    rigConfig: IRigConfig | undefined
+    projectFolderPath: string | undefined,
+    onConfigurationFileNotFound?: IOnConfigurationFileNotFoundCallback
   ): TConfigurationFile {
+    const visitedConfigurationFilePaths: Set<string> = new Set<string>();
+    const cacheEntry: IConfigurationFileCacheEntry<TConfigurationFile> =
+      this._loadConfigurationFileEntryWithCache(
+        terminal,
+        resolvedConfigurationFilePath,
+        visitedConfigurationFilePaths,
+        onConfigurationFileNotFound
+      );
+
+    const result: TConfigurationFile = this._finalizeConfigurationFile(
+      cacheEntry,
+      projectFolderPath,
+      terminal
+    );
+
+    return result;
+  }
+
+  protected async _loadConfigurationFileInnerWithCacheAsync(
+    terminal: ITerminal,
+    resolvedConfigurationFilePath: string,
+    projectFolderPath: string | undefined,
+    onFileNotFound?: IOnConfigurationFileNotFoundCallback
+  ): Promise<TConfigurationFile> {
+    const visitedConfigurationFilePaths: Set<string> = new Set<string>();
+    const cacheEntry: IConfigurationFileCacheEntry<TConfigurationFile> =
+      await this._loadConfigurationFileEntryWithCacheAsync(
+        terminal,
+        resolvedConfigurationFilePath,
+        visitedConfigurationFilePaths,
+        onFileNotFound
+      );
+
+    const result: TConfigurationFile = this._finalizeConfigurationFile(
+      cacheEntry,
+      projectFolderPath,
+      terminal
+    );
+
+    return result;
+  }
+
+  private _loadConfigurationFileEntryWithCache(
+    terminal: ITerminal,
+    resolvedConfigurationFilePath: string,
+    visitedConfigurationFilePaths: Set<string>,
+    onFileNotFound?: IOnConfigurationFileNotFoundCallback
+  ): IConfigurationFileCacheEntry<TConfigurationFile> {
     if (visitedConfigurationFilePaths.has(resolvedConfigurationFilePath)) {
       const resolvedConfigurationFilePathForLogging: string = ConfigurationFileBase._formatPathForLogging(
         resolvedConfigurationFilePath
@@ -369,13 +539,15 @@ export abstract class ConfigurationFileBase<TConfigurationFile, TExtraOptions ex
     }
     visitedConfigurationFilePaths.add(resolvedConfigurationFilePath);
 
-    let cacheEntry: TConfigurationFile | undefined = this._configCache.get(resolvedConfigurationFilePath);
+    let cacheEntry: IConfigurationFileCacheEntry<TConfigurationFile> | undefined = this._configCache.get(
+      resolvedConfigurationFilePath
+    );
     if (!cacheEntry) {
-      cacheEntry = this._loadConfigurationFileInner(
+      cacheEntry = this._loadConfigurationFileEntry(
         terminal,
         resolvedConfigurationFilePath,
         visitedConfigurationFilePaths,
-        rigConfig
+        onFileNotFound
       );
       this._configCache.set(resolvedConfigurationFilePath, cacheEntry);
     }
@@ -383,12 +555,12 @@ export abstract class ConfigurationFileBase<TConfigurationFile, TExtraOptions ex
     return cacheEntry;
   }
 
-  protected async _loadConfigurationFileInnerWithCacheAsync(
+  private async _loadConfigurationFileEntryWithCacheAsync(
     terminal: ITerminal,
     resolvedConfigurationFilePath: string,
     visitedConfigurationFilePaths: Set<string>,
-    rigConfig: IRigConfig | undefined
-  ): Promise<TConfigurationFile> {
+    onConfigurationFileNotFound?: IOnConfigurationFileNotFoundCallback
+  ): Promise<IConfigurationFileCacheEntry<TConfigurationFile>> {
     if (visitedConfigurationFilePaths.has(resolvedConfigurationFilePath)) {
       const resolvedConfigurationFilePathForLogging: string = ConfigurationFileBase._formatPathForLogging(
         resolvedConfigurationFilePath
@@ -400,16 +572,15 @@ export abstract class ConfigurationFileBase<TConfigurationFile, TExtraOptions ex
     }
     visitedConfigurationFilePaths.add(resolvedConfigurationFilePath);
 
-    let cacheEntryPromise: Promise<TConfigurationFile> | undefined = this._configPromiseCache.get(
-      resolvedConfigurationFilePath
-    );
+    let cacheEntryPromise: Promise<IConfigurationFileCacheEntry<TConfigurationFile>> | undefined =
+      this._configPromiseCache.get(resolvedConfigurationFilePath);
     if (!cacheEntryPromise) {
-      cacheEntryPromise = this._loadConfigurationFileInnerAsync(
+      cacheEntryPromise = this._loadConfigurationFileEntryAsync(
         terminal,
         resolvedConfigurationFilePath,
         visitedConfigurationFilePaths,
-        rigConfig
-      ).then((value: TConfigurationFile) => {
+        onConfigurationFileNotFound
+      ).then((value: IConfigurationFileCacheEntry<TConfigurationFile>) => {
         this._configCache.set(resolvedConfigurationFilePath, value);
         return value;
       });
@@ -419,48 +590,59 @@ export abstract class ConfigurationFileBase<TConfigurationFile, TExtraOptions ex
     return await cacheEntryPromise;
   }
 
-  protected abstract _tryLoadConfigurationFileInRig(
-    terminal: ITerminal,
-    rigConfig: IRigConfig,
-    visitedConfigurationFilePaths: Set<string>
-  ): TConfigurationFile | undefined;
-
-  protected abstract _tryLoadConfigurationFileInRigAsync(
-    terminal: ITerminal,
-    rigConfig: IRigConfig,
-    visitedConfigurationFilePaths: Set<string>
-  ): Promise<TConfigurationFile | undefined>;
-
-  private _parseAndResolveConfigurationFile(
+  /**
+   * Parses the raw JSON-with-comments text of the configuration file.
+   * @param fileText - The text of the configuration file
+   * @param resolvedConfigurationFilePathForLogging - The path to the configuration file, formatted for logs
+   * @returns The parsed configuration file
+   */
+  private _parseConfigurationFile(
     fileText: string,
-    resolvedConfigurationFilePath: string,
     resolvedConfigurationFilePathForLogging: string
   ): IConfigurationJson & TConfigurationFile {
     let configurationJson: IConfigurationJson & TConfigurationFile;
     try {
       configurationJson = JsonFile.parseString(fileText);
     } catch (e) {
-      throw new Error(`In config file "${resolvedConfigurationFilePathForLogging}": ${e}`);
+      throw new Error(`In configuration file "${resolvedConfigurationFilePathForLogging}": ${e}`);
     }
 
-    this._annotateProperties(resolvedConfigurationFilePath, configurationJson);
+    return configurationJson;
+  }
 
-    for (const [jsonPath, metadata] of Object.entries(this._jsonPathMetadata)) {
+  /**
+   * Resolves all path properties and annotates properties with their original values.
+   * @param entry - The cache entry for the loaded configuration file
+   * @param projectFolderPath - The project folder path, if applicable
+   * @returns The configuration file with all path properties resolved
+   */
+  private _contextualizeConfigurationFile(
+    entry: IConfigurationFileCacheEntry<TConfigurationFile>,
+    projectFolderPath: string | undefined
+  ): IConfigurationJson & TConfigurationFile {
+    // Deep copy the configuration file because different callers might contextualize properties differently.
+    const result: IConfigurationJson & TConfigurationFile = structuredClone(entry.configurationFile);
+
+    const { resolvedConfigurationFilePath } = entry;
+
+    this._annotateProperties(resolvedConfigurationFilePath, result);
+
+    for (const [jsonPath, metadata] of this._jsonPathMetadata) {
       JSONPath({
         path: jsonPath,
-        json: configurationJson,
+        json: result,
         callback: (payload: unknown, payloadType: string, fullPayload: IJsonPathCallbackObject) => {
           const resolvedPath: string = this._resolvePathProperty(
             {
               propertyName: fullPayload.path,
               propertyValue: fullPayload.value,
               configurationFilePath: resolvedConfigurationFilePath,
-              configurationFile: configurationJson
+              configurationFile: result,
+              projectFolderPath
             },
             metadata
           );
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          (fullPayload.parent as any)[fullPayload.parentProperty] = resolvedPath;
+          (fullPayload.parent as Record<string, string>)[fullPayload.parentProperty] = resolvedPath;
         },
         otherTypeCallback: () => {
           throw new Error('@other() tags are not supported');
@@ -468,18 +650,91 @@ export abstract class ConfigurationFileBase<TConfigurationFile, TExtraOptions ex
       });
     }
 
-    return configurationJson;
+    return result;
+  }
+
+  /**
+   * Resolves all path properties and merges parent properties.
+   * @param entry - The cache entry for the loaded configuration file
+   * @param projectFolderPath - The project folder path, if applicable
+   * @returns The flattened, unvalidated configuration file, with path properties resolved
+   */
+  private _contextualizeAndFlattenConfigurationFile(
+    entry: IConfigurationFileCacheEntry<TConfigurationFile>,
+    projectFolderPath: string | undefined
+  ): Partial<TConfigurationFile> {
+    const { parent, resolvedConfigurationFilePath } = entry;
+    const parentConfig: TConfigurationFile | {} = parent
+      ? this._contextualizeAndFlattenConfigurationFile(parent, projectFolderPath)
+      : {};
+
+    const currentConfig: IConfigurationJson & TConfigurationFile = this._contextualizeConfigurationFile(
+      entry,
+      projectFolderPath
+    );
+
+    const result: Partial<TConfigurationFile> = this._mergeConfigurationFiles(
+      parentConfig,
+      currentConfig,
+      resolvedConfigurationFilePath
+    );
+
+    return result;
+  }
+
+  /**
+   * Resolves all path properties, merges parent properties, and validates the configuration file.
+   * @param entry - The cache entry for the loaded configuration file
+   * @param projectFolderPath - The project folder path, if applicable
+   * @param terminal - The terminal to log validation messages to
+   * @returns The finalized configuration file
+   */
+  private _finalizeConfigurationFile(
+    entry: IConfigurationFileCacheEntry<TConfigurationFile>,
+    projectFolderPath: string | undefined,
+    terminal: ITerminal
+  ): TConfigurationFile {
+    const { resolvedConfigurationFilePathForLogging } = entry;
+
+    const result: Partial<TConfigurationFile> = this._contextualizeAndFlattenConfigurationFile(
+      entry,
+      projectFolderPath
+    );
+
+    try {
+      this._schema.validateObject(result, resolvedConfigurationFilePathForLogging);
+    } catch (e) {
+      throw new Error(`Resolved configuration object does not match schema: ${e}`);
+    }
+
+    if (
+      this._customValidationFunction &&
+      !this._customValidationFunction(
+        result as TConfigurationFile,
+        resolvedConfigurationFilePathForLogging,
+        terminal
+      )
+    ) {
+      // To suppress this error, the function may throw its own error, such as an AlreadyReportedError if it already
+      // logged to the terminal.
+      throw new Error(
+        `Resolved configuration file at "${resolvedConfigurationFilePathForLogging}" failed custom validation.`
+      );
+    }
+
+    // If the schema validates, we can assume that the configuration file is complete.
+    return result as TConfigurationFile;
   }
 
   // NOTE: Internal calls to load a configuration file should use `_loadConfigurationFileInnerWithCache`.
   // Don't call this function directly, as it does not provide config file loop detection,
   // and you won't get the advantage of queueing up for a config file that is already loading.
-  private _loadConfigurationFileInner(
+  private _loadConfigurationFileEntry(
     terminal: ITerminal,
     resolvedConfigurationFilePath: string,
     visitedConfigurationFilePaths: Set<string>,
-    rigConfig: IRigConfig | undefined
-  ): TConfigurationFile {
+    fileNotFoundFallback?: IOnConfigurationFileNotFoundCallback
+  ): IConfigurationFileCacheEntry<TConfigurationFile> {
     const resolvedConfigurationFilePathForLogging: string = ConfigurationFileBase._formatPathForLogging(
       resolvedConfigurationFilePath
     );
@@ -489,48 +744,46 @@ export abstract class ConfigurationFileBase<TConfigurationFile, TExtraOptions ex
       fileText = FileSystem.readFile(resolvedConfigurationFilePath);
     } catch (e) {
       if (FileSystem.isNotExistError(e as Error)) {
-        if (rigConfig) {
-          terminal.writeDebugLine(
-            `Config file "${resolvedConfigurationFilePathForLogging}" does not exist. Attempting to load via rig.`
-          );
-          const rigResult: TConfigurationFile | undefined = this._tryLoadConfigurationFileInRig(
-            terminal,
-            rigConfig,
-            visitedConfigurationFilePaths
-          );
-          if (rigResult) {
-            return rigResult;
+        const fallbackPath: string | undefined = fileNotFoundFallback?.(
+          resolvedConfigurationFilePathForLogging
+        );
+        if (fallbackPath) {
+          try {
+            return this._loadConfigurationFileEntryWithCache(
+              terminal,
+              fallbackPath,
+              visitedConfigurationFilePaths
+            );
+          } catch (fallbackError) {
+            if (!FileSystem.isNotExistError(fallbackError as Error)) {
+              throw fallbackError;
+            }
+            // Otherwise report the missing original file.
           }
-        } else {
-          terminal.writeDebugLine(
-            `Configuration file "${resolvedConfigurationFilePathForLogging}" not found.`
-          );
         }
 
+        terminal.writeDebugLine(`Configuration file "${resolvedConfigurationFilePathForLogging}" not found.`);
         (e as Error).message = `File does not exist: ${resolvedConfigurationFilePathForLogging}`;
       }
 
       throw e;
     }
-
-    const configurationJson: IConfigurationJson & TConfigurationFile = this._parseAndResolveConfigurationFile(
+    const configurationJson: IConfigurationJson & TConfigurationFile = this._parseConfigurationFile(
       fileText,
-      resolvedConfigurationFilePath,
       resolvedConfigurationFilePathForLogging
     );
 
-    let parentConfiguration: TConfigurationFile | undefined;
+    let parentConfiguration: IConfigurationFileCacheEntry<TConfigurationFile> | undefined;
     if (configurationJson.extends) {
       try {
         const resolvedParentConfigPath: string = Import.resolveModule({
           modulePath: configurationJson.extends,
           baseFolderPath: nodeJsPath.dirname(resolvedConfigurationFilePath)
         });
-        parentConfiguration = this._loadConfigurationFileInnerWithCache(
+        parentConfiguration = this._loadConfigurationFileEntryWithCache(
           terminal,
           resolvedParentConfigPath,
-          visitedConfigurationFilePaths,
-          undefined
+          visitedConfigurationFilePaths
         );
       } catch (e) {
         if (FileSystem.isNotExistError(e as Error)) {
@@ -544,30 +797,24 @@ export abstract class ConfigurationFileBase<TConfigurationFile, TExtraOptions ex
       }
     }
 
-    const result: Partial<TConfigurationFile> = this._mergeConfigurationFiles(
-      parentConfiguration || {},
-      configurationJson,
-      resolvedConfigurationFilePath
-    );
-    try {
-      this._schema.validateObject(result, resolvedConfigurationFilePathForLogging);
-    } catch (e) {
-      throw new Error(`Resolved configuration object does not match schema: ${e}`);
-    }
-
-    // If the schema validates, we can assume that the configuration file is complete.
-    return result as TConfigurationFile;
+    const result: IConfigurationFileCacheEntry<TConfigurationFile> = {
+      configurationFile: configurationJson,
+      resolvedConfigurationFilePath,
+      resolvedConfigurationFilePathForLogging,
+      parent: parentConfiguration
+    };
+    return result;
   }
 
   // NOTE: Internal calls to load a configuration file should use `_loadConfigurationFileInnerWithCacheAsync`.
   // Don't call this function directly, as it does not provide config file loop detection,
   // and you won't get the advantage of queueing up for a config file that is already loading.
-  private async _loadConfigurationFileInnerAsync(
+  private async _loadConfigurationFileEntryAsync(
     terminal: ITerminal,
     resolvedConfigurationFilePath: string,
     visitedConfigurationFilePaths: Set<string>,
-    rigConfig: IRigConfig | undefined
-  ): Promise<TConfigurationFile> {
+    fileNotFoundFallback?: IOnConfigurationFileNotFoundCallback
+  ): Promise<IConfigurationFileCacheEntry<TConfigurationFile>> {
     const resolvedConfigurationFilePathForLogging: string = ConfigurationFileBase._formatPathForLogging(
       resolvedConfigurationFilePath
     );
@@ -577,48 +824,46 @@ export abstract class ConfigurationFileBase<TConfigurationFile, TExtraOptions ex
       fileText = await FileSystem.readFileAsync(resolvedConfigurationFilePath);
     } catch (e) {
       if (FileSystem.isNotExistError(e as Error)) {
-        if (rigConfig) {
-          terminal.writeDebugLine(
-            `Config file "${resolvedConfigurationFilePathForLogging}" does not exist. Attempting to load via rig.`
-          );
-          const rigResult: TConfigurationFile | undefined = await this._tryLoadConfigurationFileInRigAsync(
-            terminal,
-            rigConfig,
-            visitedConfigurationFilePaths
-          );
-          if (rigResult) {
-            return rigResult;
+        const fallbackPath: string | undefined = fileNotFoundFallback?.(
+          resolvedConfigurationFilePathForLogging
+        );
+        if (fallbackPath) {
+          try {
+            return await this._loadConfigurationFileEntryWithCacheAsync(
+              terminal,
+              fallbackPath,
+              visitedConfigurationFilePaths
+            );
+          } catch (fallbackError) {
+            if (!FileSystem.isNotExistError(fallbackError as Error)) {
+              throw fallbackError;
+            }
+            // Otherwise report the missing original file.
           }
-        } else {
-          terminal.writeDebugLine(
-            `Configuration file "${resolvedConfigurationFilePathForLogging}" not found.`
-          );
         }
 
+        terminal.writeDebugLine(`Configuration file "${resolvedConfigurationFilePathForLogging}" not found.`);
         (e as Error).message = `File does not exist: ${resolvedConfigurationFilePathForLogging}`;
       }
 
       throw e;
     }
-
-    const configurationJson: IConfigurationJson & TConfigurationFile = this._parseAndResolveConfigurationFile(
+    const configurationJson: IConfigurationJson & TConfigurationFile = this._parseConfigurationFile(
       fileText,
-      resolvedConfigurationFilePath,
       resolvedConfigurationFilePathForLogging
     );
 
-    let parentConfiguration: TConfigurationFile | undefined;
+    let parentConfiguration: IConfigurationFileCacheEntry<TConfigurationFile> | undefined;
     if (configurationJson.extends) {
       try {
-        const resolvedParentConfigPath: string = Import.resolveModule({
+        const resolvedParentConfigPath: string = await Import.resolveModuleAsync({
           modulePath: configurationJson.extends,
           baseFolderPath: nodeJsPath.dirname(resolvedConfigurationFilePath)
         });
-        parentConfiguration = await this._loadConfigurationFileInnerWithCacheAsync(
+        parentConfiguration = await this._loadConfigurationFileEntryWithCacheAsync(
           terminal,
           resolvedParentConfigPath,
-          visitedConfigurationFilePaths,
-          undefined
+          visitedConfigurationFilePaths
         );
       } catch (e) {
         if (FileSystem.isNotExistError(e as Error)) {
@@ -632,45 +877,32 @@ export abstract class ConfigurationFileBase<TConfigurationFile, TExtraOptions ex
       }
     }
 
-    const result: Partial<TConfigurationFile> = this._mergeConfigurationFiles(
-      parentConfiguration || {},
-      configurationJson,
-      resolvedConfigurationFilePath
-    );
-    try {
-      this._schema.validateObject(result, resolvedConfigurationFilePathForLogging);
-    } catch (e) {
-      throw new Error(`Resolved configuration object does not match schema: ${e}`);
-    }
-
-    // If the schema validates, we can assume that the configuration file is complete.
-    return result as TConfigurationFile;
+    const result: IConfigurationFileCacheEntry<TConfigurationFile> = {
+      configurationFile: configurationJson,
+      resolvedConfigurationFilePath,
+      resolvedConfigurationFilePathForLogging,
+      parent: parentConfiguration
+    };
+    return result;
   }
 
-  private _annotateProperties<TObject>(resolvedConfigurationFilePath: string, obj: TObject): void {
-    if (!obj) {
+  private _annotateProperties<TObject>(resolvedConfigurationFilePath: string, root: TObject): void {
+    if (!root) {
       return;
     }
 
-    if (typeof obj === 'object') {
-      this._annotateProperty(resolvedConfigurationFilePath, obj);
+    const queue: Set<TObject> = new Set([root]);
+    for (const obj of queue) {
+      if (obj && typeof obj === 'object') {
+        (obj as unknown as IAnnotatedField<TObject>)[CONFIGURATION_FILE_FIELD_ANNOTATION] = {
+          configurationFilePath: resolvedConfigurationFilePath,
+          originalValues: { ...obj }
+        };
 
-      for (const objValue of Object.values(obj)) {
-        this._annotateProperties(resolvedConfigurationFilePath, objValue);
+        for (const objValue of Object.values(obj)) {
+          queue.add(objValue as TObject);
+        }
       }
-    }
-  }
-
-  private _annotateProperty<TObject>(resolvedConfigurationFilePath: string, obj: TObject): void {
-    if (!obj) {
-      return;
-    }
-
-    if (typeof obj === 'object') {
-      (obj as unknown as IAnnotatedField<TObject>)[CONFIGURATION_FILE_FIELD_ANNOTATION] = {
-        configurationFilePath: resolvedConfigurationFilePath,
-        originalValues: { ...obj }
-      };
     }
   }
 
@@ -678,7 +910,7 @@ export abstract class ConfigurationFileBase<TConfigurationFile, TExtraOptions ex
     resolverOptions: IJsonPathMetadataResolverOptions<TConfigurationFile>,
     metadata: IJsonPathMetadata<TConfigurationFile>
   ): string {
-    const { propertyValue, configurationFilePath } = resolverOptions;
+    const { propertyValue, configurationFilePath, projectFolderPath } = resolverOptions;
     const resolutionMethod: PathResolutionMethod | undefined = metadata.pathResolutionMethod;
     if (resolutionMethod === undefined) {
       return propertyValue;
@@ -690,8 +922,7 @@ export abstract class ConfigurationFileBase<TConfigurationFile, TExtraOptions ex
       }
 
       case PathResolutionMethod.resolvePathRelativeToProjectRoot: {
-        const packageRoot: string | undefined =
-          this._packageJsonLookup.tryGetPackageFolderFor(configurationFilePath);
+        const packageRoot: string | undefined = projectFolderPath;
         if (!packageRoot) {
           throw new Error(
             `Could not find a package root for path "${ConfigurationFileBase._formatPathForLogging(
@@ -769,10 +1000,12 @@ export abstract class ConfigurationFileBase<TConfigurationFile, TExtraOptions ex
     // contain inheritance type annotation keys, or other built-in properties that we ignore
     // (eg. "extends", "$schema").
     const currentObjectPropertyNames: Set<string> = new Set(Object.keys(currentObject));
-    // An array of property names that should be included in the resulting object.
-    const filteredObjectPropertyNames: (keyof TField)[] = [];
     // A map of property names to their inheritance type.
     const inheritanceTypeMap: Map<keyof TField, IPropertyInheritance<InheritanceType>> = new Map();
+
+    // The set of property names that should be included in the resulting object
+    // All names from the parent are assumed to already be filtered.
+    const mergedPropertyNames: Set<keyof TField> = new Set(Object.keys(parentObject));
 
     // Do a first pass to gather and strip the inheritance type annotations from the merging object.
     for (const propertyName of currentObjectPropertyNames) {
@@ -827,18 +1060,12 @@ export abstract class ConfigurationFileBase<TConfigurationFile, TExtraOptions ex
             );
         }
       } else {
-        filteredObjectPropertyNames.push(propertyName);
+        mergedPropertyNames.add(propertyName);
       }
     }
 
-    // We only filter the currentObject because the parent object should already be filtered
-    const propertyNames: Set<keyof TField> = new Set([
-      ...Object.keys(parentObject),
-      ...filteredObjectPropertyNames
-    ]);
-
     // Cycle through properties and merge them
-    for (const propertyName of propertyNames) {
+    for (const propertyName of mergedPropertyNames) {
       const propertyValue: TField[keyof TField] | undefined = currentObject[propertyName];
       const parentPropertyValue: TField[keyof TField] | undefined = parentObject[propertyName];
 

--- a/libraries/heft-config-file/src/ConfigurationFileBase.ts
+++ b/libraries/heft-config-file/src/ConfigurationFileBase.ts
@@ -925,9 +925,9 @@ export abstract class ConfigurationFileBase<TConfigurationFile, TExtraOptions ex
         const packageRoot: string | undefined = projectFolderPath;
         if (!packageRoot) {
           throw new Error(
-            `Could not find a package root for path "${ConfigurationFileBase._formatPathForLogging(
+            `Project-relative resolution was requested in "${ConfigurationFileBase._formatPathForLogging(
               configurationFilePath
-            )}"`
+            )}" but no project root was provided to the configuration file loader.`
           );
         }
 

--- a/libraries/heft-config-file/src/NonProjectConfigurationFile.ts
+++ b/libraries/heft-config-file/src/NonProjectConfigurationFile.ts
@@ -1,9 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import { FileSystem } from '@rushstack/node-core-library';
+import { FileSystem, PackageJsonLookup } from '@rushstack/node-core-library';
 import type { ITerminal } from '@rushstack/terminal';
-import type { IRigConfig } from '@rushstack/rig-package';
 
 import { ConfigurationFileBase } from './ConfigurationFileBase';
 
@@ -19,7 +18,11 @@ export class NonProjectConfigurationFile<TConfigurationFile> extends Configurati
    * `extends` properties. Will throw an error if the file cannot be found.
    */
   public loadConfigurationFile(terminal: ITerminal, filePath: string): TConfigurationFile {
-    return this._loadConfigurationFileInnerWithCache(terminal, filePath, new Set<string>(), undefined);
+    return this._loadConfigurationFileInnerWithCache(
+      terminal,
+      filePath,
+      PackageJsonLookup.instance.tryGetPackageFolderFor(filePath)
+    );
   }
 
   /**
@@ -33,8 +36,7 @@ export class NonProjectConfigurationFile<TConfigurationFile> extends Configurati
     return await this._loadConfigurationFileInnerWithCacheAsync(
       terminal,
       filePath,
-      new Set<string>(),
-      undefined
+      PackageJsonLookup.instance.tryGetPackageFolderFor(filePath)
     );
   }
 
@@ -69,23 +71,5 @@ export class NonProjectConfigurationFile<TConfigurationFile> extends Configurati
       }
       throw e;
     }
-  }
-
-  protected _tryLoadConfigurationFileInRig(
-    terminal: ITerminal,
-    rigConfig: IRigConfig,
-    visitedConfigurationFilePaths: Set<string>
-  ): TConfigurationFile | undefined {
-    // This is a no-op because we don't support rigging for non-project configuration files
-    return undefined;
-  }
-
-  protected async _tryLoadConfigurationFileInRigAsync(
-    terminal: ITerminal,
-    rigConfig: IRigConfig,
-    visitedConfigurationFilePaths: Set<string>
-  ): Promise<TConfigurationFile | undefined> {
-    // This is a no-op because we don't support rigging for non-project configuration files
-    return undefined;
   }
 }

--- a/libraries/heft-config-file/src/index.ts
+++ b/libraries/heft-config-file/src/index.ts
@@ -10,6 +10,7 @@
 
 export {
   ConfigurationFileBase,
+  type CustomValidationFunction,
   type IConfigurationFileOptionsBase,
   type IConfigurationFileOptionsWithJsonSchemaFilePath,
   type IConfigurationFileOptionsWithJsonSchemaObject,
@@ -21,6 +22,7 @@ export {
   type IJsonPathsMetadata,
   InheritanceType,
   type INonCustomJsonPathMetadata,
+  type IOnConfigurationFileNotFoundCallback,
   type IOriginalValueOptions,
   type IPropertiesInheritance,
   type IPropertyInheritance,
@@ -44,7 +46,11 @@ export const ConfigurationFile: typeof ProjectConfigurationFile = ProjectConfigu
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export type ConfigurationFile<TConfigurationFile> = ProjectConfigurationFile<TConfigurationFile>;
 
-export { ProjectConfigurationFile, type IProjectConfigurationFileOptions } from './ProjectConfigurationFile';
+export {
+  ProjectConfigurationFile,
+  type IProjectConfigurationFileOptions,
+  type IProjectConfigurationFileSpecification
+} from './ProjectConfigurationFile';
 export { NonProjectConfigurationFile } from './NonProjectConfigurationFile';
 
 export * as TestUtilities from './TestUtilities';

--- a/libraries/heft-config-file/src/test/ConfigurationFile.test.ts
+++ b/libraries/heft-config-file/src/test/ConfigurationFile.test.ts
@@ -1826,7 +1826,7 @@ describe('ConfigurationFile', () => {
       // a newline on Windows, and a curly brace on other platforms, even though the location is
       // accurate in both cases. Use a regex to match either.
       expect(() => configFileLoader.loadConfigurationFileForProject(terminal, __dirname)).toThrowError(
-        /In config file "<project root>\/lib\/test\/errorCases\/invalidJson\/config.json": SyntaxError: Unexpected token '(}|\\n)' at 2:19/
+        /In configuration file "<project root>\/lib\/test\/errorCases\/invalidJson\/config.json": SyntaxError: Unexpected token '(}|\\n)' at 2:19/
       );
 
       jest.restoreAllMocks();
@@ -1861,7 +1861,7 @@ describe('ConfigurationFile', () => {
       await expect(
         configFileLoader.loadConfigurationFileForProjectAsync(terminal, __dirname)
       ).rejects.toThrowError(
-        /In config file "<project root>\/lib\/test\/errorCases\/invalidJson\/config.json": SyntaxError: Unexpected token '(}|\\n)' at 2:19/
+        /In configuration file "<project root>\/lib\/test\/errorCases\/invalidJson\/config.json": SyntaxError: Unexpected token '(}|\\n)' at 2:19/
       );
 
       jest.restoreAllMocks();

--- a/libraries/heft-config-file/src/test/__snapshots__/ConfigurationFile.test.ts.snap
+++ b/libraries/heft-config-file/src/test/__snapshots__/ConfigurationFile.test.ts.snap
@@ -748,7 +748,7 @@ Object {
 
 exports[`ConfigurationFile loading a rig correctly loads a config file inside a rig 1`] = `
 Object {
-  "debug": "Config file \\"<project root>/lib/test/project-referencing-rig/config/simplestConfigFile.json\\" does not exist. Attempting to load via rig.[n]",
+  "debug": "Configuration file \\"<project root>/lib/test/project-referencing-rig/config/simplestConfigFile.json\\" does not exist. Attempting to load via rig (\\"<project root>/lib/test/project-referencing-rig/node_modules/test-rig/profiles/default\\").[n]",
   "error": "",
   "log": "",
   "verbose": "",
@@ -758,7 +758,7 @@ Object {
 
 exports[`ConfigurationFile loading a rig correctly loads a config file inside a rig async 1`] = `
 Object {
-  "debug": "Config file \\"<project root>/lib/test/project-referencing-rig/config/simplestConfigFile.json\\" does not exist. Attempting to load via rig.[n]",
+  "debug": "Configuration file \\"<project root>/lib/test/project-referencing-rig/config/simplestConfigFile.json\\" does not exist. Attempting to load via rig (\\"<project root>/lib/test/project-referencing-rig/node_modules/test-rig/profiles/default\\").[n]",
   "error": "",
   "log": "",
   "verbose": "",
@@ -768,7 +768,7 @@ Object {
 
 exports[`ConfigurationFile loading a rig correctly loads a config file inside a rig via tryLoadConfigurationFileForProject 1`] = `
 Object {
-  "debug": "Config file \\"<project root>/lib/test/project-referencing-rig/config/simplestConfigFile.json\\" does not exist. Attempting to load via rig.[n]",
+  "debug": "Configuration file \\"<project root>/lib/test/project-referencing-rig/config/simplestConfigFile.json\\" does not exist. Attempting to load via rig (\\"<project root>/lib/test/project-referencing-rig/node_modules/test-rig/profiles/default\\").[n]",
   "error": "",
   "log": "",
   "verbose": "",
@@ -778,7 +778,7 @@ Object {
 
 exports[`ConfigurationFile loading a rig correctly loads a config file inside a rig via tryLoadConfigurationFileForProjectAsync 1`] = `
 Object {
-  "debug": "Config file \\"<project root>/lib/test/project-referencing-rig/config/simplestConfigFile.json\\" does not exist. Attempting to load via rig.[n]",
+  "debug": "Configuration file \\"<project root>/lib/test/project-referencing-rig/config/simplestConfigFile.json\\" does not exist. Attempting to load via rig (\\"<project root>/lib/test/project-referencing-rig/node_modules/test-rig/profiles/default\\").[n]",
   "error": "",
   "log": "",
   "verbose": "",
@@ -790,7 +790,7 @@ exports[`ConfigurationFile loading a rig throws an error when a config file does
 
 exports[`ConfigurationFile loading a rig throws an error when a config file doesn't exist in a project referencing a rig, which also doesn't have the file 2`] = `
 Object {
-  "debug": "Config file \\"<project root>/lib/test/project-referencing-rig/config/notExist.json\\" does not exist. Attempting to load via rig.[n]Configuration file \\"<project root>/lib/test/project-referencing-rig/node_modules/test-rig/profiles/default/config/notExist.json\\" not found.[n]Configuration file \\"config/notExist.json\\" not found in rig (\\"<project root>/lib/test/project-referencing-rig/node_modules/test-rig/profiles/default\\")[n]",
+  "debug": "Configuration file \\"<project root>/lib/test/project-referencing-rig/config/notExist.json\\" does not exist. Attempting to load via rig (\\"<project root>/lib/test/project-referencing-rig/node_modules/test-rig/profiles/default\\").[n]Configuration file \\"<project root>/lib/test/project-referencing-rig/node_modules/test-rig/profiles/default/config/notExist.json\\" not found.[n]Configuration file \\"<project root>/lib/test/project-referencing-rig/config/notExist.json\\" not found.[n]",
   "error": "",
   "log": "",
   "verbose": "",
@@ -802,7 +802,7 @@ exports[`ConfigurationFile loading a rig throws an error when a config file does
 
 exports[`ConfigurationFile loading a rig throws an error when a config file doesn't exist in a project referencing a rig, which also doesn't have the file async 2`] = `
 Object {
-  "debug": "Config file \\"<project root>/lib/test/project-referencing-rig/config/notExist.json\\" does not exist. Attempting to load via rig.[n]Configuration file \\"<project root>/lib/test/project-referencing-rig/node_modules/test-rig/profiles/default/config/notExist.json\\" not found.[n]Configuration file \\"config/notExist.json\\" not found in rig (\\"<project root>/lib/test/project-referencing-rig/node_modules/test-rig/profiles/default\\")[n]",
+  "debug": "Configuration file \\"<project root>/lib/test/project-referencing-rig/config/notExist.json\\" does not exist. Attempting to load via rig (\\"<project root>/lib/test/project-referencing-rig/node_modules/test-rig/profiles/default\\").[n]Configuration file \\"<project root>/lib/test/project-referencing-rig/node_modules/test-rig/profiles/default/config/notExist.json\\" not found.[n]Configuration file \\"<project root>/lib/test/project-referencing-rig/config/notExist.json\\" not found.[n]",
   "error": "",
   "log": "",
   "verbose": "",


### PR DESCRIPTION
## Summary
Adds a new API to `HeftConfiguration`, `tryLoadProjectConfigurationFileAsync`, so that plugins can load riggable config files without taking a direct dependency (and risking version duplication) on `@rushstack/heft-config-file`.

Starts addressing #5092. The motivation is to get us to a world where Heft plugins don't need any runtime dependencies other than on any external tools they bring with them, because all the core functionality of a Heft plugin is available on arguments passed to `apply`, similar to prior art in webpack plugins, that have the `compiler.webpack` field that provides access to all functionality that would otherwise be obtained via `import ... from 'webpack'`.

This API change removes any need for Heft plugins to take their own dependency on the `@rushstack/heft-config-file` package for normal scenarios.

## Details
Fixes an issue with `PathResolutionMethod.resolveRelativeToProjectRoot` when extending from a file that lives in a different package. It was previously resolving relative to the package that contained the file being extended from, rather than the file that contains the original loaded configuration file.

Adds a new `customValidationFunction` option to the configuration file APIs that can be used to perform additional validation after loading a file.

Uses this API in `heft-api-extractor-plugin`, `heft-sass-plugin`, and `heft-typescript-plugin`.
Currently doesn't expose the version that throws if the file cannot be found.

All needed types are re-exported under the `ConfigurationFile` namespace on `@rushstack/heft`.

## How it was tested
Existing build tests for these plugins.

## Impacted documentation
API Documentation for `@rushstack/heft`.