### PR TITLE
[node-core-library] Fix FileSystem.isErrnoException

### DIFF
--- a/common/changes/@rushstack/node-core-library/fix-node-errno_2025-04-30-17-39.json
+++ b/common/changes/@rushstack/node-core-library/fix-node-errno_2025-04-30-17-39.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/node-core-library",
+      "comment": "Fix a bug in `FileSystem.isErrnoException` that failed to identify errors if the underlying method was invoked using only a file descriptor, e.g. for `fs.readSync`.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/node-core-library"
+}

--- a/libraries/node-core-library/src/FileSystem.ts
+++ b/libraries/node-core-library/src/FileSystem.ts
@@ -1508,10 +1508,11 @@ export class FileSystem {
    */
   public static isErrnoException(error: Error): error is NodeJS.ErrnoException {
     const typedError: NodeJS.ErrnoException = error;
+    // Don't check for `path` because the syscall may not have a path.
+    // For example, when invoked with a file descriptor.
     return (
       typeof typedError.code === 'string' &&
       typeof typedError.errno === 'number' &&
-      typeof typedError.path === 'string' &&
       typeof typedError.syscall === 'string'
     );
   }

--- a/libraries/node-core-library/src/test/FileSystem.test.ts
+++ b/libraries/node-core-library/src/test/FileSystem.test.ts
@@ -1,25 +1,55 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+import fs from 'node:fs';
+
 import { FileSystem } from '../FileSystem';
 import { PosixModeBits } from '../PosixModeBits';
 
-// The PosixModeBits are intended to be used with bitwise operations.
-/* eslint-disable no-bitwise */
+describe(FileSystem.name, () => {
+  test(FileSystem.formatPosixModeBits.name, () => {
+    // The PosixModeBits are intended to be used with bitwise operations.
+    /* eslint-disable no-bitwise */
+    let modeBits: number = PosixModeBits.AllRead | PosixModeBits.AllWrite;
 
-test('PosixModeBits tests', () => {
-  let modeBits: number = PosixModeBits.AllRead | PosixModeBits.AllWrite;
+    expect(FileSystem.formatPosixModeBits(modeBits)).toEqual('-rw-rw-rw-');
 
-  expect(FileSystem.formatPosixModeBits(modeBits)).toEqual('-rw-rw-rw-');
+    modeBits |= PosixModeBits.GroupExecute;
+    expect(FileSystem.formatPosixModeBits(modeBits)).toEqual('-rw-rwxrw-');
 
-  modeBits |= PosixModeBits.GroupExecute;
-  expect(FileSystem.formatPosixModeBits(modeBits)).toEqual('-rw-rwxrw-');
+    // Add the group execute bit
+    modeBits |= PosixModeBits.OthersExecute;
+    expect(FileSystem.formatPosixModeBits(modeBits)).toEqual('-rw-rwxrwx');
 
-  // Add the group execute bit
-  modeBits |= PosixModeBits.OthersExecute;
-  expect(FileSystem.formatPosixModeBits(modeBits)).toEqual('-rw-rwxrwx');
+    // Add the group execute bit
+    modeBits &= ~PosixModeBits.AllWrite;
+    expect(FileSystem.formatPosixModeBits(modeBits)).toEqual('-r--r-xr-x');
+    /* eslint-enable no-bitwise */
+  });
 
-  // Add the group execute bit
-  modeBits &= ~PosixModeBits.AllWrite;
-  expect(FileSystem.formatPosixModeBits(modeBits)).toEqual('-r--r-xr-x');
+  describe(FileSystem.isErrnoException.name, () => {
+    test('Should return false for a non-ErrnoException', () => {
+      const error: Error = new Error('Test error');
+      expect(FileSystem.isErrnoException(error)).toBe(false);
+    });
+
+    test('Should return true for an error on a path call', () => {
+      expect.assertions(1);
+      try {
+        fs.openSync(`${__dirname}/nonexistent.txt`, 'r');
+      } catch (error) {
+        expect(FileSystem.isErrnoException(error)).toBe(true);
+      }
+    });
+
+    test('Should return true for an error on a file descriptor call', () => {
+      const buffer: Buffer = Buffer.allocUnsafeSlow(1024);
+      expect.assertions(1);
+      try {
+        fs.readSync(11, buffer, 0, buffer.length, -1);
+      } catch (error) {
+        expect(FileSystem.isErrnoException(error)).toBe(true);
+      }
+    });
+  });
 });


### PR DESCRIPTION
## Summary
Fixes a gap in `FileSystem.isErrnoException` for instances where the file system call was not provided with a file path, e.g. `fs.readSync`, which only takes a file descriptor.

## Details
The method was expecting the `path` property to always be present and be a string, but not all methods are provided with a path.

## How it was tested
Added unit tests.

## Impacted documentation
None.