### PR TITLE
[rush] Add Linux/MacOS support for 'virtual-store-dir-max-length' default value in PNPM v10

### DIFF
--- a/common/changes/@microsoft/rush/pnpm-virtual-store-dir-max-length-fix_2025-06-03-18-27.json
+++ b/common/changes/@microsoft/rush/pnpm-virtual-store-dir-max-length-fix_2025-06-03-18-27.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add Linux/MacOS support for new 'virtual-store-dir-max-length'",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/logic/pnpm/PnpmLinkManager.ts
+++ b/libraries/rush-lib/src/logic/pnpm/PnpmLinkManager.ts
@@ -325,9 +325,13 @@ export class PnpmLinkManager extends BaseLinkManager {
       const { depPathToFilename } = await import('@pnpm/dependency-path');
 
       // project@file+projects+presentation-integration-tests.tgz_jsdom@11.12.0
-      // The second parameter is max length of virtual store dir, for v10 default is 60 https://pnpm.io/next/npmrc#virtual-store-dir-max-length
+      // The second parameter is max length of virtual store dir,
+      // for v10 default is 120 on Linux/MacOS and 60 on Windows https://pnpm.io/next/settings#virtualstoredirmaxlength
       // TODO Read virtual-store-dir-max-length from .npmrc
-      const folderName: string = depPathToFilename(tempProjectDependencyKey, 60);
+      const folderName: string = depPathToFilename(
+        tempProjectDependencyKey,
+        process.platform === 'win32' ? 60 : 120
+      );
       return path.join(
         this._rushConfiguration.commonTempFolder,
         RushConstants.nodeModulesFolderName,
@@ -339,7 +343,7 @@ export class PnpmLinkManager extends BaseLinkManager {
       const { depPathToFilename } = await import('@pnpm/dependency-path-lockfile-pre-v10');
 
       // project@file+projects+presentation-integration-tests.tgz_jsdom@11.12.0
-      // The second parameter is max length of virtual store dir, for v9 default is 120 https://pnpm.io/next/npmrc#virtual-store-dir-max-length
+      // The second parameter is max length of virtual store dir, for v9 default is 120 https://pnpm.io/9.x/npmrc#virtual-store-dir-max-length
       // TODO Read virtual-store-dir-max-length from .npmrc
       const folderName: string = depPathToFilename(tempProjectDependencyKey, 120);
       return path.join(


### PR DESCRIPTION
## Summary

The default value of `virtual-store-dir-max-length` on Linux/MacOS is 120: https://pnpm.io/next/settings#virtualstoredirmaxlength

## How it was tested

Tested on Linux and Windows [with pnpm v10 using azure-sdk-for-js repo](https://github.com/Azure/azure-sdk-for-js/compare/main...jeremymeng:azure-sdk-for-js:engsys/rush-pnpm-upgrades) 
