### PR TITLE
[heft-lint] Fix autofixer when a file contains only fixable issues

### DIFF
--- a/common/changes/@rushstack/heft-lint-plugin/fix-eslint-fix_2025-03-24-22-49.json
+++ b/common/changes/@rushstack/heft-lint-plugin/fix-eslint-fix_2025-03-24-22-49.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-lint-plugin",
+      "comment": "Fix the `--fix` argument when the file only contains fixable issues.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft-lint-plugin"
+}

--- a/heft-plugins/heft-lint-plugin/src/Eslint.ts
+++ b/heft-plugins/heft-lint-plugin/src/Eslint.ts
@@ -178,7 +178,12 @@ export class Eslint extends LinterBase<TEslint.ESLint.LintResult> {
 
     const trimmedLintResults: TEslint.ESLint.LintResult[] = [];
     for (const lintResult of lintResults) {
-      if (lintResult.messages.length > 0 || lintResult.warningCount > 0 || lintResult.errorCount > 0) {
+      if (
+        lintResult.messages.length > 0 ||
+        lintResult.warningCount > 0 ||
+        lintResult.errorCount > 0 ||
+        fixMessages.length > 0
+      ) {
         trimmedLintResults.push(lintResult);
       }
     }


### PR DESCRIPTION
## Summary
Fixes an issue with the heft-lint-plugin `--fix` argument when a file contains only fixable issues.

## Details
The lint result shows up as having no messages, no warnings or errors when `--fix` is passed, so need to select based on the presence of the pre-extracted "fixable" messages.

## How it was tested
Local run against rules with autofixers.

## Impacted documentation
None. Works per original documentation.