### PR TITLE
[rush] Support --changed-projects-only in watch mode

### DIFF
--- a/common/changes/@microsoft/rush/watch-changed-only_2025-04-16-21-54.json
+++ b/common/changes/@microsoft/rush/watch-changed-only_2025-04-16-21-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Support the `--changed-projects-only` flag in watch mode and allow it to be toggled between iterations.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -409,6 +409,7 @@ export interface IConfigurationEnvironmentVariable {
 // @alpha
 export interface ICreateOperationsContext {
     readonly buildCacheConfiguration: BuildCacheConfiguration | undefined;
+    readonly changedProjectsOnly: boolean;
     readonly cobuildConfiguration: CobuildConfiguration | undefined;
     readonly customParameters: ReadonlyMap<string, CommandLineParameter>;
     readonly includePhaseDeps: boolean;
@@ -663,6 +664,7 @@ export interface IOperationSettings {
     dependsOnAdditionalFiles?: string[];
     dependsOnEnvVars?: string[];
     disableBuildCacheForOperation?: boolean;
+    ignoreChangedProjectsOnlyFlag?: boolean;
     operationName: string;
     outputFolderNames?: string[];
     sharding?: IRushPhaseSharding;

--- a/libraries/rush-lib/src/api/RushProjectConfiguration.ts
+++ b/libraries/rush-lib/src/api/RushProjectConfiguration.ts
@@ -141,6 +141,11 @@ export interface IOperationSettings {
    * If true, this operation can use cobuilds for orchestration without restoring build cache entries.
    */
   allowCobuildWithoutCache?: boolean;
+
+  /**
+   * If true, this operation will never be skipped by the `--changed-projects-only` flag.
+   */
+  ignoreChangedProjectsOnlyFlag?: boolean;
 }
 
 interface IOldRushProjectJson {

--- a/libraries/rush-lib/src/logic/ProjectWatcher.ts
+++ b/libraries/rush-lib/src/logic/ProjectWatcher.ts
@@ -69,6 +69,7 @@ export class ProjectWatcher {
   private _onAbort: undefined | (() => void);
   private _getPromptLines: undefined | IPromptGeneratorFunction;
 
+  private _lastStatus: string | undefined;
   private _renderedStatusLines: number;
 
   public isPaused: boolean = false;
@@ -138,6 +139,10 @@ export class ProjectWatcher {
 
   public clearStatus(): void {
     this._renderedStatusLines = 0;
+  }
+
+  public rerenderStatus(): void {
+    this._setStatus(this._lastStatus ?? 'Waiting for changes...');
   }
 
   public setPromptGenerator(promptGenerator: IPromptGeneratorFunction): void {
@@ -427,6 +432,7 @@ export class ProjectWatcher {
       readline.clearScreenDown(process.stdout);
     }
     this._renderedStatusLines = statusLines.length;
+    this._lastStatus = status;
 
     this._terminal.writeLine(Colorize.bold(Colorize.cyan(statusLines.join('\n'))));
   }

--- a/libraries/rush-lib/src/logic/operations/PhasedOperationPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/PhasedOperationPlugin.ts
@@ -111,14 +111,12 @@ function configureOperations(operations: ReadonlySet<Operation>, context: ICreat
   if (!isInitial && changedProjectsOnly) {
     const potentiallyAffectedOperations: Set<Operation> = new Set(operationsWithWork);
     for (const operation of potentiallyAffectedOperations) {
+      if (operation.settings?.ignoreChangedProjectsOnlyFlag) {
+        operationsWithWork.add(operation);
+      }
+
       for (const consumer of operation.consumers) {
         potentiallyAffectedOperations.add(consumer);
-      }
-    }
-
-    for (const operation of operations) {
-      if (potentiallyAffectedOperations.has(operation) && operation.settings?.ignoreChangedProjectsOnlyFlag) {
-        operationsWithWork.add(operation);
       }
     }
   } else {

--- a/libraries/rush-lib/src/logic/operations/PhasedOperationPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/PhasedOperationPlugin.ts
@@ -28,72 +28,19 @@ function createOperations(
   existingOperations: Set<Operation>,
   context: ICreateOperationsContext
 ): Set<Operation> {
-  const {
-    projectsInUnknownState: changedProjects,
-    phaseOriginal,
-    phaseSelection,
-    projectSelection,
-    projectConfigurations,
-    includePhaseDeps,
-    isInitial
-  } = context;
+  const { phaseSelection, projectSelection, projectConfigurations } = context;
 
   const operations: Map<string, Operation> = new Map();
 
   // Create tasks for selected phases and projects
   // This also creates the minimal set of dependencies needed
-  for (const phase of phaseOriginal) {
+  for (const phase of phaseSelection) {
     for (const project of projectSelection) {
       getOrCreateOperation(phase, project);
     }
   }
 
-  // Grab all operations that were explicitly requested.
-  const operationsWithWork: Set<Operation> = new Set();
-  for (const operation of existingOperations) {
-    const { associatedPhase, associatedProject } = operation;
-    if (!associatedPhase || !associatedProject) {
-      // Fix this when these are required properties.
-      continue;
-    }
-
-    if (phaseSelection.has(associatedPhase) && changedProjects.has(associatedProject)) {
-      operationsWithWork.add(operation);
-    }
-  }
-
-  // Add all operations that are selected that depend on the explicitly requested operations.
-  // This will mostly be relevant during watch; in initial runs it should not add any new operations.
-  for (const operation of operationsWithWork) {
-    for (const consumer of operation.consumers) {
-      operationsWithWork.add(consumer);
-    }
-  }
-
-  if (includePhaseDeps && isInitial) {
-    // Add all operations that are dependencies of the operations already scheduled.
-    for (const operation of operationsWithWork) {
-      for (const dependency of operation.dependencies) {
-        operationsWithWork.add(dependency);
-      }
-    }
-  }
-
-  for (const operation of existingOperations) {
-    // Enable exactly the set of operations that are requested.
-    operation.enabled &&= operationsWithWork.has(operation);
-
-    if (!includePhaseDeps || !isInitial) {
-      const { associatedPhase, associatedProject } = operation;
-      if (!associatedPhase || !associatedProject) {
-        // Fix this when these are required properties.
-        continue;
-      }
-
-      // This filter makes the "unsafe" selections happen.
-      operation.enabled &&= phaseSelection.has(associatedPhase) && projectSelection.has(associatedProject);
-    }
-  }
+  configureOperations(existingOperations, context);
 
   return existingOperations;
 
@@ -138,6 +85,71 @@ function createOperations(
     }
 
     return operation;
+  }
+}
+
+function configureOperations(operations: ReadonlySet<Operation>, context: ICreateOperationsContext): void {
+  const {
+    changedProjectsOnly,
+    projectsInUnknownState: changedProjects,
+    phaseOriginal,
+    phaseSelection,
+    projectSelection,
+    includePhaseDeps,
+    isInitial
+  } = context;
+
+  // Grab all operations that were explicitly requested.
+  const operationsWithWork: Set<Operation> = new Set();
+  for (const operation of operations) {
+    const { associatedPhase, associatedProject } = operation;
+    if (phaseOriginal.has(associatedPhase) && changedProjects.has(associatedProject)) {
+      operationsWithWork.add(operation);
+    }
+  }
+
+  if (!isInitial && changedProjectsOnly) {
+    const potentiallyAffectedOperations: Set<Operation> = new Set(operationsWithWork);
+    for (const operation of potentiallyAffectedOperations) {
+      for (const consumer of operation.consumers) {
+        potentiallyAffectedOperations.add(consumer);
+      }
+    }
+
+    for (const operation of operations) {
+      if (potentiallyAffectedOperations.has(operation) && operation.settings?.ignoreChangedProjectsOnlyFlag) {
+        operationsWithWork.add(operation);
+      }
+    }
+  } else {
+    // Add all operations that are selected that depend on the explicitly requested operations.
+    // This will mostly be relevant during watch; in initial runs it should not add any new operations.
+    for (const operation of operationsWithWork) {
+      for (const consumer of operation.consumers) {
+        operationsWithWork.add(consumer);
+      }
+    }
+  }
+
+  if (includePhaseDeps) {
+    // Add all operations that are dependencies of the operations already scheduled.
+    for (const operation of operationsWithWork) {
+      for (const dependency of operation.dependencies) {
+        operationsWithWork.add(dependency);
+      }
+    }
+  }
+
+  for (const operation of operations) {
+    // Enable exactly the set of operations that are requested.
+    operation.enabled &&= operationsWithWork.has(operation);
+
+    if (!includePhaseDeps || !isInitial) {
+      const { associatedPhase, associatedProject } = operation;
+
+      // This filter makes the "unsafe" selections happen.
+      operation.enabled &&= phaseSelection.has(associatedPhase) && projectSelection.has(associatedProject);
+    }
   }
 }
 

--- a/libraries/rush-lib/src/pluginFramework/PhasedCommandHooks.ts
+++ b/libraries/rush-lib/src/pluginFramework/PhasedCommandHooks.ts
@@ -49,6 +49,12 @@ export interface ICreateOperationsContext {
    */
   readonly buildCacheConfiguration: BuildCacheConfiguration | undefined;
   /**
+   * If true, for an incremental build, Rush will only include projects with immediate changes or projects with no consumers.
+   * @remarks
+   * This is an optimization that may produce invalid outputs if some of the intervening projects are impacted by the changes.
+   */
+  readonly changedProjectsOnly: boolean;
+  /**
    * The configuration for the cobuild, if cobuild feature and build cache feature are both enabled.
    */
   readonly cobuildConfiguration: CobuildConfiguration | undefined;

--- a/libraries/rush-lib/src/schemas/rush-project.schema.json
+++ b/libraries/rush-lib/src/schemas/rush-project.schema.json
@@ -106,6 +106,10 @@
           "allowCobuildWithoutCache": {
             "type": "boolean",
             "description": "If true, this operation will not need to use the build cache to leverage cobuilds"
+          },
+          "ignoreChangedProjectsOnlyFlag": {
+            "type": "boolean",
+            "description": "If true, this operation never be skipped by the `--changed-projects-only` flag. This is useful for projects that bundle code from other packages."
           }
         }
       }


### PR DESCRIPTION
## Summary
Defines a behavior for `--changed-projects-only` in Rush watch-mode phased commands.

## Details
- For the initial build, does nothing, since there is no concept of "project that doesn't need to be built"
- For watch-mode rebuilds, only operations for projects that have changed files, or downstream operations that specify `ignoreChangedProjectsOnlyFlag` in `rush-project.json` will be executed.

You can toggle the behavior on or off between iterations by pressing `c` on the command line.

## How it was tested
Local run of `rush start --to heft-webpack5-everything-test` against a different worktree.
![image](https://github.com/user-attachments/assets/425db663-a82b-4288-839b-c86af0db2453)

## Impacted documentation
Documentation for the command line parameter. The toggle is documented in the CLI UX.