### PR TITLE
[api-extractor] Correctly omit declarations associated with an entity whose release tag does not meet the configured threshold in API reports

### DIFF
--- a/build-tests/api-extractor-lib2-test/dist/api-extractor-lib2-test.d.ts
+++ b/build-tests/api-extractor-lib2-test/dist/api-extractor-lib2-test.d.ts
@@ -7,7 +7,7 @@
  * @packageDocumentation
  */
 
-/** @public */
+/** @beta */
 declare class DefaultClass {
 }
 export default DefaultClass;

--- a/build-tests/api-extractor-lib2-test/etc/api-extractor-lib2-test.alpha.api.md
+++ b/build-tests/api-extractor-lib2-test/etc/api-extractor-lib2-test.alpha.api.md
@@ -4,7 +4,7 @@
 
 ```ts
 
-// @public (undocumented)
+// @beta (undocumented)
 class DefaultClass {
 }
 export default DefaultClass;

--- a/build-tests/api-extractor-lib2-test/etc/api-extractor-lib2-test.api.md
+++ b/build-tests/api-extractor-lib2-test/etc/api-extractor-lib2-test.api.md
@@ -4,7 +4,7 @@
 
 ```ts
 
-// @public (undocumented)
+// @beta (undocumented)
 class DefaultClass {
 }
 export default DefaultClass;

--- a/build-tests/api-extractor-lib2-test/etc/api-extractor-lib2-test.public.api.md
+++ b/build-tests/api-extractor-lib2-test/etc/api-extractor-lib2-test.public.api.md
@@ -4,8 +4,6 @@
 
 ```ts
 
-export default DefaultClass;
-
 // @public (undocumented)
 export class Lib2Class {
     // (undocumented)

--- a/build-tests/api-extractor-lib2-test/etc/api-extractor-lib2-test.public.api.md
+++ b/build-tests/api-extractor-lib2-test/etc/api-extractor-lib2-test.public.api.md
@@ -4,9 +4,6 @@
 
 ```ts
 
-// @public (undocumented)
-class DefaultClass {
-}
 export default DefaultClass;
 
 // @public (undocumented)

--- a/build-tests/api-extractor-lib2-test/src/index.ts
+++ b/build-tests/api-extractor-lib2-test/src/index.ts
@@ -18,5 +18,5 @@ export class Lib2Class {
 /** @alpha */
 export interface Lib2Interface {}
 
-/** @public */
+/** @beta */
 export default class DefaultClass {}

--- a/common/changes/@microsoft/api-extractor/trim-export-default-from-reports_2025-04-29-00-30.json
+++ b/common/changes/@microsoft/api-extractor/trim-export-default-from-reports_2025-04-29-00-30.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/api-extractor",
-      "comment": "Correctly omit declarations associated with an entity whose release tag does not meet the configured threshold in API reports",
+      "comment": "Fix an issue where default exports were sometimes trimmed incorrectly in .api.md files when using `reportVariants` (GitHub #4775)",
       "type": "patch"
     }
   ],

--- a/common/changes/@microsoft/api-extractor/trim-export-default-from-reports_2025-04-29-00-30.json
+++ b/common/changes/@microsoft/api-extractor/trim-export-default-from-reports_2025-04-29-00-30.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Correctly omit declarations associated with an entity whose release tag does not meet the configured threshold in API reports",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor"
+}


### PR DESCRIPTION
Fix for #4775

For an example of the changed behavior, see the diff between the first two commits in this PR. The first adds a repro test scenario, and the second shows the change in behavior.
- Note that the public API report _before_ includes `export default DefaultClass;` when it should not (`DefaultClass` is tagged as `@beta`).