### PR TITLE
[node-core-library] Negative symlink cache in RealNodeModulePath

### DIFF
--- a/common/changes/@rushstack/node-core-library/lstat-cache_2025-03-10-22-47.json
+++ b/common/changes/@rushstack/node-core-library/lstat-cache_2025-03-10-22-47.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/node-core-library",
+      "comment": "In `RealNodeModulePathResolver`, add negative caching when a path segment that might be a symbolic link is not.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/node-core-library"
+}

--- a/common/changes/@rushstack/node-core-library/lstat-cache_2025-03-10-22-49.json
+++ b/common/changes/@rushstack/node-core-library/lstat-cache_2025-03-10-22-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/node-core-library",
+      "comment": "In `RealNodeModulePathResolver`, add the option to configure to throw or not throw for non-existent paths.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/node-core-library"
+}

--- a/common/reviews/api/node-core-library.api.md
+++ b/common/reviews/api/node-core-library.api.md
@@ -610,9 +610,9 @@ export interface IReadLinesFromIterableOptions {
 export interface IRealNodeModulePathResolverOptions {
     // (undocumented)
     fs?: Partial<Pick<typeof nodeFs, 'lstatSync' | 'readlinkSync'>>;
+    ignoreMissingPaths?: boolean;
     // (undocumented)
     path?: Partial<Pick<typeof nodePath, 'isAbsolute' | 'join' | 'resolve' | 'sep'>>;
-    throwIfNoEntry?: boolean;
 }
 
 // @public (undocumented)

--- a/common/reviews/api/node-core-library.api.md
+++ b/common/reviews/api/node-core-library.api.md
@@ -612,6 +612,7 @@ export interface IRealNodeModulePathResolverOptions {
     fs?: Partial<Pick<typeof nodeFs, 'lstatSync' | 'readlinkSync'>>;
     // (undocumented)
     path?: Partial<Pick<typeof nodePath, 'isAbsolute' | 'join' | 'resolve' | 'sep'>>;
+    throwIfNoEntry?: boolean;
 }
 
 // @public (undocumented)

--- a/libraries/node-core-library/src/RealNodeModulePath.ts
+++ b/libraries/node-core-library/src/RealNodeModulePath.ts
@@ -12,9 +12,10 @@ export interface IRealNodeModulePathResolverOptions {
   fs?: Partial<Pick<typeof nodeFs, 'lstatSync' | 'readlinkSync'>>;
   path?: Partial<Pick<typeof nodePath, 'isAbsolute' | 'join' | 'resolve' | 'sep'>>;
   /**
-   * If set to false, the resolver will not throw if part of the path does not exist.
+   * If set to true, the resolver will not throw if part of the path does not exist.
+   * @defaultValue false
    */
-  throwIfNoEntry?: boolean;
+  ignoreMissingPaths?: boolean;
 }
 
 /**
@@ -56,7 +57,7 @@ export class RealNodeModulePathResolver {
         resolve = nodePath.resolve,
         sep = nodePath.sep
       } = nodePath,
-      throwIfNoEntry = true
+      ignoreMissingPaths = false
     } = options;
     const cache: Map<string, string> = (this._cache = new Map());
     this._errorCache = new Map();
@@ -71,7 +72,7 @@ export class RealNodeModulePathResolver {
       sep
     };
     this._lstatOptions = {
-      throwIfNoEntry
+      throwIfNoEntry: !ignoreMissingPaths
     };
 
     const nodeModulesToken: string = `${sep}node_modules${sep}`;

--- a/libraries/node-core-library/src/RealNodeModulePath.ts
+++ b/libraries/node-core-library/src/RealNodeModulePath.ts
@@ -11,6 +11,10 @@ import * as nodePath from 'path';
 export interface IRealNodeModulePathResolverOptions {
   fs?: Partial<Pick<typeof nodeFs, 'lstatSync' | 'readlinkSync'>>;
   path?: Partial<Pick<typeof nodePath, 'isAbsolute' | 'join' | 'resolve' | 'sep'>>;
+  /**
+   * If set to false, the resolver will not throw if part of the path does not exist.
+   */
+  throwIfNoEntry?: boolean;
 }
 
 /**
@@ -37,9 +41,11 @@ export class RealNodeModulePathResolver {
    */
   public readonly realNodeModulePath: (input: string) => string;
 
-  private readonly _cache: Map<string, string>;
+  private readonly _cache: Map<string, string | false>;
+  private readonly _errorCache: Map<string, Error>;
   private readonly _fs: Required<NonNullable<IRealNodeModulePathResolverOptions['fs']>>;
   private readonly _path: Required<NonNullable<IRealNodeModulePathResolverOptions['path']>>;
+  private readonly _lstatOptions: Pick<nodeFs.StatSyncOptions, 'throwIfNoEntry'>;
 
   public constructor(options: IRealNodeModulePathResolverOptions = {}) {
     const {
@@ -49,9 +55,11 @@ export class RealNodeModulePathResolver {
         join = nodePath.join,
         resolve = nodePath.resolve,
         sep = nodePath.sep
-      } = nodePath
+      } = nodePath,
+      throwIfNoEntry = true
     } = options;
     const cache: Map<string, string> = (this._cache = new Map());
+    this._errorCache = new Map();
     this._fs = {
       lstatSync,
       readlinkSync
@@ -61,6 +69,9 @@ export class RealNodeModulePathResolver {
       join,
       resolve,
       sep
+    };
+    this._lstatOptions = {
+      throwIfNoEntry
     };
 
     const nodeModulesToken: string = `${sep}node_modules${sep}`;
@@ -157,18 +168,31 @@ export class RealNodeModulePathResolver {
    * @returns The target of the symbolic link, or undefined if the input is not a symbolic link
    */
   private _tryReadLink(link: string): string | undefined {
-    const cached: string | undefined = this._cache.get(link);
+    const cached: string | false | undefined = this._cache.get(link);
     if (cached) {
-      return cached;
+      return cached || undefined;
+    }
+
+    const cachedError: Error | undefined = this._errorCache.get(link);
+    if (cachedError) {
+      // Fill the properties but fix the stack trace.
+      throw Object.assign(new Error(cachedError.message), cachedError);
     }
 
     // On Windows, calling `readlink` on a directory throws an EUNKOWN, not EINVAL, so just pay the cost
     // of an lstat call.
-    const stat: nodeFs.Stats | undefined = this._fs.lstatSync(link);
-    if (stat.isSymbolicLink()) {
-      // path.join(x, '.') will trim trailing slashes, if applicable
-      const result: string = this._path.join(this._fs.readlinkSync(link, 'utf8'), '.');
-      return result;
+    try {
+      const stat: nodeFs.Stats | undefined = this._fs.lstatSync(link, this._lstatOptions);
+      if (stat?.isSymbolicLink()) {
+        // path.join(x, '.') will trim trailing slashes, if applicable
+        const result: string = this._path.join(this._fs.readlinkSync(link, 'utf8'), '.');
+        return result;
+      }
+
+      // Ensure we cache that this was not a symbolic link.
+      this._cache.set(link, false);
+    } catch (err) {
+      this._errorCache.set(link, err as Error);
     }
   }
 }

--- a/libraries/node-core-library/src/RealNodeModulePath.ts
+++ b/libraries/node-core-library/src/RealNodeModulePath.ts
@@ -169,7 +169,7 @@ export class RealNodeModulePathResolver {
    */
   private _tryReadLink(link: string): string | undefined {
     const cached: string | false | undefined = this._cache.get(link);
-    if (cached) {
+    if (cached !== undefined) {
       return cached || undefined;
     }
 

--- a/libraries/node-core-library/src/test/RealNodeModulePath.test.ts
+++ b/libraries/node-core-library/src/test/RealNodeModulePath.test.ts
@@ -49,7 +49,7 @@ describe('realNodeModulePath', () => {
 
       expect(realNodeModulePath('/foo/node_modules/foo')).toBe('/foo/node_modules/foo');
 
-      expect(mocklstatSync).toHaveBeenCalledWith('/foo/node_modules/foo');
+      expect(mocklstatSync.mock.calls[0][0]).toEqual('/foo/node_modules/foo');
       expect(mocklstatSync).toHaveBeenCalledTimes(1);
       expect(mockReadlinkSync).toHaveBeenCalledTimes(0);
     });
@@ -59,7 +59,7 @@ describe('realNodeModulePath', () => {
 
       expect(realNodeModulePath('/foo/node_modules/foo/')).toBe('/foo/node_modules/foo');
 
-      expect(mocklstatSync).toHaveBeenCalledWith('/foo/node_modules/foo');
+      expect(mocklstatSync.mock.calls[0][0]).toEqual('/foo/node_modules/foo');
       expect(mocklstatSync).toHaveBeenCalledTimes(1);
       expect(mockReadlinkSync).toHaveBeenCalledTimes(0);
     });
@@ -70,7 +70,7 @@ describe('realNodeModulePath', () => {
 
       expect(realNodeModulePath('/foo/node_modules/link')).toBe('/link/target');
 
-      expect(mocklstatSync).toHaveBeenCalledWith('/foo/node_modules/link');
+      expect(mocklstatSync.mock.calls[0][0]).toEqual('/foo/node_modules/link');
       expect(mocklstatSync).toHaveBeenCalledTimes(1);
       expect(mockReadlinkSync).toHaveBeenCalledWith('/foo/node_modules/link', 'utf8');
       expect(mockReadlinkSync).toHaveBeenCalledTimes(1);
@@ -82,7 +82,7 @@ describe('realNodeModulePath', () => {
 
       expect(realNodeModulePath('/foo/node_modules/link/bar')).toBe('/link/target/bar');
 
-      expect(mocklstatSync).toHaveBeenCalledWith('/foo/node_modules/link');
+      expect(mocklstatSync.mock.calls[0][0]).toEqual('/foo/node_modules/link');
       expect(mocklstatSync).toHaveBeenCalledTimes(1);
       expect(mockReadlinkSync).toHaveBeenCalledWith('/foo/node_modules/link', 'utf8');
       expect(mockReadlinkSync).toHaveBeenCalledTimes(1);
@@ -96,7 +96,7 @@ describe('realNodeModulePath', () => {
       expect(realNodeModulePath('/foo/node_modules/link/bar')).toBe('/link/target/bar');
       expect(realNodeModulePath('/foo/node_modules/link/')).toBe('/link/target');
 
-      expect(mocklstatSync).toHaveBeenCalledWith('/foo/node_modules/link');
+      expect(mocklstatSync.mock.calls[0][0]).toEqual('/foo/node_modules/link');
       expect(mocklstatSync).toHaveBeenCalledTimes(1);
       expect(mockReadlinkSync).toHaveBeenCalledWith('/foo/node_modules/link', 'utf8');
       expect(mockReadlinkSync).toHaveBeenCalledTimes(1);
@@ -108,7 +108,7 @@ describe('realNodeModulePath', () => {
 
       expect(realNodeModulePath('/node_modules/foo/node_modules/link')).toBe('/link/target');
 
-      expect(mocklstatSync).toHaveBeenCalledWith('/node_modules/foo/node_modules/link');
+      expect(mocklstatSync.mock.calls[0][0]).toEqual('/node_modules/foo/node_modules/link');
       expect(mocklstatSync).toHaveBeenCalledTimes(1);
       expect(mockReadlinkSync).toHaveBeenCalledWith('/node_modules/foo/node_modules/link', 'utf8');
       expect(mockReadlinkSync).toHaveBeenCalledTimes(1);
@@ -120,7 +120,7 @@ describe('realNodeModulePath', () => {
 
       expect(realNodeModulePath('/foo/node_modules/link')).toBe('/link/target');
 
-      expect(mocklstatSync).toHaveBeenCalledWith('/foo/node_modules/link');
+      expect(mocklstatSync.mock.calls[0][0]).toEqual('/foo/node_modules/link');
       expect(mocklstatSync).toHaveBeenCalledTimes(1);
       expect(mockReadlinkSync).toHaveBeenCalledWith('/foo/node_modules/link', 'utf8');
       expect(mockReadlinkSync).toHaveBeenCalledTimes(1);
@@ -136,8 +136,8 @@ describe('realNodeModulePath', () => {
         '/other/root/link/4/5/6'
       );
 
-      expect(mocklstatSync).toHaveBeenCalledWith('/foo/1/2/3/node_modules/bar/node_modules/link');
-      expect(mocklstatSync).toHaveBeenCalledWith('/foo/1/2/3/node_modules/bar');
+      expect(mocklstatSync.mock.calls[0][0]).toEqual('/foo/1/2/3/node_modules/bar/node_modules/link');
+      expect(mocklstatSync.mock.calls[1][0]).toEqual('/foo/1/2/3/node_modules/bar');
       expect(mocklstatSync).toHaveBeenCalledTimes(2);
       expect(mockReadlinkSync).toHaveBeenCalledWith('/foo/1/2/3/node_modules/bar/node_modules/link', 'utf8');
       expect(mockReadlinkSync).toHaveBeenCalledWith('/foo/1/2/3/node_modules/bar', 'utf8');
@@ -158,8 +158,8 @@ describe('realNodeModulePath', () => {
       );
       expect(realNodeModulePath('/foo/1/2/3/node_modules/bar/a/b')).toBe('/other/root/bar/a/b');
 
-      expect(mocklstatSync).toHaveBeenCalledWith('/foo/1/2/3/node_modules/bar/node_modules/link');
-      expect(mocklstatSync).toHaveBeenCalledWith('/foo/1/2/3/node_modules/bar');
+      expect(mocklstatSync.mock.calls[0][0]).toEqual('/foo/1/2/3/node_modules/bar/node_modules/link');
+      expect(mocklstatSync.mock.calls[1][0]).toEqual('/foo/1/2/3/node_modules/bar');
       expect(mocklstatSync).toHaveBeenCalledTimes(2);
       expect(mockReadlinkSync).toHaveBeenCalledWith('/foo/1/2/3/node_modules/bar/node_modules/link', 'utf8');
       expect(mockReadlinkSync).toHaveBeenCalledWith('/foo/1/2/3/node_modules/bar', 'utf8');
@@ -210,7 +210,7 @@ describe('realNodeModulePath', () => {
 
       expect(realNodeModulePath('C:\\foo\\node_modules\\foo')).toBe('C:\\foo\\node_modules\\foo');
 
-      expect(mocklstatSync).toHaveBeenCalledWith('C:\\foo\\node_modules\\foo');
+      expect(mocklstatSync.mock.calls[0][0]).toEqual('C:\\foo\\node_modules\\foo');
       expect(mocklstatSync).toHaveBeenCalledTimes(1);
       expect(mockReadlinkSync).toHaveBeenCalledTimes(0);
     });
@@ -220,7 +220,7 @@ describe('realNodeModulePath', () => {
 
       expect(realNodeModulePath('C:\\foo\\node_modules\\foo\\')).toBe('C:\\foo\\node_modules\\foo');
 
-      expect(mocklstatSync).toHaveBeenCalledWith('C:\\foo\\node_modules\\foo');
+      expect(mocklstatSync.mock.calls[0][0]).toEqual('C:\\foo\\node_modules\\foo');
       expect(mocklstatSync).toHaveBeenCalledTimes(1);
       expect(mockReadlinkSync).toHaveBeenCalledTimes(0);
     });
@@ -231,7 +231,7 @@ describe('realNodeModulePath', () => {
 
       expect(realNodeModulePath('C:\\foo\\node_modules\\link\\relative')).toBe('C:\\link\\target\\relative');
 
-      expect(mocklstatSync).toHaveBeenCalledWith('C:\\foo\\node_modules\\link');
+      expect(mocklstatSync.mock.calls[0][0]).toEqual('C:\\foo\\node_modules\\link');
       expect(mocklstatSync).toHaveBeenCalledTimes(1);
       expect(mockReadlinkSync).toHaveBeenCalledWith('C:\\foo\\node_modules\\link', 'utf8');
       expect(mockReadlinkSync).toHaveBeenCalledTimes(1);
@@ -243,7 +243,7 @@ describe('realNodeModulePath', () => {
 
       expect(realNodeModulePath('C:\\foo\\node_modules\\link\\relative')).toBe('C:\\link\\target\\relative');
 
-      expect(mocklstatSync).toHaveBeenCalledWith('C:\\foo\\node_modules\\link');
+      expect(mocklstatSync.mock.calls[0][0]).toEqual('C:\\foo\\node_modules\\link');
       expect(mocklstatSync).toHaveBeenCalledTimes(1);
       expect(mockReadlinkSync).toHaveBeenCalledWith('C:\\foo\\node_modules\\link', 'utf8');
       expect(mockReadlinkSync).toHaveBeenCalledTimes(1);
@@ -255,7 +255,7 @@ describe('realNodeModulePath', () => {
 
       expect(realNodeModulePath('C:\\foo\\node_modules\\link')).toBe('C:\\link\\target');
 
-      expect(mocklstatSync).toHaveBeenCalledWith('C:\\foo\\node_modules\\link');
+      expect(mocklstatSync.mock.calls[0][0]).toEqual('C:\\foo\\node_modules\\link');
       expect(mocklstatSync).toHaveBeenCalledTimes(1);
       expect(mockReadlinkSync).toHaveBeenCalledWith('C:\\foo\\node_modules\\link', 'utf8');
       expect(mockReadlinkSync).toHaveBeenCalledTimes(1);
@@ -267,7 +267,7 @@ describe('realNodeModulePath', () => {
 
       expect(realNodeModulePath('C:\\node_modules\\foo\\node_modules\\link')).toBe('D:\\link\\target');
 
-      expect(mocklstatSync).toHaveBeenCalledWith('C:\\node_modules\\foo\\node_modules\\link');
+      expect(mocklstatSync.mock.calls[0][0]).toEqual('C:\\node_modules\\foo\\node_modules\\link');
       expect(mocklstatSync).toHaveBeenCalledTimes(1);
       expect(mockReadlinkSync).toHaveBeenCalledWith('C:\\node_modules\\foo\\node_modules\\link', 'utf8');
       expect(mockReadlinkSync).toHaveBeenCalledTimes(1);
@@ -279,7 +279,7 @@ describe('realNodeModulePath', () => {
 
       expect(realNodeModulePath('C:\\foo\\node_modules\\link')).toBe('C:\\link\\target');
 
-      expect(mocklstatSync).toHaveBeenCalledWith('C:\\foo\\node_modules\\link');
+      expect(mocklstatSync.mock.calls[0][0]).toEqual('C:\\foo\\node_modules\\link');
       expect(mocklstatSync).toHaveBeenCalledTimes(1);
       expect(mockReadlinkSync).toHaveBeenCalledWith('C:\\foo\\node_modules\\link', 'utf8');
       expect(mockReadlinkSync).toHaveBeenCalledTimes(1);
@@ -295,8 +295,10 @@ describe('realNodeModulePath', () => {
         'D:\\other\\root\\link\\4\\5\\6'
       );
 
-      expect(mocklstatSync).toHaveBeenCalledWith('C:\\foo\\1\\2\\3\\node_modules\\bar\\node_modules\\link');
-      expect(mocklstatSync).toHaveBeenCalledWith('C:\\foo\\1\\2\\3\\node_modules\\bar');
+      expect(mocklstatSync.mock.calls[0][0]).toEqual(
+        'C:\\foo\\1\\2\\3\\node_modules\\bar\\node_modules\\link'
+      );
+      expect(mocklstatSync.mock.calls[1][0]).toEqual('C:\\foo\\1\\2\\3\\node_modules\\bar');
       expect(mocklstatSync).toHaveBeenCalledTimes(2);
       expect(mockReadlinkSync).toHaveBeenCalledWith(
         'C:\\foo\\1\\2\\3\\node_modules\\bar\\node_modules\\link',
@@ -322,8 +324,10 @@ describe('realNodeModulePath', () => {
         'D:\\other\\root\\bar\\a\\b'
       );
 
-      expect(mocklstatSync).toHaveBeenCalledWith('C:\\foo\\1\\2\\3\\node_modules\\bar\\node_modules\\link');
-      expect(mocklstatSync).toHaveBeenCalledWith('C:\\foo\\1\\2\\3\\node_modules\\bar');
+      expect(mocklstatSync.mock.calls[0][0]).toEqual(
+        'C:\\foo\\1\\2\\3\\node_modules\\bar\\node_modules\\link'
+      );
+      expect(mocklstatSync.mock.calls[1][0]).toEqual('C:\\foo\\1\\2\\3\\node_modules\\bar');
       expect(mocklstatSync).toHaveBeenCalledTimes(2);
       expect(mockReadlinkSync).toHaveBeenCalledWith(
         'C:\\foo\\1\\2\\3\\node_modules\\bar\\node_modules\\link',

--- a/libraries/node-core-library/src/test/RealNodeModulePath.test.ts
+++ b/libraries/node-core-library/src/test/RealNodeModulePath.test.ts
@@ -102,6 +102,19 @@ describe('realNodeModulePath', () => {
       expect(mockReadlinkSync).toHaveBeenCalledTimes(1);
     });
 
+    it('Caches not-symlinks', () => {
+      mocklstatSync.mockReturnValueOnce({ isSymbolicLink: () => false } as unknown as fs.Stats);
+      mockReadlinkSync.mockReturnValueOnce('/link/target');
+
+      expect(realNodeModulePath('/foo/node_modules/.pnpm')).toBe('/foo/node_modules/.pnpm');
+      expect(realNodeModulePath('/foo/node_modules/.pnpm')).toBe('/foo/node_modules/.pnpm');
+      expect(realNodeModulePath('/foo/node_modules/.pnpm')).toBe('/foo/node_modules/.pnpm');
+
+      expect(mocklstatSync.mock.calls[0][0]).toEqual('/foo/node_modules/.pnpm');
+      expect(mocklstatSync).toHaveBeenCalledTimes(1);
+      expect(mockReadlinkSync).toHaveBeenCalledTimes(0);
+    });
+
     it('Should stop after a single absolute link target', () => {
       mocklstatSync.mockReturnValueOnce({ isSymbolicLink: () => true } as unknown as fs.Stats);
       mockReadlinkSync.mockReturnValueOnce('/link/target');


### PR DESCRIPTION
## Summary
Update `RealNodeModulePath` to cache negative results (errors or when path elements aren't symbolic links) in addition to positive results.

## Details
This is particularly relevant to the `node_modules/.pnpm` and `node_modules/.bin` folders.

## How it was tested
Ran in a real project and validated that there aren't excessive statx calls to `node_modules/.pnpm`.

## Impacted documentation
This class.