### PR TITLE
[rush, heft] Revert `useNodeJSResolver: true`

### DIFF
--- a/apps/heft/src/configuration/RigPackageResolver.ts
+++ b/apps/heft/src/configuration/RigPackageResolver.ts
@@ -85,9 +85,7 @@ export class RigPackageResolver implements IRigPackageResolver {
       try {
         const resolvedPackageFolder: string = Import.resolvePackage({
           packageName: toolPackageName,
-          baseFolderPath: this._buildFolder,
-          // Use the built-in Node.js resolver so we share the cache
-          useNodeJSResolver: true
+          baseFolderPath: this._buildFolder
         });
         terminal.writeVerboseLine(
           `Resolved ${JSON.stringify(toolPackageName)} as a direct devDependency of the project.`
@@ -119,9 +117,7 @@ export class RigPackageResolver implements IRigPackageResolver {
         try {
           const resolvedPackageFolder: string = Import.resolvePackage({
             packageName: toolPackageName,
-            baseFolderPath: path.dirname(rigPackageJsonPath),
-            // Use the built-in Node.js resolver so we share the cache
-            useNodeJSResolver: true
+            baseFolderPath: path.dirname(rigPackageJsonPath)
           });
           terminal.writeVerboseLine(
             `Resolved ${JSON.stringify(toolPackageName)} as a dependency of the ` +
@@ -142,9 +138,7 @@ export class RigPackageResolver implements IRigPackageResolver {
     try {
       const resolvedPackageFolder: string = Import.resolvePackage({
         packageName: toolPackageName,
-        baseFolderPath: this._buildFolder,
-        // Use the built-in Node.js resolver so we share the cache
-        useNodeJSResolver: true
+        baseFolderPath: this._buildFolder
       });
       terminal.writeVerboseLine(
         `Resolved ${JSON.stringify(toolPackageName)} from "${resolvedPackageFolder}".`

--- a/apps/heft/src/utilities/CoreConfigFiles.ts
+++ b/apps/heft/src/utilities/CoreConfigFiles.ts
@@ -104,9 +104,7 @@ export class CoreConfigFiles {
           return Import.resolvePackage({
             packageName: propertyValue,
             baseFolderPath: configurationFileDirectory,
-            allowSelfReference: true,
-            // Use the built-in Node.js resolver so we share the cache
-            useNodeJSResolver: true
+            allowSelfReference: true
           });
         }
       };

--- a/common/changes/@microsoft/rush/heft-revert-use-native_2025-03-11-18-53.json
+++ b/common/changes/@microsoft/rush/heft-revert-use-native_2025-03-11-18-53.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add missing `./package.json` export; revert `useNodeJSResolver: true`.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@rushstack/hashed-folder-copy-plugin/heft-revert-use-native_2025-03-11-18-53.json
+++ b/common/changes/@rushstack/hashed-folder-copy-plugin/heft-revert-use-native_2025-03-11-18-53.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/hashed-folder-copy-plugin",
+      "comment": "Add missing `./package.json` export.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/hashed-folder-copy-plugin"
+}

--- a/common/changes/@rushstack/heft/heft-revert-use-native_2025-03-11-18-53.json
+++ b/common/changes/@rushstack/heft/heft-revert-use-native_2025-03-11-18-53.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Revert `useNodeJSResolver: true` to deal with plugins that have an `exports` field that doesn't contain `./package.json`.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft"
+}

--- a/libraries/rush-lib/src/pluginFramework/PluginManager.ts
+++ b/libraries/rush-lib/src/pluginFramework/PluginManager.ts
@@ -72,8 +72,7 @@ export class PluginManager {
           pluginName: builtInPluginName,
           pluginPackageFolder: Import.resolvePackage({
             packageName: pluginPackageName,
-            baseFolderPath: __dirname,
-            useNodeJSResolver: true
+            baseFolderPath: __dirname
           })
         });
       }

--- a/libraries/rush-sdk/package.json
+++ b/libraries/rush-sdk/package.json
@@ -22,7 +22,8 @@
     "./lib/*": {
       "types": "./lib/*.d.ts",
       "default": "./lib/*.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "typesVersions": {
     "*": {

--- a/rush-plugins/rush-resolver-cache-plugin/package.json
+++ b/rush-plugins/rush-resolver-cache-plugin/package.json
@@ -31,7 +31,8 @@
     ".": {
       "require": "./lib/index.js",
       "types": "./dist/rush-resolver-cache-plugin.d.ts"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "typesVersions": {
     "*": {

--- a/rush-plugins/rush-serve-plugin/package.json
+++ b/rush-plugins/rush-serve-plugin/package.json
@@ -44,7 +44,8 @@
     },
     "./api": {
       "types": "./lib/api.types.d.ts"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "typesVersions": {
     "*": {

--- a/webpack/hashed-folder-copy-plugin/package.json
+++ b/webpack/hashed-folder-copy-plugin/package.json
@@ -15,7 +15,8 @@
     "./lib/*": {
       "types": "./lib/*.d.ts",
       "default": "./lib/*.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "typesVersions": {
     "*": {


### PR DESCRIPTION
## Summary
Reverts usage of `useNodeJSResolver: true` in `Import.resolvePackage` when loading plugins in `Heft` and `Rush` to compensate for malformed plugins that have an `exports` field that does not include an entry for `./package.json`.

## Details
Switches back to old behavior using the `resolve` npm package instead of relying on the built-in resolver.

## How it was tested
Local run.

## Impacted documentation
None