### PR TITLE
[rush] Add a `RUSH_BUILD_CACHE_OVERRIDE_JSON` env var to override the build cache configuration.

### DIFF
--- a/common/changes/@microsoft/rush/build-cache-override-support_2025-03-08-23-35.json
+++ b/common/changes/@microsoft/rush/build-cache-override-support_2025-03-08-23-35.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add support for a `RUSH_BUILD_CACHE_OVERRIDE_JSON` environment variable that takes a JSON string with the same format as the `common/config/build-cache.json` file that can be used to override the build cache configuration that is normally provided by that file.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/build-cache-override-support_2025-03-08-23-35.json
+++ b/common/changes/@microsoft/rush/build-cache-override-support_2025-03-08-23-35.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Add support for a `RUSH_BUILD_CACHE_OVERRIDE_JSON` environment variable that takes a JSON string with the same format as the `common/config/build-cache.json` file that can be used to override the build cache configuration that is normally provided by that file.",
+      "comment": "Add support for `RUSH_BUILD_CACHE_OVERRIDE_JSON` environment variable that takes a JSON string with the same format as the `common/config/build-cache.json` file and a `RUSH_BUILD_CACHE_OVERRIDE_JSON_FILE_PATH` environment variable that takes a file path that can be used to override the build cache configuration that is normally provided by that file.",
       "type": "none"
     }
   ],

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -238,6 +238,7 @@ export class EnvironmentConfiguration {
     static get buildCacheCredential(): string | undefined;
     static get buildCacheEnabled(): boolean | undefined;
     static get buildCacheOverrideJson(): string | undefined;
+    static get buildCacheOverrideJsonFilePath(): string | undefined;
     static get buildCacheWriteAllowed(): boolean | undefined;
     static get cobuildContextId(): string | undefined;
     static get cobuildLeafProjectLogOnlyAllowed(): boolean | undefined;
@@ -276,6 +277,7 @@ export const EnvironmentVariableNames: {
     readonly RUSH_BUILD_CACHE_ENABLED: "RUSH_BUILD_CACHE_ENABLED";
     readonly RUSH_BUILD_CACHE_WRITE_ALLOWED: "RUSH_BUILD_CACHE_WRITE_ALLOWED";
     readonly RUSH_BUILD_CACHE_OVERRIDE_JSON: "RUSH_BUILD_CACHE_OVERRIDE_JSON";
+    readonly RUSH_BUILD_CACHE_OVERRIDE_JSON_FILE_PATH: "RUSH_BUILD_CACHE_OVERRIDE_JSON_FILE_PATH";
     readonly RUSH_COBUILD_CONTEXT_ID: "RUSH_COBUILD_CONTEXT_ID";
     readonly RUSH_COBUILD_RUNNER_ID: "RUSH_COBUILD_RUNNER_ID";
     readonly RUSH_COBUILD_LEAF_PROJECT_LOG_ONLY_ALLOWED: "RUSH_COBUILD_LEAF_PROJECT_LOG_ONLY_ALLOWED";

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -237,6 +237,7 @@ export class EnvironmentConfiguration {
     static get allowWarningsInSuccessfulBuild(): boolean;
     static get buildCacheCredential(): string | undefined;
     static get buildCacheEnabled(): boolean | undefined;
+    static get buildCacheOverrideJson(): string | undefined;
     static get buildCacheWriteAllowed(): boolean | undefined;
     static get cobuildContextId(): string | undefined;
     static get cobuildLeafProjectLogOnlyAllowed(): boolean | undefined;
@@ -274,6 +275,7 @@ export const EnvironmentVariableNames: {
     readonly RUSH_BUILD_CACHE_CREDENTIAL: "RUSH_BUILD_CACHE_CREDENTIAL";
     readonly RUSH_BUILD_CACHE_ENABLED: "RUSH_BUILD_CACHE_ENABLED";
     readonly RUSH_BUILD_CACHE_WRITE_ALLOWED: "RUSH_BUILD_CACHE_WRITE_ALLOWED";
+    readonly RUSH_BUILD_CACHE_OVERRIDE_JSON: "RUSH_BUILD_CACHE_OVERRIDE_JSON";
     readonly RUSH_COBUILD_CONTEXT_ID: "RUSH_COBUILD_CONTEXT_ID";
     readonly RUSH_COBUILD_RUNNER_ID: "RUSH_COBUILD_RUNNER_ID";
     readonly RUSH_COBUILD_LEAF_PROJECT_LOG_ONLY_ALLOWED: "RUSH_COBUILD_LEAF_PROJECT_LOG_ONLY_ALLOWED";

--- a/libraries/rush-lib/src/api/BuildCacheConfiguration.ts
+++ b/libraries/rush-lib/src/api/BuildCacheConfiguration.ts
@@ -220,13 +220,22 @@ export class BuildCacheConfiguration {
         `${EnvironmentVariableNames.RUSH_BUILD_CACHE_OVERRIDE_JSON} environment variable`
       );
     } else {
-      try {
-        buildCacheJson = await JsonFile.loadAndValidateAsync(jsonFilePath, BUILD_CACHE_JSON_SCHEMA);
-      } catch (e) {
-        if (!FileSystem.isNotExistError(e)) {
-          throw e;
-        } else {
-          return undefined;
+      const buildCacheOverrideJsonFilePath: string | undefined =
+        EnvironmentConfiguration.buildCacheOverrideJsonFilePath;
+      if (buildCacheOverrideJsonFilePath) {
+        buildCacheJson = await JsonFile.loadAndValidateAsync(
+          buildCacheOverrideJsonFilePath,
+          BUILD_CACHE_JSON_SCHEMA
+        );
+      } else {
+        try {
+          buildCacheJson = await JsonFile.loadAndValidateAsync(jsonFilePath, BUILD_CACHE_JSON_SCHEMA);
+        } catch (e) {
+          if (!FileSystem.isNotExistError(e)) {
+            throw e;
+          } else {
+            return undefined;
+          }
         }
       }
     }

--- a/libraries/rush-lib/src/api/BuildCacheConfiguration.ts
+++ b/libraries/rush-lib/src/api/BuildCacheConfiguration.ts
@@ -2,7 +2,6 @@
 // See LICENSE in the project root for license information.
 
 import { createHash } from 'node:crypto';
-import * as path from 'path';
 
 import {
   JsonFile,
@@ -146,11 +145,12 @@ export class BuildCacheConfiguration {
     rushConfiguration: RushConfiguration,
     rushSession: RushSession
   ): Promise<BuildCacheConfiguration | undefined> {
-    const jsonFilePath: string = BuildCacheConfiguration.getBuildCacheConfigFilePath(rushConfiguration);
-    if (!FileSystem.exists(jsonFilePath)) {
-      return undefined;
-    }
-    return await BuildCacheConfiguration._loadAsync(jsonFilePath, terminal, rushConfiguration, rushSession);
+    const { buildCacheConfiguration } = await BuildCacheConfiguration._tryLoadInternalAsync(
+      terminal,
+      rushConfiguration,
+      rushSession
+    );
+    return buildCacheConfiguration;
   }
 
   /**
@@ -162,21 +162,19 @@ export class BuildCacheConfiguration {
     rushConfiguration: RushConfiguration,
     rushSession: RushSession
   ): Promise<BuildCacheConfiguration> {
-    const jsonFilePath: string = BuildCacheConfiguration.getBuildCacheConfigFilePath(rushConfiguration);
-    if (!FileSystem.exists(jsonFilePath)) {
+    const { buildCacheConfiguration, jsonFilePath } = await BuildCacheConfiguration._tryLoadInternalAsync(
+      terminal,
+      rushConfiguration,
+      rushSession
+    );
+
+    if (!buildCacheConfiguration) {
       terminal.writeErrorLine(
         `The build cache feature is not enabled. This config file is missing:\n` + jsonFilePath
       );
       terminal.writeLine(`\nThe Rush website documentation has instructions for enabling the build cache.`);
       throw new AlreadyReportedError();
     }
-
-    const buildCacheConfiguration: BuildCacheConfiguration = await BuildCacheConfiguration._loadAsync(
-      jsonFilePath,
-      terminal,
-      rushConfiguration,
-      rushSession
-    );
 
     if (!buildCacheConfiguration.buildCacheEnabled) {
       terminal.writeErrorLine(
@@ -185,6 +183,7 @@ export class BuildCacheConfiguration {
       );
       throw new AlreadyReportedError();
     }
+
     return buildCacheConfiguration;
   }
 
@@ -192,21 +191,38 @@ export class BuildCacheConfiguration {
    * Gets the absolute path to the build-cache.json file in the specified rush workspace.
    */
   public static getBuildCacheConfigFilePath(rushConfiguration: RushConfiguration): string {
-    return path.resolve(rushConfiguration.commonRushConfigFolder, RushConstants.buildCacheFilename);
+    return `${rushConfiguration.commonRushConfigFolder}/${RushConstants.buildCacheFilename}`;
   }
 
-  private static async _loadAsync(
+  private static async _tryLoadInternalAsync(
+    terminal: ITerminal,
+    rushConfiguration: RushConfiguration,
+    rushSession: RushSession
+  ): Promise<{ buildCacheConfiguration: BuildCacheConfiguration | undefined; jsonFilePath: string }> {
+    const jsonFilePath: string = BuildCacheConfiguration.getBuildCacheConfigFilePath(rushConfiguration);
+    const buildCacheConfiguration: BuildCacheConfiguration | undefined =
+      await BuildCacheConfiguration._tryLoadAsync(jsonFilePath, terminal, rushConfiguration, rushSession);
+    return { buildCacheConfiguration, jsonFilePath };
+  }
+
+  private static async _tryLoadAsync(
     jsonFilePath: string,
     terminal: ITerminal,
     rushConfiguration: RushConfiguration,
     rushSession: RushSession
-  ): Promise<BuildCacheConfiguration> {
-    const buildCacheJson: IBuildCacheJson = await JsonFile.loadAndValidateAsync(
-      jsonFilePath,
-      BuildCacheConfiguration._jsonSchema
-    );
-    const rushUserConfiguration: RushUserConfiguration = await RushUserConfiguration.initializeAsync();
+  ): Promise<BuildCacheConfiguration | undefined> {
+    let buildCacheJson: IBuildCacheJson;
+    try {
+      buildCacheJson = await JsonFile.loadAndValidateAsync(jsonFilePath, BuildCacheConfiguration._jsonSchema);
+    } catch (e) {
+      if (FileSystem.isNotExistError(e)) {
+        throw e;
+      } else {
+        return undefined;
+      }
+    }
 
+    const rushUserConfiguration: RushUserConfiguration = await RushUserConfiguration.initializeAsync();
     let innerGetCacheEntryId: GetCacheEntryIdFunction;
     try {
       innerGetCacheEntryId = CacheEntryId.parsePattern(buildCacheJson.cacheEntryNamePattern);
@@ -218,7 +234,9 @@ export class BuildCacheConfiguration {
     }
 
     const { cacheHashSalt = '', cacheProvider } = buildCacheJson;
-    const salt: string = `${RushConstants.buildCacheVersion}${cacheHashSalt ? `${RushConstants.hashDelimiter}${cacheHashSalt}` : ''}`;
+    const salt: string = `${RushConstants.buildCacheVersion}${
+      cacheHashSalt ? `${RushConstants.hashDelimiter}${cacheHashSalt}` : ''
+    }`;
     // Extend the cache entry id with to salt the hash
     // This facilitates forcing cache invalidation either when the build cache version changes (new version of Rush)
     // or when the user-side salt changes (need to purge bad cache entries, plugins including additional files)

--- a/libraries/rush-lib/src/api/BuildCacheConfiguration.ts
+++ b/libraries/rush-lib/src/api/BuildCacheConfiguration.ts
@@ -213,7 +213,7 @@ export class BuildCacheConfiguration {
   ): Promise<BuildCacheConfiguration | undefined> {
     let buildCacheJson: IBuildCacheJson;
     const buildCacheOverrideJson: string | undefined = EnvironmentConfiguration.buildCacheOverrideJson;
-    if (buildCacheOverrideJson !== undefined) {
+    if (buildCacheOverrideJson) {
       buildCacheJson = JsonFile.parseString(buildCacheOverrideJson);
       BUILD_CACHE_JSON_SCHEMA.validateObject(
         buildCacheJson,
@@ -223,7 +223,7 @@ export class BuildCacheConfiguration {
       try {
         buildCacheJson = await JsonFile.loadAndValidateAsync(jsonFilePath, BUILD_CACHE_JSON_SCHEMA);
       } catch (e) {
-        if (FileSystem.isNotExistError(e)) {
+        if (!FileSystem.isNotExistError(e)) {
           throw e;
         } else {
           return undefined;

--- a/libraries/rush-lib/src/api/EnvironmentConfiguration.ts
+++ b/libraries/rush-lib/src/api/EnvironmentConfiguration.ts
@@ -145,6 +145,15 @@ export const EnvironmentVariableNames = {
   RUSH_BUILD_CACHE_WRITE_ALLOWED: 'RUSH_BUILD_CACHE_WRITE_ALLOWED',
 
   /**
+   * Set this environment variable to a JSON string to override the build cache configuration that normally lives
+   * at `common/config/rush/build-cache.json`.
+   *
+   * This is useful for testing purposes, or for OSS repos that are have a local-only cache, but can have
+   * a different cache configuration in CI/CD pipelines.
+   */
+  RUSH_BUILD_CACHE_OVERRIDE_JSON: 'RUSH_BUILD_CACHE_OVERRIDE_JSON',
+
+  /**
    * Setting this environment variable opts into running with cobuilds. The context id should be the same across
    * multiple VMs, but changed when it is a new round of cobuilds.
    *
@@ -249,6 +258,8 @@ export class EnvironmentConfiguration {
   private static _buildCacheEnabled: boolean | undefined;
 
   private static _buildCacheWriteAllowed: boolean | undefined;
+
+  private static _buildCacheOverrideJson: string | undefined;
 
   private static _cobuildContextId: string | undefined;
 
@@ -358,6 +369,15 @@ export class EnvironmentConfiguration {
   public static get buildCacheWriteAllowed(): boolean | undefined {
     EnvironmentConfiguration._ensureValidated();
     return EnvironmentConfiguration._buildCacheWriteAllowed;
+  }
+
+  /**
+   * If set, overrides the build cache configuration that normally lives at `common/config/rush/build-cache.json`.
+   * See {@link EnvironmentVariableNames.RUSH_BUILD_CACHE_OVERRIDE_JSON}
+   */
+  public static get buildCacheOverrideJson(): string | undefined {
+    EnvironmentConfiguration._ensureValidated();
+    return EnvironmentConfiguration._buildCacheOverrideJson;
   }
 
   /**
@@ -514,6 +534,11 @@ export class EnvironmentConfiguration {
                 EnvironmentVariableNames.RUSH_BUILD_CACHE_WRITE_ALLOWED,
                 value
               );
+            break;
+          }
+
+          case EnvironmentVariableNames.RUSH_BUILD_CACHE_OVERRIDE_JSON: {
+            EnvironmentConfiguration._buildCacheOverrideJson = value;
             break;
           }
 

--- a/libraries/rush-lib/src/api/EnvironmentConfiguration.ts
+++ b/libraries/rush-lib/src/api/EnvironmentConfiguration.ts
@@ -150,8 +150,27 @@ export const EnvironmentVariableNames = {
    *
    * This is useful for testing purposes, or for OSS repos that are have a local-only cache, but can have
    * a different cache configuration in CI/CD pipelines.
+   *
+   * @remarks
+   * This is similar to {@link EnvironmentVariableNames.RUSH_BUILD_CACHE_OVERRIDE_JSON_FILE_PATH}, but it allows you to specify
+   * a JSON string instead of a file path. The two environment variables are mutually exclusive, meaning you can
+   * only use one of them at a time.
    */
   RUSH_BUILD_CACHE_OVERRIDE_JSON: 'RUSH_BUILD_CACHE_OVERRIDE_JSON',
+
+  /**
+   * Set this environment variable to the path to a `build-cache.json` file to override the build cache configuration
+   * that normally lives at `common/config/rush/build-cache.json`.
+   *
+   * This is useful for testing purposes, or for OSS repos that are have a local-only cache, but can have
+   * a different cache configuration in CI/CD pipelines.
+   *
+   * @remarks
+   * This is similar to {@link EnvironmentVariableNames.RUSH_BUILD_CACHE_OVERRIDE_JSON}, but it allows you to specify
+   * a file path instead of a JSON string. The two environment variables are mutually exclusive, meaning you can
+   * only use one of them at a time.
+   */
+  RUSH_BUILD_CACHE_OVERRIDE_JSON_FILE_PATH: 'RUSH_BUILD_CACHE_OVERRIDE_JSON_FILE_PATH',
 
   /**
    * Setting this environment variable opts into running with cobuilds. The context id should be the same across
@@ -260,6 +279,8 @@ export class EnvironmentConfiguration {
   private static _buildCacheWriteAllowed: boolean | undefined;
 
   private static _buildCacheOverrideJson: string | undefined;
+
+  private static _buildCacheOverrideJsonFilePath: string | undefined;
 
   private static _cobuildContextId: string | undefined;
 
@@ -378,6 +399,15 @@ export class EnvironmentConfiguration {
   public static get buildCacheOverrideJson(): string | undefined {
     EnvironmentConfiguration._ensureValidated();
     return EnvironmentConfiguration._buildCacheOverrideJson;
+  }
+
+  /**
+   * If set, overrides the build cache configuration that normally lives at `common/config/rush/build-cache.json`.
+   * See {@link EnvironmentVariableNames.RUSH_BUILD_CACHE_OVERRIDE_JSON_FILE_PATH}
+   */
+  public static get buildCacheOverrideJsonFilePath(): string | undefined {
+    EnvironmentConfiguration._ensureValidated();
+    return EnvironmentConfiguration._buildCacheOverrideJsonFilePath;
   }
 
   /**
@@ -542,6 +572,11 @@ export class EnvironmentConfiguration {
             break;
           }
 
+          case EnvironmentVariableNames.RUSH_BUILD_CACHE_OVERRIDE_JSON_FILE_PATH: {
+            EnvironmentConfiguration._buildCacheOverrideJsonFilePath = value;
+            break;
+          }
+
           case EnvironmentVariableNames.RUSH_COBUILD_CONTEXT_ID: {
             EnvironmentConfiguration._cobuildContextId = value;
             break;
@@ -600,6 +635,17 @@ export class EnvironmentConfiguration {
       throw new Error(
         'The following environment variables were found with the "RUSH_" prefix, but they are not ' +
           `recognized by this version of Rush: ${unknownEnvVariables.join(', ')}`
+      );
+    }
+
+    if (
+      EnvironmentConfiguration._buildCacheOverrideJsonFilePath &&
+      EnvironmentConfiguration._buildCacheOverrideJson
+    ) {
+      throw new Error(
+        `Environment variable ${EnvironmentVariableNames.RUSH_BUILD_CACHE_OVERRIDE_JSON_FILE_PATH} and ` +
+          `${EnvironmentVariableNames.RUSH_BUILD_CACHE_OVERRIDE_JSON} are mutually exclusive. ` +
+          `Only one may be specified.`
       );
     }
 


### PR DESCRIPTION
## Summary

This PR adds support for a `RUSH_BUILD_CACHE_OVERRIDE_JSON` environment variable that allows users to override the build cache configuration.

## How it was tested

Tested by setting up and pulling cache from a Gradle server in this repo.

## Impacted documentation

https://rushjs.io/pages/configs/environment_vars/#docusaurus_skipToContent_fallback