### PR TITLE
[heft-jest] (BREAKING CHANGE) Use slash-normalized relative paths for asset URLs

### DIFF
--- a/build-tests/heft-webpack5-everything-test/src/chunks/image.d.png.ts
+++ b/build-tests/heft-webpack5-everything-test/src/chunks/image.d.png.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+declare const path: string;
+
+export default path;

--- a/build-tests/heft-webpack5-everything-test/src/test/Image.test.ts
+++ b/build-tests/heft-webpack5-everything-test/src/test/Image.test.ts
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import image from '../chunks/image.png';
+
+describe('Image Test', () => {
+  it('correctly handles urls for images', () => {
+    expect(image).toBe('lib-commonjs/chunks/image.png');
+  });
+});

--- a/build-tests/heft-webpack5-everything-test/tsconfig.json
+++ b/build-tests/heft-webpack5-everything-test/tsconfig.json
@@ -5,7 +5,10 @@
     "outDir": "lib",
     "rootDir": "src",
 
+    "allowArbitraryExtensions": true,
     "forceConsistentCasingInFileNames": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
     "jsx": "react",
     "declaration": true,
     "sourceMap": true,

--- a/common/changes/@rushstack/heft-jest-plugin/main_2025-03-31-23-18.json
+++ b/common/changes/@rushstack/heft-jest-plugin/main_2025-03-31-23-18.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-jest-plugin",
+      "comment": "(BREAKING CHANGE) Update `jest-string-mock-transform` to emit slash-normalized relative paths to files, rather than absolute paths, to ensure portability of snapshots.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft-jest-plugin"
+}

--- a/heft-plugins/heft-jest-plugin/includes/jest-shared.config.json
+++ b/heft-plugins/heft-jest-plugin/includes/jest-shared.config.json
@@ -60,7 +60,7 @@
   "transformIgnorePatterns": ["\\.c?js$"],
 
   // jest-identity-mock-transform returns a proxy for exported key/value pairs, where Webpack would return a module
-  // jest-string-mock-transform returns the filename, where Webpack would return a URL
+  // jest-string-mock-transform returns the filename, relative to the current working directory, where Webpack would return a URL
   // When using the heft-jest-plugin, these will be replaced with the resolved module location
   "transform": {
     "\\.(css|sass|scss)$": "../lib/exports/jest-identity-mock-transform.js",

--- a/heft-plugins/heft-jest-plugin/src/transformers/StringMockTransformer.ts
+++ b/heft-plugins/heft-jest-plugin/src/transformers/StringMockTransformer.ts
@@ -1,7 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
-
+import { relative } from 'node:path';
 import type { SyncTransformer, TransformedSource, TransformOptions } from '@jest/transform';
+
+const isWindows: boolean = process.platform === 'win32';
 
 /**
  * This Jest transform handles imports of data files (e.g. .png, .jpg) that would normally be
@@ -11,9 +13,12 @@ import type { SyncTransformer, TransformedSource, TransformOptions } from '@jest
  */
 export class StringMockTransformer implements SyncTransformer {
   public process(sourceText: string, sourcePath: string, options: TransformOptions): TransformedSource {
-    // For a file called "myImage.png", this will generate a JS module that exports the literal string "myImage.png"
+    const relativePath: string = relative(options.config.cwd, sourcePath);
+    const normalizedRelativePath: string = isWindows ? relativePath.replace(/\\/g, '/') : relativePath;
+    // For a file called "myImage.png", this will generate a JS module that exports the slash-normalized relative
+    // path from the current working directory to "myImage.png"
     return {
-      code: `module.exports = ${JSON.stringify(sourcePath)};`
+      code: `module.exports = ${JSON.stringify(normalizedRelativePath)};`
     };
   }
 }

--- a/heft-plugins/heft-jest-plugin/src/transformers/StringMockTransformer.ts
+++ b/heft-plugins/heft-jest-plugin/src/transformers/StringMockTransformer.ts
@@ -13,7 +13,8 @@ const isWindows: boolean = process.platform === 'win32';
  */
 export class StringMockTransformer implements SyncTransformer {
   public process(sourceText: string, sourcePath: string, options: TransformOptions): TransformedSource {
-    const relativePath: string = relative(options.config.cwd, sourcePath);
+    // heft-jest-plugin enforces that config.rootDir will always be the project root folder.
+    const relativePath: string = relative(options.config.rootDir, sourcePath);
     const normalizedRelativePath: string = isWindows ? relativePath.replace(/\\/g, '/') : relativePath;
     // For a file called "myImage.png", this will generate a JS module that exports the slash-normalized relative
     // path from the current working directory to "myImage.png"


### PR DESCRIPTION
## Summary
Updates the `jest-string-mock-transformer` that is the default transformation for static assets to emit slash-normalized paths relative to `config.rootDir`, rather than absolute paths. This ensures that the result of the transform can be safely used in snapshot tests, and will continue to work if the path is passed directly into file system APIs, because the `fs` API resolves relative paths to the current working directory.

## Details
The motivation for this change is that the current implementation of the transformer is unsafe to use in snapshot tests, since it returns platform-specific absolute paths.

Example:
### src/image.test.ts
```ts
import myImage from './my-image.png';

// Path will use slashes and be relative to the current working directory
// It will be the relative path to the *output* file in the CommonJS output folder.
expect(myImage).toBe('lib-commonjs/my-image.png');
```

## How it was tested
Added a build test case.

## Impacted documentation
Docs on the default transformer.