### PR TITLE
[node-core-library] Remove the dependency on `LegacyAdatpers` in `FileSystem` and expand the `FileSystem.writeBuffersToFile*` APIs.

### DIFF
--- a/common/changes/@rushstack/node-core-library/remove-legacyAdapters-from-FileSystem_2025-03-24-22-21.json
+++ b/common/changes/@rushstack/node-core-library/remove-legacyAdapters-from-FileSystem_2025-03-24-22-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@rushstack/node-core-library"
+    }
+  ],
+  "packageName": "@rushstack/node-core-library",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/node-core-library/remove-legacyAdapters-from-FileSystem_2025-03-24-22-40.json
+++ b/common/changes/@rushstack/node-core-library/remove-legacyAdapters-from-FileSystem_2025-03-24-22-40.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/node-core-library",
+      "comment": "Expand `FileSystem.writeBuffersToFile` and `FileSystem.writeBuffersToFileAsync` to take more kinds of buffers.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/node-core-library"
+}

--- a/common/reviews/api/node-core-library.api.md
+++ b/common/reviews/api/node-core-library.api.md
@@ -7,7 +7,6 @@
 /// <reference types="node" />
 
 import * as child_process from 'child_process';
-import fs from 'fs';
 import * as nodeFs from 'fs';
 import * as nodePath from 'path';
 
@@ -215,7 +214,7 @@ export type FileSystemCopyFilesAsyncFilter = (sourcePath: string, destinationPat
 export type FileSystemCopyFilesFilter = (sourcePath: string, destinationPath: string) => boolean;
 
 // @public
-export type FileSystemStats = fs.Stats;
+export type FileSystemStats = nodeFs.Stats;
 
 // @public
 export class FileWriter {
@@ -233,7 +232,7 @@ export const FolderConstants: {
 };
 
 // @public
-export type FolderItem = fs.Dirent;
+export type FolderItem = nodeFs.Dirent;
 
 // @public
 export interface IAsyncParallelismOptions {

--- a/common/reviews/api/node-core-library.api.md
+++ b/common/reviews/api/node-core-library.api.md
@@ -202,8 +202,8 @@ export class FileSystem {
     static readLinkAsync(path: string): Promise<string>;
     static updateTimes(path: string, times: IFileSystemUpdateTimeParameters): void;
     static updateTimesAsync(path: string, times: IFileSystemUpdateTimeParameters): Promise<void>;
-    static writeBuffersToFile(filePath: string, contents: ReadonlyArray<Uint8Array>, options?: IFileSystemWriteBinaryFileOptions): void;
-    static writeBuffersToFileAsync(filePath: string, contents: ReadonlyArray<Uint8Array>, options?: IFileSystemWriteBinaryFileOptions): Promise<void>;
+    static writeBuffersToFile(filePath: string, contents: ReadonlyArray<NodeJS.ArrayBufferView>, options?: IFileSystemWriteBinaryFileOptions): void;
+    static writeBuffersToFileAsync(filePath: string, contents: ReadonlyArray<NodeJS.ArrayBufferView>, options?: IFileSystemWriteBinaryFileOptions): Promise<void>;
     static writeFile(filePath: string, contents: string | Buffer, options?: IFileSystemWriteFileOptions): void;
     static writeFileAsync(filePath: string, contents: string | Buffer, options?: IFileSystemWriteFileOptions): Promise<void>;
 }

--- a/common/reviews/api/node-core-library.api.md
+++ b/common/reviews/api/node-core-library.api.md
@@ -7,6 +7,7 @@
 /// <reference types="node" />
 
 import * as child_process from 'child_process';
+import fs from 'fs';
 import * as nodeFs from 'fs';
 import * as nodePath from 'path';
 
@@ -214,7 +215,7 @@ export type FileSystemCopyFilesAsyncFilter = (sourcePath: string, destinationPat
 export type FileSystemCopyFilesFilter = (sourcePath: string, destinationPath: string) => boolean;
 
 // @public
-export type FileSystemStats = nodeFs.Stats;
+export type FileSystemStats = fs.Stats;
 
 // @public
 export class FileWriter {
@@ -232,7 +233,7 @@ export const FolderConstants: {
 };
 
 // @public
-export type FolderItem = nodeFs.Dirent;
+export type FolderItem = fs.Dirent;
 
 // @public
 export interface IAsyncParallelismOptions {

--- a/libraries/node-core-library/src/FileSystem.ts
+++ b/libraries/node-core-library/src/FileSystem.ts
@@ -2,7 +2,8 @@
 // See LICENSE in the project root for license information.
 
 import * as nodeJsPath from 'path';
-import fs, { promises as fsPromises } from 'fs';
+import * as fs from 'fs';
+import * as fsPromises from 'fs/promises';
 import * as fsx from 'fs-extra';
 
 import { Text, type NewlineKind, Encoding } from './Text';

--- a/libraries/node-core-library/src/FileSystem.ts
+++ b/libraries/node-core-library/src/FileSystem.ts
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import * as nodeJsPath from 'path';
-import * as fs from 'fs';
+import * as nodeJsPath from 'node:path';
+import { default as fs, promises as fsPromises } from 'node:fs';
+
 import * as fsx from 'fs-extra';
 
 import { Text, type NewlineKind, Encoding } from './Text';
 import { PosixModeBits } from './PosixModeBits';
-import { LegacyAdapters } from './LegacyAdapters';
 
 /**
  * An alias for the Node.js `fs.Stats` object.
@@ -684,11 +684,7 @@ export class FileSystem {
         ...options
       };
 
-      const folderEntries: FolderItem[] = await LegacyAdapters.convertCallbackToPromise(
-        fs.readdir,
-        folderPath,
-        { withFileTypes: true }
-      );
+      const folderEntries: FolderItem[] = await fsPromises.readdir(folderPath, { withFileTypes: true });
       if (options.absolutePaths) {
         return folderEntries.map((folderEntry) => {
           folderEntry.name = nodeJsPath.resolve(folderPath, folderEntry.name);
@@ -904,9 +900,9 @@ export class FileSystem {
       // since writev() doesn't take an argument for where to start writing.
       const toCopy: Uint8Array[] = [...contents];
 
-      let handle: fs.promises.FileHandle | undefined;
+      let handle: fsPromises.FileHandle | undefined;
       try {
-        handle = await fs.promises.open(filePath, 'w');
+        handle = await fsPromises.open(filePath, 'w');
       } catch (error) {
         if (!options?.ensureFolderExists || !FileSystem.isNotExistError(error as Error)) {
           throw error;
@@ -914,7 +910,7 @@ export class FileSystem {
 
         const folderPath: string = nodeJsPath.dirname(filePath);
         await FileSystem.ensureFolderAsync(folderPath);
-        handle = await fs.promises.open(filePath, 'w');
+        handle = await fsPromises.open(filePath, 'w');
       }
 
       try {

--- a/libraries/node-core-library/src/FileSystem.ts
+++ b/libraries/node-core-library/src/FileSystem.ts
@@ -1,9 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import * as nodeJsPath from 'node:path';
-import { default as fs, promises as fsPromises } from 'node:fs';
-
+import * as nodeJsPath from 'path';
+import fs, { promises as fsPromises } from 'fs';
 import * as fsx from 'fs-extra';
 
 import { Text, type NewlineKind, Encoding } from './Text';

--- a/libraries/node-core-library/src/FileSystem.ts
+++ b/libraries/node-core-library/src/FileSystem.ts
@@ -801,13 +801,13 @@ export class FileSystem {
    */
   public static writeBuffersToFile(
     filePath: string,
-    contents: ReadonlyArray<Uint8Array>,
+    contents: ReadonlyArray<NodeJS.ArrayBufferView>,
     options?: IFileSystemWriteBinaryFileOptions
   ): void {
     FileSystem._wrapException(() => {
       // Need a mutable copy of the iterable to handle incomplete writes,
       // since writev() doesn't take an argument for where to start writing.
-      const toCopy: Uint8Array[] = [...contents];
+      const toCopy: NodeJS.ArrayBufferView[] = [...contents];
 
       let fd: number | undefined;
       try {
@@ -832,7 +832,12 @@ export class FileSystem {
             const bytesInCurrentBuffer: number = toCopy[buffersWritten].byteLength;
             if (bytesWritten < bytesInCurrentBuffer) {
               // This buffer was partially written.
-              toCopy[buffersWritten] = toCopy[buffersWritten].subarray(bytesWritten);
+              const currentToCopy: NodeJS.ArrayBufferView = toCopy[buffersWritten];
+              toCopy[buffersWritten] = new Uint8Array(
+                currentToCopy.buffer,
+                currentToCopy.byteOffset + bytesWritten,
+                currentToCopy.byteLength - bytesWritten
+              );
               break;
             }
             bytesWritten -= bytesInCurrentBuffer;
@@ -891,13 +896,13 @@ export class FileSystem {
    */
   public static async writeBuffersToFileAsync(
     filePath: string,
-    contents: ReadonlyArray<Uint8Array>,
+    contents: ReadonlyArray<NodeJS.ArrayBufferView>,
     options?: IFileSystemWriteBinaryFileOptions
   ): Promise<void> {
     await FileSystem._wrapExceptionAsync(async () => {
       // Need a mutable copy of the iterable to handle incomplete writes,
       // since writev() doesn't take an argument for where to start writing.
-      const toCopy: Uint8Array[] = [...contents];
+      const toCopy: NodeJS.ArrayBufferView[] = [...contents];
 
       let handle: fsPromises.FileHandle | undefined;
       try {
@@ -922,7 +927,12 @@ export class FileSystem {
             const bytesInCurrentBuffer: number = toCopy[buffersWritten].byteLength;
             if (bytesWritten < bytesInCurrentBuffer) {
               // This buffer was partially written.
-              toCopy[buffersWritten] = toCopy[buffersWritten].subarray(bytesWritten);
+              const currentToCopy: NodeJS.ArrayBufferView = toCopy[buffersWritten];
+              toCopy[buffersWritten] = new Uint8Array(
+                currentToCopy.buffer,
+                currentToCopy.byteOffset + bytesWritten,
+                currentToCopy.byteLength - bytesWritten
+              );
               break;
             }
             bytesWritten -= bytesInCurrentBuffer;

--- a/libraries/node-core-library/src/test/writeBuffersToFile.test.ts
+++ b/libraries/node-core-library/src/test/writeBuffersToFile.test.ts
@@ -18,20 +18,17 @@ jest.mock('fs-extra', () => {
     writevSync
   };
 });
+jest.mock('fs/promises', () => {
+  return {
+    open: openHandle
+  };
+});
 jest.mock('../Text', () => {
   return {
     Encoding: {
       Utf8: 'utf8'
     }
   };
-});
-
-import fs from 'node:fs';
-
-jest.spyOn(fs, 'promises', 'get').mockImplementation(() => {
-  return {
-    open: openHandle
-  } as unknown as typeof fs.promises;
 });
 
 describe('FileSystem', () => {


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

Removes the dependency on LegacyAdatpers in FileSystem.

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

## How it was tested

Built this repo.

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

## Impacted documentation

None.
<!--------------------------------------------------------------------------
👉 STEP 7: Does your PR affect anything that is discussed in the website docs?
     If so, please paste the URL of each affected web page, so we will
     remember to update the documentation after your PR is merged.
     (Updating the website is appreciated but not required.)
     If no docs are impacted, delete the "Impacted documentation" section.

     If you modified a JSON schema, remember to update init templates such as:
     rush-lib/assets/rush-init/*.json
     api-extractor/src/schemas/api-extractor-template.json
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 8: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
