### PR TITLE
[rush-serve-plugin] Allow configuring operation enable/disable states via websocket

### DIFF
--- a/common/changes/@microsoft/rush/watch-changed-only_2025-04-17-00-17.json
+++ b/common/changes/@microsoft/rush/watch-changed-only_2025-04-17-00-17.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix telemetry for \"--changed-projects-only\" when toggled in watch mode.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/watch-changed-only_2025-04-17-00-18.json
+++ b/common/changes/@microsoft/rush/watch-changed-only_2025-04-17-00-18.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "(rush-serve-plugin) Support websocket message to enable/disable operations.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
+++ b/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
@@ -430,6 +430,7 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
     const isQuietMode: boolean = !this._verboseParameter.value;
 
     const changedProjectsOnly: boolean = !!this._changedProjectsOnlyParameter?.value;
+    this._changedProjectsOnly = changedProjectsOnly;
 
     let buildCacheConfiguration: BuildCacheConfiguration | undefined;
     let cobuildConfiguration: CobuildConfiguration | undefined;

--- a/libraries/rush-lib/src/logic/operations/PhasedOperationPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/PhasedOperationPlugin.ts
@@ -21,6 +21,14 @@ const PLUGIN_NAME: 'PhasedOperationPlugin' = 'PhasedOperationPlugin';
 export class PhasedOperationPlugin implements IPhasedCommandPlugin {
   public apply(hooks: PhasedCommandHooks): void {
     hooks.createOperations.tap(PLUGIN_NAME, createOperations);
+    // Configure operations later.
+    hooks.createOperations.tap(
+      {
+        name: `${PLUGIN_NAME}.Configure`,
+        stage: 1000
+      },
+      configureOperations
+    );
   }
 }
 
@@ -39,8 +47,6 @@ function createOperations(
       getOrCreateOperation(phase, project);
     }
   }
-
-  configureOperations(existingOperations, context);
 
   return existingOperations;
 
@@ -88,7 +94,7 @@ function createOperations(
   }
 }
 
-function configureOperations(operations: ReadonlySet<Operation>, context: ICreateOperationsContext): void {
+function configureOperations(operations: Set<Operation>, context: ICreateOperationsContext): Set<Operation> {
   const {
     changedProjectsOnly,
     projectsInUnknownState: changedProjects,
@@ -149,6 +155,8 @@ function configureOperations(operations: ReadonlySet<Operation>, context: ICreat
       operation.enabled &&= phaseSelection.has(associatedPhase) && projectSelection.has(associatedProject);
     }
   }
+
+  return operations;
 }
 
 // Convert the [IPhase, RushConfigurationProject] into a value suitable for use as a Map key

--- a/rush-plugins/rush-serve-plugin/src/api.types.ts
+++ b/rush-plugins/rush-serve-plugin/src/api.types.ts
@@ -152,6 +152,14 @@ export interface IWebSocketSyncCommandMessage {
 }
 
 /**
+ * Message received from a WebSocket client to request invalidation of one or more operations.
+ */
+export interface IWebSocketInvalidateCommandMessage {
+  command: 'invalidate';
+  operationNames: string[];
+}
+
+/**
  * The set of possible operation enabled states.
  */
 export type OperationEnabledState = 'never' | 'changed' | 'affected';
@@ -169,4 +177,5 @@ export interface IWebSocketSetEnabledStatesCommandMessage {
  */
 export type IWebSocketCommandMessage =
   | IWebSocketSyncCommandMessage
+  | IWebSocketInvalidateCommandMessage
   | IWebSocketSetEnabledStatesCommandMessage;

--- a/rush-plugins/rush-serve-plugin/src/api.types.ts
+++ b/rush-plugins/rush-serve-plugin/src/api.types.ts
@@ -152,6 +152,16 @@ export interface IWebSocketSyncCommandMessage {
 }
 
 /**
+ * Message received from a WebSocket client to change the enabled states of operations.
+ */
+export interface IWebSocketSetEnabledStatesCommandMessage {
+  command: 'set-enabled-states';
+  enabledStateByOperationName: Record<string, boolean>;
+}
+
+/**
  * The set of possible messages received from a WebSocket client.
  */
-export type IWebSocketCommandMessage = IWebSocketSyncCommandMessage;
+export type IWebSocketCommandMessage =
+  | IWebSocketSyncCommandMessage
+  | IWebSocketSetEnabledStatesCommandMessage;

--- a/rush-plugins/rush-serve-plugin/src/api.types.ts
+++ b/rush-plugins/rush-serve-plugin/src/api.types.ts
@@ -152,11 +152,16 @@ export interface IWebSocketSyncCommandMessage {
 }
 
 /**
+ * The set of possible operation enabled states.
+ */
+export type OperationEnabledState = 'never' | 'changed' | 'affected';
+
+/**
  * Message received from a WebSocket client to change the enabled states of operations.
  */
 export interface IWebSocketSetEnabledStatesCommandMessage {
   command: 'set-enabled-states';
-  enabledStateByOperationName: Record<string, boolean>;
+  enabledStateByOperationName: Record<string, OperationEnabledState>;
 }
 
 /**


### PR DESCRIPTION
## Summary
Adds a new command to the websocket protocol to set the `enabled` state of operations in the current session.

## Details
Adds a command `set-enabled-states` that takes a `{ [operationName: string]: boolean }` to configure the base enabled states for operations. This is applied after the default selection filter, but will only include operations that are related to changes (invalidating operations will make more projects be considered "changed").

Adds a command `invalidate` that takes an array of operation names to request that they be executed on the next pass.

Also fixes an inaccuracy in the reporting of the status of the `--changed-projects-only` flag when telemetry is enabled, since it can be toggled at runtime.

## How it was tested
For the telemetry flag, a local run.
For the websocket, currently hasn't been.

## Impacted documentation
Web socket protocol.