### PR TITLE
[node-core-library] Add and use `useNodeJSResolver` option on `Import.resolvePackage`

### DIFF
--- a/apps/heft/src/configuration/RigPackageResolver.ts
+++ b/apps/heft/src/configuration/RigPackageResolver.ts
@@ -85,7 +85,9 @@ export class RigPackageResolver implements IRigPackageResolver {
       try {
         const resolvedPackageFolder: string = Import.resolvePackage({
           packageName: toolPackageName,
-          baseFolderPath: this._buildFolder
+          baseFolderPath: this._buildFolder,
+          // Use the built-in Node.js resolver so we share the cache
+          useNodeJSResolver: true
         });
         terminal.writeVerboseLine(
           `Resolved ${JSON.stringify(toolPackageName)} as a direct devDependency of the project.`
@@ -117,7 +119,9 @@ export class RigPackageResolver implements IRigPackageResolver {
         try {
           const resolvedPackageFolder: string = Import.resolvePackage({
             packageName: toolPackageName,
-            baseFolderPath: path.dirname(rigPackageJsonPath)
+            baseFolderPath: path.dirname(rigPackageJsonPath),
+            // Use the built-in Node.js resolver so we share the cache
+            useNodeJSResolver: true
           });
           terminal.writeVerboseLine(
             `Resolved ${JSON.stringify(toolPackageName)} as a dependency of the ` +
@@ -138,7 +142,9 @@ export class RigPackageResolver implements IRigPackageResolver {
     try {
       const resolvedPackageFolder: string = Import.resolvePackage({
         packageName: toolPackageName,
-        baseFolderPath: this._buildFolder
+        baseFolderPath: this._buildFolder,
+        // Use the built-in Node.js resolver so we share the cache
+        useNodeJSResolver: true
       });
       terminal.writeVerboseLine(
         `Resolved ${JSON.stringify(toolPackageName)} from "${resolvedPackageFolder}".`

--- a/apps/heft/src/utilities/CoreConfigFiles.ts
+++ b/apps/heft/src/utilities/CoreConfigFiles.ts
@@ -104,7 +104,9 @@ export class CoreConfigFiles {
           return Import.resolvePackage({
             packageName: propertyValue,
             baseFolderPath: configurationFileDirectory,
-            allowSelfReference: true
+            allowSelfReference: true,
+            // Use the built-in Node.js resolver so we share the cache
+            useNodeJSResolver: true
           });
         }
       };

--- a/apps/rush/src/start-dev.ts
+++ b/apps/rush/src/start-dev.ts
@@ -20,7 +20,8 @@ function includePlugin(pluginName: string, pluginPackageName?: string): void {
     pluginName: pluginName,
     pluginPackageFolder: Import.resolvePackage({
       packageName: pluginPackageName,
-      baseFolderPath: __dirname
+      baseFolderPath: __dirname,
+      useNodeJSResolver: true
     })
   });
 }

--- a/common/changes/@microsoft/rush/heft-resolve-cache_2025-03-11-01-23.json
+++ b/common/changes/@microsoft/rush/heft-resolve-cache_2025-03-11-01-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Use `useNodeJSResolver: true` in `Import.resolvePackage` calls.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@rushstack/heft-jest-plugin/heft-resolve-cache_2025-03-11-01-23.json
+++ b/common/changes/@rushstack/heft-jest-plugin/heft-resolve-cache_2025-03-11-01-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-jest-plugin",
+      "comment": "Use `useNodeJSResolver: true` in `Import.resolvePackage` calls.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft-jest-plugin"
+}

--- a/common/changes/@rushstack/heft-serverless-stack-plugin/heft-resolve-cache_2025-03-11-01-23.json
+++ b/common/changes/@rushstack/heft-serverless-stack-plugin/heft-resolve-cache_2025-03-11-01-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-serverless-stack-plugin",
+      "comment": "Use `useNodeJSResolver: true` in `Import.resolvePackage` calls.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft-serverless-stack-plugin"
+}

--- a/common/changes/@rushstack/heft-storybook-plugin/heft-resolve-cache_2025-03-11-01-23.json
+++ b/common/changes/@rushstack/heft-storybook-plugin/heft-resolve-cache_2025-03-11-01-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-storybook-plugin",
+      "comment": "Use `useNodeJSResolver: true` in `Import.resolvePackage` calls.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft-storybook-plugin"
+}

--- a/common/changes/@rushstack/heft/heft-resolve-cache_2025-03-11-01-23.json
+++ b/common/changes/@rushstack/heft/heft-resolve-cache_2025-03-11-01-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Use `useNodeJSResolver: true` in `Import.resolvePackage` calls.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft"
+}

--- a/common/changes/@rushstack/node-core-library/heft-resolve-cache_2025-03-11-01-20.json
+++ b/common/changes/@rushstack/node-core-library/heft-resolve-cache_2025-03-11-01-20.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/node-core-library",
+      "comment": "Add `useNodeJSResolver` option to `Import.resolvePackage` to rely on the built-in `require.resolve` and share its cache.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/node-core-library"
+}

--- a/common/reviews/api/node-core-library.api.md
+++ b/common/reviews/api/node-core-library.api.md
@@ -398,6 +398,7 @@ export interface IImportResolvePackageAsyncOptions extends IImportResolveAsyncOp
 // @public
 export interface IImportResolvePackageOptions extends IImportResolveOptions {
     packageName: string;
+    useNodeJSResolver?: boolean;
 }
 
 // @public

--- a/heft-plugins/heft-jest-plugin/src/JestPlugin.ts
+++ b/heft-plugins/heft-jest-plugin/src/JestPlugin.ts
@@ -949,7 +949,7 @@ export default class JestPlugin implements IHeftTaskPlugin<IJestPluginOptions> {
             const resolvedPackagePath: string =
               packageName === PLUGIN_PACKAGE_NAME
                 ? PLUGIN_PACKAGE_FOLDER
-                : Import.resolvePackage({ baseFolderPath: configDir, packageName });
+                : Import.resolvePackage({ baseFolderPath: configDir, packageName, useNodeJSResolver: true });
             // First entry is the entire match
             const restOfPath: string = path.normalize(
               './' + propertyValue.slice(packageDirMatches[0].length)

--- a/heft-plugins/heft-jest-plugin/src/patches/jestWorkerPatch.ts
+++ b/heft-plugins/heft-jest-plugin/src/patches/jestWorkerPatch.ts
@@ -43,13 +43,22 @@ function applyPatch(): void {
   try {
     let contextFolder: string = __dirname;
     // Resolve the "@jest/core" package relative to Heft
-    contextFolder = Import.resolvePackage({ packageName: '@jest/core', baseFolderPath: contextFolder });
+    contextFolder = Import.resolvePackage({
+      packageName: '@jest/core',
+      baseFolderPath: contextFolder,
+      useNodeJSResolver: true
+    });
     // Resolve the "@jest/reporters" package relative to "@jest/core"
-    contextFolder = Import.resolvePackage({ packageName: '@jest/reporters', baseFolderPath: contextFolder });
+    contextFolder = Import.resolvePackage({
+      packageName: '@jest/reporters',
+      baseFolderPath: contextFolder,
+      useNodeJSResolver: true
+    });
     // Resolve the "jest-worker" package relative to "@jest/reporters"
     const jestWorkerFolder: string = Import.resolvePackage({
       packageName: 'jest-worker',
-      baseFolderPath: contextFolder
+      baseFolderPath: contextFolder,
+      useNodeJSResolver: true
     });
 
     const baseWorkerPoolPath: string = path.join(jestWorkerFolder, 'build/base/BaseWorkerPool.js');

--- a/heft-plugins/heft-serverless-stack-plugin/src/ServerlessStackPlugin.ts
+++ b/heft-plugins/heft-serverless-stack-plugin/src/ServerlessStackPlugin.ts
@@ -84,7 +84,8 @@ export default class ServerlessStackPlugin implements IHeftTaskPlugin {
     try {
       sstCliPackagePath = Import.resolvePackage({
         packageName: SST_CLI_PACKAGE_NAME,
-        baseFolderPath: options.heftConfiguration.buildFolderPath
+        baseFolderPath: options.heftConfiguration.buildFolderPath,
+        useNodeJSResolver: true
       });
     } catch (e) {
       this._logger.emitError(

--- a/heft-plugins/heft-storybook-plugin/src/StorybookPlugin.ts
+++ b/heft-plugins/heft-storybook-plugin/src/StorybookPlugin.ts
@@ -314,7 +314,8 @@ export default class StorybookPlugin implements IHeftTaskPlugin<IStorybookPlugin
     try {
       storykitFolderPath = Import.resolvePackage({
         packageName: storykitPackageName,
-        baseFolderPath: heftConfiguration.buildFolderPath
+        baseFolderPath: heftConfiguration.buildFolderPath,
+        useNodeJSResolver: true
       });
     } catch (ex) {
       throw new Error(`The ${taskSession.taskName} task cannot start: ` + (ex as Error).message);
@@ -328,7 +329,8 @@ export default class StorybookPlugin implements IHeftTaskPlugin<IStorybookPlugin
     try {
       storyBookCliPackage = Import.resolvePackage({
         packageName: cliPackageName,
-        baseFolderPath: storykitFolderPath
+        baseFolderPath: storykitFolderPath,
+        useNodeJSResolver: true
       });
     } catch (ex) {
       throw new Error(`The ${taskSession.taskName} task cannot start: ` + (ex as Error).message);

--- a/libraries/node-core-library/src/test/__snapshots__/Import.test.ts.snap
+++ b/libraries/node-core-library/src/test/__snapshots__/Import.test.ts.snap
@@ -10,7 +10,7 @@ exports[`Import resolveModule includeSystemModules throws on an attempt to resol
 
 exports[`Import resolvePackage allowSelfReference fails to resolve a path inside this package with allowSelfReference turned on 1`] = `"The package name \\"@rushstack/node-core-library/lib/Constants.js\\" contains an invalid character: \\"/\\""`;
 
-exports[`Import resolvePackage allowSelfReference throws on an attempt to reference this package without allowSelfReference turned on 1`] = `"Cannot find package \\"@rushstack/node-core-library\\" from \\"<packageRoot>/lib/test\\": Error: Cannot find module '@rushstack/node-core-library/' from '<dirname>'."`;
+exports[`Import resolvePackage allowSelfReference throws on an attempt to reference this package without allowSelfReference turned on 1`] = `"Cannot find package \\"@rushstack/node-core-library\\" from \\"<packageRoot>/lib/test\\": Error: Cannot find module '@rushstack/node-core-library/package.json' from '<dirname>'."`;
 
 exports[`Import resolvePackage fails to resolve a path inside a dependency 1`] = `"The package name \\"@rushstack/heft/lib/start.js\\" contains an invalid character: \\"/\\""`;
 
@@ -18,4 +18,4 @@ exports[`Import resolvePackage fails to resolve a path inside a dependency of a 
 
 exports[`Import resolvePackage includeSystemModules throws on an attempt to resolve a non-existing path inside a system module with includeSystemModules turned on 1`] = `"The package name \\"fs/foo/bar\\" contains an invalid character: \\"/\\""`;
 
-exports[`Import resolvePackage includeSystemModules throws on an attempt to resolve a system module without includeSystemModules turned on 1`] = `"Cannot find package \\"fs\\" from \\"<packageRoot>/lib/test\\": Error: Cannot find module 'fs/' from '<dirname>'."`;
+exports[`Import resolvePackage includeSystemModules throws on an attempt to resolve a system module without includeSystemModules turned on 1`] = `"Cannot find package \\"fs\\" from \\"<packageRoot>/lib/test\\": Error: Cannot find module 'fs/package.json' from '<dirname>'."`;

--- a/libraries/rush-lib/src/pluginFramework/PluginManager.ts
+++ b/libraries/rush-lib/src/pluginFramework/PluginManager.ts
@@ -72,7 +72,8 @@ export class PluginManager {
           pluginName: builtInPluginName,
           pluginPackageFolder: Import.resolvePackage({
             packageName: pluginPackageName,
-            baseFolderPath: __dirname
+            baseFolderPath: __dirname,
+            useNodeJSResolver: true
           })
         });
       }

--- a/libraries/rush-sdk/src/generate-stubs.ts
+++ b/libraries/rush-sdk/src/generate-stubs.ts
@@ -51,7 +51,8 @@ function generateLibFilesRecursively(options: {
 export async function runAsync(): Promise<void> {
   const rushLibFolder: string = Import.resolvePackage({
     baseFolderPath: __dirname,
-    packageName: '@microsoft/rush-lib'
+    packageName: '@microsoft/rush-lib',
+    useNodeJSResolver: true
   });
 
   const stubsTargetPath: string = path.resolve(__dirname, '../lib');


### PR DESCRIPTION
## Summary
Adds a new option `useNodeJSResolver: boolean` to `Import.resolvePackage` to use the built-in `require.resolve` algorithm to find the package instead of the `resolve` npm package.

## Details
Also changes the query passed to `resolve` if not using `useNodeJSResolver: true` to append `/package.json` instead of simply `/`.

The motivation for this change is that by using `require.resolve` we are able to share NodeJS's caching layer for resolutions.

## How it was tested
It is used by the various plugin resolvers in this repository.

## Impacted documentation
Only the added option.