### PR TITLE
[heft] feat: add new task-level timing metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ These GitHub repositories provide supplementary resources for Rush Stack:
 | [/build-tests/eslint-bulk-suppressions-test-legacy](./build-tests/eslint-bulk-suppressions-test-legacy/) | Sample code to test eslint bulk suppressions for versions of eslint < 8.57.0 |
 | [/build-tests/hashed-folder-copy-plugin-webpack5-test](./build-tests/hashed-folder-copy-plugin-webpack5-test/) | Building this project exercises @rushstack/hashed-folder-copy-plugin with Webpack 5. NOTE - THIS TEST IS CURRENTLY EXPECTED TO BE BROKEN |
 | [/build-tests/heft-copy-files-test](./build-tests/heft-copy-files-test/) | Building this project tests copying files with Heft |
+| [/build-tests/heft-example-lifecycle-plugin](./build-tests/heft-example-lifecycle-plugin/) | This is an example heft plugin for testing the lifecycle hooks |
 | [/build-tests/heft-example-plugin-01](./build-tests/heft-example-plugin-01/) | This is an example heft plugin that exposes hooks for other plugins |
 | [/build-tests/heft-example-plugin-02](./build-tests/heft-example-plugin-02/) | This is an example heft plugin that taps the hooks exposed from heft-example-plugin-01 |
 | [/build-tests/heft-fastify-test](./build-tests/heft-fastify-test/) | This project tests Heft support for the Fastify framework for Node.js services |

--- a/apps/heft/src/cli/HeftActionRunner.ts
+++ b/apps/heft/src/cli/HeftActionRunner.ts
@@ -403,14 +403,19 @@ export class HeftActionRunner {
 
       // Create operations for each task
       for (const task of phase.tasks) {
-        const taskOperation: Operation = _getOrCreateTaskOperation(internalHeftSession, task, operations);
+        const taskOperation: Operation = _getOrCreateTaskOperation(
+          internalHeftSession,
+          this._metricsCollector,
+          task,
+          operations
+        );
         // Set the phase operation as a dependency of the task operation to ensure the phase operation runs first
         taskOperation.addDependency(phaseOperation);
 
         // Set all dependency tasks as dependencies of the task operation
         for (const dependencyTask of task.dependencyTasks) {
           taskOperation.addDependency(
-            _getOrCreateTaskOperation(internalHeftSession, dependencyTask, operations)
+            _getOrCreateTaskOperation(internalHeftSession, this._metricsCollector, dependencyTask, operations)
           );
         }
 
@@ -459,6 +464,7 @@ function _getOrCreatePhaseOperation(
 function _getOrCreateTaskOperation(
   this: void,
   internalHeftSession: InternalHeftSession,
+  metricsCollector: MetricsCollector,
   task: HeftTask,
   operations: Map<string, Operation>
 ): Operation {
@@ -469,6 +475,7 @@ function _getOrCreateTaskOperation(
     operation = new Operation({
       groupName: task.parentPhase.phaseName,
       runner: new TaskOperationRunner({
+        metricsCollector,
         internalHeftSession,
         task
       })

--- a/apps/heft/src/index.ts
+++ b/apps/heft/src/index.ts
@@ -61,9 +61,12 @@ export type {
 
 export {
   type IHeftRecordMetricsHookOptions,
+  type IHeftMetricsHookOptions,
   type IMetricsData,
   type IPerformanceData as _IPerformanceData,
-  MetricsCollector as _MetricsCollector
+  MetricsCollector as _MetricsCollector,
+  type IHeftTaskRecordMetricsHookOptions,
+  type ITaskMetricsData
 } from './metrics/MetricsCollector';
 
 export type { IScopedLogger } from './pluginFramework/logging/ScopedLogger';

--- a/apps/heft/src/pluginFramework/HeftLifecycle.ts
+++ b/apps/heft/src/pluginFramework/HeftLifecycle.ts
@@ -67,7 +67,8 @@ export class HeftLifecycle extends HeftPluginHost {
       clean: new AsyncParallelHook<IHeftLifecycleCleanHookOptions>(),
       toolStart: new AsyncParallelHook<IHeftLifecycleToolStartHookOptions>(),
       toolFinish: new AsyncParallelHook<IHeftLifecycleToolFinishHookOptions>(),
-      recordMetrics: internalHeftSession.metricsCollector.recordMetricsHook
+      recordMetrics: internalHeftSession.metricsCollector.recordMetricsHook,
+      recordTaskMetrics: internalHeftSession.metricsCollector.recordTaskMetricsHook
     };
   }
 

--- a/apps/heft/src/pluginFramework/HeftLifecycleSession.ts
+++ b/apps/heft/src/pluginFramework/HeftLifecycleSession.ts
@@ -4,7 +4,11 @@
 import * as path from 'path';
 import type { AsyncParallelHook } from 'tapable';
 
-import type { IHeftRecordMetricsHookOptions, MetricsCollector } from '../metrics/MetricsCollector';
+import type {
+  IHeftRecordMetricsHookOptions,
+  IHeftTaskRecordMetricsHookOptions,
+  MetricsCollector
+} from '../metrics/MetricsCollector';
 import type { ScopedLogger, IScopedLogger } from './logging/ScopedLogger';
 import type { IInternalHeftSessionOptions } from './InternalHeftSession';
 import type { IHeftParameters } from './HeftParameterManager';
@@ -111,6 +115,14 @@ export interface IHeftLifecycleHooks {
    * @public
    */
   recordMetrics: AsyncParallelHook<IHeftRecordMetricsHookOptions>;
+
+  /**
+   * The `recordTaskMetrics` hook is called at the end of every Heft task execution. It is called after all
+   * tasks have completed execution (or been canceled). To use it,
+   *  call `recordTaskMetrics.tapPromise(<pluginName>, <callback>)`.
+   * @public
+   */
+  recordTaskMetrics: AsyncParallelHook<IHeftTaskRecordMetricsHookOptions>;
 }
 
 /**

--- a/apps/heft/src/pluginFramework/HeftTaskSession.ts
+++ b/apps/heft/src/pluginFramework/HeftTaskSession.ts
@@ -232,6 +232,7 @@ export interface IHeftTaskSessionOptions extends IHeftPhaseSessionOptions {
 }
 
 export class HeftTaskSession implements IHeftTaskSession {
+  public readonly phaseName: string;
   public readonly taskName: string;
   public readonly hooks: IHeftTaskHooks;
   public readonly tempFolderPath: string;
@@ -280,6 +281,7 @@ export class HeftTaskSession implements IHeftTaskSession {
     this.logger = loggingManager.requestScopedLogger(`${phase.phaseName}:${task.taskName}`);
     this.metricsCollector = metricsCollector;
     this.taskName = task.taskName;
+    this.phaseName = phase.phaseName;
     this.hooks = {
       run: new AsyncParallelHook(['runHookOptions']),
       runIncremental: new AsyncParallelHook(['runIncrementalHookOptions']),

--- a/build-tests/heft-example-lifecycle-plugin/.eslintrc.js
+++ b/build-tests/heft-example-lifecycle-plugin/.eslintrc.js
@@ -1,0 +1,9 @@
+// This is a workaround for https://github.com/eslint/eslint/issues/3458
+require('local-eslint-config/patch/modern-module-resolution');
+// This is a workaround for https://github.com/microsoft/rushstack/issues/3021
+require('local-eslint-config/patch/custom-config-package-names');
+
+module.exports = {
+  extends: ['local-eslint-config/profile/node-trusted-tool', 'local-eslint-config/mixins/friendly-locals'],
+  parserOptions: { tsconfigRootDir: __dirname }
+};

--- a/build-tests/heft-example-lifecycle-plugin/config/heft.json
+++ b/build-tests/heft-example-lifecycle-plugin/config/heft.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/heft/v0/heft.schema.json",
+
+  // TODO: Add comments
+  "phasesByName": {
+    "build": {
+      "cleanFiles": [{ "includeGlobs": ["dist", "lib"] }],
+
+      "tasksByName": {
+        "typescript": {
+          "taskPlugin": {
+            "pluginPackage": "@rushstack/heft-typescript-plugin"
+          }
+        },
+        "lint": {
+          "taskDependencies": ["typescript"],
+          "taskPlugin": {
+            "pluginPackage": "@rushstack/heft-lint-plugin"
+          }
+        }
+      }
+    }
+  }
+}

--- a/build-tests/heft-example-lifecycle-plugin/config/rush-project.json
+++ b/build-tests/heft-example-lifecycle-plugin/config/rush-project.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/rush/v5/rush-project.schema.json",
+
+  "operationSettings": [
+    {
+      "operationName": "_phase:build",
+      "outputFolderNames": ["lib", "dist"]
+    }
+  ]
+}

--- a/build-tests/heft-example-lifecycle-plugin/heft-plugin.json
+++ b/build-tests/heft-example-lifecycle-plugin/heft-plugin.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/heft/v0/heft-plugin.schema.json",
+
+  "lifecyclePlugins": [
+    {
+      "pluginName": "example-lifecycle-plugin",
+      "entryPoint": "./lib/index"
+    }
+  ]
+}

--- a/build-tests/heft-example-lifecycle-plugin/package.json
+++ b/build-tests/heft-example-lifecycle-plugin/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "heft-example-lifecycle-plugin",
+  "description": "This is an example heft plugin for testing the lifecycle hooks",
+  "version": "1.0.0",
+  "private": true,
+  "main": "./lib/index.js",
+  "typings": "./lib/index.d.ts",
+  "scripts": {
+    "build": "heft build --clean",
+    "start": "heft build-watch",
+    "_phase:build": "heft run --only build -- --clean"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "local-eslint-config": "workspace:*",
+    "@rushstack/heft": "workspace:*",
+    "@rushstack/heft-lint-plugin": "workspace:*",
+    "@rushstack/heft-typescript-plugin": "workspace:*",
+    "@types/node": "20.17.19",
+    "eslint": "~8.57.0",
+    "typescript": "~5.8.2"
+  }
+}

--- a/build-tests/heft-example-lifecycle-plugin/src/index.ts
+++ b/build-tests/heft-example-lifecycle-plugin/src/index.ts
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import type {
+  IHeftLifecyclePlugin,
+  IHeftLifecycleSession,
+  IHeftTaskRecordMetricsHookOptions
+} from '@rushstack/heft';
+
+export const PLUGIN_NAME: 'example-lifecycle-plugin' = 'example-lifecycle-plugin';
+
+export default class ExampleLifecyclePlugin implements IHeftLifecyclePlugin {
+  public apply(session: IHeftLifecycleSession): void {
+    const { logger } = session;
+    session.hooks.recordTaskMetrics.tapPromise(
+      PLUGIN_NAME,
+      async (metrics: IHeftTaskRecordMetricsHookOptions) => {
+        const { taskName, taskTotalExecutionMs, phaseName } = metrics.metricData;
+        logger.terminal.writeLine(
+          `Finished ${phaseName}:${taskName} in ${taskTotalExecutionMs.toFixed(2)}ms`
+        );
+      }
+    );
+  }
+}

--- a/build-tests/heft-example-lifecycle-plugin/tsconfig.json
+++ b/build-tests/heft-example-lifecycle-plugin/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json.schemastore.org/tsconfig",
+
+  "compilerOptions": {
+    "outDir": "lib",
+    "rootDir": "src",
+
+    "forceConsistentCasingInFileNames": true,
+    "jsx": "react",
+    "declaration": true,
+    "sourceMap": true,
+    "declarationMap": true,
+    "inlineSources": true,
+    "experimentalDecorators": true,
+    "strictNullChecks": true,
+    "noUnusedLocals": true,
+    "types": ["node"],
+
+    "module": "commonjs",
+    "target": "es2017",
+    "lib": ["es2017"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["node_modules", "lib"]
+}

--- a/build-tests/heft-node-everything-test/config/heft.json
+++ b/build-tests/heft-node-everything-test/config/heft.json
@@ -4,6 +4,12 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/heft/v0/heft.schema.json",
 
+  "heftPlugins": [
+    {
+      "pluginPackage": "heft-example-lifecycle-plugin"
+    }
+  ],
+
   // TODO: Add comments
   "phasesByName": {
     "build": {

--- a/build-tests/heft-node-everything-test/package.json
+++ b/build-tests/heft-node-everything-test/package.json
@@ -23,6 +23,7 @@
     "@types/heft-jest": "1.0.1",
     "@types/node": "20.17.19",
     "eslint": "~8.57.0",
+    "heft-example-lifecycle-plugin": "workspace:*",
     "heft-example-plugin-01": "workspace:*",
     "heft-example-plugin-02": "workspace:*",
     "tslint": "~5.20.1",

--- a/common/changes/@rushstack/heft/sennyeya-heft-metrics_2025-05-13-15-54.json
+++ b/common/changes/@rushstack/heft/sennyeya-heft-metrics_2025-05-13-15-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Add new hook for collecting granular task-level metrics.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft"
+}

--- a/common/config/rush/browser-approved-packages.json
+++ b/common/config/rush/browser-approved-packages.json
@@ -59,6 +59,10 @@
       "allowedCategories": [ "libraries" ]
     },
     {
+      "name": "heft-example-lifecycle-plugin",
+      "allowedCategories": [ "tests" ]
+    },
+    {
       "name": "local-web-rig",
       "allowedCategories": [ "libraries", "vscode-extensions" ]
     },

--- a/common/config/subspaces/default/pnpm-lock.yaml
+++ b/common/config/subspaces/default/pnpm-lock.yaml
@@ -1294,6 +1294,30 @@ importers:
         specifier: workspace:*
         version: link:../../apps/heft
 
+  ../../../build-tests/heft-example-lifecycle-plugin:
+    devDependencies:
+      '@rushstack/heft':
+        specifier: workspace:*
+        version: link:../../apps/heft
+      '@rushstack/heft-lint-plugin':
+        specifier: workspace:*
+        version: link:../../heft-plugins/heft-lint-plugin
+      '@rushstack/heft-typescript-plugin':
+        specifier: workspace:*
+        version: link:../../heft-plugins/heft-typescript-plugin
+      '@types/node':
+        specifier: 20.17.19
+        version: 20.17.19
+      eslint:
+        specifier: ~8.57.0
+        version: 8.57.0
+      local-eslint-config:
+        specifier: workspace:*
+        version: link:../../eslint/local-eslint-config
+      typescript:
+        specifier: ~5.8.2
+        version: 5.8.2
+
   ../../../build-tests/heft-example-plugin-01:
     dependencies:
       tapable:
@@ -1562,6 +1586,9 @@ importers:
       eslint:
         specifier: ~8.57.0
         version: 8.57.0
+      heft-example-lifecycle-plugin:
+        specifier: workspace:*
+        version: link:../heft-example-lifecycle-plugin
       heft-example-plugin-01:
         specifier: workspace:*
         version: link:../heft-example-plugin-01

--- a/common/reviews/api/heft.api.md
+++ b/common/reviews/api/heft.api.md
@@ -151,6 +151,7 @@ export interface IHeftLifecycleCleanHookOptions {
 export interface IHeftLifecycleHooks {
     clean: AsyncParallelHook<IHeftLifecycleCleanHookOptions>;
     recordMetrics: AsyncParallelHook<IHeftRecordMetricsHookOptions>;
+    recordTaskMetrics: AsyncParallelHook<IHeftTaskRecordMetricsHookOptions>;
     toolFinish: AsyncParallelHook<IHeftLifecycleToolFinishHookOptions>;
     toolStart: AsyncParallelHook<IHeftLifecycleToolStartHookOptions>;
 }
@@ -174,6 +175,14 @@ export interface IHeftLifecycleToolFinishHookOptions {
 
 // @public
 export interface IHeftLifecycleToolStartHookOptions {
+}
+
+// @public (undocumented)
+export interface IHeftMetricsHookOptions<T> {
+    // (undocumented)
+    metricData: T;
+    // (undocumented)
+    metricName: string;
 }
 
 // @public
@@ -200,12 +209,7 @@ export interface IHeftPlugin<TSession extends IHeftLifecycleSession | IHeftTaskS
 }
 
 // @public (undocumented)
-export interface IHeftRecordMetricsHookOptions {
-    // (undocumented)
-    metricData: IMetricsData;
-    // (undocumented)
-    metricName: string;
-}
+export type IHeftRecordMetricsHookOptions = IHeftMetricsHookOptions<IMetricsData>;
 
 // @public
 export interface IHeftTaskFileOperations {
@@ -223,6 +227,9 @@ export interface IHeftTaskHooks {
 // @public
 export interface IHeftTaskPlugin<TOptions = void> extends IHeftPlugin<IHeftTaskSession, TOptions> {
 }
+
+// @public (undocumented)
+export type IHeftTaskRecordMetricsHookOptions = IHeftMetricsHookOptions<ITaskMetricsData>;
 
 // @public
 export interface IHeftTaskRunHookOptions {
@@ -269,7 +276,7 @@ export interface IMetricsData {
     totalUptimeMs: number;
 }
 
-// @internal (undocumented)
+// @public (undocumented)
 export interface _IPerformanceData {
     // (undocumented)
     encounteredError?: boolean;
@@ -315,6 +322,14 @@ export interface IScopedLogger {
     readonly terminal: ITerminal;
 }
 
+// @public (undocumented)
+export interface ITaskMetricsData {
+    encounteredError?: boolean;
+    phaseName: string;
+    taskName: string;
+    taskTotalExecutionMs: number;
+}
+
 // @public
 export interface IWatchedFileState {
     changed: boolean;
@@ -341,6 +356,9 @@ export class _MetricsCollector {
     recordAsync(command: string, performanceData?: Partial<_IPerformanceData>, parameters?: Record<string, string>): Promise<void>;
     // (undocumented)
     readonly recordMetricsHook: AsyncParallelHook<IHeftRecordMetricsHookOptions>;
+    recordTaskAsync(taskName: string, phaseName: string, performanceData?: Partial<_IPerformanceData>): Promise<void>;
+    // (undocumented)
+    readonly recordTaskMetricsHook: AsyncParallelHook<IHeftTaskRecordMetricsHookOptions>;
     setStartTime(): void;
 }
 

--- a/rush.json
+++ b/rush.json
@@ -792,6 +792,12 @@
       "shouldPublish": false
     },
     {
+      "packageName": "heft-example-lifecycle-plugin",
+      "projectFolder": "build-tests/heft-example-lifecycle-plugin",
+      "reviewCategory": "tests",
+      "shouldPublish": false
+    },
+    {
       "packageName": "heft-example-plugin-01",
       "projectFolder": "build-tests/heft-example-plugin-01",
       "reviewCategory": "tests",


### PR DESCRIPTION
## Summary

Adds task-level metrics for reporting on how long specific plugins take to execute, like the Typescript, Jest, and Webpack plugins. These are currently only logged out to console in verbose mode.

## Details

I copied most of the existing implementation of the `recordMetrics` hook to create a `recordTaskMetrics` hook - the idea here is being able to report on the specific amount of time that each task takes and add more granular reporting. Let me know what you think about the metric envelope.

## How it was tested

Added a test `heft-lifecycle-plugin` that logs out the time taken for each task (you can still see the verbose logs too). Example:
```
 ---- build started ---- 
[build:typescript] Using TypeScript version 5.8.2
[lifecycle:example-lifecycle-plugin] Finished build:typescript in 822.40ms
[build:lint] Using ESLint version 8.57.0
[build:lint] Using TSLint version 5.20.1
[build:typescript] All requested file copy operations are up to date. Nothing to do.
[lifecycle:example-lifecycle-plugin] Finished build:lint in 0.49ms
[build:api-extractor] Using API Extractor version 7.52.8
[build:api-extractor] Analysis will use the bundled TypeScript version 5.8.2
[lifecycle:example-lifecycle-plugin] Finished build:api-extractor in 594.27ms
[lifecycle:example-lifecycle-plugin] Finished build:metadata-test in 595.94ms
 ---- build finished (1.815s) ---- 
[lifecycle:example-lifecycle-plugin] Finished build in 1815.37ms
 ---- test started ---- 
[test:jest] Using Jest version 29.5.0
[test:example-plugin-02] !!!!!!!!!!!!!!! Plugin "example-plugin-01" hook called !!!!!!!!!!!!!!! 
[lifecycle:example-lifecycle-plugin] Finished test:example-plugin-01 in 0.16ms
Determining test suites to run...[test:jest] 
[test:jest] Run start. 1 test suite
[test:jest] START lib/test/ExampleTest.test.js
[test:jest] PASS lib/test/ExampleTest.test.js (duration: 0.203s, 3 passed, 0 failed)
[test:jest] 
[test:jest] Tests finished:
[test:jest]   Successes: 3
[test:jest]   Failures: 0
[test:jest]   Total: 3
[lifecycle:example-lifecycle-plugin] Finished test:jest in 625.79ms
 ---- test finished (0.640s) ---- 
[lifecycle:example-lifecycle-plugin] Finished test in 640.48ms
-------------------- Finished (2.459s) --------------------
```

## Impacted documentation
Not sure?
