### PR TITLE
[ts-command-line] Remove deprecations and perform updates planned for the next major bump.

### DIFF
--- a/apps/api-documenter/src/cli/BaseAction.ts
+++ b/apps/api-documenter/src/cli/BaseAction.ts
@@ -32,7 +32,6 @@ export abstract class BaseAction extends CommandLineAction {
   protected constructor(options: ICommandLineActionOptions) {
     super(options);
 
-    // override
     this._inputFolderParameter = this.defineStringParameter({
       parameterLongName: '--input-folder',
       parameterShortName: '-i',

--- a/apps/api-documenter/src/cli/GenerateAction.ts
+++ b/apps/api-documenter/src/cli/GenerateAction.ts
@@ -22,8 +22,7 @@ export class GenerateAction extends BaseAction {
     });
   }
 
-  protected async onExecute(): Promise<void> {
-    // override
+  protected override async onExecuteAsync(): Promise<void> {
     // Look for the config file under the current folder
 
     let configFilePath: string = path.join(process.cwd(), DocumenterConfig.FILENAME);

--- a/apps/api-documenter/src/cli/MarkdownAction.ts
+++ b/apps/api-documenter/src/cli/MarkdownAction.ts
@@ -16,8 +16,7 @@ export class MarkdownAction extends BaseAction {
     });
   }
 
-  protected async onExecute(): Promise<void> {
-    // override
+  protected override async onExecuteAsync(): Promise<void> {
     const { apiModel, outputFolder } = this.buildApiModel();
 
     const markdownDocumenter: MarkdownDocumenter = new MarkdownDocumenter({

--- a/apps/api-documenter/src/cli/YamlAction.ts
+++ b/apps/api-documenter/src/cli/YamlAction.ts
@@ -50,8 +50,7 @@ export class YamlAction extends BaseAction {
     });
   }
 
-  protected async onExecute(): Promise<void> {
-    // override
+  protected override async onExecuteAsync(): Promise<void> {
     const { apiModel, inputFolder, outputFolder } = this.buildApiModel();
 
     const yamlDocumenter: YamlDocumenter = this._officeParameter.value

--- a/apps/api-documenter/src/documenters/OfficeYamlDocumenter.ts
+++ b/apps/api-documenter/src/documenters/OfficeYamlDocumenter.ts
@@ -65,7 +65,6 @@ export class OfficeYamlDocumenter extends YamlDocumenter {
 
   /** @override */
   protected onGetTocRoot(): IYamlTocItem {
-    // override
     return {
       name: 'API reference',
       href: 'overview.md',

--- a/apps/api-extractor/src/cli/ApiExtractorCommandLine.ts
+++ b/apps/api-extractor/src/cli/ApiExtractorCommandLine.ts
@@ -32,21 +32,22 @@ export class ApiExtractorCommandLine extends CommandLineParser {
     });
   }
 
-  protected onExecute(): Promise<void> {
-    // override
+  protected override async onExecuteAsync(): Promise<void> {
     if (this._debugParameter.value) {
       InternalError.breakInDebugger = true;
     }
 
-    return super.onExecute().catch((error) => {
+    process.exitCode = 1;
+    try {
+      await super.onExecuteAsync();
+      process.exitCode = 0;
+    } catch (error) {
       if (this._debugParameter.value) {
         console.error(os.EOL + error.stack);
       } else {
         console.error(os.EOL + Colorize.red('ERROR: ' + error.message.trim()));
       }
-
-      process.exitCode = 1;
-    });
+    }
   }
 
   private _populateActions(): void {

--- a/apps/api-extractor/src/cli/InitAction.ts
+++ b/apps/api-extractor/src/cli/InitAction.ts
@@ -21,8 +21,7 @@ export class InitAction extends CommandLineAction {
     });
   }
 
-  protected async onExecute(): Promise<void> {
-    // override
+  protected override async onExecuteAsync(): Promise<void> {
     const inputFilePath: string = path.resolve(__dirname, '../schemas/api-extractor-template.json');
     const outputFilePath: string = path.resolve(ExtractorConfig.FILENAME);
 

--- a/apps/api-extractor/src/cli/RunAction.ts
+++ b/apps/api-extractor/src/cli/RunAction.ts
@@ -71,8 +71,7 @@ export class RunAction extends CommandLineAction {
     });
   }
 
-  protected async onExecute(): Promise<void> {
-    // override
+  protected override async onExecuteAsync(): Promise<void> {
     const lookup: PackageJsonLookup = new PackageJsonLookup();
     let configFilename: string;
 

--- a/apps/cpu-profile-summarizer/src/start.ts
+++ b/apps/cpu-profile-summarizer/src/start.ts
@@ -147,7 +147,7 @@ class CpuProfileSummarizerCommandLineParser extends CommandLineParser {
     });
   }
 
-  protected async onExecute(): Promise<void> {
+  protected override async onExecuteAsync(): Promise<void> {
     const input: readonly string[] = this._inputParameter.values;
     const output: string = this._outputParameter.value;
 

--- a/apps/heft/src/cli/HeftCommandLineParser.ts
+++ b/apps/heft/src/cli/HeftCommandLineParser.ts
@@ -228,7 +228,7 @@ export class HeftCommandLineParser extends CommandLineParser {
       // try to evaluate any parameters. This is to ensure that the
       // `--debug` flag is defined correctly before we do this not-so-rigorous
       // parameter parsing.
-      throw new InternalError('onDefineParameters() has not yet been called.');
+      throw new InternalError('parameters have not yet been defined.');
     }
 
     const toolParameters: Set<string> = getToolParameterNamesFromArgs(args);

--- a/apps/heft/src/cli/HeftCommandLineParser.ts
+++ b/apps/heft/src/cli/HeftCommandLineParser.ts
@@ -176,7 +176,7 @@ export class HeftCommandLineParser extends CommandLineParser {
     }
   }
 
-  protected async onExecute(): Promise<void> {
+  protected override async onExecuteAsync(): Promise<void> {
     try {
       const selectedAction: CommandLineAction | undefined = this.selectedAction;
 
@@ -196,7 +196,7 @@ export class HeftCommandLineParser extends CommandLineParser {
         commandName,
         unaliasedCommandName
       };
-      await super.onExecute();
+      await super.onExecuteAsync();
     } catch (e) {
       await this._reportErrorAndSetExitCodeAsync(e as Error);
     }

--- a/apps/heft/src/cli/actions/AliasAction.ts
+++ b/apps/heft/src/cli/actions/AliasAction.ts
@@ -22,7 +22,7 @@ export class AliasAction extends AliasCommandLineAction {
     this._terminal = options.terminal;
   }
 
-  protected async onExecute(): Promise<void> {
+  protected override async onExecuteAsync(): Promise<void> {
     const toolFilename: string = this._toolFilename;
     const actionName: string = this.actionName;
     const targetAction: CommandLineAction = this.targetAction;
@@ -34,6 +34,6 @@ export class AliasAction extends AliasCommandLineAction {
         `${defaultParametersString ? ` ${defaultParametersString}` : ''}".`
     );
 
-    await super.onExecute();
+    await super.onExecuteAsync();
   }
 }

--- a/apps/heft/src/cli/actions/CleanAction.ts
+++ b/apps/heft/src/cli/actions/CleanAction.ts
@@ -76,7 +76,7 @@ export class CleanAction extends CommandLineAction implements IHeftAction {
     return this._selectedPhases;
   }
 
-  protected async onExecute(): Promise<void> {
+  protected override async onExecuteAsync(): Promise<void> {
     const { heftConfiguration } = this._internalHeftSession;
     const abortSignal: AbortSignal = ensureCliAbortSignal(this._terminal);
 

--- a/apps/heft/src/cli/actions/PhaseAction.ts
+++ b/apps/heft/src/cli/actions/PhaseAction.ts
@@ -47,7 +47,7 @@ export class PhaseAction extends CommandLineAction implements IHeftAction {
     return this._selectedPhases;
   }
 
-  protected async onExecute(): Promise<void> {
+  protected override async onExecuteAsync(): Promise<void> {
     await this._actionRunner.executeAsync();
   }
 }

--- a/apps/heft/src/cli/actions/RunAction.ts
+++ b/apps/heft/src/cli/actions/RunAction.ts
@@ -145,7 +145,7 @@ export class RunAction extends ScopedCommandLineAction implements IHeftAction {
     this._actionRunner.defineParameters(scopedParameterProvider);
   }
 
-  protected async onExecute(): Promise<void> {
+  protected override async onExecuteAsync(): Promise<void> {
     await this._actionRunner.executeAsync();
   }
 }

--- a/apps/lockfile-explorer/src/cli/explorer/ExplorerCommandLineParser.ts
+++ b/apps/lockfile-explorer/src/cli/explorer/ExplorerCommandLineParser.ts
@@ -59,7 +59,7 @@ export class ExplorerCommandLineParser extends CommandLineParser {
     return this._debugParameter.value;
   }
 
-  protected async onExecute(): Promise<void> {
+  protected override async onExecuteAsync(): Promise<void> {
     const lockfileExplorerProjectRoot: string = PackageJsonLookup.instance.tryGetPackageFolderFor(__dirname)!;
     const lockfileExplorerPackageJson: IPackageJson = JsonFile.load(
       `${lockfileExplorerProjectRoot}/package.json`

--- a/apps/lockfile-explorer/src/cli/lint/LintCommandLineParser.ts
+++ b/apps/lockfile-explorer/src/cli/lint/LintCommandLineParser.ts
@@ -26,7 +26,7 @@ export class LintCommandLineParser extends CommandLineParser {
     this._populateActions();
   }
 
-  protected override async onExecute(): Promise<void> {
+  protected override async onExecuteAsync(): Promise<void> {
     const lockfileExplorerProjectRoot: string = PackageJsonLookup.instance.tryGetPackageFolderFor(__dirname)!;
     const lockfileExplorerPackageJson: IPackageJson = JsonFile.load(
       `${lockfileExplorerProjectRoot}/package.json`
@@ -37,7 +37,7 @@ export class LintCommandLineParser extends CommandLineParser {
       Colorize.bold(`\nRush Lockfile Lint ${appVersion}`) + Colorize.cyan(' - https://lfx.rushstack.io/\n')
     );
 
-    await super.onExecute();
+    await super.onExecuteAsync();
   }
 
   private _populateActions(): void {

--- a/apps/lockfile-explorer/src/cli/lint/actions/CheckAction.ts
+++ b/apps/lockfile-explorer/src/cli/lint/actions/CheckAction.ts
@@ -174,7 +174,7 @@ export class CheckAction extends CommandLineAction {
     }
   }
 
-  protected async onExecute(): Promise<void> {
+  protected override async onExecuteAsync(): Promise<void> {
     const rushConfiguration: RushConfiguration | undefined = RushConfiguration.tryLoadFromDefaultLocation();
     if (!rushConfiguration) {
       throw new Error(

--- a/apps/lockfile-explorer/src/cli/lint/actions/InitAction.ts
+++ b/apps/lockfile-explorer/src/cli/lint/actions/InitAction.ts
@@ -25,7 +25,7 @@ export class InitAction extends CommandLineAction {
     this._terminal = parser.globalTerminal;
   }
 
-  protected async onExecute(): Promise<void> {
+  protected override async onExecuteAsync(): Promise<void> {
     const rushConfiguration: RushConfiguration | undefined = RushConfiguration.tryLoadFromDefaultLocation();
     if (!rushConfiguration) {
       throw new Error(

--- a/apps/rundown/src/cli/InspectAction.ts
+++ b/apps/rundown/src/cli/InspectAction.ts
@@ -25,7 +25,7 @@ export class InspectAction extends BaseReportAction {
     });
   }
 
-  protected async onExecute(): Promise<void> {
+  protected override async onExecuteAsync(): Promise<void> {
     const rundown: Rundown = new Rundown();
     await rundown.invokeAsync(
       this.scriptParameter.value,

--- a/apps/rundown/src/cli/SnapshotAction.ts
+++ b/apps/rundown/src/cli/SnapshotAction.ts
@@ -16,7 +16,7 @@ export class SnapshotAction extends BaseReportAction {
     });
   }
 
-  protected async onExecute(): Promise<void> {
+  protected override async onExecuteAsync(): Promise<void> {
     const rundown: Rundown = new Rundown();
     await rundown.invokeAsync(
       this.scriptParameter.value,

--- a/apps/trace-import/src/TraceImportCommandLineParser.ts
+++ b/apps/trace-import/src/TraceImportCommandLineParser.ts
@@ -66,8 +66,7 @@ export class TraceImportCommandLineParser extends CommandLineParser {
     });
   }
 
-  protected async onExecute(): Promise<void> {
-    // override
+  protected override async onExecuteAsync(): Promise<void> {
     if (this._debugParameter.value) {
       InternalError.breakInDebugger = true;
     }

--- a/build-tests/api-extractor-test-05/dist/tsdoc-metadata.json
+++ b/build-tests/api-extractor-test-05/dist/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.51.1"
+      "packageVersion": "7.52.4"
     }
   ]
 }

--- a/common/changes/@microsoft/api-documenter/remove-deprecations_2025-04-21-18-08.json
+++ b/common/changes/@microsoft/api-documenter/remove-deprecations_2025-04-21-18-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-documenter",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/api-documenter"
+}

--- a/common/changes/@microsoft/api-extractor/remove-deprecations_2025-04-21-18-08.json
+++ b/common/changes/@microsoft/api-extractor/remove-deprecations_2025-04-21-18-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor"
+}

--- a/common/changes/@microsoft/rush/remove-deprecations_2025-04-21-18-08.json
+++ b/common/changes/@microsoft/rush/remove-deprecations_2025-04-21-18-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@rushstack/cpu-profile-summarizer/remove-deprecations_2025-04-21-18-08.json
+++ b/common/changes/@rushstack/cpu-profile-summarizer/remove-deprecations_2025-04-21-18-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/cpu-profile-summarizer",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/cpu-profile-summarizer"
+}

--- a/common/changes/@rushstack/heft/remove-deprecations_2025-04-21-02-44.json
+++ b/common/changes/@rushstack/heft/remove-deprecations_2025-04-21-02-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/heft"
+}

--- a/common/changes/@rushstack/lockfile-explorer/remove-deprecations_2025-04-21-18-08.json
+++ b/common/changes/@rushstack/lockfile-explorer/remove-deprecations_2025-04-21-18-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/lockfile-explorer",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/lockfile-explorer"
+}

--- a/common/changes/@rushstack/node-core-library/remove-deprecations_2025-04-21-18-08.json
+++ b/common/changes/@rushstack/node-core-library/remove-deprecations_2025-04-21-18-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/node-core-library",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/node-core-library"
+}

--- a/common/changes/@rushstack/package-extractor/remove-deprecations_2025-04-21-18-08.json
+++ b/common/changes/@rushstack/package-extractor/remove-deprecations_2025-04-21-18-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/package-extractor",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/package-extractor"
+}

--- a/common/changes/@rushstack/rundown/remove-deprecations_2025-04-21-18-08.json
+++ b/common/changes/@rushstack/rundown/remove-deprecations_2025-04-21-18-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/rundown",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/rundown"
+}

--- a/common/changes/@rushstack/trace-import/remove-deprecations_2025-04-21-18-08.json
+++ b/common/changes/@rushstack/trace-import/remove-deprecations_2025-04-21-18-08.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/trace-import",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/trace-import"
+}

--- a/common/changes/@rushstack/ts-command-line/remove-deprecations_2025-04-21-02-44.json
+++ b/common/changes/@rushstack/ts-command-line/remove-deprecations_2025-04-21-02-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/ts-command-line",
+      "comment": "Remove the deprecated `onDefineParameters`, `execute`, `executeWithoutErrorHandling`, and `onDefineUnscopedParameters` functions.",
+      "type": "major"
+    }
+  ],
+  "packageName": "@rushstack/ts-command-line"
+}

--- a/common/changes/@rushstack/ts-command-line/remove-deprecations_2025-04-21-03-03.json
+++ b/common/changes/@rushstack/ts-command-line/remove-deprecations_2025-04-21-03-03.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/ts-command-line",
+      "comment": "Rename `onExecute` to `onExecuteAsync`, `CommandLineParameter` to `CommandLineParameterBase`, and `completions` to `getCompletionsAsync`.",
+      "type": "major"
+    }
+  ],
+  "packageName": "@rushstack/ts-command-line"
+}

--- a/common/reviews/api/ts-command-line.api.md
+++ b/common/reviews/api/ts-command-line.api.md
@@ -10,7 +10,7 @@ import * as argparse from 'argparse';
 export class AliasCommandLineAction extends CommandLineAction {
     constructor(options: IAliasCommandLineActionOptions);
     readonly defaultParameters: ReadonlyArray<string>;
-    protected onExecute(): Promise<void>;
+    protected onExecuteAsync(): Promise<void>;
     // @internal
     _processParsedData(parserOptions: ICommandLineParserOptions, data: _ICommandLineParserData): void;
     // @internal (undocumented)
@@ -29,12 +29,12 @@ export abstract class CommandLineAction extends CommandLineParameterProvider {
     _executeAsync(): Promise<void>;
     // @internal
     _getArgumentParser(): argparse.ArgumentParser;
-    protected abstract onExecute(): Promise<void>;
+    protected abstract onExecuteAsync(): Promise<void>;
     readonly summary: string;
 }
 
 // @public
-export class CommandLineChoiceListParameter<TChoice extends string = string> extends CommandLineParameter {
+export class CommandLineChoiceListParameter<TChoice extends string = string> extends CommandLineParameterBase {
     // @internal
     constructor(definition: ICommandLineChoiceListDefinition<TChoice>);
     readonly alternatives: ReadonlySet<TChoice>;
@@ -48,7 +48,7 @@ export class CommandLineChoiceListParameter<TChoice extends string = string> ext
 }
 
 // @public
-export class CommandLineChoiceParameter<TChoice extends string = string> extends CommandLineParameter {
+export class CommandLineChoiceParameter<TChoice extends string = string> extends CommandLineParameterBase {
     // @internal
     constructor(definition: ICommandLineChoiceDefinition<TChoice>);
     readonly alternatives: ReadonlySet<TChoice>;
@@ -70,7 +70,7 @@ export enum CommandLineConstants {
 }
 
 // @public
-export class CommandLineFlagParameter extends CommandLineParameter {
+export class CommandLineFlagParameter extends CommandLineParameterBase {
     // @internal
     constructor(definition: ICommandLineFlagDefinition);
     // @override
@@ -113,8 +113,11 @@ export class CommandLineIntegerParameter extends CommandLineParameterWithArgumen
     get value(): number | undefined;
 }
 
+// @public (undocumented)
+export type CommandLineParameter = CommandLineChoiceListParameter | CommandLineChoiceParameter | CommandLineFlagParameter | CommandLineIntegerListParameter | CommandLineIntegerParameter | CommandLineStringListParameter | CommandLineStringParameter;
+
 // @public
-export abstract class CommandLineParameter {
+export abstract class CommandLineParameterBase {
     // @internal
     constructor(definition: IBaseCommandLineDefinition);
     readonly allowNonStandardEnvironmentVariableNames: boolean | undefined;
@@ -191,10 +194,8 @@ export abstract class CommandLineParameterProvider {
         defaultValue: number;
     }): IRequiredCommandLineIntegerParameter;
     defineIntegerParameter(definition: ICommandLineIntegerDefinition): CommandLineIntegerParameter;
-    // Warning: (ae-forgotten-export) The symbol "CommandLineParameter_2" needs to be exported by the entry point index.d.ts
-    //
     // @internal (undocumented)
-    protected _defineParameter(parameter: CommandLineParameter_2): void;
+    protected _defineParameter(parameter: CommandLineParameter): void;
     defineStringListParameter(definition: ICommandLineStringListDefinition): CommandLineStringListParameter;
     defineStringParameter(definition: ICommandLineStringDefinition & {
         required: false | undefined;
@@ -233,18 +234,18 @@ export abstract class CommandLineParameterProvider {
     // @internal (undocumented)
     protected readonly _registeredParameterParserKeysByName: Map<string, string>;
     // @internal (undocumented)
-    protected _registerParameter(parameter: CommandLineParameter_2, useScopedLongName: boolean, ignoreShortName: boolean): void;
+    protected _registerParameter(parameter: CommandLineParameter, useScopedLongName: boolean, ignoreShortName: boolean): void;
     get remainder(): CommandLineRemainder | undefined;
     renderHelpText(): string;
     renderUsageText(): string;
 }
 
 // @public
-export abstract class CommandLineParameterWithArgument extends CommandLineParameter {
+export abstract class CommandLineParameterWithArgument extends CommandLineParameterBase {
     // @internal
     constructor(definition: IBaseCommandLineDefinitionWithArgument);
     readonly argumentName: string;
-    readonly completions: (() => Promise<ReadonlyArray<string> | ReadonlySet<string>>) | undefined;
+    readonly getCompletionsAsync: (() => Promise<ReadonlyArray<string> | ReadonlySet<string>>) | undefined;
 }
 
 // @public
@@ -257,7 +258,7 @@ export abstract class CommandLineParser extends CommandLineParameterProvider {
     getAction(actionName: string): CommandLineAction;
     // @internal
     protected _getArgumentParser(): argparse.ArgumentParser;
-    protected onExecute(): Promise<void>;
+    protected onExecuteAsync(): Promise<void>;
     // @internal (undocumented)
     _registerDefinedParameters(state: _IRegisterDefinedParametersState): void;
     selectedAction: CommandLineAction | undefined;
@@ -306,7 +307,7 @@ export class CommandLineStringParameter extends CommandLineParameterWithArgument
 // @public (undocumented)
 export class DynamicCommandLineAction extends CommandLineAction {
     // (undocumented)
-    protected onExecute(): Promise<void>;
+    protected onExecuteAsync(): Promise<void>;
 }
 
 // @public (undocumented)
@@ -337,7 +338,7 @@ export interface IBaseCommandLineDefinition {
 // @public
 export interface IBaseCommandLineDefinitionWithArgument extends IBaseCommandLineDefinition {
     argumentName: string;
-    completions?: () => Promise<ReadonlyArray<string> | ReadonlySet<string>>;
+    getCompletionsAsync?: () => Promise<ReadonlyArray<string> | ReadonlySet<string>>;
 }
 
 // @public
@@ -440,13 +441,13 @@ export interface IScopedLongNameParseResult {
 export abstract class ScopedCommandLineAction extends CommandLineAction {
     constructor(options: ICommandLineActionOptions);
     // @internal (undocumented)
-    protected _defineParameter(parameter: CommandLineParameter_2): void;
+    protected _defineParameter(parameter: CommandLineParameter): void;
     // @internal
     _executeAsync(): Promise<void>;
     // @internal
     protected _getScopedCommandLineParser(): CommandLineParser;
     protected abstract onDefineScopedParameters(scopedParameterProvider: CommandLineParameterProvider): void;
-    protected abstract onExecute(): Promise<void>;
+    protected abstract onExecuteAsync(): Promise<void>;
     get parameters(): ReadonlyArray<CommandLineParameter>;
     // @internal
     _processParsedData(parserOptions: ICommandLineParserOptions, data: _ICommandLineParserData): void;

--- a/common/reviews/api/ts-command-line.api.md
+++ b/common/reviews/api/ts-command-line.api.md
@@ -217,8 +217,6 @@ export abstract class CommandLineParameterProvider {
     getParameterStringMap(): Record<string, string>;
     getStringListParameter(parameterLongName: string, parameterScope?: string): CommandLineStringListParameter;
     getStringParameter(parameterLongName: string, parameterScope?: string): CommandLineStringParameter;
-    // @deprecated (undocumented)
-    protected onDefineParameters?(): void;
     get parameters(): ReadonlyArray<CommandLineParameter>;
     get parametersProcessed(): boolean;
     parseScopedLongName(scopedLongName: string): IScopedLongNameParseResult;
@@ -254,11 +252,7 @@ export abstract class CommandLineParser extends CommandLineParameterProvider {
     constructor(options: ICommandLineParserOptions);
     get actions(): ReadonlyArray<CommandLineAction>;
     addAction(action: CommandLineAction): void;
-    // @deprecated (undocumented)
-    execute(args?: string[]): Promise<boolean>;
     executeAsync(args?: string[]): Promise<boolean>;
-    // @deprecated (undocumented)
-    executeWithoutErrorHandling(args?: string[]): Promise<void>;
     executeWithoutErrorHandlingAsync(args?: string[]): Promise<void>;
     getAction(actionName: string): CommandLineAction;
     // @internal
@@ -452,8 +446,6 @@ export abstract class ScopedCommandLineAction extends CommandLineAction {
     // @internal
     protected _getScopedCommandLineParser(): CommandLineParser;
     protected abstract onDefineScopedParameters(scopedParameterProvider: CommandLineParameterProvider): void;
-    // @deprecated (undocumented)
-    protected onDefineUnscopedParameters?(): void;
     protected abstract onExecute(): Promise<void>;
     get parameters(): ReadonlyArray<CommandLineParameter>;
     // @internal

--- a/libraries/node-core-library/src/ProtectableMapView.ts
+++ b/libraries/node-core-library/src/ProtectableMapView.ts
@@ -21,24 +21,21 @@ export class ProtectableMapView<K, V> extends Map<K, V> {
     this._parameters = parameters;
   }
 
-  public clear(): void {
-    // override
+  public override clear(): void {
     if (this._parameters.onClear) {
       this._parameters.onClear(this._owner);
     }
     super.clear();
   }
 
-  public delete(key: K): boolean {
-    // override
+  public override delete(key: K): boolean {
     if (this._parameters.onDelete) {
       this._parameters.onDelete(this._owner, key);
     }
     return super.delete(key);
   }
 
-  public set(key: K, value: V): this {
-    // override
+  public override set(key: K, value: V): this {
     let modifiedValue: V = value;
     if (this._parameters.onSet) {
       modifiedValue = this._parameters.onSet(this._owner, key, modifiedValue);

--- a/libraries/package-extractor/src/scripts/createLinks/cli/CreateLinksCommandLineParser.ts
+++ b/libraries/package-extractor/src/scripts/createLinks/cli/CreateLinksCommandLineParser.ts
@@ -23,12 +23,11 @@ export class CreateLinksCommandLineParser extends CommandLineParser {
     this.addAction(new RemoveLinksAction(this._terminal));
   }
 
-  protected async onExecute(): Promise<void> {
-    // override
+  protected override async onExecuteAsync(): Promise<void> {
     process.exitCode = 1;
 
     try {
-      await super.onExecute();
+      await super.onExecuteAsync();
       process.exitCode = 0;
     } catch (error) {
       if (!(error instanceof AlreadyReportedError)) {

--- a/libraries/package-extractor/src/scripts/createLinks/cli/actions/CreateLinksAction.ts
+++ b/libraries/package-extractor/src/scripts/createLinks/cli/actions/CreateLinksAction.ts
@@ -98,7 +98,7 @@ export class CreateLinksAction extends CommandLineAction {
     });
   }
 
-  protected async onExecute(): Promise<void> {
+  protected override async onExecuteAsync(): Promise<void> {
     const extractorMetadataObject: IExtractorMetadataJson = await getExtractorMetadataAsync();
     const realizeFiles: boolean = this._realizeFilesParameter.value;
     const linkBins: boolean = this._linkBinsParameter.value;

--- a/libraries/package-extractor/src/scripts/createLinks/cli/actions/RemoveLinksAction.ts
+++ b/libraries/package-extractor/src/scripts/createLinks/cli/actions/RemoveLinksAction.ts
@@ -38,7 +38,7 @@ export class RemoveLinksAction extends CommandLineAction {
     this._terminal = terminal;
   }
 
-  protected async onExecute(): Promise<void> {
+  protected override async onExecuteAsync(): Promise<void> {
     const extractorMetadataObject: IExtractorMetadataJson = await getExtractorMetadataAsync();
 
     this._terminal.writeLine(`Removing links for extraction at path "${TARGET_ROOT_FOLDER}"`);

--- a/libraries/rush-lib/src/cli/RushCommandLineParser.ts
+++ b/libraries/rush-lib/src/cli/RushCommandLineParser.ts
@@ -224,7 +224,7 @@ export class RushCommandLineParser extends CommandLineParser {
     return await super.executeAsync(args);
   }
 
-  protected async onExecute(): Promise<void> {
+  protected override async onExecuteAsync(): Promise<void> {
     // Defensively set the exit code to 1 so if Rush crashes for whatever reason, we'll have a nonzero exit code.
     // For example, Node.js currently has the inexcusable design of terminating with zero exit code when
     // there is an uncaught promise exception.  This will supposedly be fixed in Node.js 9.
@@ -298,7 +298,7 @@ export class RushCommandLineParser extends CommandLineParser {
     }
 
     try {
-      await super.onExecute();
+      await super.onExecuteAsync();
     } finally {
       if (this.telemetry) {
         this.flushTelemetry();

--- a/libraries/rush-lib/src/cli/actions/BaseRushAction.ts
+++ b/libraries/rush-lib/src/cli/actions/BaseRushAction.ts
@@ -57,7 +57,7 @@ export abstract class BaseConfiglessRushAction extends CommandLineAction impleme
     this.rushGlobalFolder = rushGlobalFolder;
   }
 
-  protected onExecute(): Promise<void> {
+  protected override async onExecuteAsync(): Promise<void> {
     this._ensureEnvironment();
 
     if (this.rushConfiguration) {
@@ -74,7 +74,8 @@ export abstract class BaseConfiglessRushAction extends CommandLineAction impleme
     if (!RushCommandLineParser.shouldRestrictConsoleOutput()) {
       this.terminal.write(`Starting "rush ${this.actionName}"\n`);
     }
-    return this.runAsync();
+
+    return await this.runAsync();
   }
 
   /**
@@ -113,7 +114,7 @@ export abstract class BaseRushAction extends BaseConfiglessRushAction {
 
   protected readonly rushConfiguration!: RushConfiguration;
 
-  protected async onExecute(): Promise<void> {
+  protected override async onExecuteAsync(): Promise<void> {
     if (!this.rushConfiguration) {
       throw Utilities.getRushConfigNotFoundError();
     }
@@ -130,7 +131,7 @@ export abstract class BaseRushAction extends BaseConfiglessRushAction {
       await sessionHooks.initialize.promise(this);
     }
 
-    return super.onExecute();
+    return super.onExecuteAsync();
   }
 
   /**

--- a/libraries/rush-lib/src/cli/parsing/SelectionParameterSet.ts
+++ b/libraries/rush-lib/src/cli/parsing/SelectionParameterSet.ts
@@ -75,7 +75,7 @@ export class SelectionParameterSet {
 
     this._selectorParserByScope = selectorParsers;
 
-    const getSpecifierCompletions: () => Promise<string[]> = async (): Promise<string[]> => {
+    const getCompletionsAsync: () => Promise<string[]> = async (): Promise<string[]> => {
       const completions: string[] = ['.'];
       for (const [prefix, selector] of selectorParsers) {
         for (const completion of selector.getCompletions()) {
@@ -101,7 +101,7 @@ export class SelectionParameterSet {
         ' Each "--to" parameter expands this selection to include PROJECT and all its dependencies.' +
         ' "." can be used as shorthand for the project in the current working directory.' +
         ' For details, refer to the website article "Selecting subsets of projects".',
-      completions: getSpecifierCompletions
+      getCompletionsAsync
     });
     this._toExceptProject = action.defineStringListParameter({
       parameterLongName: '--to-except',
@@ -114,7 +114,7 @@ export class SelectionParameterSet {
         ' but not PROJECT itself.' +
         ' "." can be used as shorthand for the project in the current working directory.' +
         ' For details, refer to the website article "Selecting subsets of projects".',
-      completions: getSpecifierCompletions
+      getCompletionsAsync
     });
 
     this._fromProject = action.defineStringListParameter({
@@ -128,7 +128,7 @@ export class SelectionParameterSet {
         ' plus all dependencies of this set.' +
         ' "." can be used as shorthand for the project in the current working directory.' +
         ' For details, refer to the website article "Selecting subsets of projects".',
-      completions: getSpecifierCompletions
+      getCompletionsAsync
     });
     this._onlyProject = action.defineStringListParameter({
       parameterLongName: '--only',
@@ -141,7 +141,7 @@ export class SelectionParameterSet {
         ' "." can be used as shorthand for the project in the current working directory.' +
         ' Note that this parameter is "unsafe" as it may produce a selection that excludes some dependencies.' +
         ' For details, refer to the website article "Selecting subsets of projects".',
-      completions: getSpecifierCompletions
+      getCompletionsAsync
     });
 
     this._impactedByProject = action.defineStringListParameter({
@@ -156,7 +156,7 @@ export class SelectionParameterSet {
         ' "." can be used as shorthand for the project in the current working directory.' +
         ' Note that this parameter is "unsafe" as it may produce a selection that excludes some dependencies.' +
         ' For details, refer to the website article "Selecting subsets of projects".',
-      completions: getSpecifierCompletions
+      getCompletionsAsync
     });
 
     this._impactedByExceptProject = action.defineStringListParameter({
@@ -171,7 +171,7 @@ export class SelectionParameterSet {
         ' "." can be used as shorthand for the project in the current working directory.' +
         ' Note that this parameter is "unsafe" as it may produce a selection that excludes some dependencies.' +
         ' For details, refer to the website article "Selecting subsets of projects".',
-      completions: getSpecifierCompletions
+      getCompletionsAsync
     });
 
     this._toVersionPolicy = action.defineStringListParameter({

--- a/libraries/rush-lib/src/logic/operations/ProjectLogWritable.ts
+++ b/libraries/rush-lib/src/logic/operations/ProjectLogWritable.ts
@@ -104,7 +104,7 @@ export class JsonLFileWritable extends TerminalWritable {
   }
 
   // Override writeChunk function to throw custom error
-  public writeChunk(chunk: ITerminalChunk): void {
+  public override writeChunk(chunk: ITerminalChunk): void {
     if (!this._writer) {
       throw new InternalError(`Log writer was closed for ${this.logPath}`);
     }
@@ -152,7 +152,7 @@ export class SplitLogFileWritable extends TerminalWritable {
   }
 
   // Override writeChunk function to throw custom error
-  public writeChunk(chunk: ITerminalChunk): void {
+  public override writeChunk(chunk: ITerminalChunk): void {
     if (!this._logWriter) {
       throw new InternalError(`Log writer was closed for ${this.logPath}`);
     }

--- a/libraries/ts-command-line/README.md
+++ b/libraries/ts-command-line/README.md
@@ -90,7 +90,7 @@ export class PushAction extends CommandLineAction {
     });
   }
 
-  protected async onExecute(): Promise<void> { // abstract
+  protected override async onExecuteAsync(): Promise<void> { // abstract
     await BusinessLogic.doTheWork(this._force.value, this._protocol.value || "(none)");
   }
 }
@@ -117,9 +117,9 @@ export class WidgetCommandLine extends CommandLineParser {
     });
   }
 
-  protected async onExecute(): Promise<void> { // override
+  protected override async onExecuteAsync(): Promise<void> {
     BusinessLogic.configureLogger(this._verbose.value);
-    await super.onExecute();
+    await super.onExecuteAsync();
   }
 }
 ```

--- a/libraries/ts-command-line/src/index.ts
+++ b/libraries/ts-command-line/src/index.ts
@@ -29,9 +29,9 @@ export type {
 } from './parameters/CommandLineDefinition';
 
 export {
+  type CommandLineParameter,
   CommandLineParameterKind,
-  // TODO: Export both `CommandLineParameter` and `CommandLineParameterBase` in the next major bump
-  CommandLineParameterBase as CommandLineParameter,
+  CommandLineParameterBase,
   CommandLineParameterWithArgument
 } from './parameters/BaseClasses';
 

--- a/libraries/ts-command-line/src/parameters/BaseClasses.ts
+++ b/libraries/ts-command-line/src/parameters/BaseClasses.ts
@@ -61,6 +61,9 @@ const SCOPE_REGEXP: RegExp = /^[a-z0-9]+(-[a-z0-9]+)*$/;
  */
 const ENVIRONMENT_VARIABLE_NAME_REGEXP: RegExp = /^[A-Z_][A-Z0-9_]*$/;
 
+/**
+ * @public
+ */
 export type CommandLineParameter =
   | CommandLineChoiceListParameter
   | CommandLineChoiceParameter
@@ -279,8 +282,10 @@ export abstract class CommandLineParameterWithArgument extends CommandLineParame
   /** {@inheritDoc IBaseCommandLineDefinitionWithArgument.argumentName} */
   public readonly argumentName: string;
 
-  /** {@inheritDoc IBaseCommandLineDefinitionWithArgument.completions} */
-  public readonly completions: (() => Promise<ReadonlyArray<string> | ReadonlySet<string>>) | undefined;
+  /** {@inheritDoc IBaseCommandLineDefinitionWithArgument.getCompletionsAsync} */
+  public readonly getCompletionsAsync:
+    | (() => Promise<ReadonlyArray<string> | ReadonlySet<string>>)
+    | undefined;
 
   /** @internal */
   public constructor(definition: IBaseCommandLineDefinitionWithArgument) {
@@ -306,6 +311,6 @@ export abstract class CommandLineParameterWithArgument extends CommandLineParame
       );
     }
     this.argumentName = definition.argumentName;
-    this.completions = definition.completions;
+    this.getCompletionsAsync = definition.getCompletionsAsync;
   }
 }

--- a/libraries/ts-command-line/src/parameters/CommandLineChoiceListParameter.ts
+++ b/libraries/ts-command-line/src/parameters/CommandLineChoiceListParameter.ts
@@ -20,7 +20,7 @@ export class CommandLineChoiceListParameter<
   /** {@inheritDoc ICommandLineChoiceListDefinition.completions} */
   public readonly completions: (() => Promise<ReadonlyArray<TChoice> | ReadonlySet<TChoice>>) | undefined;
 
-  /** {@inheritDoc CommandLineParameter.kind} */
+  /** {@inheritDoc CommandLineParameterBase.kind} */
   public readonly kind: CommandLineParameterKind.ChoiceList = CommandLineParameterKind.ChoiceList;
 
   /** @internal */
@@ -40,7 +40,7 @@ export class CommandLineChoiceListParameter<
   }
 
   /**
-   * {@inheritDoc CommandLineParameter._setValue}
+   * {@inheritDoc CommandLineParameterBase._setValue}
    * @internal
    */
   public _setValue(data: unknown): void {
@@ -92,7 +92,7 @@ export class CommandLineChoiceListParameter<
     return this._values;
   }
 
-  /** {@inheritDoc CommandLineParameter.appendToArgList} @override */
+  /** {@inheritDoc CommandLineParameterBase.appendToArgList} @override */
   public appendToArgList(argList: string[]): void {
     if (this.values.length > 0) {
       for (const value of this.values) {

--- a/libraries/ts-command-line/src/parameters/CommandLineChoiceParameter.ts
+++ b/libraries/ts-command-line/src/parameters/CommandLineChoiceParameter.ts
@@ -29,7 +29,7 @@ export class CommandLineChoiceParameter<TChoice extends string = string> extends
   /** {@inheritDoc ICommandLineChoiceDefinition.completions} */
   public readonly completions: (() => Promise<ReadonlyArray<TChoice> | ReadonlySet<TChoice>>) | undefined;
 
-  /** {@inheritDoc CommandLineParameter.kind} */
+  /** {@inheritDoc CommandLineParameterBase.kind} */
   public readonly kind: CommandLineParameterKind.Choice = -CommandLineParameterKind.Choice;
 
   /** @internal */
@@ -57,7 +57,7 @@ export class CommandLineChoiceParameter<TChoice extends string = string> extends
   }
 
   /**
-   * {@inheritDoc CommandLineParameter._setValue}
+   * {@inheritDoc CommandLineParameterBase._setValue}
    * @internal
    */
   public _setValue(data: unknown): void {
@@ -96,7 +96,7 @@ export class CommandLineChoiceParameter<TChoice extends string = string> extends
   }
 
   /**
-   * {@inheritDoc CommandLineParameter._getSupplementaryNotes}
+   * {@inheritDoc CommandLineParameterBase._getSupplementaryNotes}
    * @internal
    */
   public _getSupplementaryNotes(supplementaryNotes: string[]): void {
@@ -118,7 +118,7 @@ export class CommandLineChoiceParameter<TChoice extends string = string> extends
     return this._value;
   }
 
-  /** {@inheritDoc CommandLineParameter.appendToArgList} @override */
+  /** {@inheritDoc CommandLineParameterBase.appendToArgList} @override */
   public appendToArgList(argList: string[]): void {
     if (this.value !== undefined) {
       argList.push(this.longName);

--- a/libraries/ts-command-line/src/parameters/CommandLineDefinition.ts
+++ b/libraries/ts-command-line/src/parameters/CommandLineDefinition.ts
@@ -127,10 +127,8 @@ export interface IBaseCommandLineDefinitionWithArgument extends IBaseCommandLine
    * @remarks
    * This option is only used when `ICommandLineParserOptions.enableTabCompletionAction`
    * is enabled.
-   *
-   * In a future release, this will be renamed to `getCompletionsAsync`
    */
-  completions?: () => Promise<ReadonlyArray<string> | ReadonlySet<string>>;
+  getCompletionsAsync?: () => Promise<ReadonlyArray<string> | ReadonlySet<string>>;
 }
 
 /**

--- a/libraries/ts-command-line/src/parameters/CommandLineFlagParameter.ts
+++ b/libraries/ts-command-line/src/parameters/CommandLineFlagParameter.ts
@@ -11,7 +11,7 @@ import { CommandLineParameterBase, CommandLineParameterKind } from './BaseClasse
 export class CommandLineFlagParameter extends CommandLineParameterBase {
   private _value: boolean = false;
 
-  /** {@inheritDoc CommandLineParameter.kind} */
+  /** {@inheritDoc CommandLineParameterBase.kind} */
   public readonly kind: CommandLineParameterKind.Flag = CommandLineParameterKind.Flag;
 
   /** @internal */
@@ -20,7 +20,7 @@ export class CommandLineFlagParameter extends CommandLineParameterBase {
   }
 
   /**
-   * {@inheritDoc CommandLineParameter._setValue}
+   * {@inheritDoc CommandLineParameterBase._setValue}
    * @internal
    */
   public _setValue(data: unknown): void {
@@ -68,7 +68,7 @@ export class CommandLineFlagParameter extends CommandLineParameterBase {
     return this._value;
   }
 
-  /** {@inheritDoc CommandLineParameter.appendToArgList} @override */
+  /** {@inheritDoc CommandLineParameterBase.appendToArgList} @override */
   public appendToArgList(argList: string[]): void {
     if (this.value) {
       argList.push(this.longName);

--- a/libraries/ts-command-line/src/parameters/CommandLineIntegerListParameter.ts
+++ b/libraries/ts-command-line/src/parameters/CommandLineIntegerListParameter.ts
@@ -12,7 +12,7 @@ import { EnvironmentVariableParser } from './EnvironmentVariableParser';
 export class CommandLineIntegerListParameter extends CommandLineParameterWithArgument {
   private _values: number[] = [];
 
-  /** {@inheritDoc CommandLineParameter.kind} */
+  /** {@inheritDoc CommandLineParameterBase.kind} */
   public readonly kind: CommandLineParameterKind.IntegerList = CommandLineParameterKind.IntegerList;
 
   /** @internal */
@@ -21,7 +21,7 @@ export class CommandLineIntegerListParameter extends CommandLineParameterWithArg
   }
 
   /**
-   * {@inheritDoc CommandLineParameter._setValue}
+   * {@inheritDoc CommandLineParameterBase._setValue}
    * @internal
    */
   public _setValue(data: unknown): void {
@@ -75,7 +75,7 @@ export class CommandLineIntegerListParameter extends CommandLineParameterWithArg
     return this._values;
   }
 
-  /** {@inheritDoc CommandLineParameter.appendToArgList} @override */
+  /** {@inheritDoc CommandLineParameterBase.appendToArgList} @override */
   public appendToArgList(argList: string[]): void {
     if (this.values.length > 0) {
       for (const value of this.values) {

--- a/libraries/ts-command-line/src/parameters/CommandLineIntegerParameter.ts
+++ b/libraries/ts-command-line/src/parameters/CommandLineIntegerParameter.ts
@@ -22,7 +22,7 @@ export class CommandLineIntegerParameter extends CommandLineParameterWithArgumen
 
   private _value: number | undefined = undefined;
 
-  /** {@inheritDoc CommandLineParameter.kind} */
+  /** {@inheritDoc CommandLineParameterBase.kind} */
   public readonly kind: CommandLineParameterKind.Integer = CommandLineParameterKind.Integer;
 
   /** @internal */
@@ -33,7 +33,7 @@ export class CommandLineIntegerParameter extends CommandLineParameterWithArgumen
   }
 
   /**
-   * {@inheritDoc CommandLineParameter._setValue}
+   * {@inheritDoc CommandLineParameterBase._setValue}
    * @internal
    */
   public _setValue(data: unknown): void {
@@ -71,7 +71,7 @@ export class CommandLineIntegerParameter extends CommandLineParameterWithArgumen
   }
 
   /**
-   * {@inheritDoc CommandLineParameter._getSupplementaryNotes}
+   * {@inheritDoc CommandLineParameterBase._getSupplementaryNotes}
    * @internal
    */
   public _getSupplementaryNotes(supplementaryNotes: string[]): void {
@@ -93,7 +93,7 @@ export class CommandLineIntegerParameter extends CommandLineParameterWithArgumen
     return this._value;
   }
 
-  /** {@inheritDoc CommandLineParameter.appendToArgList} @override */
+  /** {@inheritDoc CommandLineParameterBase.appendToArgList} @override */
   public appendToArgList(argList: string[]): void {
     if (this.value !== undefined) {
       argList.push(this.longName);

--- a/libraries/ts-command-line/src/parameters/CommandLineRemainder.ts
+++ b/libraries/ts-command-line/src/parameters/CommandLineRemainder.ts
@@ -30,7 +30,7 @@ export class CommandLineRemainder {
   }
 
   /**
-   * {@inheritDoc CommandLineParameter._setValue}
+   * {@inheritDoc CommandLineParameterBase._setValue}
    * @internal
    */
   public _setValue(data: unknown): void {
@@ -42,7 +42,7 @@ export class CommandLineRemainder {
     this._values.push(...data);
   }
 
-  /** {@inheritDoc CommandLineParameter.appendToArgList} @override */
+  /** {@inheritDoc CommandLineParameterBase.appendToArgList} @override */
   public appendToArgList(argList: string[]): void {
     if (this.values.length > 0) {
       for (const value of this.values) {

--- a/libraries/ts-command-line/src/parameters/CommandLineStringListParameter.ts
+++ b/libraries/ts-command-line/src/parameters/CommandLineStringListParameter.ts
@@ -12,7 +12,7 @@ import { EnvironmentVariableParser } from './EnvironmentVariableParser';
 export class CommandLineStringListParameter extends CommandLineParameterWithArgument {
   private _values: string[] = [];
 
-  /** {@inheritDoc CommandLineParameter.kind} */
+  /** {@inheritDoc CommandLineParameterBase.kind} */
   public readonly kind: CommandLineParameterKind.StringList = CommandLineParameterKind.StringList;
 
   /** @internal */
@@ -21,7 +21,7 @@ export class CommandLineStringListParameter extends CommandLineParameterWithArgu
   }
 
   /**
-   * {@inheritDoc CommandLineParameter._setValue}
+   * {@inheritDoc CommandLineParameterBase._setValue}
    * @internal
    */
   public _setValue(data: unknown): void {
@@ -64,7 +64,7 @@ export class CommandLineStringListParameter extends CommandLineParameterWithArgu
     return this._values;
   }
 
-  /** {@inheritDoc CommandLineParameter.appendToArgList} @override */
+  /** {@inheritDoc CommandLineParameterBase.appendToArgList} @override */
   public appendToArgList(argList: string[]): void {
     if (this.values.length > 0) {
       for (const value of this.values) {

--- a/libraries/ts-command-line/src/parameters/CommandLineStringParameter.ts
+++ b/libraries/ts-command-line/src/parameters/CommandLineStringParameter.ts
@@ -22,7 +22,7 @@ export class CommandLineStringParameter extends CommandLineParameterWithArgument
 
   private _value: string | undefined = undefined;
 
-  /** {@inheritDoc CommandLineParameter.kind} */
+  /** {@inheritDoc CommandLineParameterBase.kind} */
   public readonly kind: CommandLineParameterKind.String = CommandLineParameterKind.String;
 
   /** @internal */
@@ -34,7 +34,7 @@ export class CommandLineStringParameter extends CommandLineParameterWithArgument
   }
 
   /**
-   * {@inheritDoc CommandLineParameter._setValue}
+   * {@inheritDoc CommandLineParameterBase._setValue}
    * @internal
    */
   public _setValue(data: unknown): void {
@@ -67,7 +67,7 @@ export class CommandLineStringParameter extends CommandLineParameterWithArgument
   }
 
   /**
-   * {@inheritDoc CommandLineParameter._getSupplementaryNotes}
+   * {@inheritDoc CommandLineParameterBase._getSupplementaryNotes}
    * @internal
    */
   public _getSupplementaryNotes(supplementaryNotes: string[]): void {
@@ -91,7 +91,7 @@ export class CommandLineStringParameter extends CommandLineParameterWithArgument
     return this._value;
   }
 
-  /** {@inheritDoc CommandLineParameter.appendToArgList} @override */
+  /** {@inheritDoc CommandLineParameterBase.appendToArgList} @override */
   public appendToArgList(argList: string[]): void {
     if (this.value !== undefined) {
       argList.push(this.longName);

--- a/libraries/ts-command-line/src/providers/AliasCommandLineAction.ts
+++ b/libraries/ts-command-line/src/providers/AliasCommandLineAction.ts
@@ -185,7 +185,7 @@ export class AliasCommandLineAction extends CommandLineAction {
   /**
    * Executes the target action.
    */
-  protected async onExecute(): Promise<void> {
+  protected override async onExecuteAsync(): Promise<void> {
     await this.targetAction._executeAsync();
   }
 }

--- a/libraries/ts-command-line/src/providers/CommandLineAction.ts
+++ b/libraries/ts-command-line/src/providers/CommandLineAction.ts
@@ -101,8 +101,6 @@ export abstract class CommandLineAction extends CommandLineParameterProvider {
       }
       originalArgumentParserErrorFn(err);
     };
-
-    this.onDefineParameters?.();
   }
 
   /**

--- a/libraries/ts-command-line/src/providers/CommandLineAction.ts
+++ b/libraries/ts-command-line/src/providers/CommandLineAction.ts
@@ -107,16 +107,15 @@ export abstract class CommandLineAction extends CommandLineParameterProvider {
    * Invoked by CommandLineParser.onExecute().
    * @internal
    */
-  public _executeAsync(): Promise<void> {
-    return this.onExecute();
+  public async _executeAsync(): Promise<void> {
+    await this.onExecuteAsync();
   }
 
   /**
    * {@inheritDoc CommandLineParameterProvider._getArgumentParser}
    * @internal
    */
-  public _getArgumentParser(): argparse.ArgumentParser {
-    // override
+  public override _getArgumentParser(): argparse.ArgumentParser {
     if (!this._argumentParser) {
       // We will improve this in the future
       throw new Error('The CommandLineAction must be added to a CommandLineParser before it can be used');
@@ -127,9 +126,6 @@ export abstract class CommandLineAction extends CommandLineParameterProvider {
 
   /**
    * Your subclass should implement this hook to perform the operation.
-   *
-   * @remarks
-   * In a future release, this function will be renamed to onExecuteAsync
    */
-  protected abstract onExecute(): Promise<void>;
+  protected abstract onExecuteAsync(): Promise<void>;
 }

--- a/libraries/ts-command-line/src/providers/CommandLineParameterProvider.ts
+++ b/libraries/ts-command-line/src/providers/CommandLineParameterProvider.ts
@@ -140,7 +140,7 @@ export abstract class CommandLineParameterProvider {
   /**
    * Returns a collection of the parameters that were defined for this object.
    */
-  public get parameters(): ReadonlyArray<CommandLineParameterBase> {
+  public get parameters(): ReadonlyArray<CommandLineParameter> {
     return this._parameters;
   }
 

--- a/libraries/ts-command-line/src/providers/CommandLineParameterProvider.ts
+++ b/libraries/ts-command-line/src/providers/CommandLineParameterProvider.ts
@@ -589,11 +589,6 @@ export abstract class CommandLineParameterProvider {
   }
 
   /**
-   * @deprecated - Define parameters in the constructor
-   */
-  protected onDefineParameters?(): void;
-
-  /**
    * Retrieves the argparse object.
    * @internal
    */

--- a/libraries/ts-command-line/src/providers/CommandLineParser.ts
+++ b/libraries/ts-command-line/src/providers/CommandLineParser.ts
@@ -84,8 +84,6 @@ export abstract class CommandLineParser extends CommandLineParameterProvider {
           `For detailed help about a specific command, use: ${this._options.toolFilename} <command> -h`
       )
     });
-
-    this.onDefineParameters?.();
   }
 
   /**
@@ -196,14 +194,6 @@ export abstract class CommandLineParser extends CommandLineParameterProvider {
   }
 
   /**
-   * @deprecated Use {@link CommandLineParser.executeAsync} instead.
-   */
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  public async execute(args?: string[]): Promise<boolean> {
-    return await this.executeAsync(args);
-  }
-
-  /**
    * This is similar to {@link CommandLineParser.executeAsync}, except that execution errors
    * simply cause the promise to reject.  It is the caller's responsibility to trap
    */
@@ -303,14 +293,6 @@ export abstract class CommandLineParser extends CommandLineParameterProvider {
 
       throw err;
     }
-  }
-
-  /**
-   * @deprecated Use {@link CommandLineParser.executeWithoutErrorHandlingAsync} instead.
-   */
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  public async executeWithoutErrorHandling(args?: string[]): Promise<void> {
-    await this.executeWithoutErrorHandlingAsync(args);
   }
 
   /** @internal */

--- a/libraries/ts-command-line/src/providers/CommandLineParser.ts
+++ b/libraries/ts-command-line/src/providers/CommandLineParser.ts
@@ -277,7 +277,7 @@ export abstract class CommandLineParser extends CommandLineParameterProvider {
       }
 
       this.selectedAction?._processParsedData(this._options, data);
-      await this.onExecute();
+      await this.onExecuteAsync();
     } catch (err) {
       if (err instanceof CommandLineParserExitError) {
         if (!err.exitCode) {
@@ -325,8 +325,7 @@ export abstract class CommandLineParser extends CommandLineParameterProvider {
    * {@inheritDoc CommandLineParameterProvider._getArgumentParser}
    * @internal
    */
-  protected _getArgumentParser(): argparse.ArgumentParser {
-    // override
+  protected override _getArgumentParser(): argparse.ArgumentParser {
     return this._argumentParser;
   }
 
@@ -334,7 +333,7 @@ export abstract class CommandLineParser extends CommandLineParameterProvider {
    * This hook allows the subclass to perform additional operations before or after
    * the chosen action is executed.
    */
-  protected async onExecute(): Promise<void> {
+  protected async onExecuteAsync(): Promise<void> {
     if (this.selectedAction) {
       await this.selectedAction._executeAsync();
     }

--- a/libraries/ts-command-line/src/providers/CommandLineParserExitError.ts
+++ b/libraries/ts-command-line/src/providers/CommandLineParserExitError.ts
@@ -20,13 +20,11 @@ export class CommandLineParserExitError extends Error {
 }
 
 export class CustomArgumentParser extends argparse.ArgumentParser {
-  public exit(status: number, message: string): void {
-    // override
+  public override exit(status: number, message: string): void {
     throw new CommandLineParserExitError(status, message);
   }
 
-  public error(err: Error | string): void {
-    // override
+  public override error(err: Error | string): void {
     // Ensure the ParserExitError bubbles up to the top without any special processing
     if (err instanceof CommandLineParserExitError) {
       throw err;

--- a/libraries/ts-command-line/src/providers/DynamicCommandLineAction.ts
+++ b/libraries/ts-command-line/src/providers/DynamicCommandLineAction.ts
@@ -7,7 +7,7 @@ import { CommandLineAction } from './CommandLineAction';
  * @public
  */
 export class DynamicCommandLineAction extends CommandLineAction {
-  protected async onExecute(): Promise<void> {
+  protected override async onExecuteAsync(): Promise<void> {
     // abstract
     // (handled by the external code)
   }

--- a/libraries/ts-command-line/src/providers/ScopedCommandLineAction.ts
+++ b/libraries/ts-command-line/src/providers/ScopedCommandLineAction.ts
@@ -5,7 +5,7 @@ import { SCOPING_PARAMETER_GROUP } from '../Constants';
 import { CommandLineAction, type ICommandLineActionOptions } from './CommandLineAction';
 import { CommandLineParser, type ICommandLineParserOptions } from './CommandLineParser';
 import { CommandLineParserExitError } from './CommandLineParserExitError';
-import type { CommandLineParameter, CommandLineParameterBase } from '../parameters/BaseClasses';
+import type { CommandLineParameter } from '../parameters/BaseClasses';
 import type {
   CommandLineParameterProvider,
   ICommandLineParserData,
@@ -69,8 +69,7 @@ class InternalScopedCommandLineParser extends CommandLineParser {
     super._registerDefinedParameters(this._internalOptions.registerDefinedParametersState);
   }
 
-  protected async onExecute(): Promise<void> {
-    // override
+  protected override async onExecuteAsync(): Promise<void> {
     // Only set if we made it this far, which may not be the case if an error occurred or
     // if '--help' was specified.
     this._canExecute = true;
@@ -129,11 +128,8 @@ export abstract class ScopedCommandLineAction extends CommandLineAction {
 
   /**
    * {@inheritDoc CommandLineParameterProvider.parameters}
-   *
-   * @internalremarks
-   * TODO: Replace this type with `CommandLineParameter` in the next major bump.
    */
-  public get parameters(): ReadonlyArray<CommandLineParameterBase> {
+  public get parameters(): ReadonlyArray<CommandLineParameter> {
     if (this._scopedCommandLineParser) {
       return [...super.parameters, ...this._scopedCommandLineParser.parameters];
     } else {
@@ -145,8 +141,10 @@ export abstract class ScopedCommandLineAction extends CommandLineAction {
    * {@inheritdoc CommandLineParameterProvider._processParsedData}
    * @internal
    */
-  public _processParsedData(parserOptions: ICommandLineParserOptions, data: ICommandLineParserData): void {
-    // override
+  public override _processParsedData(
+    parserOptions: ICommandLineParserOptions,
+    data: ICommandLineParserData
+  ): void {
     super._processParsedData(parserOptions, data);
 
     // This should never happen because the super method should throw if parameters haven't been registered,
@@ -174,8 +172,7 @@ export abstract class ScopedCommandLineAction extends CommandLineAction {
    * {@inheritdoc CommandLineAction._executeAsync}
    * @internal
    */
-  public async _executeAsync(): Promise<void> {
-    // override
+  public override async _executeAsync(): Promise<void> {
     if (!this._unscopedParserOptions || !this._scopedCommandLineParser) {
       throw new Error('The CommandLineAction parameters must be processed before execution.');
     }
@@ -268,7 +265,7 @@ export abstract class ScopedCommandLineAction extends CommandLineAction {
   protected abstract onDefineScopedParameters(scopedParameterProvider: CommandLineParameterProvider): void;
 
   /**
-   * {@inheritDoc CommandLineAction.onExecute}
+   * {@inheritDoc CommandLineAction.onExecuteAsync}
    */
-  protected abstract onExecute(): Promise<void>;
+  protected abstract onExecuteAsync(): Promise<void>;
 }

--- a/libraries/ts-command-line/src/providers/ScopedCommandLineAction.ts
+++ b/libraries/ts-command-line/src/providers/ScopedCommandLineAction.ts
@@ -125,8 +125,6 @@ export abstract class ScopedCommandLineAction extends CommandLineAction {
         'Scoped parameters.  Must be prefixed with "--", ex. "-- --scopedParameter ' +
         'foo --scopedFlag".  For more information on available scoped parameters, use "-- --help".'
     });
-
-    this.onDefineUnscopedParameters?.();
   }
 
   /**
@@ -182,7 +180,7 @@ export abstract class ScopedCommandLineAction extends CommandLineAction {
       throw new Error('The CommandLineAction parameters must be processed before execution.');
     }
     if (!this.remainder) {
-      throw new Error('CommandLineAction.onDefineParameters must be called before execution.');
+      throw new Error('Parameters must be defined before execution.');
     }
 
     // The '--' argument is required to separate the action parameters from the scoped parameters,
@@ -257,11 +255,6 @@ export abstract class ScopedCommandLineAction extends CommandLineAction {
       this._scopingParameters.push(parameter);
     }
   }
-
-  /**
-   * @deprecated - Define parameters in the constructor
-   */
-  protected onDefineUnscopedParameters?(): void;
 
   /**
    * The child class should implement this hook to define its scoped command-line

--- a/libraries/ts-command-line/src/providers/TabCompletionAction.ts
+++ b/libraries/ts-command-line/src/providers/TabCompletionAction.ts
@@ -69,7 +69,7 @@ export class TabCompleteAction extends CommandLineAction {
     });
   }
 
-  protected async onExecute(): Promise<void> {
+  protected override async onExecuteAsync(): Promise<void> {
     const commandLine: string = this._wordToCompleteParameter.value;
     const caretPosition: number = this._positionParameter.value || commandLine.length;
 
@@ -191,7 +191,7 @@ export class TabCompleteAction extends CommandLineAction {
       }
 
       const completionValues: ReadonlyArray<string> | ReadonlySet<string> | undefined =
-        await parameterWithArgumentOrChoices?.completions?.();
+        await parameterWithArgumentOrChoices?.getCompletionsAsync?.();
       choiceParameterValues = completionValues instanceof Set ? completionValues : new Set(completionValues);
     }
 

--- a/libraries/ts-command-line/src/test/ActionlessParser.test.ts
+++ b/libraries/ts-command-line/src/test/ActionlessParser.test.ts
@@ -20,8 +20,8 @@ class TestCommandLine extends CommandLineParser {
     });
   }
 
-  protected async onExecute(): Promise<void> {
-    await super.onExecute();
+  protected override async onExecuteAsync(): Promise<void> {
+    await super.onExecuteAsync();
     this.done = true;
   }
 }

--- a/libraries/ts-command-line/src/test/AliasedCommandLineAction.test.ts
+++ b/libraries/ts-command-line/src/test/AliasedCommandLineAction.test.ts
@@ -48,8 +48,8 @@ class TestAction extends CommandLineAction {
 class TestScopedAction extends ScopedCommandLineAction {
   public done: boolean = false;
   public scopedValue: string | undefined;
-  private _verboseArg!: CommandLineFlagParameter;
-  private _scopeArg!: CommandLineStringParameter;
+  private readonly _verboseArg: CommandLineFlagParameter;
+  private readonly _scopeArg: CommandLineStringParameter;
   private _scopedArg: CommandLineStringParameter | undefined;
 
   public constructor() {
@@ -58,17 +58,7 @@ class TestScopedAction extends ScopedCommandLineAction {
       summary: 'does the scoped action',
       documentation: 'a longer description'
     });
-  }
 
-  protected async onExecute(): Promise<void> {
-    if (this._scopedArg) {
-      expect(this._scopedArg.longName).toBe(`--scoped-${this._scopeArg.value}`);
-      this.scopedValue = this._scopedArg.value;
-    }
-    this.done = true;
-  }
-
-  protected onDefineUnscopedParameters(): void {
     this._verboseArg = this.defineFlagParameter({
       parameterLongName: '--verbose',
       description: 'A flag parameter.'
@@ -80,6 +70,15 @@ class TestScopedAction extends ScopedCommandLineAction {
       argumentName: 'SCOPE',
       description: 'The scope'
     });
+  }
+
+  protected async onExecute(): Promise<void> {
+    expect(this._scopedArg).toBeDefined();
+    if (this._scopedArg) {
+      expect(this._scopedArg.longName).toBe(`--scoped-${this._scopeArg.value}`);
+      this.scopedValue = this._scopedArg.value;
+    }
+    this.done = true;
   }
 
   protected onDefineScopedParameters(scopedParameterProvider: CommandLineParameterProvider): void {

--- a/libraries/ts-command-line/src/test/AliasedCommandLineAction.test.ts
+++ b/libraries/ts-command-line/src/test/AliasedCommandLineAction.test.ts
@@ -39,7 +39,7 @@ class TestAction extends CommandLineAction {
     });
   }
 
-  protected async onExecute(): Promise<void> {
+  protected override async onExecuteAsync(): Promise<void> {
     expect(this._flag.value).toEqual(true);
     this.done = true;
   }
@@ -72,7 +72,7 @@ class TestScopedAction extends ScopedCommandLineAction {
     });
   }
 
-  protected async onExecute(): Promise<void> {
+  protected override async onExecuteAsync(): Promise<void> {
     expect(this._scopedArg).toBeDefined();
     if (this._scopedArg) {
       expect(this._scopedArg.longName).toBe(`--scoped-${this._scopeArg.value}`);

--- a/libraries/ts-command-line/src/test/AliasedCommandLineAction.test.ts
+++ b/libraries/ts-command-line/src/test/AliasedCommandLineAction.test.ts
@@ -73,7 +73,6 @@ class TestScopedAction extends ScopedCommandLineAction {
   }
 
   protected override async onExecuteAsync(): Promise<void> {
-    expect(this._scopedArg).toBeDefined();
     if (this._scopedArg) {
       expect(this._scopedArg.longName).toBe(`--scoped-${this._scopeArg.value}`);
       this.scopedValue = this._scopedArg.value;

--- a/libraries/ts-command-line/src/test/AmbiguousCommandLineParser.test.ts
+++ b/libraries/ts-command-line/src/test/AmbiguousCommandLineParser.test.ts
@@ -69,7 +69,7 @@ class AmbiguousAction extends CommandLineAction {
     });
   }
 
-  protected async onExecute(): Promise<void> {
+  protected override async onExecuteAsync(): Promise<void> {
     expect(this._short1Arg.value).toEqual('short1value');
     expect(this._shortArg2.value).toEqual('short2value');
     expect(this._scope1Arg.value).toEqual('scope1value');
@@ -96,7 +96,7 @@ class AbbreviationAction extends CommandLineAction {
     });
   }
 
-  protected async onExecute(): Promise<void> {
+  protected override async onExecuteAsync(): Promise<void> {
     this.done = true;
   }
 }
@@ -140,7 +140,7 @@ class AmbiguousScopedAction extends ScopedCommandLineAction {
     });
   }
 
-  protected async onExecute(): Promise<void> {
+  protected override async onExecuteAsync(): Promise<void> {
     expect(this._scopingArg?.value).toEqual(true);
     if (this._short1Arg?.value) {
       this.short1Value = this._short1Arg.value;
@@ -234,7 +234,7 @@ class AbbreviationScopedAction extends ScopedCommandLineAction {
     });
   }
 
-  protected async onExecute(): Promise<void> {
+  protected override async onExecuteAsync(): Promise<void> {
     expect(this._scopingArg.value).toEqual(true);
     this.done = true;
   }

--- a/libraries/ts-command-line/src/test/AmbiguousCommandLineParser.test.ts
+++ b/libraries/ts-command-line/src/test/AmbiguousCommandLineParser.test.ts
@@ -131,6 +131,13 @@ class AmbiguousScopedAction extends ScopedCommandLineAction {
       summary: 'does the scoped action',
       documentation: 'a longer description'
     });
+
+    // At least one scoping parameter is required to be defined on a scoped action
+    this._scopingArg = this.defineFlagParameter({
+      parameterLongName: '--scoping',
+      description: 'The scoping parameter',
+      parameterGroup: SCOPING_PARAMETER_GROUP
+    });
   }
 
   protected async onExecute(): Promise<void> {
@@ -151,15 +158,6 @@ class AmbiguousScopedAction extends ScopedCommandLineAction {
       this.nonConflictingValue = this._nonConflictingArg.value;
     }
     this.done = true;
-  }
-
-  protected onDefineUnscopedParameters(): void {
-    // At least one scoping parameter is required to be defined on a scoped action
-    this._scopingArg = this.defineFlagParameter({
-      parameterLongName: '--scoping',
-      description: 'The scoping parameter',
-      parameterGroup: SCOPING_PARAMETER_GROUP
-    });
   }
 
   protected onDefineScopedParameters(scopedParameterProvider: CommandLineParameterProvider): void {
@@ -209,7 +207,7 @@ class AbbreviationScopedAction extends ScopedCommandLineAction {
   public unscopedAbbreviationFlag: CommandLineFlagParameter | undefined;
   public scopedAbbreviationFlag: CommandLineFlagParameter | undefined;
 
-  private _scopingArg: CommandLineFlagParameter | undefined;
+  private readonly _scopingArg: CommandLineFlagParameter;
   private _includeScopedAbbreviationFlag: boolean;
 
   public constructor(options: IAbbreviationScopedActionOptions) {
@@ -227,20 +225,18 @@ class AbbreviationScopedAction extends ScopedCommandLineAction {
     }
 
     this._includeScopedAbbreviationFlag = !!options?.includeScopedAbbreviationFlag;
-  }
 
-  protected async onExecute(): Promise<void> {
-    expect(this._scopingArg?.value).toEqual(true);
-    this.done = true;
-  }
-
-  protected onDefineUnscopedParameters(): void {
     // At least one scoping parameter is required to be defined on a scoped action
     this._scopingArg = this.defineFlagParameter({
       parameterLongName: '--scoping',
       description: 'The scoping parameter',
       parameterGroup: SCOPING_PARAMETER_GROUP
     });
+  }
+
+  protected async onExecute(): Promise<void> {
+    expect(this._scopingArg.value).toEqual(true);
+    this.done = true;
   }
 
   protected onDefineScopedParameters(scopedParameterProvider: CommandLineParameterProvider): void {

--- a/libraries/ts-command-line/src/test/CommandLineParameter.test.ts
+++ b/libraries/ts-command-line/src/test/CommandLineParameter.test.ts
@@ -433,9 +433,23 @@ describe(CommandLineParameterBase.name, () => {
       const args: string[] = ['hello-world'];
       process.env.ENV_COLOR = '[u';
 
-      await expect(
-        commandLineParser.executeWithoutErrorHandlingAsync(args)
-      ).rejects.toThrowErrorMatchingSnapshot();
+      // TODO: When Node 18 support is removed, switch this to use
+      // ```
+      // await expect(
+      //   commandLineParser.executeWithoutErrorHandling(args)
+      // ).rejects.toThrowErrorMatchingSnapshot();
+      // ```
+
+      let error: string | undefined;
+      try {
+        await commandLineParser.executeWithoutErrorHandlingAsync(args);
+      } catch (e) {
+        error = e.message;
+      }
+
+      expect(error).toMatch(
+        /^The \[u environment variable value looks like a JSON array but failed to parse: Unexpected token /
+      );
     });
 
     it('raises an error if env var value is json containing non-scalars', async () => {

--- a/libraries/ts-command-line/src/test/CommandLineParameter.test.ts
+++ b/libraries/ts-command-line/src/test/CommandLineParameter.test.ts
@@ -433,23 +433,9 @@ describe(CommandLineParameterBase.name, () => {
       const args: string[] = ['hello-world'];
       process.env.ENV_COLOR = '[u';
 
-      // TODO: When Node 18 support is removed, switch this to use
-      // ```
-      // await expect(
-      //   commandLineParser.executeWithoutErrorHandling(args)
-      // ).rejects.toThrowErrorMatchingSnapshot();
-      // ```
-
-      let error: string | undefined;
-      try {
-        await commandLineParser.executeWithoutErrorHandlingAsync(args);
-      } catch (e) {
-        error = e.message;
-      }
-
-      expect(error).toMatch(
-        /^The \[u environment variable value looks like a JSON array but failed to parse: Unexpected token /
-      );
+      await expect(
+        commandLineParser.executeWithoutErrorHandlingAsync(args)
+      ).rejects.toThrowErrorMatchingSnapshot();
     });
 
     it('raises an error if env var value is json containing non-scalars', async () => {

--- a/libraries/ts-command-line/src/test/CommandLineParser.test.ts
+++ b/libraries/ts-command-line/src/test/CommandLineParser.test.ts
@@ -22,7 +22,7 @@ class TestAction extends CommandLineAction {
     });
   }
 
-  protected async onExecute(): Promise<void> {
+  protected override async onExecuteAsync(): Promise<void> {
     expect(this._flag.value).toEqual(true);
     this.done = true;
   }

--- a/libraries/ts-command-line/src/test/ConflictingCommandLineParser.test.ts
+++ b/libraries/ts-command-line/src/test/ConflictingCommandLineParser.test.ts
@@ -54,7 +54,7 @@ class TestAction extends CommandLineAction {
     });
   }
 
-  protected async onExecute(): Promise<void> {
+  protected override async onExecuteAsync(): Promise<void> {
     expect(this._scope1Arg.value).toEqual('scope1value');
     expect(this._scope2Arg.value).toEqual('scope2value');
     expect(this._nonConflictingArg.value).toEqual('nonconflictingvalue');
@@ -86,7 +86,7 @@ class UnscopedDuplicateArgumentTestAction extends CommandLineAction {
     });
   }
 
-  protected async onExecute(): Promise<void> {
+  protected override async onExecuteAsync(): Promise<void> {
     throw new Error('This action should not be executed');
   }
 }
@@ -115,7 +115,7 @@ class ScopedDuplicateArgumentTestAction extends CommandLineAction {
     });
   }
 
-  protected async onExecute(): Promise<void> {
+  protected override async onExecuteAsync(): Promise<void> {
     throw new Error('This action should not be executed');
   }
 }

--- a/libraries/ts-command-line/src/test/ScopedCommandLineAction.test.ts
+++ b/libraries/ts-command-line/src/test/ScopedCommandLineAction.test.ts
@@ -36,7 +36,7 @@ class TestScopedAction extends ScopedCommandLineAction {
     });
   }
 
-  protected async onExecute(): Promise<void> {
+  protected override async onExecuteAsync(): Promise<void> {
     if (this._scopedArg) {
       expect(this._scopedArg.longName).toBe(`--scoped-${this._scopeArg.value}`);
       this.scopedValue = this._scopedArg.value;

--- a/libraries/ts-command-line/src/test/TabCompleteAction.test.ts
+++ b/libraries/ts-command-line/src/test/TabCompleteAction.test.ts
@@ -92,7 +92,7 @@ function getCommandLineParser(): DynamicCommandLineParser {
     argumentName: 'PROJECT1',
     description: 'Run command in the specified project and all of its dependencies.',
     // eslint-disable-next-line @typescript-eslint/naming-convention
-    completions: async (): Promise<string[]> => {
+    getCompletionsAsync: async (): Promise<string[]> => {
       return ['abc', 'def', 'hij'];
     }
   });

--- a/libraries/ts-command-line/src/test/__snapshots__/CommandLineParameter.test.ts.snap
+++ b/libraries/ts-command-line/src/test/__snapshots__/CommandLineParameter.test.ts.snap
@@ -34,8 +34,6 @@ exports[`CommandLineParameterBase choice list raises an error if env var value i
 
 exports[`CommandLineParameterBase choice list raises an error if env var value is not a valid choice 1`] = `"Invalid value \\"oblong\\" for the environment variable ENV_COLOR.  Valid choices are: \\"purple\\", \\"yellow\\", \\"pizza\\""`;
 
-exports[`CommandLineParameterBase choice list raises an error if env var value is not valid json 1`] = `"The [u environment variable value looks like a JSON array but failed to parse: Unexpected token 'u', \\"[u\\" is not valid JSON"`;
-
 exports[`CommandLineParameterBase parses an input with ALL parameters 1`] = `
 Object {
   "argumentName": undefined,

--- a/libraries/ts-command-line/src/test/__snapshots__/CommandLineParameter.test.ts.snap
+++ b/libraries/ts-command-line/src/test/__snapshots__/CommandLineParameter.test.ts.snap
@@ -34,6 +34,8 @@ exports[`CommandLineParameterBase choice list raises an error if env var value i
 
 exports[`CommandLineParameterBase choice list raises an error if env var value is not a valid choice 1`] = `"Invalid value \\"oblong\\" for the environment variable ENV_COLOR.  Valid choices are: \\"purple\\", \\"yellow\\", \\"pizza\\""`;
 
+exports[`CommandLineParameterBase choice list raises an error if env var value is not valid json 1`] = `"The [u environment variable value looks like a JSON array but failed to parse: Unexpected token 'u', \\"[u\\" is not valid JSON"`;
+
 exports[`CommandLineParameterBase parses an input with ALL parameters 1`] = `
 Object {
   "argumentName": undefined,

--- a/libraries/ts-command-line/src/test/test-cli/PushAction.ts
+++ b/libraries/ts-command-line/src/test/test-cli/PushAction.ts
@@ -37,7 +37,7 @@ export class PushAction extends CommandLineAction {
     });
   }
 
-  protected onExecute(): Promise<void> {
+  protected onExecuteAsync(): Promise<void> {
     // abstract
     return BusinessLogic.doTheWorkAsync(this._force.value, this._protocol.value);
   }

--- a/libraries/ts-command-line/src/test/test-cli/RunAction.ts
+++ b/libraries/ts-command-line/src/test/test-cli/RunAction.ts
@@ -25,7 +25,7 @@ export class RunAction extends CommandLineAction {
     });
   }
 
-  protected async onExecute(): Promise<void> {
+  protected override async onExecuteAsync(): Promise<void> {
     // abstract
     // eslint-disable-next-line no-console
     console.log(`Console Title: ${this._title.value || '(none)'}`);

--- a/libraries/ts-command-line/src/test/test-cli/WidgetCommandLine.ts
+++ b/libraries/ts-command-line/src/test/test-cli/WidgetCommandLine.ts
@@ -19,7 +19,6 @@ export class WidgetCommandLine extends CommandLineParser {
     this.addAction(new PushAction());
     this.addAction(new RunAction());
 
-    // abstract
     this._verbose = this.defineFlagParameter({
       parameterLongName: '--verbose',
       parameterShortName: '-v',
@@ -27,9 +26,8 @@ export class WidgetCommandLine extends CommandLineParser {
     });
   }
 
-  protected onExecute(): Promise<void> {
-    // override
+  protected override async onExecuteAsync(): Promise<void> {
     BusinessLogic.configureLogger(this._verbose.value);
-    return super.onExecute();
+    return await super.onExecuteAsync();
   }
 }

--- a/repo-scripts/repo-toolbox/src/BumpCyclicsAction.ts
+++ b/repo-scripts/repo-toolbox/src/BumpCyclicsAction.ts
@@ -16,7 +16,7 @@ export class BumpCyclicsAction extends CommandLineAction {
     });
   }
 
-  protected async onExecute(): Promise<void> {
+  protected override async onExecuteAsync(): Promise<void> {
     const terminal: Terminal = new Terminal(new ConsoleTerminalProvider());
     const rushConfiguration: RushConfiguration = RushConfiguration.loadFromDefaultLocation({
       startingFolder: process.cwd()

--- a/repo-scripts/repo-toolbox/src/ReadmeAction.ts
+++ b/repo-scripts/repo-toolbox/src/ReadmeAction.ts
@@ -32,7 +32,7 @@ export class ReadmeAction extends CommandLineAction {
     return project.shouldPublish || !!project.versionPolicyName;
   }
 
-  protected async onExecute(): Promise<void> {
+  protected override async onExecuteAsync(): Promise<void> {
     const rushConfiguration: RushConfiguration = RushConfiguration.loadFromDefaultLocation();
 
     const repoReadmePath: string = path.resolve(rushConfiguration.rushJsonFolder, 'README.md');

--- a/repo-scripts/repo-toolbox/src/RecordVersionsAction.ts
+++ b/repo-scripts/repo-toolbox/src/RecordVersionsAction.ts
@@ -26,7 +26,7 @@ export class RecordVersionsAction extends CommandLineAction {
     });
   }
 
-  protected async onExecute(): Promise<void> {
+  protected override async onExecuteAsync(): Promise<void> {
     const terminal: Terminal = new Terminal(new ConsoleTerminalProvider());
     const rushConfig: RushConfiguration = RushConfiguration.loadFromDefaultLocation({
       startingFolder: process.cwd()


### PR DESCRIPTION
## Summary

This PR removes deprecated members and renames a few things that were slated for the next major bump.

## Details

Removal of `onDefineUnscopedParameters` is required for the conversion to SWC (https://github.com/microsoft/rushstack/pull/5202).

`onDefineScopedParameters` may need to be removed too.

## How it was tested

Built and ran tests.

## Impacted documentation

API docs will need to be updated.