### PR TITLE
[rush] Add safety check to Bridge Cache plugin write action

### DIFF
--- a/common/changes/@microsoft/rush/benkeen-bridge-cache-safety-check_2025-07-16-16-53.json
+++ b/common/changes/@microsoft/rush/benkeen-bridge-cache-safety-check_2025-07-16-16-53.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/benkeen-bridge-cache-safety-check_2025-07-16-16-53.json
+++ b/common/changes/@microsoft/rush/benkeen-bridge-cache-safety-check_2025-07-16-16-53.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "",
+      "comment": "Adds an optional safety check flag to the Bridge Cache plugin write action.",
       "type": "none"
     }
   ],

--- a/rush-plugins/rush-bridge-cache-plugin/README.md
+++ b/rush-plugins/rush-bridge-cache-plugin/README.md
@@ -8,7 +8,7 @@ Alternatively, the `--bridge-cache-action=read` parameter is useful for tasks su
 
 ## Here be dragons!
 
-The `write` action for plugin assumes that the work for a particular task has already been completed and the build artifacts have been generated on disk. **If you run this command on a package where the command hasn't already been run and the build artifacts are missing or incorrect, you will cache invalid content**. Be careful and beware!
+The `write` action for plugin assumes that the work for a particular task has already been completed and the build artifacts have been generated on disk. **If you run this command on a package where the command hasn't already been run and the build artifacts are missing or incorrect, you will cache invalid content**. Be careful and beware! If any defined output folders for a task are not on disk, the write action will skip that package.
 
 The `read` action for this plugin makes no guarantee that the requested operations will have their outputs restored and is purely a best-effort.
 

--- a/rush-plugins/rush-bridge-cache-plugin/src/BridgeCachePlugin.ts
+++ b/rush-plugins/rush-bridge-cache-plugin/src/BridgeCachePlugin.ts
@@ -135,15 +135,12 @@ export class BridgeCachePlugin implements IRushPlugin {
                   operation.settings?.outputFolderNames?.length > 0
                 ) {
                   const projectFolder: string = operation.associatedProject?.projectFolder;
-                  const results: { outputFolderName: string; exists: boolean }[] =
-                    operation.settings.outputFolderNames.map((outputFolderName: string) => ({
-                      outputFolderName,
-                      exists: FileSystem.exists(`${projectFolder}/${outputFolderName}`)
-                    }));
-
-                  const missingFolders: string[] = results
-                    .filter((folder) => !folder.exists)
-                    .map((folder) => folder.outputFolderName);
+                  const missingFolders: string[] = [];
+                  operation.settings.outputFolderNames.forEach((outputFolderName: string) => {
+                      if (!FileSystem.exists(`${projectFolder}/${outputFolderName}`)) {
+                        missingFolders.push(outputFolderName);
+                      }
+                  });
                   if (missingFolders.length > 0) {
                     terminal.writeWarningLine(
                       `Operation "${operation.name}": The following output folders do not exist: "${missingFolders.join('", "')}". Skipping cache population.`

--- a/rush-plugins/rush-bridge-cache-plugin/src/BridgeCachePlugin.ts
+++ b/rush-plugins/rush-bridge-cache-plugin/src/BridgeCachePlugin.ts
@@ -14,7 +14,7 @@ import type {
   RushSession
 } from '@rushstack/rush-sdk';
 import { CommandLineParameterKind } from '@rushstack/ts-command-line';
-import type { CommandLineFlagParameter, CommandLineParameter } from '@rushstack/ts-command-line';
+import type { CommandLineParameter } from '@rushstack/ts-command-line';
 
 const PLUGIN_NAME: 'RushBridgeCachePlugin' = 'RushBridgeCachePlugin';
 
@@ -225,6 +225,14 @@ export class BridgeCachePlugin implements IRushPlugin {
       this._requireOutputFoldersParameterName
     );
 
-    return !!(requireOutputFoldersParam && (requireOutputFoldersParam as CommandLineFlagParameter).value);
+    if (!requireOutputFoldersParam) {
+      return false;
+    }
+
+    if (requireOutputFoldersParam.kind !== CommandLineParameterKind.Flag) {
+      throw new Error(`The parameter "${this._requireOutputFoldersParameterName}" must be a flag.`);
+    }
+
+    return requireOutputFoldersParam.value;
   }
 }

--- a/rush-plugins/rush-bridge-cache-plugin/src/schemas/bridge-cache-config.schema.json
+++ b/rush-plugins/rush-bridge-cache-plugin/src/schemas/bridge-cache-config.schema.json
@@ -10,6 +10,10 @@
         "actionParameterName": {
           "type": "string",
           "description": "(Required) The name of the choice parameter used to trigger this plugin on your phased commands. It should accept two values, 'read' and 'write'."
+        },
+        "requireOutputFoldersParameterName": {
+          "type": "string",
+          "description": "(Optional) The name of the parameter used to specify whether the output folders must exist for the action in order to populate the cache."
         }
       }
     }


### PR DESCRIPTION
## Summary

This adds a optional safety check flag to the `write` action for the Bridge Cache plugin to verify all defined output folders for a task has been created on disk in order to populate the cache entry. If there's any missing, it outputs a warning stating which folders are missing and doesn't populate the cache for that particular action. 