### PR TITLE
[rush] Fix implicit phase expansion regression

### DIFF
--- a/common/changes/@microsoft/rush/fix-implicit-phases_2025-04-24-22-45.json
+++ b/common/changes/@microsoft/rush/fix-implicit-phases_2025-04-24-22-45.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix an issue with implicit phase expansion when `--include-phase-deps` is not specified.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/logic/operations/PhasedOperationPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/PhasedOperationPlugin.ts
@@ -105,11 +105,13 @@ function configureOperations(operations: Set<Operation>, context: ICreateOperati
     isInitial
   } = context;
 
+  const basePhases: ReadonlySet<IPhase> = includePhaseDeps ? phaseOriginal : phaseSelection;
+
   // Grab all operations that were explicitly requested.
   const operationsWithWork: Set<Operation> = new Set();
   for (const operation of operations) {
     const { associatedPhase, associatedProject } = operation;
-    if (phaseOriginal.has(associatedPhase) && changedProjects.has(associatedProject)) {
+    if (basePhases.has(associatedPhase) && changedProjects.has(associatedProject)) {
       operationsWithWork.add(operation);
     }
   }

--- a/libraries/rush-lib/src/logic/operations/test/PhasedOperationPlugin.test.ts
+++ b/libraries/rush-lib/src/logic/operations/test/PhasedOperationPlugin.test.ts
@@ -5,12 +5,7 @@ import path from 'path';
 import { JsonFile } from '@rushstack/node-core-library';
 
 import { RushConfiguration } from '../../../api/RushConfiguration';
-import type { RushConfigurationProject } from '../../../api/RushConfigurationProject';
-import {
-  CommandLineConfiguration,
-  type IPhase,
-  type IPhasedCommandConfig
-} from '../../../api/CommandLineConfiguration';
+import { CommandLineConfiguration, type IPhasedCommandConfig } from '../../../api/CommandLineConfiguration';
 import { PhasedOperationPlugin } from '../PhasedOperationPlugin';
 import type { Operation } from '../Operation';
 import type { ICommandLineJson } from '../../../api/CommandLineJson';
@@ -21,18 +16,30 @@ import {
   PhasedCommandHooks
 } from '../../../pluginFramework/PhasedCommandHooks';
 
-interface ISerializedOperation {
-  name: string;
-  silent: boolean;
-  dependencies: string[];
+function serializeOperation(operation: Operation): string {
+  return `${operation.name} (${operation.enabled ? 'enabled' : 'disabled'}${operation.runner!.silent ? ', silent' : ''}) -> [${Array.from(
+    operation.dependencies,
+    (dep: Operation) => dep.name
+  )
+    .sort()
+    .join(', ')}]`;
 }
 
-function serializeOperation(operation: Operation): ISerializedOperation {
-  return {
-    name: operation.name,
-    silent: !operation.enabled || operation.runner!.silent,
-    dependencies: Array.from(operation.dependencies, (dep: Operation) => dep.name)
-  };
+function compareOperation(a: Operation, b: Operation): number {
+  if (a.enabled && !b.enabled) {
+    return -1;
+  }
+  if (!a.enabled && b.enabled) {
+    return 1;
+  }
+  return a.name < b.name ? -1 : a.name > b.name ? 1 : 0;
+}
+
+function expectOperationsToMatchSnapshot(operations: Set<Operation>, name: string): void {
+  const serializedOperations: string[] = Array.from(operations)
+    .sort(compareOperation)
+    .map(serializeOperation);
+  expect(serializedOperations).toMatchSnapshot(name);
 }
 
 describe(PhasedOperationPlugin.name, () => {
@@ -58,11 +65,22 @@ describe(PhasedOperationPlugin.name, () => {
     return operations;
   }
 
-  async function testCreateOperationsAsync(
-    phaseSelection: Set<IPhase>,
-    projectSelection: Set<RushConfigurationProject>,
-    changedProjects: Set<RushConfigurationProject>
-  ): Promise<Set<Operation>> {
+  interface ITestCreateOperationsContext {
+    phaseOriginal?: ICreateOperationsContext['phaseOriginal'];
+    phaseSelection: ICreateOperationsContext['phaseSelection'];
+    projectSelection: ICreateOperationsContext['projectSelection'];
+    projectsInUnknownState: ICreateOperationsContext['projectsInUnknownState'];
+    includePhaseDeps?: ICreateOperationsContext['includePhaseDeps'];
+  }
+
+  async function testCreateOperationsAsync(options: ITestCreateOperationsContext): Promise<Set<Operation>> {
+    const {
+      phaseSelection,
+      projectSelection,
+      projectsInUnknownState,
+      phaseOriginal = phaseSelection,
+      includePhaseDeps = false
+    } = options;
     const hooks: PhasedCommandHooks = new PhasedCommandHooks();
     // Apply the plugin being tested
     new PhasedOperationPlugin().apply(hooks);
@@ -71,16 +89,18 @@ describe(PhasedOperationPlugin.name, () => {
 
     const context: Pick<
       ICreateOperationsContext,
+      | 'includePhaseDeps'
       | 'phaseOriginal'
       | 'phaseSelection'
       | 'projectSelection'
       | 'projectsInUnknownState'
       | 'projectConfigurations'
     > = {
-      phaseOriginal: phaseSelection,
+      includePhaseDeps,
+      phaseOriginal,
       phaseSelection,
       projectSelection,
-      projectsInUnknownState: changedProjects,
+      projectsInUnknownState,
       projectConfigurations: new Map()
     };
     const operations: Set<Operation> = await hooks.createOperations.promise(
@@ -106,14 +126,14 @@ describe(PhasedOperationPlugin.name, () => {
       'build'
     )! as IPhasedCommandConfig;
 
-    const operations: Set<Operation> = await testCreateOperationsAsync(
-      buildCommand.phases,
-      new Set(rushConfiguration.projects),
-      new Set(rushConfiguration.projects)
-    );
+    const operations: Set<Operation> = await testCreateOperationsAsync({
+      phaseSelection: buildCommand.phases,
+      projectSelection: new Set(rushConfiguration.projects),
+      projectsInUnknownState: new Set(rushConfiguration.projects)
+    });
 
     // All projects
-    expect(Array.from(operations, serializeOperation)).toMatchSnapshot();
+    expectOperationsToMatchSnapshot(operations, 'full');
   });
 
   it('handles filtered projects', async () => {
@@ -121,31 +141,31 @@ describe(PhasedOperationPlugin.name, () => {
       'build'
     )! as IPhasedCommandConfig;
 
-    let operations: Set<Operation> = await testCreateOperationsAsync(
-      buildCommand.phases,
-      new Set([rushConfiguration.getProjectByName('g')!]),
-      new Set([rushConfiguration.getProjectByName('g')!])
-    );
+    let operations: Set<Operation> = await testCreateOperationsAsync({
+      phaseSelection: buildCommand.phases,
+      projectSelection: new Set([rushConfiguration.getProjectByName('g')!]),
+      projectsInUnknownState: new Set([rushConfiguration.getProjectByName('g')!])
+    });
 
     // Single project
-    expect(Array.from(operations, serializeOperation)).toMatchSnapshot();
+    expectOperationsToMatchSnapshot(operations, 'single');
 
-    operations = await testCreateOperationsAsync(
-      buildCommand.phases,
-      new Set([
+    operations = await testCreateOperationsAsync({
+      phaseSelection: buildCommand.phases,
+      projectSelection: new Set([
         rushConfiguration.getProjectByName('f')!,
         rushConfiguration.getProjectByName('a')!,
         rushConfiguration.getProjectByName('c')!
       ]),
-      new Set([
+      projectsInUnknownState: new Set([
         rushConfiguration.getProjectByName('f')!,
         rushConfiguration.getProjectByName('a')!,
         rushConfiguration.getProjectByName('c')!
       ])
-    );
+    });
 
     // Filtered projects
-    expect(Array.from(operations, serializeOperation)).toMatchSnapshot();
+    expectOperationsToMatchSnapshot(operations, 'filtered');
   });
 
   it('handles some changed projects', async () => {
@@ -153,27 +173,27 @@ describe(PhasedOperationPlugin.name, () => {
       'build'
     )! as IPhasedCommandConfig;
 
-    let operations: Set<Operation> = await testCreateOperationsAsync(
-      buildCommand.phases,
-      new Set(rushConfiguration.projects),
-      new Set([rushConfiguration.getProjectByName('g')!])
-    );
+    let operations: Set<Operation> = await testCreateOperationsAsync({
+      phaseSelection: buildCommand.phases,
+      projectSelection: new Set(rushConfiguration.projects),
+      projectsInUnknownState: new Set([rushConfiguration.getProjectByName('g')!])
+    });
 
     // Single project
-    expect(Array.from(operations, serializeOperation)).toMatchSnapshot();
+    expectOperationsToMatchSnapshot(operations, 'single');
 
-    operations = await testCreateOperationsAsync(
-      buildCommand.phases,
-      new Set(rushConfiguration.projects),
-      new Set([
+    operations = await testCreateOperationsAsync({
+      phaseSelection: buildCommand.phases,
+      projectSelection: new Set(rushConfiguration.projects),
+      projectsInUnknownState: new Set([
         rushConfiguration.getProjectByName('f')!,
         rushConfiguration.getProjectByName('a')!,
         rushConfiguration.getProjectByName('c')!
       ])
-    );
+    });
 
     // Filtered projects
-    expect(Array.from(operations, serializeOperation)).toMatchSnapshot();
+    expectOperationsToMatchSnapshot(operations, 'multiple');
   });
 
   it('handles some changed projects within filtered projects', async () => {
@@ -181,79 +201,130 @@ describe(PhasedOperationPlugin.name, () => {
       'build'
     )! as IPhasedCommandConfig;
 
-    const operations: Set<Operation> = await testCreateOperationsAsync(
-      buildCommand.phases,
-      new Set([
+    const operations: Set<Operation> = await testCreateOperationsAsync({
+      phaseSelection: buildCommand.phases,
+      projectSelection: new Set([
         rushConfiguration.getProjectByName('f')!,
         rushConfiguration.getProjectByName('a')!,
         rushConfiguration.getProjectByName('c')!
       ]),
-      new Set([rushConfiguration.getProjectByName('a')!, rushConfiguration.getProjectByName('c')!])
-    );
+      projectsInUnknownState: new Set([
+        rushConfiguration.getProjectByName('a')!,
+        rushConfiguration.getProjectByName('c')!
+      ])
+    });
 
     // Single project
-    expect(Array.from(operations, serializeOperation)).toMatchSnapshot();
+    expectOperationsToMatchSnapshot(operations, 'multiple');
+  });
+
+  it('handles different phaseOriginal vs phaseSelection without --include-phase-deps', async () => {
+    const operations: Set<Operation> = await testCreateOperationsAsync({
+      includePhaseDeps: false,
+      phaseSelection: new Set([
+        commandLineConfiguration.phases.get('_phase:no-deps')!,
+        commandLineConfiguration.phases.get('_phase:upstream-self')!
+      ]),
+      phaseOriginal: new Set([commandLineConfiguration.phases.get('_phase:upstream-self')!]),
+      projectSelection: new Set([rushConfiguration.getProjectByName('a')!]),
+      projectsInUnknownState: new Set([rushConfiguration.getProjectByName('a')!])
+    });
+
+    expectOperationsToMatchSnapshot(operations, 'single-project');
+  });
+
+  it('handles different phaseOriginal vs phaseSelection with --include-phase-deps', async () => {
+    const operations: Set<Operation> = await testCreateOperationsAsync({
+      includePhaseDeps: true,
+      phaseSelection: new Set([
+        commandLineConfiguration.phases.get('_phase:no-deps')!,
+        commandLineConfiguration.phases.get('_phase:upstream-self')!
+      ]),
+      phaseOriginal: new Set([commandLineConfiguration.phases.get('_phase:upstream-self')!]),
+      projectSelection: new Set([rushConfiguration.getProjectByName('a')!]),
+      projectsInUnknownState: new Set([rushConfiguration.getProjectByName('a')!])
+    });
+
+    expectOperationsToMatchSnapshot(operations, 'single-project');
+  });
+
+  it('handles different phaseOriginal vs phaseSelection cross-project with --include-phase-deps', async () => {
+    const operations: Set<Operation> = await testCreateOperationsAsync({
+      includePhaseDeps: true,
+      phaseSelection: new Set([
+        commandLineConfiguration.phases.get('_phase:no-deps')!,
+        commandLineConfiguration.phases.get('_phase:upstream-1')!
+      ]),
+      phaseOriginal: new Set([commandLineConfiguration.phases.get('_phase:upstream-1')!]),
+      projectSelection: new Set([
+        rushConfiguration.getProjectByName('a')!,
+        rushConfiguration.getProjectByName('h')!
+      ]),
+      projectsInUnknownState: new Set([rushConfiguration.getProjectByName('h')!])
+    });
+
+    expectOperationsToMatchSnapshot(operations, 'multiple-project');
   });
 
   it('handles filtered phases', async () => {
     // Single phase with a missing dependency
-    let operations: Set<Operation> = await testCreateOperationsAsync(
-      new Set([commandLineConfiguration.phases.get('_phase:upstream-self')!]),
-      new Set(rushConfiguration.projects),
-      new Set(rushConfiguration.projects)
-    );
-    expect(Array.from(operations, serializeOperation)).toMatchSnapshot();
+    let operations: Set<Operation> = await testCreateOperationsAsync({
+      phaseSelection: new Set([commandLineConfiguration.phases.get('_phase:upstream-self')!]),
+      projectSelection: new Set(rushConfiguration.projects),
+      projectsInUnknownState: new Set(rushConfiguration.projects)
+    });
+    expectOperationsToMatchSnapshot(operations, 'single-phase');
 
     // Two phases with a missing link
-    operations = await testCreateOperationsAsync(
-      new Set([
+    operations = await testCreateOperationsAsync({
+      phaseSelection: new Set([
         commandLineConfiguration.phases.get('_phase:complex')!,
         commandLineConfiguration.phases.get('_phase:upstream-3')!,
         commandLineConfiguration.phases.get('_phase:upstream-1')!,
         commandLineConfiguration.phases.get('_phase:no-deps')!
       ]),
-      new Set(rushConfiguration.projects),
-      new Set(rushConfiguration.projects)
-    );
-    expect(Array.from(operations, serializeOperation)).toMatchSnapshot();
+      projectSelection: new Set(rushConfiguration.projects),
+      projectsInUnknownState: new Set(rushConfiguration.projects)
+    });
+    expectOperationsToMatchSnapshot(operations, 'two-phases');
   });
 
   it('handles filtered phases on filtered projects', async () => {
     // Single phase with a missing dependency
-    let operations: Set<Operation> = await testCreateOperationsAsync(
-      new Set([commandLineConfiguration.phases.get('_phase:upstream-2')!]),
-      new Set([
+    let operations: Set<Operation> = await testCreateOperationsAsync({
+      phaseSelection: new Set([commandLineConfiguration.phases.get('_phase:upstream-2')!]),
+      projectSelection: new Set([
         rushConfiguration.getProjectByName('f')!,
         rushConfiguration.getProjectByName('a')!,
         rushConfiguration.getProjectByName('c')!
       ]),
-      new Set([
+      projectsInUnknownState: new Set([
         rushConfiguration.getProjectByName('f')!,
         rushConfiguration.getProjectByName('a')!,
         rushConfiguration.getProjectByName('c')!
       ])
-    );
-    expect(Array.from(operations, serializeOperation)).toMatchSnapshot();
+    });
+    expectOperationsToMatchSnapshot(operations, 'single-phase');
 
     // Phases with missing links
-    operations = await testCreateOperationsAsync(
-      new Set([
+    operations = await testCreateOperationsAsync({
+      phaseSelection: new Set([
         commandLineConfiguration.phases.get('_phase:complex')!,
         commandLineConfiguration.phases.get('_phase:upstream-3')!,
         commandLineConfiguration.phases.get('_phase:upstream-1')!,
         commandLineConfiguration.phases.get('_phase:no-deps')!
       ]),
-      new Set([
+      projectSelection: new Set([
         rushConfiguration.getProjectByName('f')!,
         rushConfiguration.getProjectByName('a')!,
         rushConfiguration.getProjectByName('c')!
       ]),
-      new Set([
+      projectsInUnknownState: new Set([
         rushConfiguration.getProjectByName('f')!,
         rushConfiguration.getProjectByName('a')!,
         rushConfiguration.getProjectByName('c')!
       ])
-    );
-    expect(Array.from(operations, serializeOperation)).toMatchSnapshot();
+    });
+    expectOperationsToMatchSnapshot(operations, 'missing-links');
   });
 });

--- a/libraries/rush-lib/src/logic/operations/test/__snapshots__/PhasedOperationPlugin.test.ts.snap
+++ b/libraries/rush-lib/src/logic/operations/test/__snapshots__/PhasedOperationPlugin.test.ts.snap
@@ -1,3256 +1,547 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`PhasedOperationPlugin handles a full build 1`] = `
+exports[`PhasedOperationPlugin handles a full build: full 1`] = `
 Array [
-  Object {
-    "dependencies": Array [],
-    "name": "a (no-deps)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "b (no-deps)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "c (no-deps)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "d (no-deps)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "e (no-deps)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "f (no-deps)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "g (no-deps)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "h (no-deps)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "i (no-deps)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "j (no-deps)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (no-deps)",
-    ],
-    "name": "a (upstream-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "b (no-deps)",
-      "a (upstream-self)",
-    ],
-    "name": "b (upstream-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "c (no-deps)",
-      "b (upstream-self)",
-    ],
-    "name": "c (upstream-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "d (no-deps)",
-      "b (upstream-self)",
-    ],
-    "name": "d (upstream-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "e (no-deps)",
-      "c (upstream-self)",
-    ],
-    "name": "e (upstream-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "f (no-deps)",
-      "a (upstream-self)",
-      "h (upstream-self)",
-    ],
-    "name": "f (upstream-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "h (no-deps)",
-      "a (upstream-self)",
-    ],
-    "name": "h (upstream-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "g (no-deps)",
-      "a (upstream-self)",
-    ],
-    "name": "g (upstream-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "i (no-deps)",
-    ],
-    "name": "i (upstream-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "j (no-deps)",
-    ],
-    "name": "j (upstream-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "a (upstream-1)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (no-deps)",
-    ],
-    "name": "b (upstream-1)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "b (no-deps)",
-    ],
-    "name": "c (upstream-1)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "b (no-deps)",
-    ],
-    "name": "d (upstream-1)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "c (no-deps)",
-    ],
-    "name": "e (upstream-1)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (no-deps)",
-      "h (no-deps)",
-    ],
-    "name": "f (upstream-1)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (no-deps)",
-    ],
-    "name": "g (upstream-1)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (no-deps)",
-    ],
-    "name": "h (upstream-1)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "i (upstream-1)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "j (upstream-1)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "a (upstream-2)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-1)",
-    ],
-    "name": "b (upstream-2)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "b (upstream-1)",
-    ],
-    "name": "c (upstream-2)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "b (upstream-1)",
-    ],
-    "name": "d (upstream-2)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "c (upstream-1)",
-    ],
-    "name": "e (upstream-2)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-1)",
-      "h (upstream-1)",
-    ],
-    "name": "f (upstream-2)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-1)",
-    ],
-    "name": "g (upstream-2)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-1)",
-    ],
-    "name": "h (upstream-2)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "i (upstream-2)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "j (upstream-2)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "a (upstream-3)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-2)",
-    ],
-    "name": "b (upstream-3)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "b (upstream-2)",
-    ],
-    "name": "c (upstream-3)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "b (upstream-2)",
-    ],
-    "name": "d (upstream-3)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "c (upstream-2)",
-    ],
-    "name": "e (upstream-3)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-2)",
-      "h (upstream-2)",
-    ],
-    "name": "f (upstream-3)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-2)",
-    ],
-    "name": "g (upstream-3)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-2)",
-    ],
-    "name": "h (upstream-3)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "i (upstream-3)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "j (upstream-3)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-1)",
-    ],
-    "name": "a (upstream-1-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "b (upstream-1)",
-    ],
-    "name": "b (upstream-1-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "c (upstream-1)",
-    ],
-    "name": "c (upstream-1-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "d (upstream-1)",
-    ],
-    "name": "d (upstream-1-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "e (upstream-1)",
-    ],
-    "name": "e (upstream-1-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "f (upstream-1)",
-    ],
-    "name": "f (upstream-1-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "g (upstream-1)",
-    ],
-    "name": "g (upstream-1-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "h (upstream-1)",
-    ],
-    "name": "h (upstream-1-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "i (upstream-1)",
-    ],
-    "name": "i (upstream-1-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "j (upstream-1)",
-    ],
-    "name": "j (upstream-1-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-2)",
-    ],
-    "name": "a (upstream-2-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "b (upstream-2)",
-    ],
-    "name": "b (upstream-2-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "c (upstream-2)",
-    ],
-    "name": "c (upstream-2-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "d (upstream-2)",
-    ],
-    "name": "d (upstream-2-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "e (upstream-2)",
-    ],
-    "name": "e (upstream-2-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "f (upstream-2)",
-    ],
-    "name": "f (upstream-2-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "g (upstream-2)",
-    ],
-    "name": "g (upstream-2-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "h (upstream-2)",
-    ],
-    "name": "h (upstream-2-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "i (upstream-2)",
-    ],
-    "name": "i (upstream-2-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "j (upstream-2)",
-    ],
-    "name": "j (upstream-2-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "a (upstream-1-self-upstream)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-1-self)",
-    ],
-    "name": "b (upstream-1-self-upstream)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "b (upstream-1-self)",
-    ],
-    "name": "c (upstream-1-self-upstream)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "b (upstream-1-self)",
-    ],
-    "name": "d (upstream-1-self-upstream)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "c (upstream-1-self)",
-    ],
-    "name": "e (upstream-1-self-upstream)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-1-self)",
-      "h (upstream-1-self)",
-    ],
-    "name": "f (upstream-1-self-upstream)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-1-self)",
-    ],
-    "name": "g (upstream-1-self-upstream)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-1-self)",
-    ],
-    "name": "h (upstream-1-self-upstream)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "i (upstream-1-self-upstream)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "j (upstream-1-self-upstream)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-3)",
-    ],
-    "name": "a (complex)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "b (upstream-3)",
-      "a (upstream-1-self-upstream)",
-      "a (upstream-2-self)",
-    ],
-    "name": "b (complex)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "c (upstream-3)",
-      "b (upstream-1-self-upstream)",
-      "b (upstream-2-self)",
-    ],
-    "name": "c (complex)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "d (upstream-3)",
-      "b (upstream-1-self-upstream)",
-      "b (upstream-2-self)",
-    ],
-    "name": "d (complex)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "e (upstream-3)",
-      "c (upstream-1-self-upstream)",
-      "c (upstream-2-self)",
-    ],
-    "name": "e (complex)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "f (upstream-3)",
-      "a (upstream-1-self-upstream)",
-      "h (upstream-1-self-upstream)",
-      "a (upstream-2-self)",
-      "h (upstream-2-self)",
-    ],
-    "name": "f (complex)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "g (upstream-3)",
-      "a (upstream-1-self-upstream)",
-      "a (upstream-2-self)",
-    ],
-    "name": "g (complex)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "h (upstream-3)",
-      "a (upstream-1-self-upstream)",
-      "a (upstream-2-self)",
-    ],
-    "name": "h (complex)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "i (upstream-3)",
-    ],
-    "name": "i (complex)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "j (upstream-3)",
-    ],
-    "name": "j (complex)",
-    "silent": false,
-  },
+  "a (complex) (enabled) -> [a (upstream-3)]",
+  "a (no-deps) (enabled) -> []",
+  "a (upstream-1) (enabled) -> []",
+  "a (upstream-1-self) (enabled) -> [a (upstream-1)]",
+  "a (upstream-1-self-upstream) (enabled) -> []",
+  "a (upstream-2) (enabled) -> []",
+  "a (upstream-2-self) (enabled) -> [a (upstream-2)]",
+  "a (upstream-3) (enabled) -> []",
+  "a (upstream-self) (enabled) -> [a (no-deps)]",
+  "b (complex) (enabled) -> [a (upstream-1-self-upstream), a (upstream-2-self), b (upstream-3)]",
+  "b (no-deps) (enabled) -> []",
+  "b (upstream-1) (enabled) -> [a (no-deps)]",
+  "b (upstream-1-self) (enabled) -> [b (upstream-1)]",
+  "b (upstream-1-self-upstream) (enabled) -> [a (upstream-1-self)]",
+  "b (upstream-2) (enabled) -> [a (upstream-1)]",
+  "b (upstream-2-self) (enabled) -> [b (upstream-2)]",
+  "b (upstream-3) (enabled) -> [a (upstream-2)]",
+  "b (upstream-self) (enabled) -> [a (upstream-self), b (no-deps)]",
+  "c (complex) (enabled) -> [b (upstream-1-self-upstream), b (upstream-2-self), c (upstream-3)]",
+  "c (no-deps) (enabled) -> []",
+  "c (upstream-1) (enabled) -> [b (no-deps)]",
+  "c (upstream-1-self) (enabled) -> [c (upstream-1)]",
+  "c (upstream-1-self-upstream) (enabled) -> [b (upstream-1-self)]",
+  "c (upstream-2) (enabled) -> [b (upstream-1)]",
+  "c (upstream-2-self) (enabled) -> [c (upstream-2)]",
+  "c (upstream-3) (enabled) -> [b (upstream-2)]",
+  "c (upstream-self) (enabled) -> [b (upstream-self), c (no-deps)]",
+  "d (complex) (enabled) -> [b (upstream-1-self-upstream), b (upstream-2-self), d (upstream-3)]",
+  "d (no-deps) (enabled) -> []",
+  "d (upstream-1) (enabled) -> [b (no-deps)]",
+  "d (upstream-1-self) (enabled) -> [d (upstream-1)]",
+  "d (upstream-1-self-upstream) (enabled) -> [b (upstream-1-self)]",
+  "d (upstream-2) (enabled) -> [b (upstream-1)]",
+  "d (upstream-2-self) (enabled) -> [d (upstream-2)]",
+  "d (upstream-3) (enabled) -> [b (upstream-2)]",
+  "d (upstream-self) (enabled) -> [b (upstream-self), d (no-deps)]",
+  "e (complex) (enabled) -> [c (upstream-1-self-upstream), c (upstream-2-self), e (upstream-3)]",
+  "e (no-deps) (enabled) -> []",
+  "e (upstream-1) (enabled) -> [c (no-deps)]",
+  "e (upstream-1-self) (enabled) -> [e (upstream-1)]",
+  "e (upstream-1-self-upstream) (enabled) -> [c (upstream-1-self)]",
+  "e (upstream-2) (enabled) -> [c (upstream-1)]",
+  "e (upstream-2-self) (enabled) -> [e (upstream-2)]",
+  "e (upstream-3) (enabled) -> [c (upstream-2)]",
+  "e (upstream-self) (enabled) -> [c (upstream-self), e (no-deps)]",
+  "f (complex) (enabled) -> [a (upstream-1-self-upstream), a (upstream-2-self), f (upstream-3), h (upstream-1-self-upstream), h (upstream-2-self)]",
+  "f (no-deps) (enabled) -> []",
+  "f (upstream-1) (enabled) -> [a (no-deps), h (no-deps)]",
+  "f (upstream-1-self) (enabled) -> [f (upstream-1)]",
+  "f (upstream-1-self-upstream) (enabled) -> [a (upstream-1-self), h (upstream-1-self)]",
+  "f (upstream-2) (enabled) -> [a (upstream-1), h (upstream-1)]",
+  "f (upstream-2-self) (enabled) -> [f (upstream-2)]",
+  "f (upstream-3) (enabled) -> [a (upstream-2), h (upstream-2)]",
+  "f (upstream-self) (enabled) -> [a (upstream-self), f (no-deps), h (upstream-self)]",
+  "g (complex) (enabled) -> [a (upstream-1-self-upstream), a (upstream-2-self), g (upstream-3)]",
+  "g (no-deps) (enabled) -> []",
+  "g (upstream-1) (enabled) -> [a (no-deps)]",
+  "g (upstream-1-self) (enabled) -> [g (upstream-1)]",
+  "g (upstream-1-self-upstream) (enabled) -> [a (upstream-1-self)]",
+  "g (upstream-2) (enabled) -> [a (upstream-1)]",
+  "g (upstream-2-self) (enabled) -> [g (upstream-2)]",
+  "g (upstream-3) (enabled) -> [a (upstream-2)]",
+  "g (upstream-self) (enabled) -> [a (upstream-self), g (no-deps)]",
+  "h (complex) (enabled) -> [a (upstream-1-self-upstream), a (upstream-2-self), h (upstream-3)]",
+  "h (no-deps) (enabled) -> []",
+  "h (upstream-1) (enabled) -> [a (no-deps)]",
+  "h (upstream-1-self) (enabled) -> [h (upstream-1)]",
+  "h (upstream-1-self-upstream) (enabled) -> [a (upstream-1-self)]",
+  "h (upstream-2) (enabled) -> [a (upstream-1)]",
+  "h (upstream-2-self) (enabled) -> [h (upstream-2)]",
+  "h (upstream-3) (enabled) -> [a (upstream-2)]",
+  "h (upstream-self) (enabled) -> [a (upstream-self), h (no-deps)]",
+  "i (complex) (enabled) -> [i (upstream-3)]",
+  "i (no-deps) (enabled) -> []",
+  "i (upstream-1) (enabled) -> []",
+  "i (upstream-1-self) (enabled) -> [i (upstream-1)]",
+  "i (upstream-1-self-upstream) (enabled) -> []",
+  "i (upstream-2) (enabled) -> []",
+  "i (upstream-2-self) (enabled) -> [i (upstream-2)]",
+  "i (upstream-3) (enabled) -> []",
+  "i (upstream-self) (enabled) -> [i (no-deps)]",
+  "j (complex) (enabled) -> [j (upstream-3)]",
+  "j (no-deps) (enabled) -> []",
+  "j (upstream-1) (enabled) -> []",
+  "j (upstream-1-self) (enabled) -> [j (upstream-1)]",
+  "j (upstream-1-self-upstream) (enabled) -> []",
+  "j (upstream-2) (enabled) -> []",
+  "j (upstream-2-self) (enabled) -> [j (upstream-2)]",
+  "j (upstream-3) (enabled) -> []",
+  "j (upstream-self) (enabled) -> [j (no-deps)]",
 ]
 `;
 
-exports[`PhasedOperationPlugin handles filtered phases 1`] = `
+exports[`PhasedOperationPlugin handles different phaseOriginal vs phaseSelection cross-project with --include-phase-deps: multiple-project 1`] = `
 Array [
-  Object {
-    "dependencies": Array [
-      "a (no-deps)",
-    ],
-    "name": "a (upstream-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "a (no-deps)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "b (no-deps)",
-      "a (upstream-self)",
-    ],
-    "name": "b (upstream-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "b (no-deps)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "c (no-deps)",
-      "b (upstream-self)",
-    ],
-    "name": "c (upstream-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "c (no-deps)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "d (no-deps)",
-      "b (upstream-self)",
-    ],
-    "name": "d (upstream-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "d (no-deps)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "e (no-deps)",
-      "c (upstream-self)",
-    ],
-    "name": "e (upstream-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "e (no-deps)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "f (no-deps)",
-      "a (upstream-self)",
-      "h (upstream-self)",
-    ],
-    "name": "f (upstream-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "f (no-deps)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "h (no-deps)",
-      "a (upstream-self)",
-    ],
-    "name": "h (upstream-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "h (no-deps)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "g (no-deps)",
-      "a (upstream-self)",
-    ],
-    "name": "g (upstream-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "g (no-deps)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "i (no-deps)",
-    ],
-    "name": "i (upstream-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "i (no-deps)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "j (no-deps)",
-    ],
-    "name": "j (upstream-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "j (no-deps)",
-    "silent": true,
-  },
+  "a (no-deps) (enabled) -> []",
+  "h (upstream-1) (enabled) -> [a (no-deps)]",
+  "a (upstream-1) (disabled) -> []",
+  "h (no-deps) (disabled) -> []",
 ]
 `;
 
-exports[`PhasedOperationPlugin handles filtered phases 2`] = `
+exports[`PhasedOperationPlugin handles different phaseOriginal vs phaseSelection with --include-phase-deps: single-project 1`] = `
 Array [
-  Object {
-    "dependencies": Array [
-      "a (upstream-3)",
-    ],
-    "name": "a (complex)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "a (upstream-3)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "b (upstream-3)",
-      "a (upstream-1-self-upstream)",
-      "a (upstream-2-self)",
-    ],
-    "name": "b (complex)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-2)",
-    ],
-    "name": "b (upstream-3)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "a (upstream-2)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "a (upstream-1-self-upstream)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-2)",
-    ],
-    "name": "a (upstream-2-self)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "c (upstream-3)",
-      "b (upstream-1-self-upstream)",
-      "b (upstream-2-self)",
-    ],
-    "name": "c (complex)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "b (upstream-2)",
-    ],
-    "name": "c (upstream-3)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-1)",
-    ],
-    "name": "b (upstream-2)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "a (upstream-1)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-1-self)",
-    ],
-    "name": "b (upstream-1-self-upstream)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-1)",
-    ],
-    "name": "a (upstream-1-self)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "b (upstream-2)",
-    ],
-    "name": "b (upstream-2-self)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "d (upstream-3)",
-      "b (upstream-1-self-upstream)",
-      "b (upstream-2-self)",
-    ],
-    "name": "d (complex)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "b (upstream-2)",
-    ],
-    "name": "d (upstream-3)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "e (upstream-3)",
-      "c (upstream-1-self-upstream)",
-      "c (upstream-2-self)",
-    ],
-    "name": "e (complex)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "c (upstream-2)",
-    ],
-    "name": "e (upstream-3)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "b (upstream-1)",
-    ],
-    "name": "c (upstream-2)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "a (no-deps)",
-    ],
-    "name": "b (upstream-1)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "a (no-deps)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "b (upstream-1-self)",
-    ],
-    "name": "c (upstream-1-self-upstream)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "b (upstream-1)",
-    ],
-    "name": "b (upstream-1-self)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "c (upstream-2)",
-    ],
-    "name": "c (upstream-2-self)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "f (upstream-3)",
-      "a (upstream-1-self-upstream)",
-      "h (upstream-1-self-upstream)",
-      "a (upstream-2-self)",
-      "h (upstream-2-self)",
-    ],
-    "name": "f (complex)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-2)",
-      "h (upstream-2)",
-    ],
-    "name": "f (upstream-3)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-1)",
-    ],
-    "name": "h (upstream-2)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-1-self)",
-    ],
-    "name": "h (upstream-1-self-upstream)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "h (upstream-2)",
-    ],
-    "name": "h (upstream-2-self)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "g (upstream-3)",
-      "a (upstream-1-self-upstream)",
-      "a (upstream-2-self)",
-    ],
-    "name": "g (complex)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-2)",
-    ],
-    "name": "g (upstream-3)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "h (upstream-3)",
-      "a (upstream-1-self-upstream)",
-      "a (upstream-2-self)",
-    ],
-    "name": "h (complex)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-2)",
-    ],
-    "name": "h (upstream-3)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "i (upstream-3)",
-    ],
-    "name": "i (complex)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "i (upstream-3)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "j (upstream-3)",
-    ],
-    "name": "j (complex)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "j (upstream-3)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "b (no-deps)",
-    ],
-    "name": "c (upstream-1)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "b (no-deps)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "b (no-deps)",
-    ],
-    "name": "d (upstream-1)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "c (no-deps)",
-    ],
-    "name": "e (upstream-1)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "c (no-deps)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (no-deps)",
-      "h (no-deps)",
-    ],
-    "name": "f (upstream-1)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "h (no-deps)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (no-deps)",
-    ],
-    "name": "g (upstream-1)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (no-deps)",
-    ],
-    "name": "h (upstream-1)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "i (upstream-1)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "j (upstream-1)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "d (no-deps)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "e (no-deps)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "f (no-deps)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "g (no-deps)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "i (no-deps)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "j (no-deps)",
-    "silent": false,
-  },
+  "a (no-deps) (enabled) -> []",
+  "a (upstream-self) (enabled) -> [a (no-deps)]",
 ]
 `;
 
-exports[`PhasedOperationPlugin handles filtered phases on filtered projects 1`] = `
+exports[`PhasedOperationPlugin handles different phaseOriginal vs phaseSelection without --include-phase-deps: single-project 1`] = `
 Array [
-  Object {
-    "dependencies": Array [
-      "a (upstream-1)",
-      "h (upstream-1)",
-    ],
-    "name": "f (upstream-2)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "a (upstream-1)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "a (no-deps)",
-    ],
-    "name": "h (upstream-1)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "a (no-deps)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "a (upstream-2)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "b (upstream-1)",
-    ],
-    "name": "c (upstream-2)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (no-deps)",
-    ],
-    "name": "b (upstream-1)",
-    "silent": true,
-  },
+  "a (no-deps) (enabled) -> []",
+  "a (upstream-self) (enabled) -> [a (no-deps)]",
 ]
 `;
 
-exports[`PhasedOperationPlugin handles filtered phases on filtered projects 2`] = `
+exports[`PhasedOperationPlugin handles filtered phases on filtered projects: missing-links 1`] = `
 Array [
-  Object {
-    "dependencies": Array [
-      "f (upstream-3)",
-      "a (upstream-1-self-upstream)",
-      "h (upstream-1-self-upstream)",
-      "a (upstream-2-self)",
-      "h (upstream-2-self)",
-    ],
-    "name": "f (complex)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-2)",
-      "h (upstream-2)",
-    ],
-    "name": "f (upstream-3)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "a (upstream-2)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-1)",
-    ],
-    "name": "h (upstream-2)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "a (upstream-1)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "a (upstream-1-self-upstream)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-1-self)",
-    ],
-    "name": "h (upstream-1-self-upstream)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-1)",
-    ],
-    "name": "a (upstream-1-self)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-2)",
-    ],
-    "name": "a (upstream-2-self)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "h (upstream-2)",
-    ],
-    "name": "h (upstream-2-self)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-3)",
-    ],
-    "name": "a (complex)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "a (upstream-3)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "c (upstream-3)",
-      "b (upstream-1-self-upstream)",
-      "b (upstream-2-self)",
-    ],
-    "name": "c (complex)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "b (upstream-2)",
-    ],
-    "name": "c (upstream-3)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-1)",
-    ],
-    "name": "b (upstream-2)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-1-self)",
-    ],
-    "name": "b (upstream-1-self-upstream)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "b (upstream-2)",
-    ],
-    "name": "b (upstream-2-self)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "a (no-deps)",
-      "h (no-deps)",
-    ],
-    "name": "f (upstream-1)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "a (no-deps)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "h (no-deps)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "b (no-deps)",
-    ],
-    "name": "c (upstream-1)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "b (no-deps)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "f (no-deps)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "c (no-deps)",
-    "silent": false,
-  },
+  "a (complex) (enabled) -> [a (upstream-3)]",
+  "a (no-deps) (enabled) -> []",
+  "a (upstream-1) (enabled) -> []",
+  "a (upstream-3) (enabled) -> []",
+  "c (complex) (enabled) -> [b (upstream-1-self-upstream), b (upstream-2-self), c (upstream-3)]",
+  "c (no-deps) (enabled) -> []",
+  "c (upstream-1) (enabled) -> [b (no-deps)]",
+  "c (upstream-3) (enabled) -> [b (upstream-2)]",
+  "f (complex) (enabled) -> [a (upstream-1-self-upstream), a (upstream-2-self), f (upstream-3), h (upstream-1-self-upstream), h (upstream-2-self)]",
+  "f (no-deps) (enabled) -> []",
+  "f (upstream-1) (enabled) -> [a (no-deps), h (no-deps)]",
+  "f (upstream-3) (enabled) -> [a (upstream-2), h (upstream-2)]",
+  "a (upstream-1-self) (disabled) -> [a (upstream-1)]",
+  "a (upstream-1-self-upstream) (disabled) -> []",
+  "a (upstream-2) (disabled) -> []",
+  "a (upstream-2-self) (disabled) -> [a (upstream-2)]",
+  "b (no-deps) (disabled) -> []",
+  "b (upstream-1-self-upstream) (disabled) -> [a (upstream-1-self)]",
+  "b (upstream-2) (disabled) -> [a (upstream-1)]",
+  "b (upstream-2-self) (disabled) -> [b (upstream-2)]",
+  "h (no-deps) (disabled) -> []",
+  "h (upstream-1-self-upstream) (disabled) -> [a (upstream-1-self)]",
+  "h (upstream-2) (disabled) -> [a (upstream-1)]",
+  "h (upstream-2-self) (disabled) -> [h (upstream-2)]",
 ]
 `;
 
-exports[`PhasedOperationPlugin handles filtered projects 1`] = `
+exports[`PhasedOperationPlugin handles filtered phases on filtered projects: single-phase 1`] = `
 Array [
-  Object {
-    "dependencies": Array [],
-    "name": "g (no-deps)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "g (no-deps)",
-      "a (upstream-self)",
-    ],
-    "name": "g (upstream-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (no-deps)",
-    ],
-    "name": "a (upstream-self)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "a (no-deps)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "a (no-deps)",
-    ],
-    "name": "g (upstream-1)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-1)",
-    ],
-    "name": "g (upstream-2)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "a (upstream-1)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-2)",
-    ],
-    "name": "g (upstream-3)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "a (upstream-2)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "g (upstream-1)",
-    ],
-    "name": "g (upstream-1-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "g (upstream-2)",
-    ],
-    "name": "g (upstream-2-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-1-self)",
-    ],
-    "name": "g (upstream-1-self-upstream)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-1)",
-    ],
-    "name": "a (upstream-1-self)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "g (upstream-3)",
-      "a (upstream-1-self-upstream)",
-      "a (upstream-2-self)",
-    ],
-    "name": "g (complex)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "a (upstream-1-self-upstream)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-2)",
-    ],
-    "name": "a (upstream-2-self)",
-    "silent": true,
-  },
+  "a (upstream-2) (enabled) -> []",
+  "c (upstream-2) (enabled) -> [b (upstream-1)]",
+  "f (upstream-2) (enabled) -> [a (upstream-1), h (upstream-1)]",
+  "a (no-deps) (disabled) -> []",
+  "a (upstream-1) (disabled) -> []",
+  "b (upstream-1) (disabled) -> [a (no-deps)]",
+  "h (upstream-1) (disabled) -> [a (no-deps)]",
 ]
 `;
 
-exports[`PhasedOperationPlugin handles filtered projects 2`] = `
+exports[`PhasedOperationPlugin handles filtered phases: single-phase 1`] = `
 Array [
-  Object {
-    "dependencies": Array [],
-    "name": "f (no-deps)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "a (no-deps)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "c (no-deps)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "f (no-deps)",
-      "a (upstream-self)",
-      "h (upstream-self)",
-    ],
-    "name": "f (upstream-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (no-deps)",
-    ],
-    "name": "a (upstream-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "h (no-deps)",
-      "a (upstream-self)",
-    ],
-    "name": "h (upstream-self)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "h (no-deps)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "c (no-deps)",
-      "b (upstream-self)",
-    ],
-    "name": "c (upstream-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "b (no-deps)",
-      "a (upstream-self)",
-    ],
-    "name": "b (upstream-self)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "b (no-deps)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "a (no-deps)",
-      "h (no-deps)",
-    ],
-    "name": "f (upstream-1)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "a (upstream-1)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "b (no-deps)",
-    ],
-    "name": "c (upstream-1)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-1)",
-      "h (upstream-1)",
-    ],
-    "name": "f (upstream-2)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (no-deps)",
-    ],
-    "name": "h (upstream-1)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "a (upstream-2)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "b (upstream-1)",
-    ],
-    "name": "c (upstream-2)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (no-deps)",
-    ],
-    "name": "b (upstream-1)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-2)",
-      "h (upstream-2)",
-    ],
-    "name": "f (upstream-3)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-1)",
-    ],
-    "name": "h (upstream-2)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "a (upstream-3)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "b (upstream-2)",
-    ],
-    "name": "c (upstream-3)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-1)",
-    ],
-    "name": "b (upstream-2)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "f (upstream-1)",
-    ],
-    "name": "f (upstream-1-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-1)",
-    ],
-    "name": "a (upstream-1-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "c (upstream-1)",
-    ],
-    "name": "c (upstream-1-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "f (upstream-2)",
-    ],
-    "name": "f (upstream-2-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-2)",
-    ],
-    "name": "a (upstream-2-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "c (upstream-2)",
-    ],
-    "name": "c (upstream-2-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-1-self)",
-      "h (upstream-1-self)",
-    ],
-    "name": "f (upstream-1-self-upstream)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "h (upstream-1)",
-    ],
-    "name": "h (upstream-1-self)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "a (upstream-1-self-upstream)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "b (upstream-1-self)",
-    ],
-    "name": "c (upstream-1-self-upstream)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "b (upstream-1)",
-    ],
-    "name": "b (upstream-1-self)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "f (upstream-3)",
-      "a (upstream-1-self-upstream)",
-      "h (upstream-1-self-upstream)",
-      "a (upstream-2-self)",
-      "h (upstream-2-self)",
-    ],
-    "name": "f (complex)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-1-self)",
-    ],
-    "name": "h (upstream-1-self-upstream)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "h (upstream-2)",
-    ],
-    "name": "h (upstream-2-self)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-3)",
-    ],
-    "name": "a (complex)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "c (upstream-3)",
-      "b (upstream-1-self-upstream)",
-      "b (upstream-2-self)",
-    ],
-    "name": "c (complex)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-1-self)",
-    ],
-    "name": "b (upstream-1-self-upstream)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "b (upstream-2)",
-    ],
-    "name": "b (upstream-2-self)",
-    "silent": true,
-  },
+  "a (upstream-self) (enabled) -> [a (no-deps)]",
+  "b (upstream-self) (enabled) -> [a (upstream-self), b (no-deps)]",
+  "c (upstream-self) (enabled) -> [b (upstream-self), c (no-deps)]",
+  "d (upstream-self) (enabled) -> [b (upstream-self), d (no-deps)]",
+  "e (upstream-self) (enabled) -> [c (upstream-self), e (no-deps)]",
+  "f (upstream-self) (enabled) -> [a (upstream-self), f (no-deps), h (upstream-self)]",
+  "g (upstream-self) (enabled) -> [a (upstream-self), g (no-deps)]",
+  "h (upstream-self) (enabled) -> [a (upstream-self), h (no-deps)]",
+  "i (upstream-self) (enabled) -> [i (no-deps)]",
+  "j (upstream-self) (enabled) -> [j (no-deps)]",
+  "a (no-deps) (disabled) -> []",
+  "b (no-deps) (disabled) -> []",
+  "c (no-deps) (disabled) -> []",
+  "d (no-deps) (disabled) -> []",
+  "e (no-deps) (disabled) -> []",
+  "f (no-deps) (disabled) -> []",
+  "g (no-deps) (disabled) -> []",
+  "h (no-deps) (disabled) -> []",
+  "i (no-deps) (disabled) -> []",
+  "j (no-deps) (disabled) -> []",
 ]
 `;
 
-exports[`PhasedOperationPlugin handles some changed projects 1`] = `
+exports[`PhasedOperationPlugin handles filtered phases: two-phases 1`] = `
 Array [
-  Object {
-    "dependencies": Array [],
-    "name": "a (no-deps)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "b (no-deps)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "c (no-deps)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "d (no-deps)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "e (no-deps)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "f (no-deps)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "g (no-deps)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "h (no-deps)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "i (no-deps)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "j (no-deps)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "a (no-deps)",
-    ],
-    "name": "a (upstream-self)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "b (no-deps)",
-      "a (upstream-self)",
-    ],
-    "name": "b (upstream-self)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "c (no-deps)",
-      "b (upstream-self)",
-    ],
-    "name": "c (upstream-self)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "d (no-deps)",
-      "b (upstream-self)",
-    ],
-    "name": "d (upstream-self)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "e (no-deps)",
-      "c (upstream-self)",
-    ],
-    "name": "e (upstream-self)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "f (no-deps)",
-      "a (upstream-self)",
-      "h (upstream-self)",
-    ],
-    "name": "f (upstream-self)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "h (no-deps)",
-      "a (upstream-self)",
-    ],
-    "name": "h (upstream-self)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "g (no-deps)",
-      "a (upstream-self)",
-    ],
-    "name": "g (upstream-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "i (no-deps)",
-    ],
-    "name": "i (upstream-self)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "j (no-deps)",
-    ],
-    "name": "j (upstream-self)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "a (upstream-1)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "a (no-deps)",
-    ],
-    "name": "b (upstream-1)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "b (no-deps)",
-    ],
-    "name": "c (upstream-1)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "b (no-deps)",
-    ],
-    "name": "d (upstream-1)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "c (no-deps)",
-    ],
-    "name": "e (upstream-1)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "a (no-deps)",
-      "h (no-deps)",
-    ],
-    "name": "f (upstream-1)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "a (no-deps)",
-    ],
-    "name": "g (upstream-1)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (no-deps)",
-    ],
-    "name": "h (upstream-1)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "i (upstream-1)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "j (upstream-1)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "a (upstream-2)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-1)",
-    ],
-    "name": "b (upstream-2)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "b (upstream-1)",
-    ],
-    "name": "c (upstream-2)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "b (upstream-1)",
-    ],
-    "name": "d (upstream-2)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "c (upstream-1)",
-    ],
-    "name": "e (upstream-2)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-1)",
-      "h (upstream-1)",
-    ],
-    "name": "f (upstream-2)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-1)",
-    ],
-    "name": "g (upstream-2)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-1)",
-    ],
-    "name": "h (upstream-2)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "i (upstream-2)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "j (upstream-2)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "a (upstream-3)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-2)",
-    ],
-    "name": "b (upstream-3)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "b (upstream-2)",
-    ],
-    "name": "c (upstream-3)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "b (upstream-2)",
-    ],
-    "name": "d (upstream-3)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "c (upstream-2)",
-    ],
-    "name": "e (upstream-3)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-2)",
-      "h (upstream-2)",
-    ],
-    "name": "f (upstream-3)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-2)",
-    ],
-    "name": "g (upstream-3)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-2)",
-    ],
-    "name": "h (upstream-3)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "i (upstream-3)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "j (upstream-3)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-1)",
-    ],
-    "name": "a (upstream-1-self)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "b (upstream-1)",
-    ],
-    "name": "b (upstream-1-self)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "c (upstream-1)",
-    ],
-    "name": "c (upstream-1-self)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "d (upstream-1)",
-    ],
-    "name": "d (upstream-1-self)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "e (upstream-1)",
-    ],
-    "name": "e (upstream-1-self)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "f (upstream-1)",
-    ],
-    "name": "f (upstream-1-self)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "g (upstream-1)",
-    ],
-    "name": "g (upstream-1-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "h (upstream-1)",
-    ],
-    "name": "h (upstream-1-self)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "i (upstream-1)",
-    ],
-    "name": "i (upstream-1-self)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "j (upstream-1)",
-    ],
-    "name": "j (upstream-1-self)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-2)",
-    ],
-    "name": "a (upstream-2-self)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "b (upstream-2)",
-    ],
-    "name": "b (upstream-2-self)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "c (upstream-2)",
-    ],
-    "name": "c (upstream-2-self)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "d (upstream-2)",
-    ],
-    "name": "d (upstream-2-self)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "e (upstream-2)",
-    ],
-    "name": "e (upstream-2-self)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "f (upstream-2)",
-    ],
-    "name": "f (upstream-2-self)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "g (upstream-2)",
-    ],
-    "name": "g (upstream-2-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "h (upstream-2)",
-    ],
-    "name": "h (upstream-2-self)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "i (upstream-2)",
-    ],
-    "name": "i (upstream-2-self)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "j (upstream-2)",
-    ],
-    "name": "j (upstream-2-self)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "a (upstream-1-self-upstream)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-1-self)",
-    ],
-    "name": "b (upstream-1-self-upstream)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "b (upstream-1-self)",
-    ],
-    "name": "c (upstream-1-self-upstream)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "b (upstream-1-self)",
-    ],
-    "name": "d (upstream-1-self-upstream)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "c (upstream-1-self)",
-    ],
-    "name": "e (upstream-1-self-upstream)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-1-self)",
-      "h (upstream-1-self)",
-    ],
-    "name": "f (upstream-1-self-upstream)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-1-self)",
-    ],
-    "name": "g (upstream-1-self-upstream)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-1-self)",
-    ],
-    "name": "h (upstream-1-self-upstream)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "i (upstream-1-self-upstream)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "j (upstream-1-self-upstream)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-3)",
-    ],
-    "name": "a (complex)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "b (upstream-3)",
-      "a (upstream-1-self-upstream)",
-      "a (upstream-2-self)",
-    ],
-    "name": "b (complex)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "c (upstream-3)",
-      "b (upstream-1-self-upstream)",
-      "b (upstream-2-self)",
-    ],
-    "name": "c (complex)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "d (upstream-3)",
-      "b (upstream-1-self-upstream)",
-      "b (upstream-2-self)",
-    ],
-    "name": "d (complex)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "e (upstream-3)",
-      "c (upstream-1-self-upstream)",
-      "c (upstream-2-self)",
-    ],
-    "name": "e (complex)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "f (upstream-3)",
-      "a (upstream-1-self-upstream)",
-      "h (upstream-1-self-upstream)",
-      "a (upstream-2-self)",
-      "h (upstream-2-self)",
-    ],
-    "name": "f (complex)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "g (upstream-3)",
-      "a (upstream-1-self-upstream)",
-      "a (upstream-2-self)",
-    ],
-    "name": "g (complex)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "h (upstream-3)",
-      "a (upstream-1-self-upstream)",
-      "a (upstream-2-self)",
-    ],
-    "name": "h (complex)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "i (upstream-3)",
-    ],
-    "name": "i (complex)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "j (upstream-3)",
-    ],
-    "name": "j (complex)",
-    "silent": true,
-  },
+  "a (complex) (enabled) -> [a (upstream-3)]",
+  "a (no-deps) (enabled) -> []",
+  "a (upstream-1) (enabled) -> []",
+  "a (upstream-3) (enabled) -> []",
+  "b (complex) (enabled) -> [a (upstream-1-self-upstream), a (upstream-2-self), b (upstream-3)]",
+  "b (no-deps) (enabled) -> []",
+  "b (upstream-1) (enabled) -> [a (no-deps)]",
+  "b (upstream-3) (enabled) -> [a (upstream-2)]",
+  "c (complex) (enabled) -> [b (upstream-1-self-upstream), b (upstream-2-self), c (upstream-3)]",
+  "c (no-deps) (enabled) -> []",
+  "c (upstream-1) (enabled) -> [b (no-deps)]",
+  "c (upstream-3) (enabled) -> [b (upstream-2)]",
+  "d (complex) (enabled) -> [b (upstream-1-self-upstream), b (upstream-2-self), d (upstream-3)]",
+  "d (no-deps) (enabled) -> []",
+  "d (upstream-1) (enabled) -> [b (no-deps)]",
+  "d (upstream-3) (enabled) -> [b (upstream-2)]",
+  "e (complex) (enabled) -> [c (upstream-1-self-upstream), c (upstream-2-self), e (upstream-3)]",
+  "e (no-deps) (enabled) -> []",
+  "e (upstream-1) (enabled) -> [c (no-deps)]",
+  "e (upstream-3) (enabled) -> [c (upstream-2)]",
+  "f (complex) (enabled) -> [a (upstream-1-self-upstream), a (upstream-2-self), f (upstream-3), h (upstream-1-self-upstream), h (upstream-2-self)]",
+  "f (no-deps) (enabled) -> []",
+  "f (upstream-1) (enabled) -> [a (no-deps), h (no-deps)]",
+  "f (upstream-3) (enabled) -> [a (upstream-2), h (upstream-2)]",
+  "g (complex) (enabled) -> [a (upstream-1-self-upstream), a (upstream-2-self), g (upstream-3)]",
+  "g (no-deps) (enabled) -> []",
+  "g (upstream-1) (enabled) -> [a (no-deps)]",
+  "g (upstream-3) (enabled) -> [a (upstream-2)]",
+  "h (complex) (enabled) -> [a (upstream-1-self-upstream), a (upstream-2-self), h (upstream-3)]",
+  "h (no-deps) (enabled) -> []",
+  "h (upstream-1) (enabled) -> [a (no-deps)]",
+  "h (upstream-3) (enabled) -> [a (upstream-2)]",
+  "i (complex) (enabled) -> [i (upstream-3)]",
+  "i (no-deps) (enabled) -> []",
+  "i (upstream-1) (enabled) -> []",
+  "i (upstream-3) (enabled) -> []",
+  "j (complex) (enabled) -> [j (upstream-3)]",
+  "j (no-deps) (enabled) -> []",
+  "j (upstream-1) (enabled) -> []",
+  "j (upstream-3) (enabled) -> []",
+  "a (upstream-1-self) (disabled) -> [a (upstream-1)]",
+  "a (upstream-1-self-upstream) (disabled) -> []",
+  "a (upstream-2) (disabled) -> []",
+  "a (upstream-2-self) (disabled) -> [a (upstream-2)]",
+  "b (upstream-1-self) (disabled) -> [b (upstream-1)]",
+  "b (upstream-1-self-upstream) (disabled) -> [a (upstream-1-self)]",
+  "b (upstream-2) (disabled) -> [a (upstream-1)]",
+  "b (upstream-2-self) (disabled) -> [b (upstream-2)]",
+  "c (upstream-1-self-upstream) (disabled) -> [b (upstream-1-self)]",
+  "c (upstream-2) (disabled) -> [b (upstream-1)]",
+  "c (upstream-2-self) (disabled) -> [c (upstream-2)]",
+  "h (upstream-1-self-upstream) (disabled) -> [a (upstream-1-self)]",
+  "h (upstream-2) (disabled) -> [a (upstream-1)]",
+  "h (upstream-2-self) (disabled) -> [h (upstream-2)]",
 ]
 `;
 
-exports[`PhasedOperationPlugin handles some changed projects 2`] = `
+exports[`PhasedOperationPlugin handles filtered projects: filtered 1`] = `
 Array [
-  Object {
-    "dependencies": Array [],
-    "name": "a (no-deps)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "b (no-deps)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "c (no-deps)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "d (no-deps)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "e (no-deps)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "f (no-deps)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "g (no-deps)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "h (no-deps)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "i (no-deps)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "j (no-deps)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "a (no-deps)",
-    ],
-    "name": "a (upstream-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "b (no-deps)",
-      "a (upstream-self)",
-    ],
-    "name": "b (upstream-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "c (no-deps)",
-      "b (upstream-self)",
-    ],
-    "name": "c (upstream-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "d (no-deps)",
-      "b (upstream-self)",
-    ],
-    "name": "d (upstream-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "e (no-deps)",
-      "c (upstream-self)",
-    ],
-    "name": "e (upstream-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "f (no-deps)",
-      "a (upstream-self)",
-      "h (upstream-self)",
-    ],
-    "name": "f (upstream-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "h (no-deps)",
-      "a (upstream-self)",
-    ],
-    "name": "h (upstream-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "g (no-deps)",
-      "a (upstream-self)",
-    ],
-    "name": "g (upstream-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "i (no-deps)",
-    ],
-    "name": "i (upstream-self)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "j (no-deps)",
-    ],
-    "name": "j (upstream-self)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "a (upstream-1)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (no-deps)",
-    ],
-    "name": "b (upstream-1)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "b (no-deps)",
-    ],
-    "name": "c (upstream-1)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "b (no-deps)",
-    ],
-    "name": "d (upstream-1)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "c (no-deps)",
-    ],
-    "name": "e (upstream-1)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (no-deps)",
-      "h (no-deps)",
-    ],
-    "name": "f (upstream-1)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (no-deps)",
-    ],
-    "name": "g (upstream-1)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (no-deps)",
-    ],
-    "name": "h (upstream-1)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "i (upstream-1)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "j (upstream-1)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "a (upstream-2)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-1)",
-    ],
-    "name": "b (upstream-2)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "b (upstream-1)",
-    ],
-    "name": "c (upstream-2)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "b (upstream-1)",
-    ],
-    "name": "d (upstream-2)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "c (upstream-1)",
-    ],
-    "name": "e (upstream-2)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-1)",
-      "h (upstream-1)",
-    ],
-    "name": "f (upstream-2)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-1)",
-    ],
-    "name": "g (upstream-2)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-1)",
-    ],
-    "name": "h (upstream-2)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "i (upstream-2)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "j (upstream-2)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "a (upstream-3)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-2)",
-    ],
-    "name": "b (upstream-3)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "b (upstream-2)",
-    ],
-    "name": "c (upstream-3)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "b (upstream-2)",
-    ],
-    "name": "d (upstream-3)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "c (upstream-2)",
-    ],
-    "name": "e (upstream-3)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-2)",
-      "h (upstream-2)",
-    ],
-    "name": "f (upstream-3)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-2)",
-    ],
-    "name": "g (upstream-3)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-2)",
-    ],
-    "name": "h (upstream-3)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "i (upstream-3)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "j (upstream-3)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-1)",
-    ],
-    "name": "a (upstream-1-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "b (upstream-1)",
-    ],
-    "name": "b (upstream-1-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "c (upstream-1)",
-    ],
-    "name": "c (upstream-1-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "d (upstream-1)",
-    ],
-    "name": "d (upstream-1-self)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "e (upstream-1)",
-    ],
-    "name": "e (upstream-1-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "f (upstream-1)",
-    ],
-    "name": "f (upstream-1-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "g (upstream-1)",
-    ],
-    "name": "g (upstream-1-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "h (upstream-1)",
-    ],
-    "name": "h (upstream-1-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "i (upstream-1)",
-    ],
-    "name": "i (upstream-1-self)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "j (upstream-1)",
-    ],
-    "name": "j (upstream-1-self)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-2)",
-    ],
-    "name": "a (upstream-2-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "b (upstream-2)",
-    ],
-    "name": "b (upstream-2-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "c (upstream-2)",
-    ],
-    "name": "c (upstream-2-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "d (upstream-2)",
-    ],
-    "name": "d (upstream-2-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "e (upstream-2)",
-    ],
-    "name": "e (upstream-2-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "f (upstream-2)",
-    ],
-    "name": "f (upstream-2-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "g (upstream-2)",
-    ],
-    "name": "g (upstream-2-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "h (upstream-2)",
-    ],
-    "name": "h (upstream-2-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "i (upstream-2)",
-    ],
-    "name": "i (upstream-2-self)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "j (upstream-2)",
-    ],
-    "name": "j (upstream-2-self)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "a (upstream-1-self-upstream)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-1-self)",
-    ],
-    "name": "b (upstream-1-self-upstream)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "b (upstream-1-self)",
-    ],
-    "name": "c (upstream-1-self-upstream)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "b (upstream-1-self)",
-    ],
-    "name": "d (upstream-1-self-upstream)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "c (upstream-1-self)",
-    ],
-    "name": "e (upstream-1-self-upstream)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-1-self)",
-      "h (upstream-1-self)",
-    ],
-    "name": "f (upstream-1-self-upstream)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-1-self)",
-    ],
-    "name": "g (upstream-1-self-upstream)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-1-self)",
-    ],
-    "name": "h (upstream-1-self-upstream)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "i (upstream-1-self-upstream)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "j (upstream-1-self-upstream)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-3)",
-    ],
-    "name": "a (complex)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "b (upstream-3)",
-      "a (upstream-1-self-upstream)",
-      "a (upstream-2-self)",
-    ],
-    "name": "b (complex)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "c (upstream-3)",
-      "b (upstream-1-self-upstream)",
-      "b (upstream-2-self)",
-    ],
-    "name": "c (complex)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "d (upstream-3)",
-      "b (upstream-1-self-upstream)",
-      "b (upstream-2-self)",
-    ],
-    "name": "d (complex)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "e (upstream-3)",
-      "c (upstream-1-self-upstream)",
-      "c (upstream-2-self)",
-    ],
-    "name": "e (complex)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "f (upstream-3)",
-      "a (upstream-1-self-upstream)",
-      "h (upstream-1-self-upstream)",
-      "a (upstream-2-self)",
-      "h (upstream-2-self)",
-    ],
-    "name": "f (complex)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "g (upstream-3)",
-      "a (upstream-1-self-upstream)",
-      "a (upstream-2-self)",
-    ],
-    "name": "g (complex)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "h (upstream-3)",
-      "a (upstream-1-self-upstream)",
-      "a (upstream-2-self)",
-    ],
-    "name": "h (complex)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "i (upstream-3)",
-    ],
-    "name": "i (complex)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "j (upstream-3)",
-    ],
-    "name": "j (complex)",
-    "silent": true,
-  },
+  "a (complex) (enabled) -> [a (upstream-3)]",
+  "a (no-deps) (enabled) -> []",
+  "a (upstream-1) (enabled) -> []",
+  "a (upstream-1-self) (enabled) -> [a (upstream-1)]",
+  "a (upstream-1-self-upstream) (enabled) -> []",
+  "a (upstream-2) (enabled) -> []",
+  "a (upstream-2-self) (enabled) -> [a (upstream-2)]",
+  "a (upstream-3) (enabled) -> []",
+  "a (upstream-self) (enabled) -> [a (no-deps)]",
+  "c (complex) (enabled) -> [b (upstream-1-self-upstream), b (upstream-2-self), c (upstream-3)]",
+  "c (no-deps) (enabled) -> []",
+  "c (upstream-1) (enabled) -> [b (no-deps)]",
+  "c (upstream-1-self) (enabled) -> [c (upstream-1)]",
+  "c (upstream-1-self-upstream) (enabled) -> [b (upstream-1-self)]",
+  "c (upstream-2) (enabled) -> [b (upstream-1)]",
+  "c (upstream-2-self) (enabled) -> [c (upstream-2)]",
+  "c (upstream-3) (enabled) -> [b (upstream-2)]",
+  "c (upstream-self) (enabled) -> [b (upstream-self), c (no-deps)]",
+  "f (complex) (enabled) -> [a (upstream-1-self-upstream), a (upstream-2-self), f (upstream-3), h (upstream-1-self-upstream), h (upstream-2-self)]",
+  "f (no-deps) (enabled) -> []",
+  "f (upstream-1) (enabled) -> [a (no-deps), h (no-deps)]",
+  "f (upstream-1-self) (enabled) -> [f (upstream-1)]",
+  "f (upstream-1-self-upstream) (enabled) -> [a (upstream-1-self), h (upstream-1-self)]",
+  "f (upstream-2) (enabled) -> [a (upstream-1), h (upstream-1)]",
+  "f (upstream-2-self) (enabled) -> [f (upstream-2)]",
+  "f (upstream-3) (enabled) -> [a (upstream-2), h (upstream-2)]",
+  "f (upstream-self) (enabled) -> [a (upstream-self), f (no-deps), h (upstream-self)]",
+  "b (no-deps) (disabled) -> []",
+  "b (upstream-1) (disabled) -> [a (no-deps)]",
+  "b (upstream-1-self) (disabled) -> [b (upstream-1)]",
+  "b (upstream-1-self-upstream) (disabled) -> [a (upstream-1-self)]",
+  "b (upstream-2) (disabled) -> [a (upstream-1)]",
+  "b (upstream-2-self) (disabled) -> [b (upstream-2)]",
+  "b (upstream-self) (disabled) -> [a (upstream-self), b (no-deps)]",
+  "h (no-deps) (disabled) -> []",
+  "h (upstream-1) (disabled) -> [a (no-deps)]",
+  "h (upstream-1-self) (disabled) -> [h (upstream-1)]",
+  "h (upstream-1-self-upstream) (disabled) -> [a (upstream-1-self)]",
+  "h (upstream-2) (disabled) -> [a (upstream-1)]",
+  "h (upstream-2-self) (disabled) -> [h (upstream-2)]",
+  "h (upstream-self) (disabled) -> [a (upstream-self), h (no-deps)]",
 ]
 `;
 
-exports[`PhasedOperationPlugin handles some changed projects within filtered projects 1`] = `
+exports[`PhasedOperationPlugin handles filtered projects: single 1`] = `
 Array [
-  Object {
-    "dependencies": Array [],
-    "name": "f (no-deps)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "a (no-deps)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "c (no-deps)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "f (no-deps)",
-      "a (upstream-self)",
-      "h (upstream-self)",
-    ],
-    "name": "f (upstream-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (no-deps)",
-    ],
-    "name": "a (upstream-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "h (no-deps)",
-      "a (upstream-self)",
-    ],
-    "name": "h (upstream-self)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "h (no-deps)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "c (no-deps)",
-      "b (upstream-self)",
-    ],
-    "name": "c (upstream-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "b (no-deps)",
-      "a (upstream-self)",
-    ],
-    "name": "b (upstream-self)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "b (no-deps)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "a (no-deps)",
-      "h (no-deps)",
-    ],
-    "name": "f (upstream-1)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "a (upstream-1)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "b (no-deps)",
-    ],
-    "name": "c (upstream-1)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-1)",
-      "h (upstream-1)",
-    ],
-    "name": "f (upstream-2)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (no-deps)",
-    ],
-    "name": "h (upstream-1)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "a (upstream-2)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "b (upstream-1)",
-    ],
-    "name": "c (upstream-2)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (no-deps)",
-    ],
-    "name": "b (upstream-1)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-2)",
-      "h (upstream-2)",
-    ],
-    "name": "f (upstream-3)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-1)",
-    ],
-    "name": "h (upstream-2)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "a (upstream-3)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "b (upstream-2)",
-    ],
-    "name": "c (upstream-3)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-1)",
-    ],
-    "name": "b (upstream-2)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "f (upstream-1)",
-    ],
-    "name": "f (upstream-1-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-1)",
-    ],
-    "name": "a (upstream-1-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "c (upstream-1)",
-    ],
-    "name": "c (upstream-1-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "f (upstream-2)",
-    ],
-    "name": "f (upstream-2-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-2)",
-    ],
-    "name": "a (upstream-2-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "c (upstream-2)",
-    ],
-    "name": "c (upstream-2-self)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-1-self)",
-      "h (upstream-1-self)",
-    ],
-    "name": "f (upstream-1-self-upstream)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "h (upstream-1)",
-    ],
-    "name": "h (upstream-1-self)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [],
-    "name": "a (upstream-1-self-upstream)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "b (upstream-1-self)",
-    ],
-    "name": "c (upstream-1-self-upstream)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "b (upstream-1)",
-    ],
-    "name": "b (upstream-1-self)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "f (upstream-3)",
-      "a (upstream-1-self-upstream)",
-      "h (upstream-1-self-upstream)",
-      "a (upstream-2-self)",
-      "h (upstream-2-self)",
-    ],
-    "name": "f (complex)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-1-self)",
-    ],
-    "name": "h (upstream-1-self-upstream)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "h (upstream-2)",
-    ],
-    "name": "h (upstream-2-self)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-3)",
-    ],
-    "name": "a (complex)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "c (upstream-3)",
-      "b (upstream-1-self-upstream)",
-      "b (upstream-2-self)",
-    ],
-    "name": "c (complex)",
-    "silent": false,
-  },
-  Object {
-    "dependencies": Array [
-      "a (upstream-1-self)",
-    ],
-    "name": "b (upstream-1-self-upstream)",
-    "silent": true,
-  },
-  Object {
-    "dependencies": Array [
-      "b (upstream-2)",
-    ],
-    "name": "b (upstream-2-self)",
-    "silent": true,
-  },
+  "g (complex) (enabled) -> [a (upstream-1-self-upstream), a (upstream-2-self), g (upstream-3)]",
+  "g (no-deps) (enabled) -> []",
+  "g (upstream-1) (enabled) -> [a (no-deps)]",
+  "g (upstream-1-self) (enabled) -> [g (upstream-1)]",
+  "g (upstream-1-self-upstream) (enabled) -> [a (upstream-1-self)]",
+  "g (upstream-2) (enabled) -> [a (upstream-1)]",
+  "g (upstream-2-self) (enabled) -> [g (upstream-2)]",
+  "g (upstream-3) (enabled) -> [a (upstream-2)]",
+  "g (upstream-self) (enabled) -> [a (upstream-self), g (no-deps)]",
+  "a (no-deps) (disabled) -> []",
+  "a (upstream-1) (disabled) -> []",
+  "a (upstream-1-self) (disabled) -> [a (upstream-1)]",
+  "a (upstream-1-self-upstream) (disabled) -> []",
+  "a (upstream-2) (disabled) -> []",
+  "a (upstream-2-self) (disabled) -> [a (upstream-2)]",
+  "a (upstream-self) (disabled) -> [a (no-deps)]",
+]
+`;
+
+exports[`PhasedOperationPlugin handles some changed projects within filtered projects: multiple 1`] = `
+Array [
+  "a (complex) (enabled) -> [a (upstream-3)]",
+  "a (no-deps) (enabled) -> []",
+  "a (upstream-1) (enabled) -> []",
+  "a (upstream-1-self) (enabled) -> [a (upstream-1)]",
+  "a (upstream-1-self-upstream) (enabled) -> []",
+  "a (upstream-2) (enabled) -> []",
+  "a (upstream-2-self) (enabled) -> [a (upstream-2)]",
+  "a (upstream-3) (enabled) -> []",
+  "a (upstream-self) (enabled) -> [a (no-deps)]",
+  "c (complex) (enabled) -> [b (upstream-1-self-upstream), b (upstream-2-self), c (upstream-3)]",
+  "c (no-deps) (enabled) -> []",
+  "c (upstream-1) (enabled) -> [b (no-deps)]",
+  "c (upstream-1-self) (enabled) -> [c (upstream-1)]",
+  "c (upstream-1-self-upstream) (enabled) -> [b (upstream-1-self)]",
+  "c (upstream-2) (enabled) -> [b (upstream-1)]",
+  "c (upstream-2-self) (enabled) -> [c (upstream-2)]",
+  "c (upstream-3) (enabled) -> [b (upstream-2)]",
+  "c (upstream-self) (enabled) -> [b (upstream-self), c (no-deps)]",
+  "f (complex) (enabled) -> [a (upstream-1-self-upstream), a (upstream-2-self), f (upstream-3), h (upstream-1-self-upstream), h (upstream-2-self)]",
+  "f (upstream-1) (enabled) -> [a (no-deps), h (no-deps)]",
+  "f (upstream-1-self) (enabled) -> [f (upstream-1)]",
+  "f (upstream-1-self-upstream) (enabled) -> [a (upstream-1-self), h (upstream-1-self)]",
+  "f (upstream-2) (enabled) -> [a (upstream-1), h (upstream-1)]",
+  "f (upstream-2-self) (enabled) -> [f (upstream-2)]",
+  "f (upstream-3) (enabled) -> [a (upstream-2), h (upstream-2)]",
+  "f (upstream-self) (enabled) -> [a (upstream-self), f (no-deps), h (upstream-self)]",
+  "b (no-deps) (disabled) -> []",
+  "b (upstream-1) (disabled) -> [a (no-deps)]",
+  "b (upstream-1-self) (disabled) -> [b (upstream-1)]",
+  "b (upstream-1-self-upstream) (disabled) -> [a (upstream-1-self)]",
+  "b (upstream-2) (disabled) -> [a (upstream-1)]",
+  "b (upstream-2-self) (disabled) -> [b (upstream-2)]",
+  "b (upstream-self) (disabled) -> [a (upstream-self), b (no-deps)]",
+  "f (no-deps) (disabled) -> []",
+  "h (no-deps) (disabled) -> []",
+  "h (upstream-1) (disabled) -> [a (no-deps)]",
+  "h (upstream-1-self) (disabled) -> [h (upstream-1)]",
+  "h (upstream-1-self-upstream) (disabled) -> [a (upstream-1-self)]",
+  "h (upstream-2) (disabled) -> [a (upstream-1)]",
+  "h (upstream-2-self) (disabled) -> [h (upstream-2)]",
+  "h (upstream-self) (disabled) -> [a (upstream-self), h (no-deps)]",
+]
+`;
+
+exports[`PhasedOperationPlugin handles some changed projects: multiple 1`] = `
+Array [
+  "a (complex) (enabled) -> [a (upstream-3)]",
+  "a (no-deps) (enabled) -> []",
+  "a (upstream-1) (enabled) -> []",
+  "a (upstream-1-self) (enabled) -> [a (upstream-1)]",
+  "a (upstream-1-self-upstream) (enabled) -> []",
+  "a (upstream-2) (enabled) -> []",
+  "a (upstream-2-self) (enabled) -> [a (upstream-2)]",
+  "a (upstream-3) (enabled) -> []",
+  "a (upstream-self) (enabled) -> [a (no-deps)]",
+  "b (complex) (enabled) -> [a (upstream-1-self-upstream), a (upstream-2-self), b (upstream-3)]",
+  "b (upstream-1) (enabled) -> [a (no-deps)]",
+  "b (upstream-1-self) (enabled) -> [b (upstream-1)]",
+  "b (upstream-1-self-upstream) (enabled) -> [a (upstream-1-self)]",
+  "b (upstream-2) (enabled) -> [a (upstream-1)]",
+  "b (upstream-2-self) (enabled) -> [b (upstream-2)]",
+  "b (upstream-3) (enabled) -> [a (upstream-2)]",
+  "b (upstream-self) (enabled) -> [a (upstream-self), b (no-deps)]",
+  "c (complex) (enabled) -> [b (upstream-1-self-upstream), b (upstream-2-self), c (upstream-3)]",
+  "c (no-deps) (enabled) -> []",
+  "c (upstream-1) (enabled) -> [b (no-deps)]",
+  "c (upstream-1-self) (enabled) -> [c (upstream-1)]",
+  "c (upstream-1-self-upstream) (enabled) -> [b (upstream-1-self)]",
+  "c (upstream-2) (enabled) -> [b (upstream-1)]",
+  "c (upstream-2-self) (enabled) -> [c (upstream-2)]",
+  "c (upstream-3) (enabled) -> [b (upstream-2)]",
+  "c (upstream-self) (enabled) -> [b (upstream-self), c (no-deps)]",
+  "d (complex) (enabled) -> [b (upstream-1-self-upstream), b (upstream-2-self), d (upstream-3)]",
+  "d (upstream-1-self-upstream) (enabled) -> [b (upstream-1-self)]",
+  "d (upstream-2) (enabled) -> [b (upstream-1)]",
+  "d (upstream-2-self) (enabled) -> [d (upstream-2)]",
+  "d (upstream-3) (enabled) -> [b (upstream-2)]",
+  "d (upstream-self) (enabled) -> [b (upstream-self), d (no-deps)]",
+  "e (complex) (enabled) -> [c (upstream-1-self-upstream), c (upstream-2-self), e (upstream-3)]",
+  "e (upstream-1) (enabled) -> [c (no-deps)]",
+  "e (upstream-1-self) (enabled) -> [e (upstream-1)]",
+  "e (upstream-1-self-upstream) (enabled) -> [c (upstream-1-self)]",
+  "e (upstream-2) (enabled) -> [c (upstream-1)]",
+  "e (upstream-2-self) (enabled) -> [e (upstream-2)]",
+  "e (upstream-3) (enabled) -> [c (upstream-2)]",
+  "e (upstream-self) (enabled) -> [c (upstream-self), e (no-deps)]",
+  "f (complex) (enabled) -> [a (upstream-1-self-upstream), a (upstream-2-self), f (upstream-3), h (upstream-1-self-upstream), h (upstream-2-self)]",
+  "f (no-deps) (enabled) -> []",
+  "f (upstream-1) (enabled) -> [a (no-deps), h (no-deps)]",
+  "f (upstream-1-self) (enabled) -> [f (upstream-1)]",
+  "f (upstream-1-self-upstream) (enabled) -> [a (upstream-1-self), h (upstream-1-self)]",
+  "f (upstream-2) (enabled) -> [a (upstream-1), h (upstream-1)]",
+  "f (upstream-2-self) (enabled) -> [f (upstream-2)]",
+  "f (upstream-3) (enabled) -> [a (upstream-2), h (upstream-2)]",
+  "f (upstream-self) (enabled) -> [a (upstream-self), f (no-deps), h (upstream-self)]",
+  "g (complex) (enabled) -> [a (upstream-1-self-upstream), a (upstream-2-self), g (upstream-3)]",
+  "g (upstream-1) (enabled) -> [a (no-deps)]",
+  "g (upstream-1-self) (enabled) -> [g (upstream-1)]",
+  "g (upstream-1-self-upstream) (enabled) -> [a (upstream-1-self)]",
+  "g (upstream-2) (enabled) -> [a (upstream-1)]",
+  "g (upstream-2-self) (enabled) -> [g (upstream-2)]",
+  "g (upstream-3) (enabled) -> [a (upstream-2)]",
+  "g (upstream-self) (enabled) -> [a (upstream-self), g (no-deps)]",
+  "h (complex) (enabled) -> [a (upstream-1-self-upstream), a (upstream-2-self), h (upstream-3)]",
+  "h (upstream-1) (enabled) -> [a (no-deps)]",
+  "h (upstream-1-self) (enabled) -> [h (upstream-1)]",
+  "h (upstream-1-self-upstream) (enabled) -> [a (upstream-1-self)]",
+  "h (upstream-2) (enabled) -> [a (upstream-1)]",
+  "h (upstream-2-self) (enabled) -> [h (upstream-2)]",
+  "h (upstream-3) (enabled) -> [a (upstream-2)]",
+  "h (upstream-self) (enabled) -> [a (upstream-self), h (no-deps)]",
+  "b (no-deps) (disabled) -> []",
+  "d (no-deps) (disabled) -> []",
+  "d (upstream-1) (disabled) -> [b (no-deps)]",
+  "d (upstream-1-self) (disabled) -> [d (upstream-1)]",
+  "e (no-deps) (disabled) -> []",
+  "g (no-deps) (disabled) -> []",
+  "h (no-deps) (disabled) -> []",
+  "i (complex) (disabled) -> [i (upstream-3)]",
+  "i (no-deps) (disabled) -> []",
+  "i (upstream-1) (disabled) -> []",
+  "i (upstream-1-self) (disabled) -> [i (upstream-1)]",
+  "i (upstream-1-self-upstream) (disabled) -> []",
+  "i (upstream-2) (disabled) -> []",
+  "i (upstream-2-self) (disabled) -> [i (upstream-2)]",
+  "i (upstream-3) (disabled) -> []",
+  "i (upstream-self) (disabled) -> [i (no-deps)]",
+  "j (complex) (disabled) -> [j (upstream-3)]",
+  "j (no-deps) (disabled) -> []",
+  "j (upstream-1) (disabled) -> []",
+  "j (upstream-1-self) (disabled) -> [j (upstream-1)]",
+  "j (upstream-1-self-upstream) (disabled) -> []",
+  "j (upstream-2) (disabled) -> []",
+  "j (upstream-2-self) (disabled) -> [j (upstream-2)]",
+  "j (upstream-3) (disabled) -> []",
+  "j (upstream-self) (disabled) -> [j (no-deps)]",
+]
+`;
+
+exports[`PhasedOperationPlugin handles some changed projects: single 1`] = `
+Array [
+  "g (complex) (enabled) -> [a (upstream-1-self-upstream), a (upstream-2-self), g (upstream-3)]",
+  "g (no-deps) (enabled) -> []",
+  "g (upstream-1) (enabled) -> [a (no-deps)]",
+  "g (upstream-1-self) (enabled) -> [g (upstream-1)]",
+  "g (upstream-1-self-upstream) (enabled) -> [a (upstream-1-self)]",
+  "g (upstream-2) (enabled) -> [a (upstream-1)]",
+  "g (upstream-2-self) (enabled) -> [g (upstream-2)]",
+  "g (upstream-3) (enabled) -> [a (upstream-2)]",
+  "g (upstream-self) (enabled) -> [a (upstream-self), g (no-deps)]",
+  "a (complex) (disabled) -> [a (upstream-3)]",
+  "a (no-deps) (disabled) -> []",
+  "a (upstream-1) (disabled) -> []",
+  "a (upstream-1-self) (disabled) -> [a (upstream-1)]",
+  "a (upstream-1-self-upstream) (disabled) -> []",
+  "a (upstream-2) (disabled) -> []",
+  "a (upstream-2-self) (disabled) -> [a (upstream-2)]",
+  "a (upstream-3) (disabled) -> []",
+  "a (upstream-self) (disabled) -> [a (no-deps)]",
+  "b (complex) (disabled) -> [a (upstream-1-self-upstream), a (upstream-2-self), b (upstream-3)]",
+  "b (no-deps) (disabled) -> []",
+  "b (upstream-1) (disabled) -> [a (no-deps)]",
+  "b (upstream-1-self) (disabled) -> [b (upstream-1)]",
+  "b (upstream-1-self-upstream) (disabled) -> [a (upstream-1-self)]",
+  "b (upstream-2) (disabled) -> [a (upstream-1)]",
+  "b (upstream-2-self) (disabled) -> [b (upstream-2)]",
+  "b (upstream-3) (disabled) -> [a (upstream-2)]",
+  "b (upstream-self) (disabled) -> [a (upstream-self), b (no-deps)]",
+  "c (complex) (disabled) -> [b (upstream-1-self-upstream), b (upstream-2-self), c (upstream-3)]",
+  "c (no-deps) (disabled) -> []",
+  "c (upstream-1) (disabled) -> [b (no-deps)]",
+  "c (upstream-1-self) (disabled) -> [c (upstream-1)]",
+  "c (upstream-1-self-upstream) (disabled) -> [b (upstream-1-self)]",
+  "c (upstream-2) (disabled) -> [b (upstream-1)]",
+  "c (upstream-2-self) (disabled) -> [c (upstream-2)]",
+  "c (upstream-3) (disabled) -> [b (upstream-2)]",
+  "c (upstream-self) (disabled) -> [b (upstream-self), c (no-deps)]",
+  "d (complex) (disabled) -> [b (upstream-1-self-upstream), b (upstream-2-self), d (upstream-3)]",
+  "d (no-deps) (disabled) -> []",
+  "d (upstream-1) (disabled) -> [b (no-deps)]",
+  "d (upstream-1-self) (disabled) -> [d (upstream-1)]",
+  "d (upstream-1-self-upstream) (disabled) -> [b (upstream-1-self)]",
+  "d (upstream-2) (disabled) -> [b (upstream-1)]",
+  "d (upstream-2-self) (disabled) -> [d (upstream-2)]",
+  "d (upstream-3) (disabled) -> [b (upstream-2)]",
+  "d (upstream-self) (disabled) -> [b (upstream-self), d (no-deps)]",
+  "e (complex) (disabled) -> [c (upstream-1-self-upstream), c (upstream-2-self), e (upstream-3)]",
+  "e (no-deps) (disabled) -> []",
+  "e (upstream-1) (disabled) -> [c (no-deps)]",
+  "e (upstream-1-self) (disabled) -> [e (upstream-1)]",
+  "e (upstream-1-self-upstream) (disabled) -> [c (upstream-1-self)]",
+  "e (upstream-2) (disabled) -> [c (upstream-1)]",
+  "e (upstream-2-self) (disabled) -> [e (upstream-2)]",
+  "e (upstream-3) (disabled) -> [c (upstream-2)]",
+  "e (upstream-self) (disabled) -> [c (upstream-self), e (no-deps)]",
+  "f (complex) (disabled) -> [a (upstream-1-self-upstream), a (upstream-2-self), f (upstream-3), h (upstream-1-self-upstream), h (upstream-2-self)]",
+  "f (no-deps) (disabled) -> []",
+  "f (upstream-1) (disabled) -> [a (no-deps), h (no-deps)]",
+  "f (upstream-1-self) (disabled) -> [f (upstream-1)]",
+  "f (upstream-1-self-upstream) (disabled) -> [a (upstream-1-self), h (upstream-1-self)]",
+  "f (upstream-2) (disabled) -> [a (upstream-1), h (upstream-1)]",
+  "f (upstream-2-self) (disabled) -> [f (upstream-2)]",
+  "f (upstream-3) (disabled) -> [a (upstream-2), h (upstream-2)]",
+  "f (upstream-self) (disabled) -> [a (upstream-self), f (no-deps), h (upstream-self)]",
+  "h (complex) (disabled) -> [a (upstream-1-self-upstream), a (upstream-2-self), h (upstream-3)]",
+  "h (no-deps) (disabled) -> []",
+  "h (upstream-1) (disabled) -> [a (no-deps)]",
+  "h (upstream-1-self) (disabled) -> [h (upstream-1)]",
+  "h (upstream-1-self-upstream) (disabled) -> [a (upstream-1-self)]",
+  "h (upstream-2) (disabled) -> [a (upstream-1)]",
+  "h (upstream-2-self) (disabled) -> [h (upstream-2)]",
+  "h (upstream-3) (disabled) -> [a (upstream-2)]",
+  "h (upstream-self) (disabled) -> [a (upstream-self), h (no-deps)]",
+  "i (complex) (disabled) -> [i (upstream-3)]",
+  "i (no-deps) (disabled) -> []",
+  "i (upstream-1) (disabled) -> []",
+  "i (upstream-1-self) (disabled) -> [i (upstream-1)]",
+  "i (upstream-1-self-upstream) (disabled) -> []",
+  "i (upstream-2) (disabled) -> []",
+  "i (upstream-2-self) (disabled) -> [i (upstream-2)]",
+  "i (upstream-3) (disabled) -> []",
+  "i (upstream-self) (disabled) -> [i (no-deps)]",
+  "j (complex) (disabled) -> [j (upstream-3)]",
+  "j (no-deps) (disabled) -> []",
+  "j (upstream-1) (disabled) -> []",
+  "j (upstream-1-self) (disabled) -> [j (upstream-1)]",
+  "j (upstream-1-self-upstream) (disabled) -> []",
+  "j (upstream-2) (disabled) -> []",
+  "j (upstream-2-self) (disabled) -> [j (upstream-2)]",
+  "j (upstream-3) (disabled) -> []",
+  "j (upstream-self) (disabled) -> [j (no-deps)]",
 ]
 `;


### PR DESCRIPTION
## Summary
Fixes a regression in which commands would sometimes not execute all operations on which they depended if not all phases were explicitly specified in the command definition.

## Details
The runtime distinguishes the exact set of phases defined in command-line.json from the expanded set that includes all dependencies of those phases. For commands where these two sets differed, if `--include-phase-deps` was not specified, phases that were not explicitly listed were being omitted.

## How it was tested
Updated the unit tests for PhasedOperationPlugin

## Impacted documentation
Making this work as expected.