### PR TITLE
[heft-config-file] Let null reset properties

### DIFF
--- a/apps/api-extractor/config/heft.json
+++ b/apps/api-extractor/config/heft.json
@@ -7,6 +7,8 @@
   /**
    * Optionally specifies another JSON config file that this file extends from. This provides a way for standard
    * settings to be shared across multiple projects.
+   *
+   * To delete an inherited setting, set it to `null` in this file.
    */
   "extends": "decoupled-local-node-rig/profiles/default/config/heft.json",
 

--- a/apps/heft/src/schemas/heft-legacy.schema.json
+++ b/apps/heft/src/schemas/heft-legacy.schema.json
@@ -20,7 +20,7 @@
     },
 
     "extends": {
-      "description": "Optionally specifies another JSON config file that this file extends from.  This provides a way for standard settings to be shared across multiple projects.",
+      "description": "Optionally specifies another JSON config file that this file extends from.  This provides a way for standard settings to be shared across multiple projects. To delete an inherited setting, set it to `null` in this file.",
       "type": "string"
     },
 

--- a/apps/heft/src/schemas/heft.schema.json
+++ b/apps/heft/src/schemas/heft.schema.json
@@ -104,7 +104,7 @@
     },
 
     "extends": {
-      "description": "Optionally specifies another JSON config file that this file extends from.  This provides a way for standard settings to be shared across multiple projects.",
+      "description": "Optionally specifies another JSON config file that this file extends from.  This provides a way for standard settings to be shared across multiple projects. To delete an inherited setting, set it to `null` in this file.",
       "type": "string"
     },
 

--- a/apps/heft/src/schemas/node-service.schema.json
+++ b/apps/heft/src/schemas/node-service.schema.json
@@ -13,7 +13,7 @@
     },
 
     "extends": {
-      "description": "Optionally specifies another JSON config file that this file extends from.  This provides a way for standard settings to be shared across multiple projects.",
+      "description": "Optionally specifies another JSON config file that this file extends from.  This provides a way for standard settings to be shared across multiple projects. To delete an inherited setting, set it to `null` in this file.",
       "type": "string"
     },
 

--- a/apps/heft/src/schemas/templates/heft.json
+++ b/apps/heft/src/schemas/templates/heft.json
@@ -7,6 +7,8 @@
   /**
    * Optionally specifies another JSON config file that this file extends from. This provides a way for standard
    * settings to be shared across multiple projects.
+   *
+   * To delete an inherited setting, set it to `null` in this file.
    */
   // "extends": "base-project/config/heft.json",
 

--- a/apps/lockfile-explorer-web/config/heft.json
+++ b/apps/lockfile-explorer-web/config/heft.json
@@ -7,6 +7,8 @@
   /**
    * Optionally specifies another JSON config file that this file extends from. This provides a way for standard
    * settings to be shared across multiple projects.
+   *
+   * To delete an inherited setting, set it to `null` in this file.
    */
   "extends": "local-web-rig/profiles/app/config/heft.json",
 

--- a/apps/lockfile-explorer/config/heft.json
+++ b/apps/lockfile-explorer/config/heft.json
@@ -7,6 +7,8 @@
   /**
    * Optionally specifies another JSON config file that this file extends from. This provides a way for standard
    * settings to be shared across multiple projects.
+   *
+   * To delete an inherited setting, set it to `null` in this file.
    */
   "extends": "local-node-rig/profiles/default/config/heft.json",
 

--- a/apps/lockfile-explorer/config/node-service.json
+++ b/apps/lockfile-explorer/config/node-service.json
@@ -8,6 +8,8 @@
   /**
    * Optionally specifies another JSON config file that this file extends from. This provides a way for standard
    * settings to be shared across multiple projects.
+   *
+   * To delete an inherited setting, set it to `null` in this file.
    */
   // "extends": "base-project/config/serve-command.json",
 

--- a/build-tests-samples/heft-web-rig-library-tutorial/config/api-extractor.json
+++ b/build-tests-samples/heft-web-rig-library-tutorial/config/api-extractor.json
@@ -8,6 +8,8 @@
    * Optionally specifies another JSON config file that this file extends from.  This provides a way for
    * standard settings to be shared across multiple projects.
    *
+   * To delete an inherited setting, set it to `null` in this file.
+   *
    * If the path starts with "./" or "../", the path is resolved relative to the folder of the file that contains
    * the "extends" field.  Otherwise, the first path segment is interpreted as an NPM package name, and will be
    * resolved using NodeJS require().

--- a/build-tests/heft-fastify-test/config/node-service.json
+++ b/build-tests/heft-fastify-test/config/node-service.json
@@ -8,6 +8,8 @@
   /**
    * Optionally specifies another JSON config file that this file extends from. This provides a way for standard
    * settings to be shared across multiple projects.
+   *
+   * To delete an inherited setting, set it to `null` in this file.
    */
   // "extends": "base-project/config/serve-command.json",
 

--- a/build-tests/localization-plugin-test-01/config/heft.json
+++ b/build-tests/localization-plugin-test-01/config/heft.json
@@ -7,6 +7,8 @@
   /**
    * Optionally specifies another JSON config file that this file extends from. This provides a way for standard
    * settings to be shared across multiple projects.
+   *
+   * To delete an inherited setting, set it to `null` in this file.
    */
   "extends": "local-node-rig/profiles/default/config/heft.json",
 

--- a/build-tests/localization-plugin-test-02/config/heft.json
+++ b/build-tests/localization-plugin-test-02/config/heft.json
@@ -7,6 +7,8 @@
   /**
    * Optionally specifies another JSON config file that this file extends from. This provides a way for standard
    * settings to be shared across multiple projects.
+   *
+   * To delete an inherited setting, set it to `null` in this file.
    */
   "extends": "local-node-rig/profiles/default/config/heft.json",
 

--- a/common/changes/@microsoft/api-extractor/config-file-null_2025-04-16-01-15.json
+++ b/common/changes/@microsoft/api-extractor/config-file-null_2025-04-16-01-15.json
@@ -1,7 +1,7 @@
 {
   "changes": [
     {
-      "comment": "Update documentation for ",
+      "comment": "Update documentation for `extends`",
       "type": "patch",
       "packageName": "@microsoft/api-extractor"
     }

--- a/common/changes/@microsoft/api-extractor/config-file-null_2025-04-16-01-15.json
+++ b/common/changes/@microsoft/api-extractor/config-file-null_2025-04-16-01-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Update documentation for ",
+      "type": "patch",
+      "packageName": "@microsoft/api-extractor"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "dmichon-msft@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush/config-file-null_2025-04-16-01-15.json
+++ b/common/changes/@microsoft/rush/config-file-null_2025-04-16-01-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Update documentation for ",
+      "type": "none",
+      "packageName": "@microsoft/rush"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "dmichon-msft@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush/config-file-null_2025-04-16-01-15.json
+++ b/common/changes/@microsoft/rush/config-file-null_2025-04-16-01-15.json
@@ -1,7 +1,7 @@
 {
   "changes": [
     {
-      "comment": "Update documentation for ",
+      "comment": "Update documentation for `extends`",
       "type": "none",
       "packageName": "@microsoft/rush"
     }

--- a/common/changes/@rushstack/heft-api-extractor-plugin/config-file-null_2025-04-16-01-15.json
+++ b/common/changes/@rushstack/heft-api-extractor-plugin/config-file-null_2025-04-16-01-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Update documentation for ",
+      "type": "patch",
+      "packageName": "@rushstack/heft-api-extractor-plugin"
+    }
+  ],
+  "packageName": "@rushstack/heft-api-extractor-plugin",
+  "email": "dmichon-msft@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/heft-api-extractor-plugin/config-file-null_2025-04-16-01-15.json
+++ b/common/changes/@rushstack/heft-api-extractor-plugin/config-file-null_2025-04-16-01-15.json
@@ -1,7 +1,7 @@
 {
   "changes": [
     {
-      "comment": "Update documentation for ",
+      "comment": "Update documentation for `extends`",
       "type": "patch",
       "packageName": "@rushstack/heft-api-extractor-plugin"
     }

--- a/common/changes/@rushstack/heft-config-file/config-file-null_2025-04-16-00-37.json
+++ b/common/changes/@rushstack/heft-config-file/config-file-null_2025-04-16-00-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-config-file",
+      "comment": "Allow use of the value `null` to discard any value set for the property from a parent config file..",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft-config-file"
+}

--- a/common/changes/@rushstack/heft-node-rig/config-file-null_2025-04-16-01-15.json
+++ b/common/changes/@rushstack/heft-node-rig/config-file-null_2025-04-16-01-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Update documentation for ",
+      "type": "patch",
+      "packageName": "@rushstack/heft-node-rig"
+    }
+  ],
+  "packageName": "@rushstack/heft-node-rig",
+  "email": "dmichon-msft@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/heft-node-rig/config-file-null_2025-04-16-01-15.json
+++ b/common/changes/@rushstack/heft-node-rig/config-file-null_2025-04-16-01-15.json
@@ -1,7 +1,7 @@
 {
   "changes": [
     {
-      "comment": "Update documentation for ",
+      "comment": "Update documentation for `extends`",
       "type": "patch",
       "packageName": "@rushstack/heft-node-rig"
     }

--- a/common/changes/@rushstack/heft-sass-plugin/config-file-null_2025-04-16-01-15.json
+++ b/common/changes/@rushstack/heft-sass-plugin/config-file-null_2025-04-16-01-15.json
@@ -1,7 +1,7 @@
 {
   "changes": [
     {
-      "comment": "Update documentation for ",
+      "comment": "Update documentation for `extends`",
       "type": "patch",
       "packageName": "@rushstack/heft-sass-plugin"
     }

--- a/common/changes/@rushstack/heft-sass-plugin/config-file-null_2025-04-16-01-15.json
+++ b/common/changes/@rushstack/heft-sass-plugin/config-file-null_2025-04-16-01-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Update documentation for ",
+      "type": "patch",
+      "packageName": "@rushstack/heft-sass-plugin"
+    }
+  ],
+  "packageName": "@rushstack/heft-sass-plugin",
+  "email": "dmichon-msft@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/heft-typescript-plugin/config-file-null_2025-04-16-01-15.json
+++ b/common/changes/@rushstack/heft-typescript-plugin/config-file-null_2025-04-16-01-15.json
@@ -1,7 +1,7 @@
 {
   "changes": [
     {
-      "comment": "Update documentation for ",
+      "comment": "Update documentation for `extends`",
       "type": "patch",
       "packageName": "@rushstack/heft-typescript-plugin"
     }

--- a/common/changes/@rushstack/heft-typescript-plugin/config-file-null_2025-04-16-01-15.json
+++ b/common/changes/@rushstack/heft-typescript-plugin/config-file-null_2025-04-16-01-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Update documentation for ",
+      "type": "patch",
+      "packageName": "@rushstack/heft-typescript-plugin"
+    }
+  ],
+  "packageName": "@rushstack/heft-typescript-plugin",
+  "email": "dmichon-msft@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/heft-web-rig/config-file-null_2025-04-16-01-15.json
+++ b/common/changes/@rushstack/heft-web-rig/config-file-null_2025-04-16-01-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Update documentation for ",
+      "type": "patch",
+      "packageName": "@rushstack/heft-web-rig"
+    }
+  ],
+  "packageName": "@rushstack/heft-web-rig",
+  "email": "dmichon-msft@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/heft-web-rig/config-file-null_2025-04-16-01-15.json
+++ b/common/changes/@rushstack/heft-web-rig/config-file-null_2025-04-16-01-15.json
@@ -1,7 +1,7 @@
 {
   "changes": [
     {
-      "comment": "Update documentation for ",
+      "comment": "Update documentation for `extends`",
       "type": "patch",
       "packageName": "@rushstack/heft-web-rig"
     }

--- a/common/changes/@rushstack/heft/config-file-null_2025-04-16-01-15.json
+++ b/common/changes/@rushstack/heft/config-file-null_2025-04-16-01-15.json
@@ -1,7 +1,7 @@
 {
   "changes": [
     {
-      "comment": "Update documentation for ",
+      "comment": "Update documentation for `extends`",
       "type": "patch",
       "packageName": "@rushstack/heft"
     }

--- a/common/changes/@rushstack/heft/config-file-null_2025-04-16-01-15.json
+++ b/common/changes/@rushstack/heft/config-file-null_2025-04-16-01-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Update documentation for ",
+      "type": "patch",
+      "packageName": "@rushstack/heft"
+    }
+  ],
+  "packageName": "@rushstack/heft",
+  "email": "dmichon-msft@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/lockfile-explorer/config-file-null_2025-04-16-01-15.json
+++ b/common/changes/@rushstack/lockfile-explorer/config-file-null_2025-04-16-01-15.json
@@ -1,7 +1,7 @@
 {
   "changes": [
     {
-      "comment": "Update documentation for ",
+      "comment": "Update documentation for `extends`",
       "type": "patch",
       "packageName": "@rushstack/lockfile-explorer"
     }

--- a/common/changes/@rushstack/lockfile-explorer/config-file-null_2025-04-16-01-15.json
+++ b/common/changes/@rushstack/lockfile-explorer/config-file-null_2025-04-16-01-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Update documentation for ",
+      "type": "patch",
+      "packageName": "@rushstack/lockfile-explorer"
+    }
+  ],
+  "packageName": "@rushstack/lockfile-explorer",
+  "email": "dmichon-msft@users.noreply.github.com"
+}

--- a/heft-plugins/heft-api-extractor-plugin/src/schemas/api-extractor-task.schema.json
+++ b/heft-plugins/heft-api-extractor-plugin/src/schemas/api-extractor-task.schema.json
@@ -13,7 +13,7 @@
     },
 
     "extends": {
-      "description": "Optionally specifies another JSON config file that this file extends from.  This provides a way for standard settings to be shared across multiple projects.",
+      "description": "Optionally specifies another JSON config file that this file extends from.  This provides a way for standard settings to be shared across multiple projects. To delete an inherited setting, set it to `null` in this file.",
       "type": "string"
     },
 

--- a/heft-plugins/heft-sass-plugin/src/schemas/heft-sass-plugin.schema.json
+++ b/heft-plugins/heft-sass-plugin/src/schemas/heft-sass-plugin.schema.json
@@ -13,7 +13,7 @@
     },
 
     "extends": {
-      "description": "Optionally specifies another JSON config file that this file extends from.  This provides a way for standard settings to be shared across multiple projects.",
+      "description": "Optionally specifies another JSON config file that this file extends from.  This provides a way for standard settings to be shared across multiple projects. To delete an inherited setting, set it to `null` in this file.",
       "type": "string"
     },
 

--- a/heft-plugins/heft-sass-plugin/src/templates/sass.json
+++ b/heft-plugins/heft-sass-plugin/src/templates/sass.json
@@ -7,6 +7,8 @@
   /**
    * Optionally specifies another JSON config file that this file extends from. This provides a way for standard
    * settings to be shared across multiple projects.
+   *
+   * To delete an inherited setting, set it to `null` in this file.
    */
   // "extends": "base-project/config/serve-command.json",
 

--- a/heft-plugins/heft-typescript-plugin/src/schemas/typescript.schema.json
+++ b/heft-plugins/heft-typescript-plugin/src/schemas/typescript.schema.json
@@ -13,7 +13,7 @@
     },
 
     "extends": {
-      "description": "Optionally specifies another JSON config file that this file extends from.  This provides a way for standard settings to be shared across multiple projects.",
+      "description": "Optionally specifies another JSON config file that this file extends from.  This provides a way for standard settings to be shared across multiple projects. To delete an inherited setting, set it to `null` in this file.",
       "type": "string"
     },
 

--- a/libraries/heft-config-file/src/test/ConfigurationFile.test.ts
+++ b/libraries/heft-config-file/src/test/ConfigurationFile.test.ts
@@ -251,6 +251,7 @@ describe('ConfigurationFile', () => {
       things: string[];
       thingsObj: { A: { B: string }; D: { E: string } };
       booleanProp: boolean;
+      stringProp?: string;
     }
 
     it('Correctly loads the config file', () => {
@@ -266,7 +267,8 @@ describe('ConfigurationFile', () => {
       const expectedConfigFile: ISimpleConfigFile = {
         things: ['A', 'B', 'C'],
         thingsObj: { A: { B: 'C' }, D: { E: 'F' } },
-        booleanProp: true
+        booleanProp: true,
+        stringProp: 'someValue'
       };
       expect(JSON.stringify(loadedConfigFile)).toEqual(JSON.stringify(expectedConfigFile));
     });
@@ -284,7 +286,8 @@ describe('ConfigurationFile', () => {
       const expectedConfigFile: ISimpleConfigFile = {
         things: ['A', 'B', 'C'],
         thingsObj: { A: { B: 'C' }, D: { E: 'F' } },
-        booleanProp: true
+        booleanProp: true,
+        stringProp: 'someValue'
       };
       expect(JSON.stringify(loadedConfigFile)).toEqual(JSON.stringify(expectedConfigFile));
     });
@@ -317,7 +320,8 @@ describe('ConfigurationFile', () => {
           A: { B: nodeJsPath.resolve(__dirname, configFileFolderName, 'C') },
           D: { E: nodeJsPath.resolve(__dirname, configFileFolderName, 'F') }
         },
-        booleanProp: true
+        booleanProp: true,
+        stringProp: 'someValue'
       };
       expect(JSON.stringify(loadedConfigFile)).toEqual(JSON.stringify(expectedConfigFile));
     });
@@ -350,7 +354,8 @@ describe('ConfigurationFile', () => {
           A: { B: nodeJsPath.resolve(__dirname, configFileFolderName, 'C') },
           D: { E: nodeJsPath.resolve(__dirname, configFileFolderName, 'F') }
         },
-        booleanProp: true
+        booleanProp: true,
+        stringProp: 'someValue'
       };
       expect(JSON.stringify(loadedConfigFile)).toEqual(JSON.stringify(expectedConfigFile));
     });
@@ -383,7 +388,8 @@ describe('ConfigurationFile', () => {
           A: { B: nodeJsPath.resolve(projectRoot, 'C') },
           D: { E: nodeJsPath.resolve(projectRoot, 'F') }
         },
-        booleanProp: true
+        booleanProp: true,
+        stringProp: 'someValue'
       };
       expect(JSON.stringify(loadedConfigFile)).toEqual(JSON.stringify(expectedConfigFile));
     });
@@ -416,7 +422,8 @@ describe('ConfigurationFile', () => {
           A: { B: nodeJsPath.resolve(projectRoot, 'C') },
           D: { E: nodeJsPath.resolve(projectRoot, 'F') }
         },
-        booleanProp: true
+        booleanProp: true,
+        stringProp: 'someValue'
       };
       expect(JSON.stringify(loadedConfigFile)).toEqual(JSON.stringify(expectedConfigFile));
     });
@@ -435,6 +442,7 @@ describe('ConfigurationFile', () => {
       things: string[];
       thingsObj: { A: { B?: string; D?: string }; D?: { E: string }; F?: { G: string } };
       booleanProp: boolean;
+      stringProp?: string;
     }
 
     it('Correctly loads the config file with default config meta', () => {

--- a/libraries/heft-config-file/src/test/simpleConfigFile/simpleConfigFile.json
+++ b/libraries/heft-config-file/src/test/simpleConfigFile/simpleConfigFile.json
@@ -9,5 +9,7 @@
       "E": "F"
     }
   },
-  "booleanProp": true
+  "booleanProp": true,
+
+  "stringProp": "someValue"
 }

--- a/libraries/heft-config-file/src/test/simpleConfigFile/simpleConfigFile.schema.json
+++ b/libraries/heft-config-file/src/test/simpleConfigFile/simpleConfigFile.schema.json
@@ -24,6 +24,10 @@
 
     "booleanProp": {
       "type": "boolean"
+    },
+
+    "stringProp": {
+      "type": "string"
     }
   }
 }

--- a/libraries/heft-config-file/src/test/simpleConfigFileWithExtends/simpleConfigFileWithExtends.json
+++ b/libraries/heft-config-file/src/test/simpleConfigFileWithExtends/simpleConfigFileWithExtends.json
@@ -13,5 +13,7 @@
     }
   },
 
-  "booleanProp": false
+  "booleanProp": false,
+
+  "stringProp": null
 }

--- a/libraries/rush-lib/assets/website-only/rush-project.json
+++ b/libraries/rush-lib/assets/website-only/rush-project.json
@@ -8,6 +8,8 @@
   /**
    * Optionally specifies another JSON config file that this file extends from. This provides a way for standard
    * settings to be shared across multiple projects.
+   *
+   * To delete an inherited setting, set it to `null` in this file.
    */
   // "extends": "my-rig/profiles/default/config/rush-project.json",
 

--- a/libraries/rush-lib/src/schemas/pnpm-config.schema.json
+++ b/libraries/rush-lib/src/schemas/pnpm-config.schema.json
@@ -11,7 +11,7 @@
     },
 
     "extends": {
-      "description": "Optionally specifies another JSON config file that this file extends from. This provides a way for standard settings to be shared across multiple projects.",
+      "description": "Optionally specifies another JSON config file that this file extends from. This provides a way for standard settings to be shared across multiple projects. To delete an inherited setting, set it to `null` in this file.",
       "type": "string"
     },
 

--- a/libraries/rush-lib/src/schemas/rush-project.schema.json
+++ b/libraries/rush-lib/src/schemas/rush-project.schema.json
@@ -12,7 +12,7 @@
     },
 
     "extends": {
-      "description": "Optionally specifies another JSON config file that this file extends from. This provides a way for standard settings to be shared across multiple projects.",
+      "description": "Optionally specifies another JSON config file that this file extends from. This provides a way for standard settings to be shared across multiple projects. To delete an inherited setting, set it to `null` in this file.",
       "type": "string"
     },
 

--- a/rigs/heft-node-rig/profiles/default/config/heft.json
+++ b/rigs/heft-node-rig/profiles/default/config/heft.json
@@ -7,6 +7,8 @@
   /**
    * Optionally specifies another JSON config file that this file extends from. This provides a way for standard
    * settings to be shared across multiple projects.
+   *
+   * To delete an inherited setting, set it to `null` in this file.
    */
   // "extends": "base-project/config/heft.json",
 

--- a/rigs/heft-node-rig/profiles/default/config/typescript.json
+++ b/rigs/heft-node-rig/profiles/default/config/typescript.json
@@ -7,6 +7,8 @@
   /**
    * Optionally specifies another JSON config file that this file extends from. This provides a way for standard
    * settings to be shared across multiple projects.
+   *
+   * To delete an inherited setting, set it to `null` in this file.
    */
   // "extends": "base-project/config/typescript.json",
 

--- a/rigs/heft-web-rig/profiles/app/config/heft.json
+++ b/rigs/heft-web-rig/profiles/app/config/heft.json
@@ -7,6 +7,8 @@
   /**
    * Optionally specifies another JSON config file that this file extends from. This provides a way for standard
    * settings to be shared across multiple projects.
+   *
+   * To delete an inherited setting, set it to `null` in this file.
    */
   // "extends": "base-project/config/heft.json",
 

--- a/rigs/heft-web-rig/profiles/app/config/sass.json
+++ b/rigs/heft-web-rig/profiles/app/config/sass.json
@@ -10,6 +10,8 @@
   /**
    * Optionally specifies another JSON config file that this file extends from. This provides a way for standard
    * settings to be shared across multiple projects.
+   *
+   * To delete an inherited setting, set it to `null` in this file.
    */
   // "extends": "base-project/config/serve-command.json",
 

--- a/rigs/heft-web-rig/profiles/app/config/typescript.json
+++ b/rigs/heft-web-rig/profiles/app/config/typescript.json
@@ -7,6 +7,8 @@
   /**
    * Optionally specifies another JSON config file that this file extends from. This provides a way for standard
    * settings to be shared across multiple projects.
+   *
+   * To delete an inherited setting, set it to `null` in this file.
    */
   // "extends": "base-project/config/typescript.json",
 

--- a/rigs/heft-web-rig/profiles/library/config/api-extractor-task.json
+++ b/rigs/heft-web-rig/profiles/library/config/api-extractor-task.json
@@ -10,6 +10,8 @@
   /**
    * Optionally specifies another JSON config file that this file extends from. This provides a way for standard
    * settings to be shared across multiple projects.
+   *
+   * To delete an inherited setting, set it to `null` in this file.
    */
   // "extends": "base-project/config/api-extractor-task.json",
 

--- a/rigs/heft-web-rig/profiles/library/config/heft.json
+++ b/rigs/heft-web-rig/profiles/library/config/heft.json
@@ -7,6 +7,8 @@
   /**
    * Optionally specifies another JSON config file that this file extends from. This provides a way for standard
    * settings to be shared across multiple projects.
+   *
+   * To delete an inherited setting, set it to `null` in this file.
    */
   // "extends": "base-project/config/heft.json",
 

--- a/rigs/heft-web-rig/profiles/library/config/sass.json
+++ b/rigs/heft-web-rig/profiles/library/config/sass.json
@@ -10,6 +10,8 @@
   /**
    * Optionally specifies another JSON config file that this file extends from. This provides a way for standard
    * settings to be shared across multiple projects.
+   *
+   * To delete an inherited setting, set it to `null` in this file.
    */
   // "extends": "base-project/config/serve-command.json",
 

--- a/rigs/heft-web-rig/profiles/library/config/typescript.json
+++ b/rigs/heft-web-rig/profiles/library/config/typescript.json
@@ -7,6 +7,8 @@
   /**
    * Optionally specifies another JSON config file that this file extends from. This provides a way for standard
    * settings to be shared across multiple projects.
+   *
+   * To delete an inherited setting, set it to `null` in this file.
    */
   // "extends": "base-project/config/typescript.json",
 

--- a/rush-plugins/rush-serve-plugin/src/schemas/rush-project-serve.schema.json
+++ b/rush-plugins/rush-serve-plugin/src/schemas/rush-project-serve.schema.json
@@ -12,7 +12,7 @@
     },
 
     "extends": {
-      "description": "Optionally specifies another JSON config file that this file extends from. This provides a way for standard settings to be shared across multiple projects.",
+      "description": "Optionally specifies another JSON config file that this file extends from. This provides a way for standard settings to be shared across multiple projects. To delete an inherited setting, set it to `null` in this file.",
       "type": "string"
     },
 


### PR DESCRIPTION
## Summary
Allows configuration files to use the value `null` to reset a property to the behavior it would have if it was not present in the file at all. This is useful when extending another configuration file, for example to delete a task or phase when extending a Heft configuration.

## Details
If a property is set to `null` in a configuration file, regardless of any specified custom merge behavior, the resulting merged configuration file will omit that property, as if it was not specified in the first place.

This follows prior art in TypeScripts tsconfig inheritance, which uses the same method to reset a value to "not specified".

## How it was tested
Added a test case in the simple extends scenario for a property that starts with a value but is then set to `null` when extended.

## Impacted documentation
Documentation for heft-config-file. See https://github.com/microsoft/rushstack-websites/pull/278