### PR TITLE
[rush] Clarify "rush init" template for .npmrc

### DIFF
--- a/common/changes/@microsoft/rush/main_2025-04-09-20-53.json
+++ b/common/changes/@microsoft/rush/main_2025-04-09-20-53.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Clarify registry authentication settings in \"rush init\" template for .npmrc",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/assets/rush-init/common/config/rush/[dot]npmrc
+++ b/libraries/rush-lib/assets/rush-init/common/config/rush/[dot]npmrc
@@ -22,5 +22,12 @@
 #
 #   //registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}
 #
+
+# Explicitly specify the NPM registry that "rush install" and "rush update" will use by default:
 registry=https://registry.npmjs.org/
+
+# Optionally provide an authentication token for the above registry URL (if it is a private registry):
+# //registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}
+
+# Change this to "true" if your registry requires authentication for read-only operations:
 always-auth=false

--- a/libraries/rush-lib/assets/rush-init/common/config/rush/[dot]npmrc-publish
+++ b/libraries/rush-lib/assets/rush-init/common/config/rush/[dot]npmrc-publish
@@ -18,3 +18,9 @@
 #
 #   //registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}
 #
+
+# Explicitly specify the NPM registry that "rush publish" will use by default:
+registry=https://registry.npmjs.org/
+
+# Provide an authentication token for the above registry URL:
+# //registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}


### PR DESCRIPTION


## Summary

Improve the `.npmrc` and `.npmrc-publish` documentation to avoid the confusion encountered in https://github.com/microsoft/rushstack/issues/5180
 