### PR TITLE
[heft-swc] Support watch mode

### DIFF
--- a/build-tests/heft-swc-test/package.json
+++ b/build-tests/heft-swc-test/package.json
@@ -7,6 +7,7 @@
   "license": "MIT",
   "scripts": {
     "build": "heft build --clean",
+    "build-watch": "heft build-watch --clean",
     "_phase:build": "heft run --only build -- --clean",
     "_phase:test": "heft run --only test -- --clean"
   },

--- a/common/changes/@rushstack/heft-isolated-typescript-transpile-plugin/swc-incremental_2025-07-25-23-40.json
+++ b/common/changes/@rushstack/heft-isolated-typescript-transpile-plugin/swc-incremental_2025-07-25-23-40.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-isolated-typescript-transpile-plugin",
+      "comment": "Add support for watch mode.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft-isolated-typescript-transpile-plugin"
+}

--- a/common/changes/@rushstack/heft-typescript-plugin/swc-incremental_2025-07-25-23-40.json
+++ b/common/changes/@rushstack/heft-typescript-plugin/swc-incremental_2025-07-25-23-40.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-typescript-plugin",
+      "comment": "Update internal typings.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft-typescript-plugin"
+}

--- a/heft-plugins/heft-typescript-plugin/src/internalTypings/TypeScriptInternals.ts
+++ b/heft-plugins/heft-typescript-plugin/src/internalTypings/TypeScriptInternals.ts
@@ -81,6 +81,8 @@ export interface IExtendedTypeScript {
     system?: TTypescript.System
   ): TTypescript.CompilerHost;
 
+  combinePaths(path1: string, path2: string): string;
+
   /**
    * https://github.com/microsoft/TypeScript/blob/782c09d783e006a697b4ba6d1e7ec2f718ce8393/src/compiler/utilities.ts#L6540
    */


### PR DESCRIPTION
## Summary
Adds file watching support to `@rushstack/heft-isolated-typescript-transpile-plugin`.

## Details
Wires the `tsconfig` parser into Heft's file watcher subsystem for directory reads, and checks for changes of individual files before invoking the transpiler.

## How it was tested
Invocation of `heft build-watch` in `heft-swc-test`.

## Impacted documentation
None