### PR TITLE
fix(rush): don't follow-tags on `rush version`

### DIFF
--- a/common/changes/@microsoft/rush/sennyeya-blobless-clone_2025-07-23-12-58.json
+++ b/common/changes/@microsoft/rush/sennyeya-blobless-clone_2025-07-23-12-58.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Improve performance for publishing on filtered clones.",
+      "type": "none",
+      "packageName": "@microsoft/rush"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "aramissennyeydd@users.noreply.github.com"
+}

--- a/libraries/rush-lib/src/cli/actions/VersionAction.ts
+++ b/libraries/rush-lib/src/cli/actions/VersionAction.ts
@@ -280,14 +280,14 @@ export class VersionAction extends BaseRushAction {
     }
 
     if (changeLogUpdated || packageJsonUpdated) {
-      await publishGit.pushAsync(tempBranch, !this._ignoreGitHooksParameter.value);
+      await publishGit.pushAsync(tempBranch, !this._ignoreGitHooksParameter.value, false);
 
       // Now merge to target branch.
       await publishGit.fetchAsync();
       await publishGit.checkoutAsync(targetBranch);
       await publishGit.pullAsync(!this._ignoreGitHooksParameter.value);
       await publishGit.mergeAsync(tempBranch, !this._ignoreGitHooksParameter.value);
-      await publishGit.pushAsync(targetBranch, !this._ignoreGitHooksParameter.value);
+      await publishGit.pushAsync(targetBranch, !this._ignoreGitHooksParameter.value, false);
       await publishGit.deleteBranchAsync(tempBranch, true, !this._ignoreGitHooksParameter.value);
     } else {
       // skip commits

--- a/libraries/rush-lib/src/logic/PublishGit.ts
+++ b/libraries/rush-lib/src/logic/PublishGit.ts
@@ -153,7 +153,6 @@ export class PublishGit {
         'push',
         'origin',
         `HEAD:${branchName || DUMMY_BRANCH_NAME}`,
-        '--follow-tags',
         '--verbose',
         ...(verify ? [] : ['--no-verify'])
       ]

--- a/libraries/rush-lib/src/logic/PublishGit.ts
+++ b/libraries/rush-lib/src/logic/PublishGit.ts
@@ -143,7 +143,11 @@ export class PublishGit {
     ]);
   }
 
-  public async pushAsync(branchName: string | undefined, verify: boolean = false): Promise<void> {
+  public async pushAsync(
+    branchName: string | undefined,
+    verify: boolean = false,
+    followTags: boolean = true
+  ): Promise<void> {
     await PublishUtilities.execCommandAsync(
       !!this._targetBranch,
       this._gitPath,
@@ -153,6 +157,7 @@ export class PublishGit {
         'push',
         'origin',
         `HEAD:${branchName || DUMMY_BRANCH_NAME}`,
+        ...(followTags ? ['--follow-tags'] : []),
         '--verbose',
         ...(verify ? [] : ['--no-verify'])
       ]


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

Our monorepo is growing pretty quickly and we're starting to explore blobless clones in our CI set up to improve performance. One thing that I noticed turning on blobless clones in testing is that our `rush version` execution time went from seconds to 10m+ with a lot of 
```
remote: Enumerating objects: 831265, done.
remote: Counting objects: 100% (282323/282323), done.
remote: Compressing objects: 100% (56787/56787), done.
remote: Total 831265 (delta 270471), reused 225536 (delta 225536), pack-reused 548942 (from 1)
Receiving objects: 100% (831265/831265), 100.34 MiB | 38.66 MiB/s, done.
```
logs.

## Details

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

I _think_ this is related to the use of follow-tags here. As we're only pushing a single branch in the `rush version` command, we don't need to actually do any operations related to tagging.

## How it was tested

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

Would appreciate publishing this as a prerelease version so I can test locally 🙏.

## Impacted documentation

<!--------------------------------------------------------------------------
👉 STEP 7: Does your PR affect anything that is discussed in the website docs?
     If so, please paste the URL of each affected web page, so we will
     remember to update the documentation after your PR is merged.
     (Updating the website is appreciated but not required.)
     If no docs are impacted, delete the "Impacted documentation" section.

     If you modified a JSON schema, remember to update init templates such as:
     rush-lib/assets/rush-init/*.json
     api-extractor/src/schemas/api-extractor-template.json
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 8: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
