### PR TITLE
[mcp-server] Fix some issues with the plugin loader

### DIFF
--- a/apps/rush-mcp-server/src/pluginFramework/RushMcpPluginLoader.ts
+++ b/apps/rush-mcp-server/src/pluginFramework/RushMcpPluginLoader.ts
@@ -39,11 +39,6 @@ export interface IJsonRushMcpPlugin {
    * @rushstack/mcp-server will ensure this folder is installed before loading the plugin.
    */
   autoinstaller: string;
-
-  /**
-   * The name of the plugin. This is used to identify the plugin in the MCP server.
-   */
-  pluginName: string;
 }
 
 /**
@@ -155,7 +150,7 @@ export class RushMcpPluginLoader {
         const mcpPluginSchema: JsonSchema = await JsonSchema.fromFile(mcpPluginSchemaFilePath);
         const rushMcpPluginOptionsFilePath: string = path.resolve(
           this._rushWorkspacePath,
-          `common/config/rush-mcp/${jsonMcpPlugin.pluginName}.json`
+          `common/config/rush-mcp/${jsonManifest.pluginName}.json`
         );
         // Example: /path/to/my-repo/common/config/rush-mcp/rush-mcp-example-plugin.json
         rushMcpPluginOptions = await JsonFile.loadAndValidateAsync(

--- a/apps/rush-mcp-server/src/pluginFramework/RushMcpPluginLoader.ts
+++ b/apps/rush-mcp-server/src/pluginFramework/RushMcpPluginLoader.ts
@@ -85,6 +85,10 @@ export class RushMcpPluginLoader {
     this._mcpServer = mcpServer;
   }
 
+  private static _formatError(e: Error): string {
+    return e.stack ?? RushMcpPluginLoader._formatError(e);
+  }
+
   public async loadAsync(): Promise<void> {
     const rushMcpFilePath: string = path.join(
       this._rushWorkspacePath,
@@ -169,7 +173,10 @@ export class RushMcpPluginLoader {
         }
         pluginFactory = entryPointModule.default;
       } catch (e) {
-        throw new Error(`Unable to load plugin entry point at ${fullEntryPointPath}: ` + e.toString());
+        throw new Error(
+          `Unable to load plugin entry point at ${fullEntryPointPath}:\n` +
+            RushMcpPluginLoader._formatError(e)
+        );
       }
 
       const session: RushMcpPluginSessionInternal = new RushMcpPluginSessionInternal(this._mcpServer);
@@ -178,14 +185,18 @@ export class RushMcpPluginLoader {
       try {
         plugin = pluginFactory(session, rushMcpPluginOptions);
       } catch (e) {
-        throw new Error(`Error invoking entry point for plugin ${jsonManifest.pluginName}:` + e.toString());
+        throw new Error(
+          `Error invoking entry point for plugin ${jsonManifest.pluginName}:\n` +
+            RushMcpPluginLoader._formatError(e)
+        );
       }
 
       try {
         await plugin.onInitializeAsync();
       } catch (e) {
         throw new Error(
-          `Error occurred in onInitializeAsync() for plugin ${jsonManifest.pluginName}:` + e.toString()
+          `Error occurred in onInitializeAsync() for plugin ${jsonManifest.pluginName}:\n` +
+            RushMcpPluginLoader._formatError(e)
         );
       }
     }

--- a/apps/rush-mcp-server/src/schemas/rush-mcp.schema.json
+++ b/apps/rush-mcp-server/src/schemas/rush-mcp.schema.json
@@ -16,13 +16,9 @@
           "autoinstaller": {
             "type": "string",
             "description": "The name of a Rush autoinstaller with this package as its dependency."
-          },
-          "pluginName": {
-            "type": "string",
-            "description": "The name of the plugin. This is used to identify the plugin in the MCP server."
           }
         },
-        "required": ["packageName", "autoinstaller", "pluginName"],
+        "required": ["packageName", "autoinstaller"],
         "additionalProperties": false
       }
     }

--- a/apps/rush-mcp-server/src/schemas/rush-mcp.schema.json
+++ b/apps/rush-mcp-server/src/schemas/rush-mcp.schema.json
@@ -22,7 +22,7 @@
             "description": "The name of the plugin. This is used to identify the plugin in the MCP server."
           }
         },
-        "required": ["packageName", "autoinstaller"],
+        "required": ["packageName", "autoinstaller", "pluginName"],
         "additionalProperties": false
       }
     }

--- a/apps/rush-mcp-server/src/start.ts
+++ b/apps/rush-mcp-server/src/start.ts
@@ -7,9 +7,13 @@ import { log } from './utilities/log';
 import { RushMCPServer } from './server';
 
 const main = async (): Promise<void> => {
-  const rushWorkspacePath: string | undefined = process.argv[2];
+  let rushWorkspacePath: string | undefined = process.argv[2];
   if (!rushWorkspacePath) {
     throw new Error('Please provide workspace root path as the first argument');
+  }
+
+  if (rushWorkspacePath === '.') {
+    rushWorkspacePath = process.cwd();
   }
 
   const server: RushMCPServer = new RushMCPServer(rushWorkspacePath);

--- a/apps/rush-mcp-server/src/start.ts
+++ b/apps/rush-mcp-server/src/start.ts
@@ -1,22 +1,28 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+import * as path from 'path';
+import { FileSystem } from '@rushstack/node-core-library';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 
 import { log } from './utilities/log';
 import { RushMCPServer } from './server';
 
 const main = async (): Promise<void> => {
-  let rushWorkspacePath: string | undefined = process.argv[2];
+  const rushWorkspacePath: string | undefined = process.argv[2];
   if (!rushWorkspacePath) {
     throw new Error('Please provide workspace root path as the first argument');
   }
 
-  if (rushWorkspacePath === '.') {
-    rushWorkspacePath = process.cwd();
+  const rushWorkspaceFullPath: string = path.resolve(rushWorkspacePath);
+
+  if (!(await FileSystem.existsAsync(rushWorkspaceFullPath))) {
+    throw new Error(
+      'The specified workspace root path does not exist:\n  ' + JSON.stringify(rushWorkspacePath)
+    );
   }
 
-  const server: RushMCPServer = new RushMCPServer(rushWorkspacePath);
+  const server: RushMCPServer = new RushMCPServer(rushWorkspaceFullPath);
   await server.startAsync();
   const transport: StdioServerTransport = new StdioServerTransport();
   await server.connect(transport);

--- a/build-tests/rush-mcp-example-plugin/src/rush-mcp-example-plugin.schema.json
+++ b/build-tests/rush-mcp-example-plugin/src/rush-mcp-example-plugin.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "State Capital Map",
   "type": "object",
   "required": ["capitalsByState"],

--- a/common/changes/@rushstack/mcp-server/octogonz-mcp-fixes_2025-06-06-07-20.json
+++ b/common/changes/@rushstack/mcp-server/octogonz-mcp-fixes_2025-06-06-07-20.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/mcp-server",
+      "comment": "Fix some errors when loading plugins",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/mcp-server"
+}


### PR DESCRIPTION
- Fix an issue when resolving "." on Windows OS
- Improve error reporting for plugin load failures
- Remove `pluginName` from `rush-mcp.json` because it can be obtained from the plugin manifest
