### PR TITLE
[rush] Enhance performance data in telemetry payload

### DIFF
--- a/common/changes/@microsoft/rush/performance-marks_2025-07-03-20-39.json
+++ b/common/changes/@microsoft/rush/performance-marks_2025-07-03-20-39.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add performance measures around various operations, include performance entries in telemetry payload.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -23,6 +23,7 @@ import { JsonNull } from '@rushstack/node-core-library';
 import { JsonObject } from '@rushstack/node-core-library';
 import { LookupByPath } from '@rushstack/lookup-by-path';
 import { PackageNameParser } from '@rushstack/node-core-library';
+import type { PerformanceEntry as PerformanceEntry_2 } from 'node:perf_hooks';
 import type { StdioSummarizer } from '@rushstack/terminal';
 import { SyncHook } from 'tapable';
 import { SyncWaterfallHook } from 'tapable';
@@ -884,6 +885,7 @@ export interface ITelemetryData {
     readonly machineInfo?: ITelemetryMachineInfo;
     readonly name: string;
     readonly operationResults?: Record<string, ITelemetryOperationResult>;
+    readonly performanceEntries?: readonly PerformanceEntry_2[];
     readonly platform?: string;
     readonly result: 'Succeeded' | 'Failed';
     readonly rushVersion?: string;

--- a/libraries/rush-lib/src/api/Rush.ts
+++ b/libraries/rush-lib/src/api/Rush.ts
@@ -96,7 +96,7 @@ export class Rush {
     });
     // CommandLineParser.executeAsync() should never reject the promise
     // eslint-disable-next-line no-console
-    measureAsyncFn(() => parser.executeAsync(), 'rush:parser:executeAsync').catch(console.error);
+    measureAsyncFn('rush:parser:executeAsync', () => parser.executeAsync()).catch(console.error);
   }
 
   /**

--- a/libraries/rush-lib/src/api/Rush.ts
+++ b/libraries/rush-lib/src/api/Rush.ts
@@ -15,6 +15,7 @@ import { CommandLineMigrationAdvisor } from '../cli/CommandLineMigrationAdvisor'
 import { EnvironmentVariableNames } from './EnvironmentConfiguration';
 import type { IBuiltInPluginConfiguration } from '../pluginFramework/PluginLoader/BuiltInPluginLoader';
 import { RushPnpmCommandLine } from '../cli/RushPnpmCommandLine';
+import { measureAsyncFn } from '../utilities/performance';
 
 /**
  * Options to pass to the rush "launch" functions.
@@ -93,8 +94,9 @@ export class Rush {
       alreadyReportedNodeTooNewError: options.alreadyReportedNodeTooNewError,
       builtInPluginConfigurations: options.builtInPluginConfigurations
     });
+    // CommandLineParser.executeAsync() should never reject the promise
     // eslint-disable-next-line no-console
-    parser.executeAsync().catch(console.error); // CommandLineParser.executeAsync() should never reject the promise
+    measureAsyncFn(() => parser.executeAsync(), 'rush:parser:executeAsync').catch(console.error);
   }
 
   /**

--- a/libraries/rush-lib/src/cli/RushCommandLineParser.ts
+++ b/libraries/rush-lib/src/cli/RushCommandLineParser.ts
@@ -65,6 +65,8 @@ import { InstallAutoinstallerAction } from './actions/InstallAutoinstallerAction
 import { LinkPackageAction } from './actions/LinkPackageAction';
 import { BridgePackageAction } from './actions/BridgePackageAction';
 
+import { measureAsyncFn } from '../utilities/performance';
+
 /**
  * Options for `RushCommandLineParser`.
  */
@@ -219,7 +221,10 @@ export class RushCommandLineParser extends CommandLineParser {
     this._terminalProvider.verboseEnabled = this._terminalProvider.debugEnabled =
       process.argv.indexOf('--debug') >= 0;
 
-    await this.pluginManager.tryInitializeUnassociatedPluginsAsync();
+    await measureAsyncFn(
+      () => this.pluginManager.tryInitializeUnassociatedPluginsAsync(),
+      'rush:initializeUnassociatedPlugins'
+    );
 
     return await super.executeAsync(args);
   }
@@ -298,7 +303,7 @@ export class RushCommandLineParser extends CommandLineParser {
     }
 
     try {
-      await super.onExecuteAsync();
+      await measureAsyncFn(() => super.onExecuteAsync(), 'rush:commandLineParser:onExecuteAsync');
     } finally {
       if (this.telemetry) {
         this.flushTelemetry();

--- a/libraries/rush-lib/src/cli/RushCommandLineParser.ts
+++ b/libraries/rush-lib/src/cli/RushCommandLineParser.ts
@@ -221,9 +221,8 @@ export class RushCommandLineParser extends CommandLineParser {
     this._terminalProvider.verboseEnabled = this._terminalProvider.debugEnabled =
       process.argv.indexOf('--debug') >= 0;
 
-    await measureAsyncFn(
-      () => this.pluginManager.tryInitializeUnassociatedPluginsAsync(),
-      'rush:initializeUnassociatedPlugins'
+    await measureAsyncFn('rush:initializeUnassociatedPlugins', () =>
+      this.pluginManager.tryInitializeUnassociatedPluginsAsync()
     );
 
     return await super.executeAsync(args);
@@ -303,7 +302,7 @@ export class RushCommandLineParser extends CommandLineParser {
     }
 
     try {
-      await measureAsyncFn(() => super.onExecuteAsync(), 'rush:commandLineParser:onExecuteAsync');
+      await measureAsyncFn('rush:commandLineParser:onExecuteAsync', () => super.onExecuteAsync());
     } finally {
       if (this.telemetry) {
         this.flushTelemetry();

--- a/libraries/rush-lib/src/cli/actions/BaseInstallAction.ts
+++ b/libraries/rush-lib/src/cli/actions/BaseInstallAction.ts
@@ -286,9 +286,8 @@ export abstract class BaseInstallAction extends BaseRushAction {
       installSuccessful = false;
       throw error;
     } finally {
-      await measureAsyncFn(
-        () => purgeManager.startDeleteAllAsync(),
-        'rush:installManager:startDeleteAllAsync'
+      await measureAsyncFn('rush:installManager:startDeleteAllAsync', () =>
+        purgeManager.startDeleteAllAsync()
       );
       stopwatch.stop();
 
@@ -331,7 +330,7 @@ export abstract class BaseInstallAction extends BaseRushAction {
         installManagerOptions
       );
 
-    await measureAsyncFn(() => installManager.doInstallAsync(), 'rush:installManager:doInstallAsync');
+    await measureAsyncFn('rush:installManager:doInstallAsync', () => installManager.doInstallAsync());
   }
 
   private _collectTelemetry(

--- a/libraries/rush-lib/src/cli/actions/BaseInstallAction.ts
+++ b/libraries/rush-lib/src/cli/actions/BaseInstallAction.ts
@@ -24,6 +24,7 @@ import { SUBSPACE_LONG_ARG_NAME, type SelectionParameterSet } from '../parsing/S
 import type { RushConfigurationProject } from '../../api/RushConfigurationProject';
 import type { Subspace } from '../../api/Subspace';
 import { getVariantAsync, VARIANT_PARAMETER } from '../../api/Variants';
+import { measureAsyncFn } from '../../utilities/performance';
 
 /**
  * Temporary data structure used by `BaseInstallAction.runAsync()`
@@ -285,7 +286,10 @@ export abstract class BaseInstallAction extends BaseRushAction {
       installSuccessful = false;
       throw error;
     } finally {
-      await purgeManager.startDeleteAllAsync();
+      await measureAsyncFn(
+        () => purgeManager.startDeleteAllAsync(),
+        'rush:installManager:startDeleteAllAsync'
+      );
       stopwatch.stop();
 
       this._collectTelemetry(stopwatch, installManagerOptions, installSuccessful);
@@ -327,7 +331,7 @@ export abstract class BaseInstallAction extends BaseRushAction {
         installManagerOptions
       );
 
-    await installManager.doInstallAsync();
+    await measureAsyncFn(() => installManager.doInstallAsync(), 'rush:installManager:doInstallAsync');
   }
 
   private _collectTelemetry(

--- a/libraries/rush-lib/src/cli/actions/BaseRushAction.ts
+++ b/libraries/rush-lib/src/cli/actions/BaseRushAction.ts
@@ -78,7 +78,7 @@ export abstract class BaseConfiglessRushAction extends CommandLineAction impleme
       this.terminal.write(`Starting "rush ${this.actionName}"\n`);
     }
 
-    await measureAsyncFn(() => this.runAsync(), `${PERF_PREFIX}:runAsync`);
+    await measureAsyncFn(`${PERF_PREFIX}:runAsync`, () => this.runAsync());
   }
 
   /**
@@ -124,20 +124,19 @@ export abstract class BaseRushAction extends BaseConfiglessRushAction {
 
     this._throwPluginErrorIfNeed();
 
-    await measureAsyncFn(
-      () => this.parser.pluginManager.tryInitializeAssociatedCommandPluginsAsync(this.actionName),
-      `${PERF_PREFIX}:initializePluginsAsync`
+    await measureAsyncFn(`${PERF_PREFIX}:initializePluginsAsync`, () =>
+      this.parser.pluginManager.tryInitializeAssociatedCommandPluginsAsync(this.actionName)
     );
 
     this._throwPluginErrorIfNeed();
 
     const { hooks: sessionHooks } = this.rushSession;
-    await measureAsyncFn(async () => {
+    await measureAsyncFn(`${PERF_PREFIX}:initializePlugins`, async () => {
       if (sessionHooks.initialize.isUsed()) {
         // Avoid the cost of compiling the hook if it wasn't tapped.
         await sessionHooks.initialize.promise(this);
       }
-    }, `${PERF_PREFIX}:initializePlugins`);
+    });
 
     return super.onExecuteAsync();
   }

--- a/libraries/rush-lib/src/cli/scriptActions/GlobalScriptAction.ts
+++ b/libraries/rush-lib/src/cli/scriptActions/GlobalScriptAction.ts
@@ -121,9 +121,8 @@ export class GlobalScriptAction extends BaseScriptAction<IGlobalCommandConfig> {
       this.commandLineConfiguration?.additionalPathFolders.slice() || [];
 
     if (this._autoinstallerName) {
-      await measureAsyncFn(
-        () => this._prepareAutoinstallerNameAsync(),
-        'rush:globalScriptAction:prepareAutoinstaller'
+      await measureAsyncFn('rush:globalScriptAction:prepareAutoinstaller', () =>
+        this._prepareAutoinstallerNameAsync()
       );
 
       const autoinstallerNameBinPath: string = path.join(this._autoinstallerFullPath, 'node_modules', '.bin');

--- a/libraries/rush-lib/src/cli/scriptActions/GlobalScriptAction.ts
+++ b/libraries/rush-lib/src/cli/scriptActions/GlobalScriptAction.ts
@@ -20,6 +20,7 @@ import { Utilities } from '../../utilities/Utilities';
 import { Stopwatch } from '../../utilities/Stopwatch';
 import { Autoinstaller } from '../../logic/Autoinstaller';
 import type { IGlobalCommandConfig, IShellCommandTokenContext } from '../../api/CommandLineConfiguration';
+import { measureAsyncFn } from '../../utilities/performance';
 
 /**
  * Constructor parameters for GlobalScriptAction.
@@ -120,7 +121,10 @@ export class GlobalScriptAction extends BaseScriptAction<IGlobalCommandConfig> {
       this.commandLineConfiguration?.additionalPathFolders.slice() || [];
 
     if (this._autoinstallerName) {
-      await this._prepareAutoinstallerNameAsync();
+      await measureAsyncFn(
+        () => this._prepareAutoinstallerNameAsync(),
+        'rush:globalScriptAction:prepareAutoinstaller'
+      );
 
       const autoinstallerNameBinPath: string = path.join(this._autoinstallerFullPath, 'node_modules', '.bin');
       additionalPathFolders.push(autoinstallerNameBinPath);

--- a/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
+++ b/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
@@ -59,6 +59,9 @@ import { getVariantAsync, VARIANT_PARAMETER } from '../../api/Variants';
 import { Selection } from '../../logic/Selection';
 import { NodeDiagnosticDirPlugin } from '../../logic/operations/NodeDiagnosticDirPlugin';
 import { DebugHashesPlugin } from '../../logic/operations/DebugHashesPlugin';
+import { measureAsyncFn, measureSyncFn } from '../../utilities/performance';
+
+const PERF_PREFIX: 'rush:phasedScriptAction' = 'rush:phasedScriptAction';
 
 /**
  * Constructor parameters for PhasedScriptAction.
@@ -180,18 +183,7 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
 
     this.hooks = new PhasedCommandHooks();
 
-    const terminal: Terminal = new Terminal(this.rushSession.terminalProvider);
-    this._terminal = terminal;
-
-    // Generates the default operation graph
-    new PhasedOperationPlugin().apply(this.hooks);
-    // Splices in sharded phases to the operation graph.
-    new ShardedPhasedOperationPlugin().apply(this.hooks);
-    // Applies the Shell Operation Runner to selected operations
-    new ShellOperationRunnerPlugin().apply(this.hooks);
-
-    new WeightedOperationPlugin().apply(this.hooks);
-    new ValidateOperationsPlugin(terminal).apply(this.hooks);
+    this._terminal = new Terminal(this.rushSession.terminalProvider);
 
     this._parallelismParameter = this._enableParallelism
       ? this.defineStringParameter({
@@ -334,52 +326,61 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
   }
 
   public async runAsync(): Promise<void> {
-    if (this._alwaysInstall || this._installParameter?.value) {
-      const { doBasicInstallAsync } = await import(
-        /* webpackChunkName: 'doBasicInstallAsync' */
-        '../../logic/installManager/doBasicInstallAsync'
-      );
+    const stopwatch: Stopwatch = Stopwatch.start();
 
-      const variant: string | undefined = await getVariantAsync(
-        this._variantParameter,
-        this.rushConfiguration,
-        true
-      );
-      await doBasicInstallAsync({
-        terminal: this._terminal,
-        rushConfiguration: this.rushConfiguration,
-        rushGlobalFolder: this.rushGlobalFolder,
-        isDebug: this.parser.isDebug,
-        variant,
-        beforeInstallAsync: (subspace: Subspace) =>
-          this.rushSession.hooks.beforeInstall.promise(this, subspace, variant),
-        afterInstallAsync: (subspace: Subspace) =>
-          this.rushSession.hooks.afterInstall.promise(this, subspace, variant),
-        // Eventually we may want to allow a subspace to be selected here
-        subspace: this.rushConfiguration.defaultSubspace
-      });
+    if (this._alwaysInstall || this._installParameter?.value) {
+      await measureAsyncFn(async () => {
+        const { doBasicInstallAsync } = await import(
+          /* webpackChunkName: 'doBasicInstallAsync' */
+          '../../logic/installManager/doBasicInstallAsync'
+        );
+
+        const variant: string | undefined = await getVariantAsync(
+          this._variantParameter,
+          this.rushConfiguration,
+          true
+        );
+        await doBasicInstallAsync({
+          terminal: this._terminal,
+          rushConfiguration: this.rushConfiguration,
+          rushGlobalFolder: this.rushGlobalFolder,
+          isDebug: this.parser.isDebug,
+          variant,
+          beforeInstallAsync: (subspace: Subspace) =>
+            this.rushSession.hooks.beforeInstall.promise(this, subspace, variant),
+          afterInstallAsync: (subspace: Subspace) =>
+            this.rushSession.hooks.afterInstall.promise(this, subspace, variant),
+          // Eventually we may want to allow a subspace to be selected here
+          subspace: this.rushConfiguration.defaultSubspace
+        });
+      }, `${PERF_PREFIX}:doBasicInstallAsync`);
     }
 
     if (!this._runsBeforeInstall) {
-      // TODO: Replace with last-install.flag when "rush link" and "rush unlink" are removed
-      const lastLinkFlag: FlagFile = new FlagFile(
-        this.rushConfiguration.defaultSubspace.getSubspaceTempFolderPath(),
-        RushConstants.lastLinkFlagFilename,
-        {}
-      );
-      // Only check for a valid link flag when subspaces is not enabled
-      if (!(await lastLinkFlag.isValidAsync()) && !this.rushConfiguration.subspacesFeatureEnabled) {
-        const useWorkspaces: boolean =
-          this.rushConfiguration.pnpmOptions && this.rushConfiguration.pnpmOptions.useWorkspaces;
-        if (useWorkspaces) {
-          throw new Error('Link flag invalid.\nDid you run "rush install" or "rush update"?');
-        } else {
-          throw new Error('Link flag invalid.\nDid you run "rush link"?');
+      await measureAsyncFn(async () => {
+        // TODO: Replace with last-install.flag when "rush link" and "rush unlink" are removed
+        const lastLinkFlag: FlagFile = new FlagFile(
+          this.rushConfiguration.defaultSubspace.getSubspaceTempFolderPath(),
+          RushConstants.lastLinkFlagFilename,
+          {}
+        );
+        // Only check for a valid link flag when subspaces is not enabled
+        if (!(await lastLinkFlag.isValidAsync()) && !this.rushConfiguration.subspacesFeatureEnabled) {
+          const useWorkspaces: boolean =
+            this.rushConfiguration.pnpmOptions && this.rushConfiguration.pnpmOptions.useWorkspaces;
+          if (useWorkspaces) {
+            throw new Error('Link flag invalid.\nDid you run "rush install" or "rush update"?');
+          } else {
+            throw new Error('Link flag invalid.\nDid you run "rush link"?');
+          }
         }
-      }
+      }, `${PERF_PREFIX}:checkInstallFlag`);
     }
 
-    this._doBeforeTask();
+    measureSyncFn(() => this._doBeforeTask(), `${PERF_PREFIX}:doBeforeTask`);
+
+    const hooks: PhasedCommandHooks = this.hooks;
+    const terminal: ITerminal = this._terminal;
 
     // if this is parallelizable, then use the value from the flag (undefined or a number),
     // if parallelism is not enabled, then restrict to 1 core
@@ -387,35 +388,45 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
       ? parseParallelism(this._parallelismParameter?.value)
       : 1;
 
-    const terminal: ITerminal = this._terminal;
-
-    const stopwatch: Stopwatch = Stopwatch.start();
-
-    const showTimeline: boolean = this._timelineParameter ? this._timelineParameter.value : false;
-    if (showTimeline) {
-      const { ConsoleTimelinePlugin } = await import(
-        /* webpackChunkName: 'ConsoleTimelinePlugin' */
-        '../../logic/operations/ConsoleTimelinePlugin'
-      );
-      new ConsoleTimelinePlugin(terminal).apply(this.hooks);
-    }
-
     const includePhaseDeps: boolean = this._includePhaseDeps?.value ?? false;
 
-    const diagnosticDir: string | undefined = this._nodeDiagnosticDirParameter.value;
-    if (diagnosticDir) {
-      new NodeDiagnosticDirPlugin({
-        diagnosticDir
-      }).apply(this.hooks);
-    }
+    await measureAsyncFn(async () => {
+      // Generates the default operation graph
+      new PhasedOperationPlugin().apply(hooks);
+      // Splices in sharded phases to the operation graph.
+      new ShardedPhasedOperationPlugin().apply(hooks);
+      // Applies the Shell Operation Runner to selected operations
+      new ShellOperationRunnerPlugin().apply(hooks);
 
-    // Enable the standard summary
-    new OperationResultSummarizerPlugin(terminal).apply(this.hooks);
+      new WeightedOperationPlugin().apply(hooks);
+      new ValidateOperationsPlugin(terminal).apply(hooks);
+
+      const showTimeline: boolean = this._timelineParameter?.value ?? false;
+      if (showTimeline) {
+        const { ConsoleTimelinePlugin } = await import(
+          /* webpackChunkName: 'ConsoleTimelinePlugin' */
+          '../../logic/operations/ConsoleTimelinePlugin'
+        );
+        new ConsoleTimelinePlugin(terminal).apply(this.hooks);
+      }
+
+      const diagnosticDir: string | undefined = this._nodeDiagnosticDirParameter.value;
+      if (diagnosticDir) {
+        new NodeDiagnosticDirPlugin({
+          diagnosticDir
+        }).apply(this.hooks);
+      }
+
+      // Enable the standard summary
+      new OperationResultSummarizerPlugin(terminal).apply(this.hooks);
+    }, `${PERF_PREFIX}:applyStandardPlugins`);
 
     const { hooks: sessionHooks } = this.rushSession;
     if (sessionHooks.runAnyPhasedCommand.isUsed()) {
-      // Avoid the cost of compiling the hook if it wasn't tapped.
-      await sessionHooks.runAnyPhasedCommand.promise(this);
+      await measureAsyncFn(async () => {
+        // Avoid the cost of compiling the hook if it wasn't tapped.
+        await sessionHooks.runAnyPhasedCommand.promise(this);
+      }, `${PERF_PREFIX}:runAnyPhasedCommand`);
     }
 
     const hookForAction: AsyncSeriesHook<IPhasedCommand> | undefined = sessionHooks.runPhasedCommand.get(
@@ -423,8 +434,10 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
     );
 
     if (hookForAction) {
-      // Run the more specific hook for a command with this name after the general hook
-      await hookForAction.promise(this);
+      await measureAsyncFn(async () => {
+        // Run the more specific hook for a command with this name after the general hook
+        await hookForAction.promise(this);
+      }, `${PERF_PREFIX}:runPhasedCommand`);
     }
 
     const isQuietMode: boolean = !this._verboseParameter.value;
@@ -435,22 +448,22 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
     let buildCacheConfiguration: BuildCacheConfiguration | undefined;
     let cobuildConfiguration: CobuildConfiguration | undefined;
     if (!this._disableBuildCache) {
-      buildCacheConfiguration = await BuildCacheConfiguration.tryLoadAsync(
-        terminal,
-        this.rushConfiguration,
-        this.rushSession
-      );
-      cobuildConfiguration = await CobuildConfiguration.tryLoadAsync(
-        terminal,
-        this.rushConfiguration,
-        this.rushSession
-      );
-      await cobuildConfiguration?.createLockProviderAsync(terminal);
+      await measureAsyncFn(async () => {
+        [buildCacheConfiguration, cobuildConfiguration] = await Promise.all([
+          BuildCacheConfiguration.tryLoadAsync(terminal, this.rushConfiguration, this.rushSession),
+          CobuildConfiguration.tryLoadAsync(terminal, this.rushConfiguration, this.rushSession)
+        ]);
+        if (cobuildConfiguration) {
+          await cobuildConfiguration.createLockProviderAsync(terminal);
+        }
+      }, `${PERF_PREFIX}:configureBuildCache`);
     }
 
     try {
-      const projectSelection: Set<RushConfigurationProject> =
-        await this._selectionParameters.getSelectedProjectsAsync(terminal);
+      const projectSelection: Set<RushConfigurationProject> = await measureAsyncFn(
+        () => this._selectionParameters.getSelectedProjectsAsync(terminal),
+        `${PERF_PREFIX}:getSelectedProjectsAsync`
+      );
 
       if (!projectSelection.size) {
         terminal.writeLine(
@@ -459,67 +472,69 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
         return;
       }
 
-      const isWatch: boolean = this._watchParameter?.value || this._alwaysWatch;
-
-      if (isWatch && this._noIPCParameter?.value === false) {
-        new (
-          await import(
-            /* webpackChunkName: 'IPCOperationRunnerPlugin' */ '../../logic/operations/IPCOperationRunnerPlugin'
-          )
-        ).IPCOperationRunnerPlugin().apply(this.hooks);
-      }
-
       const customParametersByName: Map<string, CommandLineParameter> = new Map();
       for (const [configParameter, parserParameter] of this.customParameters) {
         customParametersByName.set(configParameter.longName, parserParameter);
       }
 
-      if (buildCacheConfiguration?.buildCacheEnabled) {
-        terminal.writeVerboseLine(`Incremental strategy: cache restoration`);
-        new CacheableOperationPlugin({
-          allowWarningsInSuccessfulBuild:
-            !!this.rushConfiguration.experimentsConfiguration.configuration
-              .buildCacheWithAllowWarningsInSuccessfulBuild,
-          buildCacheConfiguration,
-          cobuildConfiguration,
-          terminal
-        }).apply(this.hooks);
+      const isWatch: boolean = this._watchParameter?.value || this._alwaysWatch;
 
-        if (this._debugBuildCacheIdsParameter.value) {
-          new DebugHashesPlugin(terminal).apply(this.hooks);
+      await measureAsyncFn(async () => {
+        if (isWatch && this._noIPCParameter?.value === false) {
+          new (
+            await import(
+              /* webpackChunkName: 'IPCOperationRunnerPlugin' */ '../../logic/operations/IPCOperationRunnerPlugin'
+            )
+          ).IPCOperationRunnerPlugin().apply(this.hooks);
         }
-      } else if (!this._disableBuildCache) {
-        terminal.writeVerboseLine(`Incremental strategy: output preservation`);
-        // Explicitly disabling the build cache also disables legacy skip detection.
-        new LegacySkipPlugin({
-          allowWarningsInSuccessfulBuild:
-            this.rushConfiguration.experimentsConfiguration.configuration
-              .buildSkipWithAllowWarningsInSuccessfulBuild,
-          terminal,
-          changedProjectsOnly,
-          isIncrementalBuildAllowed: this._isIncrementalBuildAllowed
-        }).apply(this.hooks);
-      } else {
-        terminal.writeVerboseLine(`Incremental strategy: none (full rebuild)`);
-      }
 
-      const showBuildPlan: boolean = this._cobuildPlanParameter?.value ?? false;
+        if (buildCacheConfiguration?.buildCacheEnabled) {
+          terminal.writeVerboseLine(`Incremental strategy: cache restoration`);
+          new CacheableOperationPlugin({
+            allowWarningsInSuccessfulBuild:
+              !!this.rushConfiguration.experimentsConfiguration.configuration
+                .buildCacheWithAllowWarningsInSuccessfulBuild,
+            buildCacheConfiguration,
+            cobuildConfiguration,
+            terminal
+          }).apply(this.hooks);
 
-      if (showBuildPlan) {
-        if (!buildCacheConfiguration?.buildCacheEnabled) {
-          throw new Error('You must have build cache enabled to use this option.');
+          if (this._debugBuildCacheIdsParameter.value) {
+            new DebugHashesPlugin(terminal).apply(this.hooks);
+          }
+        } else if (!this._disableBuildCache) {
+          terminal.writeVerboseLine(`Incremental strategy: output preservation`);
+          // Explicitly disabling the build cache also disables legacy skip detection.
+          new LegacySkipPlugin({
+            allowWarningsInSuccessfulBuild:
+              this.rushConfiguration.experimentsConfiguration.configuration
+                .buildSkipWithAllowWarningsInSuccessfulBuild,
+            terminal,
+            changedProjectsOnly,
+            isIncrementalBuildAllowed: this._isIncrementalBuildAllowed
+          }).apply(this.hooks);
+        } else {
+          terminal.writeVerboseLine(`Incremental strategy: none (full rebuild)`);
         }
-        const { BuildPlanPlugin } = await import('../../logic/operations/BuildPlanPlugin');
-        new BuildPlanPlugin(terminal).apply(this.hooks);
-      }
 
-      const { configuration: experiments } = this.rushConfiguration.experimentsConfiguration;
-      if (this.rushConfiguration?.isPnpm && experiments?.usePnpmSyncForInjectedDependencies) {
-        const { PnpmSyncCopyOperationPlugin } = await import(
-          '../../logic/operations/PnpmSyncCopyOperationPlugin'
-        );
-        new PnpmSyncCopyOperationPlugin(terminal).apply(this.hooks);
-      }
+        const showBuildPlan: boolean = this._cobuildPlanParameter?.value ?? false;
+
+        if (showBuildPlan) {
+          if (!buildCacheConfiguration?.buildCacheEnabled) {
+            throw new Error('You must have build cache enabled to use this option.');
+          }
+          const { BuildPlanPlugin } = await import('../../logic/operations/BuildPlanPlugin');
+          new BuildPlanPlugin(terminal).apply(this.hooks);
+        }
+
+        const { configuration: experiments } = this.rushConfiguration.experimentsConfiguration;
+        if (this.rushConfiguration?.isPnpm && experiments?.usePnpmSyncForInjectedDependencies) {
+          const { PnpmSyncCopyOperationPlugin } = await import(
+            '../../logic/operations/PnpmSyncCopyOperationPlugin'
+          );
+          new PnpmSyncCopyOperationPlugin(terminal).apply(this.hooks);
+        }
+      }, `${PERF_PREFIX}:applySituationalPlugins`);
 
       const relevantProjects: Set<RushConfigurationProject> =
         Selection.expandAllDependencies(projectSelection);
@@ -527,7 +542,10 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
       const projectConfigurations: ReadonlyMap<RushConfigurationProject, RushProjectConfiguration> = this
         ._runsBeforeInstall
         ? new Map()
-        : await RushProjectConfiguration.tryLoadForProjectsAsync(relevantProjects, terminal);
+        : await measureAsyncFn(
+            () => RushProjectConfiguration.tryLoadForProjectsAsync(relevantProjects, terminal),
+            `${PERF_PREFIX}:loadProjectConfigurations`
+          );
 
       const initialCreateOperationsContext: ICreateOperationsContext = {
         buildCacheConfiguration,
@@ -577,7 +595,10 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
         terminal
       };
 
-      const internalOptions: IRunPhasesOptions = await this._runInitialPhasesAsync(initialInternalOptions);
+      const internalOptions: IRunPhasesOptions = await measureAsyncFn(
+        () => this._runInitialPhasesAsync(initialInternalOptions),
+        `${PERF_PREFIX}:runInitialPhases`
+      );
 
       if (isWatch) {
         if (buildCacheConfiguration) {
@@ -589,7 +610,9 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
         terminal.writeDebugLine(`Watch mode exited.`);
       }
     } finally {
-      await cobuildConfiguration?.destroyLockProviderAsync();
+      if (cobuildConfiguration) {
+        await cobuildConfiguration.destroyLockProviderAsync();
+      }
     }
   }
 
@@ -604,28 +627,33 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
     const { projectConfigurations } = initialCreateOperationsContext;
     const { projectSelection } = initialCreateOperationsContext;
 
-    const operations: Set<Operation> = await this.hooks.createOperations.promise(
-      new Set(),
-      initialCreateOperationsContext
+    const operations: Set<Operation> = await measureAsyncFn(
+      () => this.hooks.createOperations.promise(new Set(), initialCreateOperationsContext),
+      `${PERF_PREFIX}:createOperations`
     );
 
-    terminal.write('Analyzing repo state... ');
-    const repoStateStopwatch: Stopwatch = new Stopwatch();
-    repoStateStopwatch.start();
+    const [getInputsSnapshotAsync, initialSnapshot] = await measureAsyncFn(async () => {
+      terminal.write('Analyzing repo state... ');
+      const repoStateStopwatch: Stopwatch = new Stopwatch();
+      repoStateStopwatch.start();
 
-    const analyzer: ProjectChangeAnalyzer = new ProjectChangeAnalyzer(this.rushConfiguration);
-    const getInputsSnapshotAsync: GetInputsSnapshotAsyncFn | undefined =
-      await analyzer._tryGetSnapshotProviderAsync(
-        projectConfigurations,
-        terminal,
-        // We need to include all dependencies, otherwise build cache id calculation will be incorrect
-        Selection.expandAllDependencies(projectSelection)
-      );
-    const initialSnapshot: IInputsSnapshot | undefined = await getInputsSnapshotAsync?.();
+      const analyzer: ProjectChangeAnalyzer = new ProjectChangeAnalyzer(this.rushConfiguration);
+      const innerGetInputsSnapshotAsync: GetInputsSnapshotAsyncFn | undefined =
+        await analyzer._tryGetSnapshotProviderAsync(
+          projectConfigurations,
+          terminal,
+          // We need to include all dependencies, otherwise build cache id calculation will be incorrect
+          Selection.expandAllDependencies(projectSelection)
+        );
+      const innerInitialSnapshot: IInputsSnapshot | undefined = innerGetInputsSnapshotAsync
+        ? await innerGetInputsSnapshotAsync()
+        : undefined;
 
-    repoStateStopwatch.stop();
-    terminal.writeLine(`DONE (${repoStateStopwatch.toString()})`);
-    terminal.writeLine();
+      repoStateStopwatch.stop();
+      terminal.writeLine(`DONE (${repoStateStopwatch.toString()})`);
+      terminal.writeLine();
+      return [innerGetInputsSnapshotAsync, innerInitialSnapshot];
+    }, `${PERF_PREFIX}:analyzeRepoStateAsync`);
 
     const initialExecuteOperationsContext: IExecuteOperationsContext = {
       ...initialCreateOperationsContext,
@@ -636,7 +664,10 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
       ...partialExecutionManagerOptions,
       inputsSnapshot: initialSnapshot,
       beforeExecuteOperationsAsync: async (records: Map<Operation, OperationExecutionRecord>) => {
-        await this.hooks.beforeExecuteOperations.promise(records, initialExecuteOperationsContext);
+        await measureAsyncFn(
+          () => this.hooks.beforeExecuteOperations.promise(records, initialExecuteOperationsContext),
+          `${PERF_PREFIX}:beforeExecuteOperations`
+        );
       }
     };
 
@@ -649,7 +680,10 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
       terminal
     };
 
-    await this._executeOperationsAsync(initialOptions);
+    await measureAsyncFn(
+      () => this._executeOperationsAsync(initialOptions),
+      `${PERF_PREFIX}:executeOperationsAsync`
+    );
 
     return {
       ...options,
@@ -822,8 +856,10 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
     // Loop until Ctrl+C
     while (!abortSignal.aborted) {
       // On the initial invocation, this promise will return immediately with the full set of projects
-      const { changedProjects, inputsSnapshot: state } =
-        await projectWatcher.waitForChangeAsync(onWaitingForChanges);
+      const { changedProjects, inputsSnapshot: state } = await measureAsyncFn(
+        () => projectWatcher.waitForChangeAsync(onWaitingForChanges),
+        `${PERF_PREFIX}:waitForChangeAsync`
+      );
 
       if (abortSignal.aborted) {
         return;
@@ -855,9 +891,9 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
         invalidateOperation
       };
 
-      const operations: Set<Operation> = await this.hooks.createOperations.promise(
-        new Set(),
-        executeOperationsContext
+      const operations: Set<Operation> = await measureAsyncFn(
+        () => this.hooks.createOperations.promise(new Set(), executeOperationsContext),
+        `${PERF_PREFIX}:createOperations`
       );
 
       const executeOptions: IExecutionOperationsOptions = {
@@ -870,7 +906,10 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
           ...executionManagerOptions,
           inputsSnapshot: state,
           beforeExecuteOperationsAsync: async (records: Map<Operation, OperationExecutionRecord>) => {
-            await this.hooks.beforeExecuteOperations.promise(records, executeOperationsContext);
+            await measureAsyncFn(
+              () => this.hooks.beforeExecuteOperations.promise(records, executeOperationsContext),
+              `${PERF_PREFIX}:beforeExecuteOperations`
+            );
           }
         },
         terminal
@@ -878,7 +917,10 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
 
       try {
         // Delegate the the underlying command, for only the projects that need reprocessing
-        await this._executeOperationsAsync(executeOptions);
+        await measureAsyncFn(
+          () => this._executeOperationsAsync(executeOptions),
+          `${PERF_PREFIX}:executeOperationsAsync`
+        );
       } catch (err) {
         // In watch mode, we want to rebuild even if the original build failed.
         if (!(err instanceof AlreadyReportedError)) {
@@ -905,10 +947,17 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
     let result: IExecutionResult | undefined;
 
     try {
-      result = await executionManager.executeAsync();
-      success = result.status === OperationStatus.Success;
+      const definiteResult: IExecutionResult = await measureAsyncFn(
+        () => executionManager.executeAsync(),
+        `${PERF_PREFIX}:executeOperations`
+      );
+      success = definiteResult.status === OperationStatus.Success;
+      result = definiteResult;
 
-      await this.hooks.afterExecuteOperations.promise(result, options.executeOperationsContext);
+      await measureAsyncFn(
+        () => this.hooks.afterExecuteOperations.promise(definiteResult, options.executeOperationsContext),
+        `${PERF_PREFIX}:afterExecuteOperations`
+      );
 
       stopwatch.stop();
 
@@ -938,119 +987,123 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
     }
 
     if (!ignoreHooks) {
-      this._doAfterTask();
+      measureSyncFn(() => this._doAfterTask(), `${PERF_PREFIX}:doAfterTask`);
     }
 
     if (this.parser.telemetry) {
-      const jsonOperationResults: Record<string, ITelemetryOperationResult> = {};
+      const logEntry: ITelemetryData = measureSyncFn(() => {
+        const jsonOperationResults: Record<string, ITelemetryOperationResult> = {};
 
-      const extraData: IPhasedCommandTelemetry = {
-        // Fields preserved across the command invocation
-        ...this._selectionParameters.getTelemetry(),
-        ...this.getParameterStringMap(),
-        isWatch,
-        // Fields specific to the current operation set
-        isInitial,
+        const extraData: IPhasedCommandTelemetry = {
+          // Fields preserved across the command invocation
+          ...this._selectionParameters.getTelemetry(),
+          ...this.getParameterStringMap(),
+          isWatch,
+          // Fields specific to the current operation set
+          isInitial,
 
-        countAll: 0,
-        countSuccess: 0,
-        countSuccessWithWarnings: 0,
-        countFailure: 0,
-        countBlocked: 0,
-        countFromCache: 0,
-        countSkipped: 0,
-        countNoOp: 0
-      };
+          countAll: 0,
+          countSuccess: 0,
+          countSuccessWithWarnings: 0,
+          countFailure: 0,
+          countBlocked: 0,
+          countFromCache: 0,
+          countSkipped: 0,
+          countNoOp: 0
+        };
 
-      const { _changedProjectsOnlyParameter: changedProjectsOnlyParameter } = this;
-      if (changedProjectsOnlyParameter) {
-        // Overwrite this value since we allow changing it at runtime.
-        extraData[changedProjectsOnlyParameter.scopedLongName ?? changedProjectsOnlyParameter.longName] =
-          this._changedProjectsOnly;
-      }
+        const { _changedProjectsOnlyParameter: changedProjectsOnlyParameter } = this;
+        if (changedProjectsOnlyParameter) {
+          // Overwrite this value since we allow changing it at runtime.
+          extraData[changedProjectsOnlyParameter.scopedLongName ?? changedProjectsOnlyParameter.longName] =
+            this._changedProjectsOnly;
+        }
 
-      if (result) {
-        const { operationResults } = result;
+        if (result) {
+          const { operationResults } = result;
 
-        const nonSilentDependenciesByOperation: Map<Operation, Set<string>> = new Map();
-        function getNonSilentDependencies(operation: Operation): ReadonlySet<string> {
-          let realDependencies: Set<string> | undefined = nonSilentDependenciesByOperation.get(operation);
-          if (!realDependencies) {
-            realDependencies = new Set();
-            nonSilentDependenciesByOperation.set(operation, realDependencies);
-            for (const dependency of operation.dependencies) {
-              const dependencyRecord: IOperationExecutionResult | undefined =
-                operationResults.get(dependency);
-              if (dependencyRecord?.silent) {
-                for (const deepDependency of getNonSilentDependencies(dependency)) {
-                  realDependencies.add(deepDependency);
+          const nonSilentDependenciesByOperation: Map<Operation, Set<string>> = new Map();
+          function getNonSilentDependencies(operation: Operation): ReadonlySet<string> {
+            let realDependencies: Set<string> | undefined = nonSilentDependenciesByOperation.get(operation);
+            if (!realDependencies) {
+              realDependencies = new Set();
+              nonSilentDependenciesByOperation.set(operation, realDependencies);
+              for (const dependency of operation.dependencies) {
+                const dependencyRecord: IOperationExecutionResult | undefined =
+                  operationResults.get(dependency);
+                if (dependencyRecord?.silent) {
+                  for (const deepDependency of getNonSilentDependencies(dependency)) {
+                    realDependencies.add(deepDependency);
+                  }
+                } else {
+                  realDependencies.add(dependency.name!);
                 }
-              } else {
-                realDependencies.add(dependency.name!);
               }
             }
+            return realDependencies;
           }
-          return realDependencies;
+
+          for (const [operation, operationResult] of operationResults) {
+            if (operationResult.silent) {
+              // Architectural operation. Ignore.
+              continue;
+            }
+
+            const { _operationMetadataManager: operationMetadataManager } =
+              operationResult as OperationExecutionRecord;
+
+            const { startTime, endTime } = operationResult.stopwatch;
+            jsonOperationResults[operation.name!] = {
+              startTimestampMs: startTime,
+              endTimestampMs: endTime,
+              nonCachedDurationMs: operationResult.nonCachedDurationMs,
+              wasExecutedOnThisMachine: operationMetadataManager?.wasCobuilt !== true,
+              result: operationResult.status,
+              dependencies: Array.from(getNonSilentDependencies(operation)).sort()
+            };
+
+            extraData.countAll++;
+            switch (operationResult.status) {
+              case OperationStatus.Success:
+                extraData.countSuccess++;
+                break;
+              case OperationStatus.SuccessWithWarning:
+                extraData.countSuccessWithWarnings++;
+                break;
+              case OperationStatus.Failure:
+                extraData.countFailure++;
+                break;
+              case OperationStatus.Blocked:
+                extraData.countBlocked++;
+                break;
+              case OperationStatus.FromCache:
+                extraData.countFromCache++;
+                break;
+              case OperationStatus.Skipped:
+                extraData.countSkipped++;
+                break;
+              case OperationStatus.NoOp:
+                extraData.countNoOp++;
+                break;
+              default:
+                // Do nothing.
+                break;
+            }
+          }
         }
 
-        for (const [operation, operationResult] of operationResults) {
-          if (operationResult.silent) {
-            // Architectural operation. Ignore.
-            continue;
-          }
+        const innerLogEntry: ITelemetryData = {
+          name: this.actionName,
+          durationInSeconds: stopwatch.duration,
+          result: success ? 'Succeeded' : 'Failed',
+          extraData,
+          operationResults: jsonOperationResults
+        };
 
-          const { _operationMetadataManager: operationMetadataManager } =
-            operationResult as OperationExecutionRecord;
+        return innerLogEntry;
+      }, `${PERF_PREFIX}:prepareTelemetry`);
 
-          const { startTime, endTime } = operationResult.stopwatch;
-          jsonOperationResults[operation.name!] = {
-            startTimestampMs: startTime,
-            endTimestampMs: endTime,
-            nonCachedDurationMs: operationResult.nonCachedDurationMs,
-            wasExecutedOnThisMachine: operationMetadataManager?.wasCobuilt !== true,
-            result: operationResult.status,
-            dependencies: Array.from(getNonSilentDependencies(operation)).sort()
-          };
-
-          extraData.countAll++;
-          switch (operationResult.status) {
-            case OperationStatus.Success:
-              extraData.countSuccess++;
-              break;
-            case OperationStatus.SuccessWithWarning:
-              extraData.countSuccessWithWarnings++;
-              break;
-            case OperationStatus.Failure:
-              extraData.countFailure++;
-              break;
-            case OperationStatus.Blocked:
-              extraData.countBlocked++;
-              break;
-            case OperationStatus.FromCache:
-              extraData.countFromCache++;
-              break;
-            case OperationStatus.Skipped:
-              extraData.countSkipped++;
-              break;
-            case OperationStatus.NoOp:
-              extraData.countNoOp++;
-              break;
-            default:
-              // Do nothing.
-              break;
-          }
-        }
-      }
-
-      const logEntry: ITelemetryData = {
-        name: this.actionName,
-        durationInSeconds: stopwatch.duration,
-        result: success ? 'Succeeded' : 'Failed',
-        extraData,
-        operationResults: jsonOperationResults
-      };
-
-      this.hooks.beforeLog.call(logEntry);
+      measureSyncFn(() => this.hooks.beforeLog.call(logEntry), `${PERF_PREFIX}:beforeLog`);
 
       this.parser.telemetry.log(logEntry);
 

--- a/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
+++ b/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
@@ -59,7 +59,7 @@ import { getVariantAsync, VARIANT_PARAMETER } from '../../api/Variants';
 import { Selection } from '../../logic/Selection';
 import { NodeDiagnosticDirPlugin } from '../../logic/operations/NodeDiagnosticDirPlugin';
 import { DebugHashesPlugin } from '../../logic/operations/DebugHashesPlugin';
-import { measureAsyncFn, measureSyncFn } from '../../utilities/performance';
+import { measureAsyncFn, measureFn } from '../../utilities/performance';
 
 const PERF_PREFIX: 'rush:phasedScriptAction' = 'rush:phasedScriptAction';
 
@@ -377,7 +377,7 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
       }, `${PERF_PREFIX}:checkInstallFlag`);
     }
 
-    measureSyncFn(() => this._doBeforeTask(), `${PERF_PREFIX}:doBeforeTask`);
+    measureFn(() => this._doBeforeTask(), `${PERF_PREFIX}:doBeforeTask`);
 
     const hooks: PhasedCommandHooks = this.hooks;
     const terminal: ITerminal = this._terminal;
@@ -987,11 +987,11 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
     }
 
     if (!ignoreHooks) {
-      measureSyncFn(() => this._doAfterTask(), `${PERF_PREFIX}:doAfterTask`);
+      measureFn(() => this._doAfterTask(), `${PERF_PREFIX}:doAfterTask`);
     }
 
     if (this.parser.telemetry) {
-      const logEntry: ITelemetryData = measureSyncFn(() => {
+      const logEntry: ITelemetryData = measureFn(() => {
         const jsonOperationResults: Record<string, ITelemetryOperationResult> = {};
 
         const extraData: IPhasedCommandTelemetry = {
@@ -1103,7 +1103,7 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
         return innerLogEntry;
       }, `${PERF_PREFIX}:prepareTelemetry`);
 
-      measureSyncFn(() => this.hooks.beforeLog.call(logEntry), `${PERF_PREFIX}:beforeLog`);
+      measureFn(() => this.hooks.beforeLog.call(logEntry), `${PERF_PREFIX}:beforeLog`);
 
       this.parser.telemetry.log(logEntry);
 

--- a/libraries/rush-lib/src/logic/Telemetry.ts
+++ b/libraries/rush-lib/src/logic/Telemetry.ts
@@ -168,7 +168,8 @@ export class Telemetry {
     const cpus: os.CpuInfo[] = os.cpus();
     const data: ITelemetryData = {
       ...telemetryData,
-      performanceEntries: collectPerformanceEntries(this._telemetryStartTime),
+      performanceEntries:
+        telemetryData.performanceEntries || collectPerformanceEntries(this._telemetryStartTime),
       machineInfo: telemetryData.machineInfo || {
         machineArchitecture: os.arch(),
         // The Node.js model is sometimes padded, for example:

--- a/libraries/rush-lib/src/logic/test/Telemetry.test.ts
+++ b/libraries/rush-lib/src/logic/test/Telemetry.test.ts
@@ -20,6 +20,8 @@ describe(Telemetry.name, () => {
   });
 
   beforeEach(() => {
+    performance.clearMarks();
+    performance.clearMeasures();
     jest.clearAllMocks();
   });
 
@@ -42,7 +44,8 @@ describe(Telemetry.name, () => {
       timestampMs: new Date().getTime(),
       platform: process.platform,
       rushVersion: Rush.version,
-      machineInfo: {} as ITelemetryMachineInfo
+      machineInfo: {} as ITelemetryMachineInfo,
+      performanceEntries: []
     };
 
     const logData2: ITelemetryData = {
@@ -52,7 +55,8 @@ describe(Telemetry.name, () => {
       timestampMs: new Date().getTime(),
       platform: process.platform,
       rushVersion: Rush.version,
-      machineInfo: {} as ITelemetryMachineInfo
+      machineInfo: {} as ITelemetryMachineInfo,
+      performanceEntries: []
     };
 
     telemetry.log(logData1);
@@ -96,7 +100,8 @@ describe(Telemetry.name, () => {
       timestampMs: new Date().getTime(),
       platform: process.platform,
       rushVersion: Rush.version,
-      machineInfo: {} as ITelemetryMachineInfo
+      machineInfo: {} as ITelemetryMachineInfo,
+      performanceEntries: []
     };
 
     telemetry.log(logData);

--- a/libraries/rush-lib/src/start.ts
+++ b/libraries/rush-lib/src/start.ts
@@ -3,4 +3,8 @@
 
 import { Rush } from './api/Rush';
 
+performance.mark('rush:start');
+
 Rush.launch(Rush.version, { isManaged: false });
+
+// Rush.launch has async side effects, so no point ending the measurement.

--- a/libraries/rush-lib/src/utilities/performance.ts
+++ b/libraries/rush-lib/src/utilities/performance.ts
@@ -42,7 +42,7 @@ export function measureAsyncFn<T>(fn: () => Promise<T>, name: string): Promise<T
  * @param name - The name of the performance measurement. This should be unique for each measurement.
  * @returns The result of the function.
  */
-export function measureSyncFn<T>(fn: () => T, name: string): T {
+export function measureFn<T>(fn: () => T, name: string): T {
   const start: number = performance.now();
   try {
     return fn();

--- a/libraries/rush-lib/src/utilities/performance.ts
+++ b/libraries/rush-lib/src/utilities/performance.ts
@@ -1,24 +1,23 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import type { PerformanceEntry, PerformanceMark, PerformanceMeasure } from 'node:perf_hooks';
+import type { PerformanceEntry } from 'node:perf_hooks';
 
 /**
- * Starts a performance measurement.
+ * Starts a performance measurement that can be disposed later to record the elapsed time.
  * @param name - The name of the performance measurement. This should be unique for each measurement.
- * @returns The performance mark that indicates the start of a measurement.
+ * @returns A Disposable object that, when disposed, will end and record the performance measurement.
  */
-export function startPerformanceMeasurement(name: string): PerformanceMark {
-  return performance.mark(`${name}:start`);
-}
+export function measureUntilDisposed(name: string): Disposable {
+  const start: number = performance.now();
 
-/**
- * Ends a performance measurement.
- * @param name - The name of the performance measurement. This should match the name used in `startPerformanceMeasurement`.
- * @returns The performance measure that contains the start and end marks for the measurement.
- */
-export function endPerformanceMeasurement(name: string): PerformanceMeasure {
-  return performance.measure(name, `${name}:start`);
+  return {
+    [Symbol.dispose]() {
+      performance.measure(name, {
+        start
+      });
+    }
+  };
 }
 
 /**

--- a/libraries/rush-lib/src/utilities/performance.ts
+++ b/libraries/rush-lib/src/utilities/performance.ts
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import type { PerformanceEntry, PerformanceMark, PerformanceMeasure } from 'node:perf_hooks';
+
+/**
+ * Starts a performance measurement.
+ * @param name - The name of the performance measurement. This should be unique for each measurement.
+ * @returns The performance mark that indicates the start of a measurement.
+ */
+export function startPerformanceMeasurement(name: string): PerformanceMark {
+  return performance.mark(`${name}:start`);
+}
+
+/**
+ * Ends a performance measurement.
+ * @param name - The name of the performance measurement. This should match the name used in `startPerformanceMeasurement`.
+ * @returns The performance measure that contains the start and end marks for the measurement.
+ */
+export function endPerformanceMeasurement(name: string): PerformanceMeasure {
+  return performance.measure(name, `${name}:start`);
+}
+
+/**
+ * Measures the execution time of a Promise-returning function.
+ * @param fn - A function that returns a Promise. This function will be executed, and its execution time will be measured.
+ * @param name - The name of the performance measurement. This should be unique for each measurement.
+ * @returns A Promise that resolves with the result of the function.
+ */
+export function measureAsyncFn<T>(fn: () => Promise<T>, name: string): Promise<T> {
+  const start: number = performance.now();
+  return fn().finally(() => {
+    performance.measure(name, {
+      start
+    });
+  });
+}
+
+/**
+ * Measures the execution time of a synchronous function.
+ * @param fn - A function that returns a value. This function will be executed, and its execution time will be measured.
+ * @param name - The name of the performance measurement. This should be unique for each measurement.
+ * @returns The result of the function.
+ */
+export function measureSyncFn<T>(fn: () => T, name: string): T {
+  const start: number = performance.now();
+  try {
+    return fn();
+  } finally {
+    performance.measure(name, {
+      start
+    });
+  }
+}
+
+/**
+ * Collects performance measurements that were created after a specified start time.
+ * @param startTime - The start time in milliseconds from which to collect performance measurements.
+ * @returns An array of `PerformanceEntry` objects with start times greater than or equal to the specified start time.
+ */
+export function collectPerformanceEntries(startTime: number): PerformanceEntry[] {
+  const entries: PerformanceEntry[] = performance.getEntries();
+  const startIndex: number = entries.findIndex((entry) => entry.startTime >= startTime);
+  if (startIndex === -1) {
+    return []; // No entries found after the specified start time
+  }
+  return entries.slice(startIndex);
+}

--- a/libraries/rush-lib/src/utilities/performance.ts
+++ b/libraries/rush-lib/src/utilities/performance.ts
@@ -23,11 +23,11 @@ export function endPerformanceMeasurement(name: string): PerformanceMeasure {
 
 /**
  * Measures the execution time of a Promise-returning function.
- * @param fn - A function that returns a Promise. This function will be executed, and its execution time will be measured.
  * @param name - The name of the performance measurement. This should be unique for each measurement.
+ * @param fn - A function that returns a Promise. This function will be executed, and its execution time will be measured.
  * @returns A Promise that resolves with the result of the function.
  */
-export function measureAsyncFn<T>(fn: () => Promise<T>, name: string): Promise<T> {
+export function measureAsyncFn<T>(name: string, fn: () => Promise<T>): Promise<T> {
   const start: number = performance.now();
   return fn().finally(() => {
     performance.measure(name, {
@@ -38,11 +38,11 @@ export function measureAsyncFn<T>(fn: () => Promise<T>, name: string): Promise<T
 
 /**
  * Measures the execution time of a synchronous function.
- * @param fn - A function that returns a value. This function will be executed, and its execution time will be measured.
  * @param name - The name of the performance measurement. This should be unique for each measurement.
+ * @param fn - A function that returns a value. This function will be executed, and its execution time will be measured.
  * @returns The result of the function.
  */
-export function measureFn<T>(fn: () => T, name: string): T {
+export function measureFn<T>(name: string, fn: () => T): T {
   const start: number = performance.now();
   try {
     return fn();

--- a/rush.json
+++ b/rush.json
@@ -304,7 +304,7 @@
    * that read these JSON files and do something with them.  These scripts are typically registered
    * in the "eventHooks" section.
    */
-  // "telemetryEnabled": false,
+  "telemetryEnabled": true,
 
   /**
    * Allows creation of hotfix changes. This feature is experimental so it is disabled by default.


### PR DESCRIPTION
## Summary
Adds enhanced performance monitoring data to the Rush telemetry payloads.

Note that the Rush telemetry subsystem by default only writes to a file (if enabled by the `telemetryEnabled: true` flag in `rush.json`) and does not get uploaded anywhere without custom plugins.

## Details
Adds performance measures around various critical pieces of Rush, paying particular attention to phased commands.

Updates the telemetry subsystem to extract all performance measures since the last payload (if any) and record them as a `performanceEntries` array in the telemetry payload.

Note that these values are not present during the `beforeLog` hook and are only available in `flushTelemetry`.

## How it was tested
`rush build -o tree-pattern` in rushstack repository
```json
[
  {
    "name": "build",
    "durationInSeconds": 0.21093514500000005,
    "result": "Failed",
    "extraData": {
      "command_from": "false",
      "command_impactedBy": "false",
      "command_impactedByExcept": "false",
      "command_only": "true",
      "command_to": "false",
      "command_toExcept": "false",
      "command_fromVersionPolicy": "false",
      "command_toVersionPolicy": "false",
      "--timeline": "false",
      "--log-cobuild-plan": "false",
      "--to": "",
      "--to-except": "",
      "--from": "",
      "--only": "tree-pattern",
      "--impacted-by": "",
      "--impacted-by-except": "",
      "--to-version-policy": "",
      "--from-version-policy": "",
      "--verbose": "false",
      "--include-phase-deps": "false",
      "--changed-projects-only": false,
      "--ignore-hooks": "false",
      "--debug-build-cache-ids": "false",
      "--no-color": "false",
      "--production": "false",
      "--fix": "false",
      "isWatch": false,
      "isInitial": true,
      "countAll": 1,
      "countSuccess": 0,
      "countSuccessWithWarnings": 0,
      "countFailure": 1,
      "countBlocked": 0,
      "countFromCache": 0,
      "countSkipped": 0,
      "countNoOp": 0
    },
    "operationResults": {
      "@rushstack/tree-pattern (build)": {
        "startTimestampMs": 1004.183634,
        "endTimestampMs": 1018.802925,
        "nonCachedDurationMs": 4720.420041,
        "wasExecutedOnThisMachine": true,
        "result": "FAILURE",
        "dependencies": []
      }
    },
    "performanceEntries": [
      {
        "name": "rush:initializeUnassociatedPlugins",
        "entryType": "measure",
        "startTime": 648.06951,
        "duration": 143.649452,
        "detail": null
      },
      {
        "name": "rush:action:initializePluginsAsync",
        "entryType": "measure",
        "startTime": 798.356563,
        "duration": 0.07410799999991013,
        "detail": null
      },
      {
        "name": "rush:action:initializePlugins",
        "entryType": "measure",
        "startTime": 798.445248,
        "duration": 0.8410710000000563,
        "detail": null
      },
      {
        "name": "rush:phasedScriptAction:checkInstallFlag",
        "entryType": "measure",
        "startTime": 810.56529,
        "duration": 16.51464199999998,
        "detail": null
      },
      {
        "name": "rush:phasedScriptAction:doBeforeTask",
        "entryType": "measure",
        "startTime": 827.12677,
        "duration": 0.44064300000002277,
        "detail": null
      },
      {
        "name": "rush:phasedScriptAction:applyStandardPlugins",
        "entryType": "measure",
        "startTime": 827.708677,
        "duration": 0.38100100000008297,
        "detail": null
      },
      {
        "name": "rush:phasedScriptAction:configureBuildCache",
        "entryType": "measure",
        "startTime": 828.119253,
        "duration": 23.40427299999999,
        "detail": null
      },
      {
        "name": "rush:phasedScriptAction:getSelectedProjects",
        "entryType": "measure",
        "startTime": 851.551488,
        "duration": 0.7206470000000991,
        "detail": null
      },
      {
        "name": "rush:phasedScriptAction:applySituationalPlugins",
        "entryType": "measure",
        "startTime": 852.287904,
        "duration": 1.0280309999999417,
        "detail": null
      },
      {
        "name": "rush:phasedScriptAction:loadProjectConfigurations",
        "entryType": "measure",
        "startTime": 862.261596,
        "duration": 16.415706999999998,
        "detail": null
      },
      {
        "name": "rush:phasedScriptAction:createOperations",
        "entryType": "measure",
        "startTime": 878.852461,
        "duration": 1.196866,
        "detail": null
      },
      {
        "name": "rush:phasedScriptAction:analyzeRepoState",
        "entryType": "measure",
        "startTime": 880.058784,
        "duration": 118.88852800000006,
        "detail": null
      },
      {
        "name": "rush:phasedScriptAction:executeOperationsInner",
        "entryType": "measure",
        "startTime": 1001.113829,
        "duration": 19.61600599999997,
        "detail": null
      },
      {
        "name": "rush:phasedScriptAction:beforeExecuteOperations",
        "entryType": "measure",
        "startTime": 1001.464535,
        "duration": 1.1921470000000909,
        "detail": null
      },
      {
        "name": "rush:phasedScriptAction:afterExecuteOperations",
        "entryType": "measure",
        "startTime": 1020.744743,
        "duration": 0.7373069999999871,
        "detail": null
      },
      {
        "name": "rush:phasedScriptAction:doAfterTask",
        "entryType": "measure",
        "startTime": 1021.520773,
        "duration": 0.05005300000004809,
        "detail": null
      },
      {
        "name": "rush:phasedScriptAction:prepareTelemetry",
        "entryType": "measure",
        "startTime": 1021.576747,
        "duration": 0.4743470000000798,
        "detail": null
      },
      {
        "name": "rush:phasedScriptAction:beforeLog",
        "entryType": "measure",
        "startTime": 1022.057706,
        "duration": 0.07577099999991788,
        "detail": null
      }
    ],
    "machineInfo": {
      "machineArchitecture": "x64",
      "machineCpu": "AMD EPYC 7763 64-Core Processor",
      "machineCores": 16,
      "machineTotalMemoryMiB": 64298,
      "machineFreeMemoryMiB": 59146
    },
    "timestampMs": 1751581013669,
    "platform": "linux",
    "rushVersion": "5.155.1"
  }
]
```

## Impacted documentation
Documentation about the telemetry payload.