### PR TITLE
[@rushstack/heft-config-file] Replace node structuredClone

### DIFF
--- a/common/changes/@rushstack/heft-config-file/chore-replace-node-structuredclone_2025-04-24-03-50.json
+++ b/common/changes/@rushstack/heft-config-file/chore-replace-node-structuredclone_2025-04-24-03-50.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@rushstack/heft-config-file",
-      "comment": "replace node structuredclone",
+      "comment": "Fix Node 16 compatibility by using non-built-in structuredClone",
       "type": "patch"
     }
   ],

--- a/common/changes/@rushstack/heft-config-file/chore-replace-node-structuredclone_2025-04-24-03-50.json
+++ b/common/changes/@rushstack/heft-config-file/chore-replace-node-structuredclone_2025-04-24-03-50.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-config-file",
+      "comment": "replace node structuredclone",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft-config-file"
+}

--- a/common/config/rush/browser-approved-packages.json
+++ b/common/config/rush/browser-approved-packages.json
@@ -47,6 +47,10 @@
       "allowedCategories": [ "vscode-extensions" ]
     },
     {
+      "name": "@ungap/structured-clone",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
       "name": "axios",
       "allowedCategories": [ "libraries" ]
     },

--- a/common/config/subspaces/build-tests-subspace/pnpm-lock.yaml
+++ b/common/config/subspaces/build-tests-subspace/pnpm-lock.yaml
@@ -114,10 +114,10 @@ importers:
         version: file:../../../apps/heft(@types/node@20.17.19)
       '@rushstack/heft-lint-plugin':
         specifier: file:../../heft-plugins/heft-lint-plugin
-        version: file:../../../heft-plugins/heft-lint-plugin(@rushstack/heft@0.71.2)(@types/node@20.17.19)
+        version: file:../../../heft-plugins/heft-lint-plugin(@rushstack/heft@0.73.2)(@types/node@20.17.19)
       '@rushstack/heft-typescript-plugin':
         specifier: file:../../heft-plugins/heft-typescript-plugin
-        version: file:../../../heft-plugins/heft-typescript-plugin(@rushstack/heft@0.71.2)(@types/node@20.17.19)
+        version: file:../../../heft-plugins/heft-typescript-plugin(@rushstack/heft@0.73.2)(@types/node@20.17.19)
       eslint:
         specifier: ~8.57.0
         version: 8.57.1
@@ -1492,6 +1492,9 @@ packages:
   /@ungap/structured-clone@1.2.0:
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
     dev: true
+
+  /@ungap/structured-clone@1.3.0:
+    resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
   /@vue/compiler-core@3.5.13:
     resolution: {integrity: sha512-oOdAkwqUfW1WqpwSYJce06wvt6HljgY3fGeM9NcVA1HaYOij3mZG9Rkysn0OHuyUAGMbEbARIpsG+LPVlBJ5/Q==}
@@ -6235,7 +6238,7 @@ packages:
       - typescript
     dev: true
 
-  file:../../../heft-plugins/heft-api-extractor-plugin(@rushstack/heft@0.71.2)(@types/node@20.17.19):
+  file:../../../heft-plugins/heft-api-extractor-plugin(@rushstack/heft@0.73.2)(@types/node@20.17.19):
     resolution: {directory: ../../../heft-plugins/heft-api-extractor-plugin, type: directory}
     id: file:../../../heft-plugins/heft-api-extractor-plugin
     name: '@rushstack/heft-api-extractor-plugin'
@@ -6243,14 +6246,13 @@ packages:
       '@rushstack/heft': '*'
     dependencies:
       '@rushstack/heft': file:../../../apps/heft(@types/node@20.17.19)
-      '@rushstack/heft-config-file': file:../../../libraries/heft-config-file(@types/node@20.17.19)
       '@rushstack/node-core-library': file:../../../libraries/node-core-library(@types/node@20.17.19)
       semver: 7.5.4
     transitivePeerDependencies:
       - '@types/node'
     dev: true
 
-  file:../../../heft-plugins/heft-jest-plugin(@rushstack/heft@0.71.2)(@types/node@20.17.19)(jest-environment-node@29.5.0):
+  file:../../../heft-plugins/heft-jest-plugin(@rushstack/heft@0.73.2)(@types/node@20.17.19)(jest-environment-node@29.5.0):
     resolution: {directory: ../../../heft-plugins/heft-jest-plugin, type: directory}
     id: file:../../../heft-plugins/heft-jest-plugin
     name: '@rushstack/heft-jest-plugin'
@@ -6285,7 +6287,7 @@ packages:
       - ts-node
     dev: true
 
-  file:../../../heft-plugins/heft-lint-plugin(@rushstack/heft@0.71.2)(@types/node@20.17.19):
+  file:../../../heft-plugins/heft-lint-plugin(@rushstack/heft@0.73.2)(@types/node@20.17.19):
     resolution: {directory: ../../../heft-plugins/heft-lint-plugin, type: directory}
     id: file:../../../heft-plugins/heft-lint-plugin
     name: '@rushstack/heft-lint-plugin'
@@ -6299,7 +6301,7 @@ packages:
       - '@types/node'
     dev: true
 
-  file:../../../heft-plugins/heft-typescript-plugin(@rushstack/heft@0.71.2)(@types/node@20.17.19):
+  file:../../../heft-plugins/heft-typescript-plugin(@rushstack/heft@0.73.2)(@types/node@20.17.19):
     resolution: {directory: ../../../heft-plugins/heft-typescript-plugin, type: directory}
     id: file:../../../heft-plugins/heft-typescript-plugin
     name: '@rushstack/heft-typescript-plugin'
@@ -6337,6 +6339,7 @@ packages:
       '@rushstack/node-core-library': file:../../../libraries/node-core-library(@types/node@20.17.19)
       '@rushstack/rig-package': file:../../../libraries/rig-package
       '@rushstack/terminal': file:../../../libraries/terminal(@types/node@20.17.19)
+      '@ungap/structured-clone': 1.3.0
       jsonpath-plus: 10.3.0
     transitivePeerDependencies:
       - '@types/node'
@@ -6523,7 +6526,7 @@ packages:
     transitivePeerDependencies:
       - '@types/node'
 
-  file:../../../rigs/heft-node-rig(@rushstack/heft@0.71.2)(@types/node@20.17.19):
+  file:../../../rigs/heft-node-rig(@rushstack/heft@0.73.2)(@types/node@20.17.19):
     resolution: {directory: ../../../rigs/heft-node-rig, type: directory}
     id: file:../../../rigs/heft-node-rig
     name: '@rushstack/heft-node-rig'
@@ -6533,10 +6536,10 @@ packages:
       '@microsoft/api-extractor': file:../../../apps/api-extractor(@types/node@20.17.19)
       '@rushstack/eslint-config': file:../../../eslint/eslint-config(eslint@8.57.1)(typescript@5.8.2)
       '@rushstack/heft': file:../../../apps/heft(@types/node@20.17.19)
-      '@rushstack/heft-api-extractor-plugin': file:../../../heft-plugins/heft-api-extractor-plugin(@rushstack/heft@0.71.2)(@types/node@20.17.19)
-      '@rushstack/heft-jest-plugin': file:../../../heft-plugins/heft-jest-plugin(@rushstack/heft@0.71.2)(@types/node@20.17.19)(jest-environment-node@29.5.0)
-      '@rushstack/heft-lint-plugin': file:../../../heft-plugins/heft-lint-plugin(@rushstack/heft@0.71.2)(@types/node@20.17.19)
-      '@rushstack/heft-typescript-plugin': file:../../../heft-plugins/heft-typescript-plugin(@rushstack/heft@0.71.2)(@types/node@20.17.19)
+      '@rushstack/heft-api-extractor-plugin': file:../../../heft-plugins/heft-api-extractor-plugin(@rushstack/heft@0.73.2)(@types/node@20.17.19)
+      '@rushstack/heft-jest-plugin': file:../../../heft-plugins/heft-jest-plugin(@rushstack/heft@0.73.2)(@types/node@20.17.19)(jest-environment-node@29.5.0)
+      '@rushstack/heft-lint-plugin': file:../../../heft-plugins/heft-lint-plugin(@rushstack/heft@0.73.2)(@types/node@20.17.19)
+      '@rushstack/heft-typescript-plugin': file:../../../heft-plugins/heft-typescript-plugin(@rushstack/heft@0.73.2)(@types/node@20.17.19)
       '@types/heft-jest': 1.0.1
       eslint: 8.57.1
       jest-environment-node: 29.5.0
@@ -6556,7 +6559,7 @@ packages:
     dependencies:
       '@microsoft/api-extractor': file:../../../apps/api-extractor(@types/node@20.17.19)
       '@rushstack/heft': file:../../../apps/heft(@types/node@20.17.19)
-      '@rushstack/heft-node-rig': file:../../../rigs/heft-node-rig(@rushstack/heft@0.71.2)(@types/node@20.17.19)
+      '@rushstack/heft-node-rig': file:../../../rigs/heft-node-rig(@rushstack/heft@0.73.2)(@types/node@20.17.19)
       '@types/heft-jest': 1.0.1
       '@types/node': 20.17.19
       eslint: 8.57.1

--- a/common/config/subspaces/build-tests-subspace/repo-state.json
+++ b/common/config/subspaces/build-tests-subspace/repo-state.json
@@ -1,6 +1,6 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "d9e805ea30f80e290b5d5ea83856c8b5d7302941",
+  "pnpmShrinkwrapHash": "e47112c7d099f189f37770e10351e406cf1ec451",
   "preferredVersionsHash": "54149ea3f01558a859c96dee2052b797d4defe68",
-  "packageJsonInjectedDependenciesHash": "949bb6038c34cb0580b82a6f728b26a66fff3177"
+  "packageJsonInjectedDependenciesHash": "c357a5a2403064cec9f638fe3757b1514faac82d"
 }

--- a/common/config/subspaces/build-tests-subspace/repo-state.json
+++ b/common/config/subspaces/build-tests-subspace/repo-state.json
@@ -2,5 +2,5 @@
 {
   "pnpmShrinkwrapHash": "e47112c7d099f189f37770e10351e406cf1ec451",
   "preferredVersionsHash": "54149ea3f01558a859c96dee2052b797d4defe68",
-  "packageJsonInjectedDependenciesHash": "c357a5a2403064cec9f638fe3757b1514faac82d"
+  "packageJsonInjectedDependenciesHash": "a1277b20787fa46cb118a7352d5ca6a922a1098b"
 }

--- a/common/config/subspaces/default/pnpm-lock.yaml
+++ b/common/config/subspaces/default/pnpm-lock.yaml
@@ -2971,6 +2971,9 @@ importers:
       '@rushstack/terminal':
         specifier: workspace:*
         version: link:../terminal
+      '@ungap/structured-clone':
+        specifier: ~1.3.0
+        version: 1.3.0
       jsonpath-plus:
         specifier: ~10.3.0
         version: 10.3.0
@@ -2978,6 +2981,9 @@ importers:
       '@rushstack/heft':
         specifier: 0.71.2
         version: 0.71.2(@types/node@20.17.19)
+      '@types/ungap__structured-clone':
+        specifier: ~1.2.0
+        version: 1.2.0
       decoupled-local-node-rig:
         specifier: workspace:*
         version: link:../../rigs/decoupled-local-node-rig
@@ -13398,6 +13404,10 @@ packages:
     dependencies:
       source-map: 0.6.1
 
+  /@types/ungap__structured-clone@1.2.0:
+    resolution: {integrity: sha512-ZoaihZNLeZSxESbk9PUAPZOlSpcKx81I1+4emtULDVmBLkYutTcMlCj2K9VNlf9EWODxdO6gkAqEaLorXwZQVA==}
+    dev: true
+
   /@types/unist@2.0.10:
     resolution: {integrity: sha512-IfYcSBWE3hLpBg8+X2SEa8LVkJdJEkT2Ese2aaLs3ptGdVtABxndrMaxuFlQ1qdFf9Q5rDvDpxI3WwgvKFAsQA==}
     dev: true
@@ -14143,6 +14153,10 @@ packages:
 
   /@ungap/structured-clone@1.2.0:
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
+
+  /@ungap/structured-clone@1.3.0:
+    resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    dev: false
 
   /@vscode/test-electron@1.6.2:
     resolution: {integrity: sha512-W01ajJEMx6223Y7J5yaajGjVs1QfW3YGkkOJHVKfAMEqNB1ZHN9wCcViehv5ZwVSSJnjhu6lYEYgwBdHtCxqhQ==}

--- a/common/config/subspaces/default/repo-state.json
+++ b/common/config/subspaces/default/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "1cd4f5444a9d6a085d5418372291de283264d9fb",
+  "pnpmShrinkwrapHash": "cff3c4ef9a27a2377b9fb1f907c5441b3996d5fb",
   "preferredVersionsHash": "54149ea3f01558a859c96dee2052b797d4defe68"
 }

--- a/libraries/heft-config-file/package.json
+++ b/libraries/heft-config-file/package.json
@@ -24,13 +24,13 @@
     "@rushstack/node-core-library": "workspace:*",
     "@rushstack/rig-package": "workspace:*",
     "@rushstack/terminal": "workspace:*",
-    "jsonpath-plus": "~10.3.0",
-    "@ungap/structured-clone": "~1.3.0"
+    "@ungap/structured-clone": "~1.3.0",
+    "jsonpath-plus": "~10.3.0"
   },
   "devDependencies": {
-    "local-eslint-config": "workspace:*",
     "@rushstack/heft": "0.71.2",
+    "@types/ungap__structured-clone": "~1.2.0",
     "decoupled-local-node-rig": "workspace:*",
-    "@types/ungap__structured-clone": "~1.2.0"
+    "local-eslint-config": "workspace:*"
   }
 }

--- a/libraries/heft-config-file/package.json
+++ b/libraries/heft-config-file/package.json
@@ -24,11 +24,13 @@
     "@rushstack/node-core-library": "workspace:*",
     "@rushstack/rig-package": "workspace:*",
     "@rushstack/terminal": "workspace:*",
-    "jsonpath-plus": "~10.3.0"
+    "jsonpath-plus": "~10.3.0",
+    "@ungap/structured-clone": "~1.3.0"
   },
   "devDependencies": {
     "local-eslint-config": "workspace:*",
     "@rushstack/heft": "0.71.2",
-    "decoupled-local-node-rig": "workspace:*"
+    "decoupled-local-node-rig": "workspace:*",
+    "@types/ungap__structured-clone": "~1.2.0"
   }
 }

--- a/libraries/heft-config-file/src/ConfigurationFileBase.ts
+++ b/libraries/heft-config-file/src/ConfigurationFileBase.ts
@@ -4,6 +4,7 @@
 import * as nodeJsPath from 'path';
 import { JSONPath } from 'jsonpath-plus';
 import { JsonSchema, JsonFile, Import, FileSystem } from '@rushstack/node-core-library';
+import structuredClone from '@ungap/structured-clone';
 import type { ITerminal } from '@rushstack/terminal';
 
 interface IConfigurationJson {
@@ -624,7 +625,9 @@ export abstract class ConfigurationFileBase<TConfigurationFile, TExtraOptions ex
     projectFolderPath: string | undefined
   ): IConfigurationJson & TConfigurationFile {
     // Deep copy the configuration file because different callers might contextualize properties differently.
-    const result: IConfigurationJson & TConfigurationFile = structuredClone(entry.configurationFile);
+    const result: IConfigurationJson & TConfigurationFile = structuredClone<
+      IConfigurationJson & TConfigurationFile
+    >(entry.configurationFile);
 
     const { resolvedConfigurationFilePath } = entry;
 

--- a/libraries/heft-config-file/src/ConfigurationFileBase.ts
+++ b/libraries/heft-config-file/src/ConfigurationFileBase.ts
@@ -625,6 +625,7 @@ export abstract class ConfigurationFileBase<TConfigurationFile, TExtraOptions ex
     projectFolderPath: string | undefined
   ): IConfigurationJson & TConfigurationFile {
     // Deep copy the configuration file because different callers might contextualize properties differently.
+    // TODO: Replace this version of structuredClone with the built-in version once Node 16 support is dropped on the TikTok side
     const result: IConfigurationJson & TConfigurationFile = structuredClone<
       IConfigurationJson & TConfigurationFile
     >(entry.configurationFile);


### PR DESCRIPTION
### Summery
Replace the native `structuredClone` with `@ungap/structured-clone`.In this way, Rush can still run in the Node 16 environment.