### PR TITLE
[rush] Expose `hasUncommittedChanges` flag on input snapshot

### DIFF
--- a/common/changes/@microsoft/rush/snapshot-local_2025-05-07-18-39.json
+++ b/common/changes/@microsoft/rush/snapshot-local_2025-05-07-18-39.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add `hasUncommittedChanges` to `IInputSnapshot` for use by plugins.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@rushstack/package-deps-hash/snapshot-local_2025-05-07-18-39.json
+++ b/common/changes/@rushstack/package-deps-hash/snapshot-local_2025-05-07-18-39.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/package-deps-hash",
+      "comment": "Add `getDetailedRepoState` API to expose `hasSubmodules` and `hasUncommittedChanges` in addition to the results returned by `getRepoState`.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/package-deps-hash"
+}

--- a/common/reviews/api/package-deps-hash.api.md
+++ b/common/reviews/api/package-deps-hash.api.md
@@ -7,6 +7,9 @@
 // @public
 export function ensureGitMinimumVersion(gitPath?: string): void;
 
+// @beta
+export function getDetailedRepoStateAsync(rootDirectory: string, additionalRelativePathsToHash?: string[], gitPath?: string, filterPath?: string[]): Promise<IDetailedRepoState>;
+
 // @public
 export function getGitHashForFiles(filesToHash: string[], packagePath: string, gitPath?: string): Map<string, string>;
 
@@ -24,6 +27,13 @@ export function getRepoStateAsync(rootDirectory: string, additionalRelativePaths
 
 // @beta
 export function hashFilesAsync(rootDirectory: string, filesToHash: Iterable<string> | AsyncIterable<string>, gitPath?: string): Promise<Iterable<[string, string]>>;
+
+// @beta
+export interface IDetailedRepoState {
+    files: Map<string, string>;
+    hasSubmodules: boolean;
+    hasUncommittedChanges: boolean;
+}
 
 // @beta
 export interface IFileDiffStatus {

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -535,6 +535,7 @@ export interface IInputsSnapshot {
     getOperationOwnStateHash(project: IRushConfigurationProjectForSnapshot, operationName?: string): string;
     getTrackedFileHashesForOperation(project: IRushConfigurationProjectForSnapshot, operationName?: string): ReadonlyMap<string, string>;
     readonly hashes: ReadonlyMap<string, string>;
+    readonly hasUncommittedChanges: boolean;
     readonly rootDirectory: string;
 }
 

--- a/libraries/package-deps-hash/src/index.ts
+++ b/libraries/package-deps-hash/src/index.ts
@@ -16,6 +16,8 @@
 export { getPackageDeps, getGitHashForFiles } from './getPackageDeps';
 export {
   type IFileDiffStatus,
+  type IDetailedRepoState,
+  getDetailedRepoStateAsync,
   getRepoChanges,
   getRepoRoot,
   getRepoStateAsync,

--- a/libraries/package-deps-hash/src/test/__snapshots__/getRepoDeps.test.ts.snap
+++ b/libraries/package-deps-hash/src/test/__snapshots__/getRepoDeps.test.ts.snap
@@ -1,85 +1,113 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`getRepoStateAsync can handle adding one file 1`] = `
+exports[`getDetailedRepoStateAsync can handle adding one file 1`] = `
 Object {
-  "nestedTestProject/package.json": "18a1e415e56220fa5122428a4ef8eb8874756576",
-  "nestedTestProject/src/file 1.txt": "c7b2f707ac99ca522f965210a7b6b0b109863f34",
-  "testProject/a.txt": "2e65efe2a145dda7ee51d1741299f848e5bf752e",
-  "testProject/file  2.txt": "a385f754ec4fede884a4864d090064d9aeef8ccb",
-  "testProject/file1.txt": "c7b2f707ac99ca522f965210a7b6b0b109863f34",
-  "testProject/file蝴蝶.txt": "ae814af81e16cb2ae8c57503c77e2cab6b5462ba",
-  "testProject/package.json": "18a1e415e56220fa5122428a4ef8eb8874756576",
+  "files": Object {
+    "nestedTestProject/package.json": "18a1e415e56220fa5122428a4ef8eb8874756576",
+    "nestedTestProject/src/file 1.txt": "c7b2f707ac99ca522f965210a7b6b0b109863f34",
+    "testProject/a.txt": "2e65efe2a145dda7ee51d1741299f848e5bf752e",
+    "testProject/file  2.txt": "a385f754ec4fede884a4864d090064d9aeef8ccb",
+    "testProject/file1.txt": "c7b2f707ac99ca522f965210a7b6b0b109863f34",
+    "testProject/file蝴蝶.txt": "ae814af81e16cb2ae8c57503c77e2cab6b5462ba",
+    "testProject/package.json": "18a1e415e56220fa5122428a4ef8eb8874756576",
+  },
+  "hasSubmodules": false,
+  "hasUncommittedChanges": true,
 }
 `;
 
-exports[`getRepoStateAsync can handle adding two files 1`] = `
+exports[`getDetailedRepoStateAsync can handle adding two files 1`] = `
 Object {
-  "nestedTestProject/package.json": "18a1e415e56220fa5122428a4ef8eb8874756576",
-  "nestedTestProject/src/file 1.txt": "c7b2f707ac99ca522f965210a7b6b0b109863f34",
-  "testProject/a.txt": "2e65efe2a145dda7ee51d1741299f848e5bf752e",
-  "testProject/b.txt": "2e65efe2a145dda7ee51d1741299f848e5bf752e",
-  "testProject/file  2.txt": "a385f754ec4fede884a4864d090064d9aeef8ccb",
-  "testProject/file1.txt": "c7b2f707ac99ca522f965210a7b6b0b109863f34",
-  "testProject/file蝴蝶.txt": "ae814af81e16cb2ae8c57503c77e2cab6b5462ba",
-  "testProject/package.json": "18a1e415e56220fa5122428a4ef8eb8874756576",
+  "files": Object {
+    "nestedTestProject/package.json": "18a1e415e56220fa5122428a4ef8eb8874756576",
+    "nestedTestProject/src/file 1.txt": "c7b2f707ac99ca522f965210a7b6b0b109863f34",
+    "testProject/a.txt": "2e65efe2a145dda7ee51d1741299f848e5bf752e",
+    "testProject/b.txt": "2e65efe2a145dda7ee51d1741299f848e5bf752e",
+    "testProject/file  2.txt": "a385f754ec4fede884a4864d090064d9aeef8ccb",
+    "testProject/file1.txt": "c7b2f707ac99ca522f965210a7b6b0b109863f34",
+    "testProject/file蝴蝶.txt": "ae814af81e16cb2ae8c57503c77e2cab6b5462ba",
+    "testProject/package.json": "18a1e415e56220fa5122428a4ef8eb8874756576",
+  },
+  "hasSubmodules": false,
+  "hasUncommittedChanges": true,
 }
 `;
 
-exports[`getRepoStateAsync can handle changing one file 1`] = `
+exports[`getDetailedRepoStateAsync can handle changing one file 1`] = `
 Object {
-  "nestedTestProject/package.json": "18a1e415e56220fa5122428a4ef8eb8874756576",
-  "nestedTestProject/src/file 1.txt": "c7b2f707ac99ca522f965210a7b6b0b109863f34",
-  "testProject/file  2.txt": "a385f754ec4fede884a4864d090064d9aeef8ccb",
-  "testProject/file1.txt": "f2ba8f84ab5c1bce84a7b441cb1959cfc7093b7f",
-  "testProject/file蝴蝶.txt": "ae814af81e16cb2ae8c57503c77e2cab6b5462ba",
-  "testProject/package.json": "18a1e415e56220fa5122428a4ef8eb8874756576",
+  "files": Object {
+    "nestedTestProject/package.json": "18a1e415e56220fa5122428a4ef8eb8874756576",
+    "nestedTestProject/src/file 1.txt": "c7b2f707ac99ca522f965210a7b6b0b109863f34",
+    "testProject/file  2.txt": "a385f754ec4fede884a4864d090064d9aeef8ccb",
+    "testProject/file1.txt": "f2ba8f84ab5c1bce84a7b441cb1959cfc7093b7f",
+    "testProject/file蝴蝶.txt": "ae814af81e16cb2ae8c57503c77e2cab6b5462ba",
+    "testProject/package.json": "18a1e415e56220fa5122428a4ef8eb8874756576",
+  },
+  "hasSubmodules": false,
+  "hasUncommittedChanges": true,
 }
 `;
 
-exports[`getRepoStateAsync can handle removing one file 1`] = `
+exports[`getDetailedRepoStateAsync can handle removing one file 1`] = `
 Object {
-  "nestedTestProject/package.json": "18a1e415e56220fa5122428a4ef8eb8874756576",
-  "nestedTestProject/src/file 1.txt": "c7b2f707ac99ca522f965210a7b6b0b109863f34",
-  "testProject/file  2.txt": "a385f754ec4fede884a4864d090064d9aeef8ccb",
-  "testProject/file蝴蝶.txt": "ae814af81e16cb2ae8c57503c77e2cab6b5462ba",
-  "testProject/package.json": "18a1e415e56220fa5122428a4ef8eb8874756576",
+  "files": Object {
+    "nestedTestProject/package.json": "18a1e415e56220fa5122428a4ef8eb8874756576",
+    "nestedTestProject/src/file 1.txt": "c7b2f707ac99ca522f965210a7b6b0b109863f34",
+    "testProject/file  2.txt": "a385f754ec4fede884a4864d090064d9aeef8ccb",
+    "testProject/file蝴蝶.txt": "ae814af81e16cb2ae8c57503c77e2cab6b5462ba",
+    "testProject/package.json": "18a1e415e56220fa5122428a4ef8eb8874756576",
+  },
+  "hasSubmodules": false,
+  "hasUncommittedChanges": true,
 }
 `;
 
-exports[`getRepoStateAsync can handle uncommitted filenames with spaces and non-ASCII characters 1`] = `
+exports[`getDetailedRepoStateAsync can handle uncommitted filenames with spaces and non-ASCII characters 1`] = `
 Object {
-  "nestedTestProject/package.json": "18a1e415e56220fa5122428a4ef8eb8874756576",
-  "nestedTestProject/src/file 1.txt": "c7b2f707ac99ca522f965210a7b6b0b109863f34",
-  "testProject/a  file name.txt": "2e65efe2a145dda7ee51d1741299f848e5bf752e",
-  "testProject/a file.txt": "2e65efe2a145dda7ee51d1741299f848e5bf752e",
-  "testProject/file  2.txt": "a385f754ec4fede884a4864d090064d9aeef8ccb",
-  "testProject/file1.txt": "c7b2f707ac99ca522f965210a7b6b0b109863f34",
-  "testProject/file蝴蝶.txt": "ae814af81e16cb2ae8c57503c77e2cab6b5462ba",
-  "testProject/newFile批把.txt": "2e65efe2a145dda7ee51d1741299f848e5bf752e",
-  "testProject/package.json": "18a1e415e56220fa5122428a4ef8eb8874756576",
+  "files": Object {
+    "nestedTestProject/package.json": "18a1e415e56220fa5122428a4ef8eb8874756576",
+    "nestedTestProject/src/file 1.txt": "c7b2f707ac99ca522f965210a7b6b0b109863f34",
+    "testProject/a  file name.txt": "2e65efe2a145dda7ee51d1741299f848e5bf752e",
+    "testProject/a file.txt": "2e65efe2a145dda7ee51d1741299f848e5bf752e",
+    "testProject/file  2.txt": "a385f754ec4fede884a4864d090064d9aeef8ccb",
+    "testProject/file1.txt": "c7b2f707ac99ca522f965210a7b6b0b109863f34",
+    "testProject/file蝴蝶.txt": "ae814af81e16cb2ae8c57503c77e2cab6b5462ba",
+    "testProject/newFile批把.txt": "2e65efe2a145dda7ee51d1741299f848e5bf752e",
+    "testProject/package.json": "18a1e415e56220fa5122428a4ef8eb8874756576",
+  },
+  "hasSubmodules": false,
+  "hasUncommittedChanges": true,
 }
 `;
 
-exports[`getRepoStateAsync can parse committed files 1`] = `
+exports[`getDetailedRepoStateAsync can parse committed files 1`] = `
 Object {
-  "nestedTestProject/package.json": "18a1e415e56220fa5122428a4ef8eb8874756576",
-  "nestedTestProject/src/file 1.txt": "c7b2f707ac99ca522f965210a7b6b0b109863f34",
-  "testProject/file  2.txt": "a385f754ec4fede884a4864d090064d9aeef8ccb",
-  "testProject/file1.txt": "c7b2f707ac99ca522f965210a7b6b0b109863f34",
-  "testProject/file蝴蝶.txt": "ae814af81e16cb2ae8c57503c77e2cab6b5462ba",
-  "testProject/package.json": "18a1e415e56220fa5122428a4ef8eb8874756576",
+  "files": Object {
+    "nestedTestProject/package.json": "18a1e415e56220fa5122428a4ef8eb8874756576",
+    "nestedTestProject/src/file 1.txt": "c7b2f707ac99ca522f965210a7b6b0b109863f34",
+    "testProject/file  2.txt": "a385f754ec4fede884a4864d090064d9aeef8ccb",
+    "testProject/file1.txt": "c7b2f707ac99ca522f965210a7b6b0b109863f34",
+    "testProject/file蝴蝶.txt": "ae814af81e16cb2ae8c57503c77e2cab6b5462ba",
+    "testProject/package.json": "18a1e415e56220fa5122428a4ef8eb8874756576",
+  },
+  "hasSubmodules": false,
+  "hasUncommittedChanges": false,
 }
 `;
 
-exports[`getRepoStateAsync handles requests for additional files 1`] = `
+exports[`getDetailedRepoStateAsync handles requests for additional files 1`] = `
 Object {
-  "nestedTestProject/package.json": "18a1e415e56220fa5122428a4ef8eb8874756576",
-  "nestedTestProject/src/file 1.txt": "c7b2f707ac99ca522f965210a7b6b0b109863f34",
-  "testProject/file  2.txt": "a385f754ec4fede884a4864d090064d9aeef8ccb",
-  "testProject/file1.txt": "c7b2f707ac99ca522f965210a7b6b0b109863f34",
-  "testProject/file蝴蝶.txt": "ae814af81e16cb2ae8c57503c77e2cab6b5462ba",
-  "testProject/log.log": "2e65efe2a145dda7ee51d1741299f848e5bf752e",
-  "testProject/package.json": "18a1e415e56220fa5122428a4ef8eb8874756576",
+  "files": Object {
+    "nestedTestProject/package.json": "18a1e415e56220fa5122428a4ef8eb8874756576",
+    "nestedTestProject/src/file 1.txt": "c7b2f707ac99ca522f965210a7b6b0b109863f34",
+    "testProject/file  2.txt": "a385f754ec4fede884a4864d090064d9aeef8ccb",
+    "testProject/file1.txt": "c7b2f707ac99ca522f965210a7b6b0b109863f34",
+    "testProject/file蝴蝶.txt": "ae814af81e16cb2ae8c57503c77e2cab6b5462ba",
+    "testProject/log.log": "2e65efe2a145dda7ee51d1741299f848e5bf752e",
+    "testProject/package.json": "18a1e415e56220fa5122428a4ef8eb8874756576",
+  },
+  "hasSubmodules": false,
+  "hasUncommittedChanges": false,
 }
 `;
 

--- a/libraries/rush-lib/src/cli/test/RushCommandLineParser.test.ts
+++ b/libraries/rush-lib/src/cli/test/RushCommandLineParser.test.ts
@@ -6,8 +6,12 @@ jest.mock(`@rushstack/package-deps-hash`, () => {
     getRepoRoot(dir: string): string {
       return dir;
     },
-    getRepoStateAsync(): ReadonlyMap<string, string> {
-      return new Map([['common/config/rush/npm-shrinkwrap.json', 'hash']]);
+    getDetailedRepoStateAsync(): IDetailedRepoState {
+      return {
+        hasSubmodules: false,
+        hasUncommittedChanges: false,
+        files: new Map([['common/config/rush/npm-shrinkwrap.json', 'hash']])
+      };
     },
     getRepoChangesAsync(): ReadonlyMap<string, string> {
       return new Map();
@@ -24,6 +28,7 @@ jest.mock(`@rushstack/package-deps-hash`, () => {
 import './mockRushCommandLineParser';
 
 import { FileSystem, JsonFile, Path } from '@rushstack/node-core-library';
+import type { IDetailedRepoState } from '@rushstack/package-deps-hash';
 import { Autoinstaller } from '../../logic/Autoinstaller';
 import type { ITelemetryData } from '../../logic/Telemetry';
 import { getCommandLineParserInstanceAsync } from './TestUtils';

--- a/libraries/rush-lib/src/cli/test/RushCommandLineParserFailureCases.test.ts
+++ b/libraries/rush-lib/src/cli/test/RushCommandLineParserFailureCases.test.ts
@@ -9,8 +9,12 @@ jest.mock(`@rushstack/package-deps-hash`, () => {
     getRepoRoot(dir: string): string {
       return dir;
     },
-    getRepoStateAsync(): ReadonlyMap<string, string> {
-      return new Map();
+    getDetailedRepoStateAsync(): IDetailedRepoState {
+      return {
+        hasSubmodules: false,
+        hasUncommittedChanges: false,
+        files: new Map()
+      };
     },
     getRepoChangesAsync(): ReadonlyMap<string, string> {
       return new Map();
@@ -19,6 +23,7 @@ jest.mock(`@rushstack/package-deps-hash`, () => {
 });
 
 import { FileSystem, JsonFile } from '@rushstack/node-core-library';
+import type { IDetailedRepoState } from '@rushstack/package-deps-hash';
 import { Autoinstaller } from '../../logic/Autoinstaller';
 import type { ITelemetryData } from '../../logic/Telemetry';
 import { getCommandLineParserInstanceAsync, setSpawnMock } from './TestUtils';

--- a/libraries/rush-lib/src/logic/ProjectChangeAnalyzer.ts
+++ b/libraries/rush-lib/src/logic/ProjectChangeAnalyzer.ts
@@ -9,7 +9,7 @@ import { Path, FileSystem, Async, AlreadyReportedError } from '@rushstack/node-c
 import {
   getRepoChanges,
   getRepoRoot,
-  getRepoStateAsync,
+  getDetailedRepoStateAsync,
   hashFilesAsync,
   type IFileDiffStatus
 } from '@rushstack/package-deps-hash';
@@ -304,8 +304,8 @@ export class ProjectChangeAnalyzer {
 
       return async function tryGetSnapshotAsync(): Promise<IInputsSnapshot | undefined> {
         try {
-          const [hashes, additionalFiles] = await Promise.all([
-            getRepoStateAsync(rootDirectory, additionalRelativePathsToHash, gitPath, filterPath),
+          const [{ files: hashes, hasUncommittedChanges }, additionalFiles] = await Promise.all([
+            getDetailedRepoStateAsync(rootDirectory, additionalRelativePathsToHash, gitPath, filterPath),
             getAdditionalFilesFromRushProjectConfigurationAsync(
               additionalGlobs,
               lookupByPath,
@@ -328,8 +328,9 @@ export class ProjectChangeAnalyzer {
             additionalHashes,
             globalAdditionalFiles,
             hashes,
+            hasUncommittedChanges,
             lookupByPath,
-            projectMap: projectMap,
+            projectMap,
             rootDir: rootDirectory
           });
         } catch (e) {

--- a/libraries/rush-lib/src/logic/incremental/InputsSnapshot.ts
+++ b/libraries/rush-lib/src/logic/incremental/InputsSnapshot.ts
@@ -99,6 +99,10 @@ export interface IInputsSnapshotParameters {
    */
   hashes: ReadonlyMap<string, string>;
   /**
+   * Whether or not the repository has uncommitted changes.
+   */
+  hasUncommittedChanges: boolean;
+  /**
    * Optimized lookup engine used to route `hashes` to individual projects.
    */
   lookupByPath: IReadonlyLookupByPath<IRushConfigurationProjectForSnapshot>;
@@ -130,6 +134,11 @@ export interface IInputsSnapshot {
    * The directory that all paths in `hashes` are relative to.
    */
   readonly rootDirectory: string;
+
+  /**
+   * Whether or not the repository has uncommitted changes.
+   */
+  readonly hasUncommittedChanges: boolean;
 
   /**
    * Gets the map of file paths to Git hashes that will be used to compute the local state hash of the operation.
@@ -169,6 +178,10 @@ export class InputsSnapshot implements IInputsSnapshot {
    */
   public readonly hashes: ReadonlyMap<string, string>;
   /**
+   * {@inheritdoc IInputsSnapshot.hasUncommittedChanges}
+   */
+  public readonly hasUncommittedChanges: boolean;
+  /**
    * {@inheritdoc IInputsSnapshot.rootDirectory}
    */
   public readonly rootDirectory: string;
@@ -204,6 +217,7 @@ export class InputsSnapshot implements IInputsSnapshot {
       environment = { ...process.env },
       globalAdditionalFiles,
       hashes,
+      hasUncommittedChanges,
       lookupByPath,
       rootDir
     } = params;
@@ -261,6 +275,7 @@ export class InputsSnapshot implements IInputsSnapshot {
     // Snapshot the environment so that queries are not impacted by when they happen
     this._environment = environment;
     this.hashes = hashes;
+    this.hasUncommittedChanges = hasUncommittedChanges;
     this.rootDirectory = rootDir;
   }
 

--- a/libraries/rush-lib/src/logic/incremental/test/InputsSnapshot.test.ts
+++ b/libraries/rush-lib/src/logic/incremental/test/InputsSnapshot.test.ts
@@ -31,6 +31,7 @@ describe(InputsSnapshot.name, () => {
           ['a/lib/file3.js', 'hash3'],
           ['common/config/some-config.json', 'hash5']
         ]),
+        hasUncommittedChanges: false,
         lookupByPath: new LookupByPath([[project.projectRelativeFolder, project]]),
         projectMap: new Map()
       }

--- a/libraries/rush-lib/src/logic/test/ProjectChangeAnalyzer.test.ts
+++ b/libraries/rush-lib/src/logic/test/ProjectChangeAnalyzer.test.ts
@@ -26,8 +26,12 @@ jest.mock(`@rushstack/package-deps-hash`, () => {
     getRepoRoot(dir: string): string {
       return dir;
     },
-    getRepoStateAsync(): ReadonlyMap<string, string> {
-      return mockHashes;
+    getDetailedRepoStateAsync(): IDetailedRepoState {
+      return {
+        hasSubmodules: false,
+        hasUncommittedChanges: false,
+        files: mockHashes
+      };
     },
     getRepoChangesAsync(): ReadonlyMap<string, string> {
       return new Map();
@@ -51,6 +55,7 @@ jest.mock('../incremental/InputsSnapshot', () => {
 
 import { resolve } from 'node:path';
 
+import type { IDetailedRepoState } from '@rushstack/package-deps-hash';
 import { StringBufferTerminalProvider, Terminal } from '@rushstack/terminal';
 
 import { ProjectChangeAnalyzer } from '../ProjectChangeAnalyzer';


### PR DESCRIPTION
## Summary
Adds a flag `hasUncommittedChanges` to the metadata for the input snapshot that plugins can use to identify if the current repository state has uncommitted changes. This is useful if trying to tie state to a git commit.

## Details
Adds `getDetailedRepoStateAsync` API to `@rushstack/package-deps-hash` to expose `hasUncommittedChanges` and `hasSubmodules` in addition to the existing `files` map. The information to compute these fields was already available in the calculation of `getRepoStateAsync`.

Updates `getRepoStateAsync` to just be a wrapper around `getDetailedRepoStateAsync` that extracts and returns the `files` property.

## How it was tested
Updated the existing unit tests for `getRepoStateAsync` to instead operate on the expanded data of `getDetailedRepoStateAsync`.

## Impacted documentation
The API doc for `@rushstack/package-deps-hash`, API for `IInputsSnapshot` in rush-lib.