### PR TITLE
[rush] Add "q" for "quit" to the watcher prompt

### DIFF
--- a/common/changes/@microsoft/rush/graceful-exit_2025-04-16-19-31.json
+++ b/common/changes/@microsoft/rush/graceful-exit_2025-04-16-19-31.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Bind \"q\" to gracefully exit the watcher.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}


### PR DESCRIPTION
## Summary
Bind the key `q` to gracefully exit Rush's watch mode.

## Details
Added abort support to the watcher and leveraged it here.

## How it was tested
Local invocation of `rush start` in rushstack and pressing `q` to exit.

## Impacted documentation
Documented in the CLI prompt.