### PR TITLE
[api-extractor] Fix error handling when encountering changed APIs

### DIFF
--- a/apps/api-extractor/src/cli/ApiExtractorCommandLine.ts
+++ b/apps/api-extractor/src/cli/ApiExtractorCommandLine.ts
@@ -4,7 +4,7 @@
 import * as os from 'os';
 
 import { CommandLineParser, type CommandLineFlagParameter } from '@rushstack/ts-command-line';
-import { InternalError } from '@rushstack/node-core-library';
+import { AlreadyReportedError, InternalError } from '@rushstack/node-core-library';
 import { Colorize } from '@rushstack/terminal';
 
 import { RunAction } from './RunAction';
@@ -42,10 +42,12 @@ export class ApiExtractorCommandLine extends CommandLineParser {
       await super.onExecuteAsync();
       process.exitCode = 0;
     } catch (error) {
-      if (this._debugParameter.value) {
-        console.error(os.EOL + error.stack);
-      } else {
-        console.error(os.EOL + Colorize.red('ERROR: ' + error.message.trim()));
+      if (!(error instanceof AlreadyReportedError)) {
+        if (this._debugParameter.value) {
+          console.error(os.EOL + error.stack);
+        } else {
+          console.error(os.EOL + Colorize.red('ERROR: ' + error.message.trim()));
+        }
       }
     }
   }

--- a/apps/api-extractor/src/cli/RunAction.ts
+++ b/apps/api-extractor/src/cli/RunAction.ts
@@ -3,7 +3,13 @@
 
 import * as os from 'os';
 import * as path from 'path';
-import { PackageJsonLookup, FileSystem, type IPackageJson, Path } from '@rushstack/node-core-library';
+import {
+  PackageJsonLookup,
+  FileSystem,
+  type IPackageJson,
+  Path,
+  AlreadyReportedError
+} from '@rushstack/node-core-library';
 import { Colorize } from '@rushstack/terminal';
 import {
   CommandLineAction,
@@ -138,13 +144,12 @@ export class RunAction extends CommandLineAction {
     if (extractorResult.succeeded) {
       console.log(os.EOL + 'API Extractor completed successfully');
     } else {
-      process.exitCode = 1;
-
       if (extractorResult.errorCount > 0) {
         console.log(os.EOL + Colorize.red('API Extractor completed with errors'));
       } else {
         console.log(os.EOL + Colorize.yellow('API Extractor completed with warnings'));
       }
+      throw new AlreadyReportedError();
     }
   }
 }

--- a/common/changes/@microsoft/api-extractor/user-danade-FixTsCommandLine_2025-05-13-00-41.json
+++ b/common/changes/@microsoft/api-extractor/user-danade-FixTsCommandLine_2025-05-13-00-41.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Fixes API extractor error handling when changed APIs are encountered and the \"--local\" flag is not specified",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor"
+}


### PR DESCRIPTION
## Summary

Fixes API extractor throwing of errors when changed APIs are encountered.

## Details

A recent change to the handling of errors in the API Extractor ts-command-line parser usage broke error handling when not using `--local` flag. This PR fixes that handling while keeping the newer approach intact

## How it was tested

Locally using API Extractor CLI.

## Impacted documentation

N/A