### PR TITLE
[rush] Bump pnpm-sync-lib to support PNPM v9.

### DIFF
--- a/common/changes/@microsoft/rush/pnpm-sync-0.3.1_2025-06-10-18-05.json
+++ b/common/changes/@microsoft/rush/pnpm-sync-0.3.1_2025-06-10-18-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add support for PNPM v9 to the pnpm-sync feature.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/config/subspaces/build-tests-subspace/pnpm-lock.yaml
+++ b/common/config/subspaces/build-tests-subspace/pnpm-lock.yaml
@@ -4569,7 +4569,7 @@ packages:
     dependencies:
       hosted-git-info: 4.1.0
       is-core-module: 2.15.1
-      semver: 7.6.3
+      semver: 7.7.2
       validate-npm-package-license: 3.0.4
 
   /normalize-path@3.0.0:
@@ -4900,10 +4900,11 @@ packages:
     dependencies:
       semver-compare: 1.0.0
 
-  /pnpm-sync-lib@0.3.0:
-    resolution: {integrity: sha512-Wt3Xf8pjzC2xcyN6ol5x5PdD5kU75+8OOgll2ZQsgm5uxih6dxziqRRuhNwtw94GHRd/0Oo7ESFmzmRz6OTQ0Q==}
+  /pnpm-sync-lib@0.3.2:
+    resolution: {integrity: sha512-XlHyNAHlBqIMGTBD0HfgyRyj1UpSJvVyP20ihPek00YKmMb7RJ16AxlQkjT1jQ/D6s6OAT0ety/tSxcJTrvQ4w==}
     dependencies:
-      '@pnpm/dependency-path': 2.1.8
+      '@pnpm/dependency-path-2': /@pnpm/dependency-path@2.1.8
+      '@pnpm/dependency-path-5': /@pnpm/dependency-path@5.1.7
       yaml: 2.4.1
 
   /possible-typed-array-names@1.0.0:
@@ -6503,7 +6504,7 @@ packages:
       js-yaml: 3.13.1
       npm-check: 6.0.1
       npm-package-arg: 6.1.1
-      pnpm-sync-lib: 0.3.0
+      pnpm-sync-lib: 0.3.2
       read-package-tree: 5.1.6
       rxjs: 6.6.7
       semver: 7.5.4

--- a/common/config/subspaces/build-tests-subspace/repo-state.json
+++ b/common/config/subspaces/build-tests-subspace/repo-state.json
@@ -1,6 +1,6 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "c7ba4d11d03d9e1b14ba33e023a043d385fa3fd8",
+  "pnpmShrinkwrapHash": "40cbf48a53cad8d9f815d7d1d8ec18a48233a1ad",
   "preferredVersionsHash": "54149ea3f01558a859c96dee2052b797d4defe68",
-  "packageJsonInjectedDependenciesHash": "de32ff5fe062252f7310c4fb86383790757d735c"
+  "packageJsonInjectedDependenciesHash": "8bc9d0aabfed5614af0cf7950d2ba377e412b716"
 }

--- a/common/config/subspaces/default/pnpm-lock.yaml
+++ b/common/config/subspaces/default/pnpm-lock.yaml
@@ -3376,8 +3376,8 @@ importers:
         specifier: ~6.1.0
         version: 6.1.1
       pnpm-sync-lib:
-        specifier: 0.3.0
-        version: 0.3.0
+        specifier: 0.3.1
+        version: 0.3.1
       read-package-tree:
         specifier: ~5.1.5
         version: 5.1.6
@@ -24205,10 +24205,11 @@ packages:
       - typescript
     dev: true
 
-  /pnpm-sync-lib@0.3.0:
-    resolution: {integrity: sha512-Wt3Xf8pjzC2xcyN6ol5x5PdD5kU75+8OOgll2ZQsgm5uxih6dxziqRRuhNwtw94GHRd/0Oo7ESFmzmRz6OTQ0Q==}
+  /pnpm-sync-lib@0.3.1:
+    resolution: {integrity: sha512-peW6ZHSwAfQzeH1Zobjha3op9gGUx05Uz31ZcaS1B3hUwe/5mWk//Rrk1eFix67idSWz7yGfZzT50QQPRiFcdw==}
     dependencies:
-      '@pnpm/dependency-path': 2.1.8
+      '@pnpm/dependency-path-2': /@pnpm/dependency-path@2.1.8
+      '@pnpm/dependency-path-5': /@pnpm/dependency-path@5.1.7
       yaml: 2.4.1
     dev: false
 

--- a/common/config/subspaces/default/pnpm-lock.yaml
+++ b/common/config/subspaces/default/pnpm-lock.yaml
@@ -3376,8 +3376,8 @@ importers:
         specifier: ~6.1.0
         version: 6.1.1
       pnpm-sync-lib:
-        specifier: 0.3.1
-        version: 0.3.1
+        specifier: 0.3.2
+        version: 0.3.2
       read-package-tree:
         specifier: ~5.1.5
         version: 5.1.6
@@ -24205,8 +24205,8 @@ packages:
       - typescript
     dev: true
 
-  /pnpm-sync-lib@0.3.1:
-    resolution: {integrity: sha512-peW6ZHSwAfQzeH1Zobjha3op9gGUx05Uz31ZcaS1B3hUwe/5mWk//Rrk1eFix67idSWz7yGfZzT50QQPRiFcdw==}
+  /pnpm-sync-lib@0.3.2:
+    resolution: {integrity: sha512-XlHyNAHlBqIMGTBD0HfgyRyj1UpSJvVyP20ihPek00YKmMb7RJ16AxlQkjT1jQ/D6s6OAT0ety/tSxcJTrvQ4w==}
     dependencies:
       '@pnpm/dependency-path-2': /@pnpm/dependency-path@2.1.8
       '@pnpm/dependency-path-5': /@pnpm/dependency-path@5.1.7

--- a/common/config/subspaces/default/repo-state.json
+++ b/common/config/subspaces/default/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "cf20a3884c11c43ea03f638be650d85b8a86e963",
+  "pnpmShrinkwrapHash": "9fb69036f728baa8dee343b4cbc3f70e854f8dbf",
   "preferredVersionsHash": "54149ea3f01558a859c96dee2052b797d4defe68"
 }

--- a/common/config/subspaces/default/repo-state.json
+++ b/common/config/subspaces/default/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "9fb69036f728baa8dee343b4cbc3f70e854f8dbf",
+  "pnpmShrinkwrapHash": "d132a98928f381f6aae3c1da00a3939f2d38dafe",
   "preferredVersionsHash": "54149ea3f01558a859c96dee2052b797d4defe68"
 }

--- a/libraries/rush-lib/package.json
+++ b/libraries/rush-lib/package.json
@@ -65,7 +65,7 @@
     "tar": "~6.2.1",
     "true-case-path": "~2.2.1",
     "uuid": "~8.3.2",
-    "pnpm-sync-lib": "0.3.1"
+    "pnpm-sync-lib": "0.3.2"
   },
   "devDependencies": {
     "@pnpm/lockfile.types": "~1.0.3",

--- a/libraries/rush-lib/package.json
+++ b/libraries/rush-lib/package.json
@@ -65,7 +65,7 @@
     "tar": "~6.2.1",
     "true-case-path": "~2.2.1",
     "uuid": "~8.3.2",
-    "pnpm-sync-lib": "0.3.0"
+    "pnpm-sync-lib": "0.3.1"
   },
   "devDependencies": {
     "@pnpm/lockfile.types": "~1.0.3",


### PR DESCRIPTION
## Summary

Bumps `pnpm-sync-lib` to `0.3.2` support PNPM v9.

## How it was tested

~~Attempted to bump the pnpm version in this repo to `9.15.9` and run `rush update` with the version of Rush in this branch. There are several issues.~~ This works under pnpm 8.

## Impacted documentation

None.