### PR TITLE
[rush-lib] Fix pnpm-sync caused .modules.yaml ENOENT during install

### DIFF
--- a/common/changes/@microsoft/rush/fix-pnpm-sync-modules-yaml_2025-06-23-08-37.json
+++ b/common/changes/@microsoft/rush/fix-pnpm-sync-modules-yaml_2025-06-23-08-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix pnpm-sync caused .modules.yaml ENOENT during install",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
+++ b/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
@@ -293,11 +293,12 @@ export abstract class BaseInstallManager {
     if (this.rushConfiguration.isPnpm && experiments?.usePnpmSyncForInjectedDependencies) {
       const pnpmLockfilePath: string = subspace.getTempShrinkwrapFilename();
       const dotPnpmFolder: string = `${subspace.getSubspaceTempFolderPath()}/node_modules/.pnpm`;
+      const modulesFilePath = `${subspace.getSubspaceTempFolderPath()}/node_modules/.modules.yaml`;
 
       // we have an edge case here
       // if a package.json has no dependencies, pnpm will still generate the pnpm-lock.yaml but not .pnpm folder
       // so we need to make sure pnpm-lock.yaml and .pnpm exists before calling the pnpmSync APIs
-      if ((await FileSystem.existsAsync(pnpmLockfilePath)) && (await FileSystem.existsAsync(dotPnpmFolder))) {
+      if ((await FileSystem.existsAsync(pnpmLockfilePath)) && (await FileSystem.existsAsync(dotPnpmFolder)) && (await FileSystem.existsAsync(modulesFilePath))) {
         await pnpmSyncPrepareAsync({
           lockfilePath: pnpmLockfilePath,
           dotPnpmFolder,


### PR DESCRIPTION
## Summary

Fixes #5201 

During `rush install`, after calling `pnpm install`, for repos with injected dependencies enabled, rush calls pnpm-sync.

[pnpm-sync][pnpm-sync-prepare] tries to read `.modules.yaml` during `pnpmSyncPrepareAsync()`, but the file sometimes doesn't exist, causing `rush install` to fail.

pnpm itself treats it as a special case and doens't throw when this file not eixst: https://github.com/pnpm/pnpm/blob/5d2308c9aad8b2a7e96721a13845f21e86038619/pkg-manager/modules-yaml/src/index.ts#L45

## Details

Adding one more check for this file before calling `pnpmSyncPrepareAsync()`.

## How it was tested
1. rush install and build this repo
2. run `node libraries/rush-lib/lib-commonjs/start.js install` as `rush install`
