### PR TITLE
[api-extractor] Upgrade bundled TypeScript to 5.8

### DIFF
--- a/apps/api-extractor/package.json
+++ b/apps/api-extractor/package.json
@@ -49,7 +49,7 @@
     "resolve": "~1.22.1",
     "semver": "~7.5.4",
     "source-map": "~0.6.1",
-    "typescript": "5.7.3"
+    "typescript": "5.8.2"
   },
   "devDependencies": {
     "@rushstack/heft-node-rig": "2.7.0",

--- a/apps/api-extractor/src/analyzer/TypeScriptInternals.ts
+++ b/apps/api-extractor/src/analyzer/TypeScriptInternals.ts
@@ -106,7 +106,7 @@ export class TypeScriptInternals {
     compilerOptions: ts.CompilerOptions
   ): ts.ModuleKind.CommonJS | ts.ModuleKind.ESNext | undefined {
     // Compiler internal:
-    // https://github.com/microsoft/TypeScript/blob/v5.7.2/src/compiler/program.ts#L940
+    // https://github.com/microsoft/TypeScript/blob/v5.8.2/src/compiler/program.ts#L931
 
     return ts.getModeForUsageLocation?.(file, usage, compilerOptions);
   }

--- a/common/changes/@microsoft/api-extractor/feat-ts-85_2025-03-08-00-13.json
+++ b/common/changes/@microsoft/api-extractor/feat-ts-85_2025-03-08-00-13.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Upgrade the bundled compiler engine to TypeScript 5.8.2",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor"
+}

--- a/common/config/subspaces/build-tests-subspace/pnpm-lock.yaml
+++ b/common/config/subspaces/build-tests-subspace/pnpm-lock.yaml
@@ -5754,6 +5754,12 @@ packages:
     hasBin: true
     dev: true
 
+  /typescript@5.8.2:
+    resolution: {integrity: sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+    dev: true
+
   /unbox-primitive@1.0.2:
     resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}
     dependencies:
@@ -6043,7 +6049,7 @@ packages:
       resolve: 1.22.8
       semver: 7.5.4
       source-map: 0.6.1
-      typescript: 5.7.3
+      typescript: 5.8.2
     transitivePeerDependencies:
       - '@types/node'
     dev: true

--- a/common/config/subspaces/build-tests-subspace/repo-state.json
+++ b/common/config/subspaces/build-tests-subspace/repo-state.json
@@ -1,6 +1,6 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "e5d80b8cf111a9c4f3ae1e122504d8a8a8a10212",
+  "pnpmShrinkwrapHash": "effebb9032dc4d68bae34724735623fc48ee0062",
   "preferredVersionsHash": "7aee53abbca2f0cefac5a2a8c72ca7703b10dff2",
-  "packageJsonInjectedDependenciesHash": "891f1ac2c4f24e651950979dc6efc58d0f65a9fa"
+  "packageJsonInjectedDependenciesHash": "2d41c3cdbec0377eb577311c98b3201348c78054"
 }

--- a/common/config/subspaces/default/common-versions.json
+++ b/common/config/subspaces/default/common-versions.json
@@ -100,7 +100,7 @@
       "~4.9.5",
 
       // API Extractor bundles a specific TypeScript version because it calls internal APIs
-      "5.7.3"
+      "5.8.2"
     ],
     "source-map": [
       "~0.6.1" // API Extractor is using an older version of source-map because newer versions are async

--- a/common/config/subspaces/default/pnpm-lock.yaml
+++ b/common/config/subspaces/default/pnpm-lock.yaml
@@ -89,8 +89,8 @@ importers:
         specifier: ~0.6.1
         version: 0.6.1
       typescript:
-        specifier: 5.7.3
-        version: 5.7.3
+        specifier: 5.8.2
+        version: 5.8.2
     devDependencies:
       '@rushstack/heft':
         specifier: 0.69.2
@@ -27662,6 +27662,12 @@ packages:
     resolution: {integrity: sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  /typescript@5.8.2:
+    resolution: {integrity: sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+    dev: false
 
   /uc.micro@1.0.6:
     resolution: {integrity: sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==}

--- a/common/config/subspaces/default/repo-state.json
+++ b/common/config/subspaces/default/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "da2722a86fe993181338c895b736309f15a7b6dd",
+  "pnpmShrinkwrapHash": "979e9e8b131852775c6357b477fcdf3f82e638f6",
   "preferredVersionsHash": "7aee53abbca2f0cefac5a2a8c72ca7703b10dff2"
 }


### PR DESCRIPTION
## Summary

Upgrade the bundled compiler engine to TypeScript 5.8.2.

## Details

Allows using new `erasableSyntaxOnly` option, which currently fails:

```
api-extractor 7.51.1  - https://api-extractor.com/

Using configuration from ./api-extractor.json

ERROR: Error parsing tsconfig.json content: Unknown compiler option 'erasableSyntaxOnly'.
```

Seems to work fine after the upgrade.

## How it was tested

Ran the build tests. Also manually overwrote the typescript version used by API extractor in a project, and seems to work just fine.

## Impacted documentation

None, as far as I know.