### PR TITLE
[lookup-by-path] Add `getFirstDifferenceInCommonNodes`, `tree`

### DIFF
--- a/common/changes/@rushstack/lookup-by-path/git-first-difference_2025-05-07-22-00.json
+++ b/common/changes/@rushstack/lookup-by-path/git-first-difference_2025-05-07-22-00.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/lookup-by-path",
+      "comment": "Add `getFirstDifferenceInCommonNodes` API.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/lookup-by-path"
+}

--- a/common/changes/@rushstack/lookup-by-path/git-first-difference_2025-05-07-22-01.json
+++ b/common/changes/@rushstack/lookup-by-path/git-first-difference_2025-05-07-22-01.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/lookup-by-path",
+      "comment": "Expose `tree` accessor on `IReadonlyLookupByPath` for a readonly view of the raw tree.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/lookup-by-path"
+}

--- a/common/reviews/api/lookup-by-path.api.md
+++ b/common/reviews/api/lookup-by-path.api.md
@@ -5,6 +5,18 @@
 ```ts
 
 // @beta
+export function getFirstDifferenceInCommonNodes<TItem extends {}>(options: IGetFirstDifferenceInCommonNodesOptions<TItem>): string | undefined;
+
+// @beta
+export interface IGetFirstDifferenceInCommonNodesOptions<TItem extends {}> {
+    delimiter?: string;
+    equals?: (a: TItem, b: TItem) => boolean;
+    first: IReadonlyPathTrieNode<TItem>;
+    prefix?: string;
+    second: IReadonlyPathTrieNode<TItem>;
+}
+
+// @beta
 export interface IPrefixMatch<TItem extends {}> {
     index: number;
     lastMatch?: IPrefixMatch<TItem>;
@@ -22,10 +34,14 @@ export interface IReadonlyLookupByPath<TItem extends {}> extends Iterable<[strin
     groupByChild<TInfo>(infoByPath: Map<string, TInfo>, delimiter?: string): Map<TItem, Map<string, TInfo>>;
     has(query: string, delimiter?: string): boolean;
     get size(): number;
-    // Warning: (ae-forgotten-export) The symbol "IReadonlyPathTrieNode" needs to be exported by the entry point index.d.ts
-    //
     // (undocumented)
     get tree(): IReadonlyPathTrieNode<TItem>;
+}
+
+// @beta
+export interface IReadonlyPathTrieNode<TItem extends {}> {
+    readonly children: ReadonlyMap<string, IReadonlyPathTrieNode<TItem>> | undefined;
+    readonly value: TItem | undefined;
 }
 
 // @beta

--- a/common/reviews/api/lookup-by-path.api.md
+++ b/common/reviews/api/lookup-by-path.api.md
@@ -22,6 +22,10 @@ export interface IReadonlyLookupByPath<TItem extends {}> extends Iterable<[strin
     groupByChild<TInfo>(infoByPath: Map<string, TInfo>, delimiter?: string): Map<TItem, Map<string, TInfo>>;
     has(query: string, delimiter?: string): boolean;
     get size(): number;
+    // Warning: (ae-forgotten-export) The symbol "IReadonlyPathTrieNode" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    get tree(): IReadonlyPathTrieNode<TItem>;
 }
 
 // @beta
@@ -42,6 +46,8 @@ export class LookupByPath<TItem extends {}> implements IReadonlyLookupByPath<TIt
     setItem(serializedPath: string, value: TItem, delimiter?: string): this;
     setItemFromSegments(pathSegments: Iterable<string>, value: TItem): this;
     get size(): number;
+    // (undocumented)
+    get tree(): IReadonlyPathTrieNode<TItem>;
 }
 
 ```

--- a/libraries/lookup-by-path/src/LookupByPath.ts
+++ b/libraries/lookup-by-path/src/LookupByPath.ts
@@ -16,6 +16,26 @@ interface IPathTrieNode<TItem extends {}> {
   children: Map<string, IPathTrieNode<TItem>> | undefined;
 }
 
+/**
+ * Readonly view of a node in the path trie used in LookupByPath
+ *
+ * @remarks
+ * This interface is used to facilitate parallel traversals for comparing two `LookupByPath` instances.
+ *
+ * @beta
+ */
+export interface IReadonlyPathTrieNode<TItem extends {}> {
+  /**
+   * The value that exactly matches the current relative path
+   */
+  readonly value: TItem | undefined;
+
+  /**
+   * Child nodes by subfolder
+   */
+  readonly children: ReadonlyMap<string, IReadonlyPathTrieNode<TItem>> | undefined;
+}
+
 interface IPrefixEntry {
   /**
    * The prefix that was matched
@@ -122,6 +142,11 @@ export interface IReadonlyLookupByPath<TItem extends {}> extends Iterable<[strin
    * @returns The number of entries in this trie.
    */
   get size(): number;
+
+  /**
+   * @returns The root node of the trie, corresponding to the path ''
+   */
+  get tree(): IReadonlyPathTrieNode<TItem>;
 
   /**
    * Iterates over the entries in this trie.
@@ -263,10 +288,17 @@ export class LookupByPath<TItem extends {}> implements IReadonlyLookupByPath<TIt
   }
 
   /**
-   * {@inheritdoc IReadonlyLookupByPath}
+   * {@inheritdoc IReadonlyLookupByPath.size}
    */
   public get size(): number {
     return this._size;
+  }
+
+  /**
+   * {@inheritdoc IReadonlyLookupByPath.tree}
+   */
+  public get tree(): IReadonlyPathTrieNode<TItem> {
+    return this._root;
   }
 
   /**

--- a/libraries/lookup-by-path/src/getFirstDifferenceInCommonNodes.ts
+++ b/libraries/lookup-by-path/src/getFirstDifferenceInCommonNodes.ts
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import type { IReadonlyPathTrieNode } from './LookupByPath';
+
+/**
+ * Recursively compares two path tries to find the first shared node with a different value.
+ *
+ * @param first - The first node to compare
+ * @param second - The second node to compare
+ * @param prefix - The path prefix to the current node
+ * @param delimiter - The delimiter used to join path segments
+ * @param equals - A function to compare the values of the nodes
+ * @returns The path to the first differing node, or undefined if they are identical
+ *
+ * @remarks
+ * Ignores any nodes that are not shared between the two tries.
+ */
+export function getFirstDifferenceInCommonNodes<TItem extends {}>(
+  first: IReadonlyPathTrieNode<TItem>,
+  second: IReadonlyPathTrieNode<TItem>,
+  prefix: string = '',
+  delimiter: string = '/',
+  equals: (a: TItem, b: TItem) => boolean = (a, b) => a === b
+): string | undefined {
+  const firstItem: TItem | undefined = first.value;
+  const secondItem: TItem | undefined = second.value;
+
+  if (firstItem !== undefined && secondItem !== undefined && !equals(firstItem, secondItem)) {
+    // If the value at this node changed, we only care if we were tracking it to begin with.
+    return prefix;
+  }
+
+  const { children: firstChildren } = first;
+  const { children: secondChildren } = second;
+
+  if (firstChildren && secondChildren) {
+    for (const [key, lastInputChild] of firstChildren) {
+      const secondChild: IReadonlyPathTrieNode<TItem> | undefined = secondChildren.get(key);
+      if (!secondChild) {
+        continue;
+      }
+      const result: string | undefined = getFirstDifferenceInCommonNodes(
+        lastInputChild,
+        secondChild,
+        key,
+        delimiter,
+        equals
+      );
+      if (result !== undefined) {
+        return prefix ? `${prefix}${delimiter}${result}` : result;
+      }
+    }
+  }
+
+  return;
+}

--- a/libraries/lookup-by-path/src/getFirstDifferenceInCommonNodes.ts
+++ b/libraries/lookup-by-path/src/getFirstDifferenceInCommonNodes.ts
@@ -4,30 +4,80 @@
 import type { IReadonlyPathTrieNode } from './LookupByPath';
 
 /**
+ * Options for the getFirstDifferenceInCommonNodes function.
+ * @beta
+ */
+export interface IGetFirstDifferenceInCommonNodesOptions<TItem extends {}> {
+  /**
+   * The first node to compare.
+   */
+  first: IReadonlyPathTrieNode<TItem>;
+  /**
+   * The second node to compare.
+   */
+  second: IReadonlyPathTrieNode<TItem>;
+  /**
+   * The path prefix to the current node.
+   * @defaultValue ''
+   */
+  prefix?: string;
+  /**
+   * The delimiter used to join path segments.
+   * @defaultValue '/'
+   */
+  delimiter?: string;
+  /**
+   * A function to compare the values of the nodes.
+   * If not provided, strict equality (===) is used.
+   */
+  equals?: (a: TItem, b: TItem) => boolean;
+}
+
+/**
  * Recursively compares two path tries to find the first shared node with a different value.
  *
- * @param first - The first node to compare
- * @param second - The second node to compare
- * @param prefix - The path prefix to the current node
- * @param delimiter - The delimiter used to join path segments
- * @param equals - A function to compare the values of the nodes
+ * @param options - The options for the comparison
  * @returns The path to the first differing node, or undefined if they are identical
  *
  * @remarks
  * Ignores any nodes that are not shared between the two tries.
+ *
+ * @beta
  */
 export function getFirstDifferenceInCommonNodes<TItem extends {}>(
-  first: IReadonlyPathTrieNode<TItem>,
-  second: IReadonlyPathTrieNode<TItem>,
-  prefix: string = '',
-  delimiter: string = '/',
-  equals: (a: TItem, b: TItem) => boolean = (a, b) => a === b
+  options: IGetFirstDifferenceInCommonNodesOptions<TItem>
 ): string | undefined {
+  const { first, second, prefix = '', delimiter = '/', equals = defaultEquals } = options;
+
+  return getFirstDifferenceInCommonNodesInternal({
+    first,
+    second,
+    prefix,
+    delimiter,
+    equals
+  });
+}
+
+/**
+ * Recursively compares two path tries to find the first shared node with a different value.
+ *
+ * @param options - The options for the comparison
+ * @returns The path to the first differing node, or undefined if they are identical
+ *
+ * @remarks
+ * Ignores any nodes that are not shared between the two tries.
+ * Separated out to avoid redundant parameter defaulting in the recursive calls.
+ */
+function getFirstDifferenceInCommonNodesInternal<TItem extends {}>(
+  options: Required<IGetFirstDifferenceInCommonNodesOptions<TItem>>
+): string | undefined {
+  const { first, second, prefix, delimiter, equals } = options;
+
   const firstItem: TItem | undefined = first.value;
   const secondItem: TItem | undefined = second.value;
 
   if (firstItem !== undefined && secondItem !== undefined && !equals(firstItem, secondItem)) {
-    // If the value at this node changed, we only care if we were tracking it to begin with.
+    // If this value was present in both tries with different values, return the prefix for this node.
     return prefix;
   }
 
@@ -35,18 +85,19 @@ export function getFirstDifferenceInCommonNodes<TItem extends {}>(
   const { children: secondChildren } = second;
 
   if (firstChildren && secondChildren) {
-    for (const [key, lastInputChild] of firstChildren) {
+    for (const [key, firstChild] of firstChildren) {
       const secondChild: IReadonlyPathTrieNode<TItem> | undefined = secondChildren.get(key);
       if (!secondChild) {
         continue;
       }
-      const result: string | undefined = getFirstDifferenceInCommonNodes(
-        lastInputChild,
-        secondChild,
-        key,
+      const result: string | undefined = getFirstDifferenceInCommonNodesInternal({
+        first: firstChild,
+        second: secondChild,
+        prefix: key,
         delimiter,
         equals
-      );
+      });
+
       if (result !== undefined) {
         return prefix ? `${prefix}${delimiter}${result}` : result;
       }
@@ -54,4 +105,14 @@ export function getFirstDifferenceInCommonNodes<TItem extends {}>(
   }
 
   return;
+}
+
+/**
+ * Default equality function for comparing two items, using strict equality.
+ * @param a - The first item to compare
+ * @param b - The second item to compare
+ * @returns True if the items are reference equal, false otherwise
+ */
+function defaultEquals<TItem>(a: TItem, b: TItem): boolean {
+  return a === b;
 }

--- a/libraries/lookup-by-path/src/index.ts
+++ b/libraries/lookup-by-path/src/index.ts
@@ -7,5 +7,7 @@
  * @packageDocumentation
  */
 
-export type { IPrefixMatch, IReadonlyLookupByPath } from './LookupByPath';
+export type { IPrefixMatch, IReadonlyLookupByPath, IReadonlyPathTrieNode } from './LookupByPath';
 export { LookupByPath } from './LookupByPath';
+export type { IGetFirstDifferenceInCommonNodesOptions } from './getFirstDifferenceInCommonNodes';
+export { getFirstDifferenceInCommonNodes } from './getFirstDifferenceInCommonNodes';

--- a/libraries/lookup-by-path/src/test/getFirstDifferenceInCommonNodes.test.ts
+++ b/libraries/lookup-by-path/src/test/getFirstDifferenceInCommonNodes.test.ts
@@ -1,0 +1,158 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { getFirstDifferenceInCommonNodes } from '../getFirstDifferenceInCommonNodes';
+import type { IReadonlyPathTrieNode } from '../LookupByPath';
+
+describe(getFirstDifferenceInCommonNodes.name, () => {
+  it('detects a changed file at the current node', () => {
+    const last: IReadonlyPathTrieNode<string> = {
+      children: undefined,
+      value: 'old'
+    };
+    const current: IReadonlyPathTrieNode<string> = {
+      children: undefined,
+      value: 'new'
+    };
+
+    expect(getFirstDifferenceInCommonNodes(last, current)).toBe('');
+    expect(getFirstDifferenceInCommonNodes(current, last)).toBe('');
+
+    const prefix: string = 'some/prefix';
+
+    expect(getFirstDifferenceInCommonNodes(last, current, prefix)).toBe(prefix);
+    expect(getFirstDifferenceInCommonNodes(current, last, prefix)).toBe(prefix);
+  });
+
+  it('detects no changes when both nodes are identical', () => {
+    const last: IReadonlyPathTrieNode<string> = {
+      children: new Map([
+        [
+          'same',
+          {
+            children: undefined,
+            value: 'same'
+          }
+        ]
+      ]),
+      value: undefined
+    };
+    const current: IReadonlyPathTrieNode<string> = {
+      children: new Map([
+        [
+          'same',
+          {
+            children: undefined,
+            value: 'same'
+          }
+        ]
+      ]),
+      value: undefined
+    };
+
+    expect(getFirstDifferenceInCommonNodes(last, current)).toBeUndefined();
+    expect(getFirstDifferenceInCommonNodes(current, last)).toBeUndefined();
+  });
+
+  it('detects no changes when both nodes are identical based on a custom equals', () => {
+    const last: IReadonlyPathTrieNode<string> = {
+      children: new Map([
+        [
+          'same',
+          {
+            children: undefined,
+            value: 'same'
+          }
+        ]
+      ]),
+      value: undefined
+    };
+    const current: IReadonlyPathTrieNode<string> = {
+      children: new Map([
+        [
+          'same',
+          {
+            children: undefined,
+            value: 'other'
+          }
+        ]
+      ]),
+      value: undefined
+    };
+
+    function customEquals(a: string, b: string): boolean {
+      return a === b || (a === 'same' && b === 'other') || (a === 'other' && b === 'same');
+    }
+
+    expect(getFirstDifferenceInCommonNodes(last, current, '', '/', customEquals)).toBeUndefined();
+    expect(getFirstDifferenceInCommonNodes(current, last, '', '/', customEquals)).toBeUndefined();
+  });
+
+  it('detects no changes for extra children', () => {
+    const last: IReadonlyPathTrieNode<string> = {
+      children: undefined,
+      value: undefined
+    };
+    const current: IReadonlyPathTrieNode<string> = {
+      children: new Map([
+        [
+          'same',
+          {
+            children: undefined,
+            value: 'same'
+          }
+        ]
+      ]),
+      value: undefined
+    };
+
+    expect(getFirstDifferenceInCommonNodes(last, current)).toBeUndefined();
+    expect(getFirstDifferenceInCommonNodes(current, last)).toBeUndefined();
+  });
+
+  it('detects no changes if the set of common nodes differs', () => {
+    const last: IReadonlyPathTrieNode<string> = {
+      children: undefined,
+      value: undefined
+    };
+    const current: IReadonlyPathTrieNode<string> = {
+      children: undefined,
+      value: 'new'
+    };
+
+    expect(getFirstDifferenceInCommonNodes(last, current)).toBeUndefined();
+    expect(getFirstDifferenceInCommonNodes(current, last)).toBeUndefined();
+  });
+
+  it('detects a nested change', () => {
+    const last: IReadonlyPathTrieNode<string> = {
+      children: new Map([
+        [
+          'child',
+          {
+            children: undefined,
+            value: 'old'
+          }
+        ]
+      ]),
+      value: undefined
+    };
+    const current: IReadonlyPathTrieNode<string> = {
+      children: new Map([
+        [
+          'child',
+          {
+            children: undefined,
+            value: 'new'
+          }
+        ]
+      ]),
+      value: undefined
+    };
+
+    const prefix: string = 'some/prefix';
+
+    expect(getFirstDifferenceInCommonNodes(last, current, prefix, '@')).toBe('some/prefix@child');
+    expect(getFirstDifferenceInCommonNodes(current, last, prefix, '@')).toBe('some/prefix@child');
+  });
+});

--- a/libraries/lookup-by-path/src/test/getFirstDifferenceInCommonNodes.test.ts
+++ b/libraries/lookup-by-path/src/test/getFirstDifferenceInCommonNodes.test.ts
@@ -15,13 +15,35 @@ describe(getFirstDifferenceInCommonNodes.name, () => {
       value: 'new'
     };
 
-    expect(getFirstDifferenceInCommonNodes(last, current)).toBe('');
-    expect(getFirstDifferenceInCommonNodes(current, last)).toBe('');
+    expect(
+      getFirstDifferenceInCommonNodes({
+        first: last,
+        second: current
+      })
+    ).toBe('');
+    expect(
+      getFirstDifferenceInCommonNodes({
+        first: current,
+        second: last
+      })
+    ).toBe('');
 
     const prefix: string = 'some/prefix';
 
-    expect(getFirstDifferenceInCommonNodes(last, current, prefix)).toBe(prefix);
-    expect(getFirstDifferenceInCommonNodes(current, last, prefix)).toBe(prefix);
+    expect(
+      getFirstDifferenceInCommonNodes({
+        first: last,
+        second: current,
+        prefix
+      })
+    ).toBe(prefix);
+    expect(
+      getFirstDifferenceInCommonNodes({
+        first: current,
+        second: last,
+        prefix
+      })
+    ).toBe(prefix);
   });
 
   it('detects no changes when both nodes are identical', () => {
@@ -50,8 +72,18 @@ describe(getFirstDifferenceInCommonNodes.name, () => {
       value: undefined
     };
 
-    expect(getFirstDifferenceInCommonNodes(last, current)).toBeUndefined();
-    expect(getFirstDifferenceInCommonNodes(current, last)).toBeUndefined();
+    expect(
+      getFirstDifferenceInCommonNodes({
+        first: last,
+        second: current
+      })
+    ).toBeUndefined();
+    expect(
+      getFirstDifferenceInCommonNodes({
+        first: current,
+        second: last
+      })
+    ).toBeUndefined();
   });
 
   it('detects no changes when both nodes are identical based on a custom equals', () => {
@@ -84,8 +116,20 @@ describe(getFirstDifferenceInCommonNodes.name, () => {
       return a === b || (a === 'same' && b === 'other') || (a === 'other' && b === 'same');
     }
 
-    expect(getFirstDifferenceInCommonNodes(last, current, '', '/', customEquals)).toBeUndefined();
-    expect(getFirstDifferenceInCommonNodes(current, last, '', '/', customEquals)).toBeUndefined();
+    expect(
+      getFirstDifferenceInCommonNodes({
+        first: last,
+        second: current,
+        equals: customEquals
+      })
+    ).toBeUndefined();
+    expect(
+      getFirstDifferenceInCommonNodes({
+        first: current,
+        second: last,
+        equals: customEquals
+      })
+    ).toBeUndefined();
   });
 
   it('detects no changes for extra children', () => {
@@ -106,8 +150,18 @@ describe(getFirstDifferenceInCommonNodes.name, () => {
       value: undefined
     };
 
-    expect(getFirstDifferenceInCommonNodes(last, current)).toBeUndefined();
-    expect(getFirstDifferenceInCommonNodes(current, last)).toBeUndefined();
+    expect(
+      getFirstDifferenceInCommonNodes({
+        first: last,
+        second: current
+      })
+    ).toBeUndefined();
+    expect(
+      getFirstDifferenceInCommonNodes({
+        first: current,
+        second: last
+      })
+    ).toBeUndefined();
   });
 
   it('detects no changes if the set of common nodes differs', () => {
@@ -120,8 +174,18 @@ describe(getFirstDifferenceInCommonNodes.name, () => {
       value: 'new'
     };
 
-    expect(getFirstDifferenceInCommonNodes(last, current)).toBeUndefined();
-    expect(getFirstDifferenceInCommonNodes(current, last)).toBeUndefined();
+    expect(
+      getFirstDifferenceInCommonNodes({
+        first: last,
+        second: current
+      })
+    ).toBeUndefined();
+    expect(
+      getFirstDifferenceInCommonNodes({
+        first: current,
+        second: last
+      })
+    ).toBeUndefined();
   });
 
   it('detects a nested change', () => {
@@ -152,7 +216,21 @@ describe(getFirstDifferenceInCommonNodes.name, () => {
 
     const prefix: string = 'some/prefix';
 
-    expect(getFirstDifferenceInCommonNodes(last, current, prefix, '@')).toBe('some/prefix@child');
-    expect(getFirstDifferenceInCommonNodes(current, last, prefix, '@')).toBe('some/prefix@child');
+    expect(
+      getFirstDifferenceInCommonNodes({
+        first: last,
+        second: current,
+        prefix,
+        delimiter: '@'
+      })
+    ).toBe('some/prefix@child');
+    expect(
+      getFirstDifferenceInCommonNodes({
+        first: current,
+        second: last,
+        prefix,
+        delimiter: '@'
+      })
+    ).toBe('some/prefix@child');
   });
 });


### PR DESCRIPTION
## Summary
Adds an API `getFirstDifferenceInCommonNodes` for comparing two `LookupByPath` instances of the same type.

## Details
Exposes a readonly `tree` property on `LookupByPath` that can be used for manual tree traversal.
Adds a recursive `getFirstDifferenceInCommonNodes` API that looks for value mismatches in shared nodes between two subtrees.

## How it was tested
Added unit tests.

## Impacted documentation
Documentation for this library.