### PR TITLE
[rush] Add status emojis

### DIFF
--- a/common/changes/@microsoft/rush/status-emojis_2025-07-30-23-06.json
+++ b/common/changes/@microsoft/rush/status-emojis_2025-07-30-23-06.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add emojis for operation statuses. Replace the \"x of y\" operations indicator with a breakdown by status using the emojis. Add a legend at the start of the build log.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
+++ b/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
@@ -37,7 +37,7 @@ import { PhasedOperationPlugin } from '../../logic/operations/PhasedOperationPlu
 import { ShellOperationRunnerPlugin } from '../../logic/operations/ShellOperationRunnerPlugin';
 import { Event } from '../../api/EventHooks';
 import { ProjectChangeAnalyzer } from '../../logic/ProjectChangeAnalyzer';
-import { OperationStatus } from '../../logic/operations/OperationStatus';
+import { OperationStatus, STATUS_EMOJIS } from '../../logic/operations/OperationStatus';
 import type {
   IExecutionResult,
   IOperationExecutionResult
@@ -955,7 +955,7 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
 
       stopwatch.stop();
 
-      const message: string = `rush ${this.actionName} (${stopwatch.toString()})`;
+      const message: string = `${STATUS_EMOJIS[result.status]} rush ${this.actionName} (${stopwatch.toString()})`;
       if (result.status === OperationStatus.Success) {
         terminal.writeLine(Colorize.green(message));
       } else {
@@ -966,7 +966,9 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
       stopwatch.stop();
 
       if (error instanceof AlreadyReportedError) {
-        terminal.writeLine(`rush ${this.actionName} (${stopwatch.toString()})`);
+        terminal.writeLine(
+          `${STATUS_EMOJIS[OperationStatus.Failure]} rush ${this.actionName} (${stopwatch.toString()})`
+        );
       } else {
         if (error && (error as Error).message) {
           if (this.parser.isDebug) {
@@ -976,7 +978,11 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> {
           }
         }
 
-        terminal.writeErrorLine(Colorize.red(`rush ${this.actionName} - Errors! (${stopwatch.toString()})`));
+        terminal.writeErrorLine(
+          Colorize.red(
+            `${STATUS_EMOJIS[OperationStatus.Failure]} rush ${this.actionName} - Errors! (${stopwatch.toString()})`
+          )
+        );
       }
     }
 

--- a/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
@@ -39,7 +39,7 @@ import {
  */
 export interface IOperationExecutionRecordContext {
   streamCollator: StreamCollator;
-  onOperationStatusChanged?: (record: OperationExecutionRecord) => void;
+  onOperationStatusChanged?: (record: OperationExecutionRecord, oldStatus: OperationStatus) => void;
   createEnvironment?: (record: OperationExecutionRecord) => IEnvironment;
   inputsSnapshot: IInputsSnapshot | undefined;
 
@@ -207,11 +207,12 @@ export class OperationExecutionRecord implements IOperationRunnerContext, IOpera
     return this._status;
   }
   public set status(newStatus: OperationStatus) {
-    if (newStatus === this._status) {
+    const oldStatus: OperationStatus = this._status;
+    if (newStatus === oldStatus) {
       return;
     }
     this._status = newStatus;
-    this._context.onOperationStatusChanged?.(this);
+    this._context.onOperationStatusChanged?.(this, oldStatus);
   }
 
   public get silent(): boolean {

--- a/libraries/rush-lib/src/logic/operations/OperationResultSummarizerPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationResultSummarizerPlugin.ts
@@ -11,7 +11,7 @@ import type {
 } from '../../pluginFramework/PhasedCommandHooks';
 import type { IExecutionResult, IOperationExecutionResult } from './IOperationExecutionResult';
 import type { Operation } from './Operation';
-import { OperationStatus } from './OperationStatus';
+import { OperationStatus, STATUS_EMOJIS } from './OperationStatus';
 import type { OperationExecutionRecord } from './OperationExecutionRecord';
 import type { IStopwatchResult } from '../../utilities/Stopwatch';
 
@@ -257,7 +257,7 @@ function writeDetailedSummary(
     );
 
     terminal.writeLine(
-      `${Colorize.gray('--[')} ${headingColor(subheadingText)} ${Colorize.gray(
+      `${Colorize.gray('--[')}${STATUS_EMOJIS[operationResult.status]} ${headingColor(subheadingText)} ${Colorize.gray(
         `]${'-'.repeat(middlePartLengthMinusTwoBrackets)}[`
       )} ${Colorize.white(time)} ${Colorize.gray(']--')}\n`
     );
@@ -289,14 +289,14 @@ function writeSummaryHeader(
   const headingText: string = `${status}: ${projectsText}`;
 
   // leftPart: "==[ FAILED: 2 operations "
-  const leftPartLength: number = 3 + 1 + headingText.length + 1;
+  const leftPartLength: number = 3 + 2 + headingText.length + 1;
 
   const rightPartLengthMinusBracket: number = Math.max(ASCII_HEADER_WIDTH - (leftPartLength + 1), 0);
 
   // rightPart: "]======================"
 
   terminal.writeLine(
-    `${Colorize.gray('==[')} ${headingColor(headingText)} ${Colorize.gray(
+    `${Colorize.gray('==[')}${STATUS_EMOJIS[status]} ${headingColor(headingText)} ${Colorize.gray(
       `]${'='.repeat(rightPartLengthMinusBracket)}`
     )}\n`
   );

--- a/libraries/rush-lib/src/logic/operations/OperationStatus.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationStatus.ts
@@ -53,6 +53,50 @@ export enum OperationStatus {
 }
 
 /**
+ * Mapping from {@link OperationStatus} to an emoji that can be used in the terminal.
+ * @alpha
+ */
+export const STATUS_EMOJIS: Record<OperationStatus, string> = {
+  // Most important statuses to report
+  [OperationStatus.Failure]: '❌',
+  [OperationStatus.SuccessWithWarning]: '⚠️ ',
+
+  // Use an emoji that indicates that the operation is currently executing
+  [OperationStatus.Executing]: '🔄',
+
+  // Use an emoji that indicates that the operations are yet to execute
+  [OperationStatus.Waiting]: '⏳',
+  [OperationStatus.Queued]: '⏳',
+  [OperationStatus.Ready]: '⏳',
+
+  [OperationStatus.Blocked]: '🚧',
+
+  // Use an emoji that indicates that the operation has completed successfully
+  [OperationStatus.Success]: '✅\u200b',
+
+  // Use an emoji that indicates that the operation output was reused
+  [OperationStatus.FromCache]: '📦',
+  [OperationStatus.Skipped]: '📦',
+  [OperationStatus.NoOp]: ''
+};
+
+/**
+ * The set of unique status emojis used in the `STATUS_EMOJIS` mapping.
+ * @alpha
+ */
+export const STATUS_BY_EMOJI: Map<string, OperationStatus[]> = new Map();
+for (const [status, emoji] of Object.entries(STATUS_EMOJIS)) {
+  if (emoji) {
+    let existingStatuses: OperationStatus[] | undefined = STATUS_BY_EMOJI.get(emoji);
+    if (!existingStatuses) {
+      existingStatuses = [];
+      STATUS_BY_EMOJI.set(emoji, existingStatuses);
+    }
+    existingStatuses.push(status as OperationStatus);
+  }
+}
+
+/**
  * The set of statuses that are considered terminal.
  * @alpha
  */

--- a/libraries/rush-lib/src/logic/operations/test/__snapshots__/OperationExecutionManager.test.ts.snap
+++ b/libraries/rush-lib/src/logic/operations/test/__snapshots__/OperationExecutionManager.test.ts.snap
@@ -29,24 +29,48 @@ Array [
   },
   Object {
     "kind": "O",
-    "text": "
-[gray]==[[default] [cyan]operation2 (success)[default] [gray]]=========================================[[default] [white]1 of 2[default] [gray]]==[default]
+    "text": "Legend:
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "❌ FAILURE
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "⚠️  SUCCESS WITH WARNINGS
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "🔄 EXECUTING
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "⏳ WAITING / QUEUED / READY
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "🚧 BLOCKED
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "✅​ SUCCESS
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "📦 FROM CACHE / SKIPPED
 ",
   },
   Object {
     "kind": "O",
     "text": "
-",
-  },
-  Object {
-    "kind": "O",
-    "text": "[green]\\"operation2 (success)\\" completed successfully in 15.00 seconds.[default]
-",
-  },
-  Object {
-    "kind": "O",
-    "text": "
-[gray]==[[default] [cyan]operation (success)[default] [gray]]==========================================[[default] [white]2 of 2[default] [gray]]==[default]
+[gray]==[[default] [cyan]operation2 (success)[default] [gray]]=========================================[[default][white]🔄 1 ⏳ 1[default][gray]]==[default]
 ",
   },
   Object {
@@ -56,7 +80,23 @@ Array [
   },
   Object {
     "kind": "O",
-    "text": "[green]\\"operation (success)\\" completed successfully in 15.00 seconds.[default]
+    "text": "✅​ [green]\\"operation2 (success)\\" completed successfully in 15.00 seconds.[default]
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "
+[gray]==[[default] [cyan]operation (success)[default] [gray]]=========================================[[default][white]🔄 1 ✅​ 1[default][gray]]==[default]
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "✅​ [green]\\"operation (success)\\" completed successfully in 15.00 seconds.[default]
 ",
   },
   Object {
@@ -128,7 +168,7 @@ Array [
   },
   Object {
     "kind": "O",
-    "text": "[gray]==[[default] [green]SUCCESS: 2 operations[default] [gray]]====================================================[default]
+    "text": "[gray]==[[default]✅​ [green]SUCCESS: 2 operations[default] [gray]]===================================================[default]
 
 ",
   },
@@ -189,8 +229,48 @@ Array [
   },
   Object {
     "kind": "O",
+    "text": "Legend:
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "❌ FAILURE
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "⚠️  SUCCESS WITH WARNINGS
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "🔄 EXECUTING
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "⏳ WAITING / QUEUED / READY
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "🚧 BLOCKED
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "✅​ SUCCESS
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "📦 FROM CACHE / SKIPPED
+",
+  },
+  Object {
+    "kind": "O",
     "text": "
-[gray]==[[default] [cyan]operation2 (success with warnings)[default] [gray]]===========================[[default] [white]1 of 2[default] [gray]]==[default]
+[gray]==[[default] [cyan]operation2 (success with warnings)[default] [gray]]===========================[[default][white]🔄 1 ⏳ 1[default][gray]]==[default]
 ",
   },
   Object {
@@ -212,13 +292,13 @@ Array [
   },
   Object {
     "kind": "E",
-    "text": "[yellow]\\"operation2 (success with warnings)\\" completed with warnings in 15.00 seconds.[default]
+    "text": "⚠️  [yellow]\\"operation2 (success with warnings)\\" completed with warnings in 15.00 seconds.[default]
 ",
   },
   Object {
     "kind": "O",
     "text": "
-[gray]==[[default] [cyan]operation (success with warnings)[default] [gray]]============================[[default] [white]2 of 2[default] [gray]]==[default]
+[gray]==[[default] [cyan]operation (success with warnings)[default] [gray]]==========================[[default][white]⚠️  1 🔄 1[default][gray]]==[default]
 ",
   },
   Object {
@@ -240,7 +320,7 @@ Array [
   },
   Object {
     "kind": "E",
-    "text": "[yellow]\\"operation (success with warnings)\\" completed with warnings in 15.00 seconds.[default]
+    "text": "⚠️  [yellow]\\"operation (success with warnings)\\" completed with warnings in 15.00 seconds.[default]
 ",
   },
   Object {
@@ -312,13 +392,13 @@ Array [
   },
   Object {
     "kind": "O",
-    "text": "[gray]==[[default] [yellow]SUCCESS WITH WARNINGS: 2 operations[default] [gray]]======================================[default]
+    "text": "[gray]==[[default]⚠️  [yellow]SUCCESS WITH WARNINGS: 2 operations[default] [gray]]=====================================[default]
 
 ",
   },
   Object {
     "kind": "O",
-    "text": "[gray]--[[default] [yellow]WARNING: operation (success with warnings)[default] [gray]]------------[[default] [white]15.00 seconds[default] [gray]]--[default]
+    "text": "[gray]--[[default]⚠️  [yellow]WARNING: operation (success with warnings)[default] [gray]]------------[[default] [white]15.00 seconds[default] [gray]]--[default]
 
 ",
   },
@@ -329,7 +409,7 @@ Array [
   },
   Object {
     "kind": "O",
-    "text": "[gray]--[[default] [yellow]WARNING: operation2 (success with warnings)[default] [gray]]-----------[[default] [white]15.00 seconds[default] [gray]]--[default]
+    "text": "[gray]--[[default]⚠️  [yellow]WARNING: operation2 (success with warnings)[default] [gray]]-----------[[default] [white]15.00 seconds[default] [gray]]--[default]
 
 ",
   },
@@ -376,8 +456,48 @@ Array [
   },
   Object {
     "kind": "O",
+    "text": "Legend:
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "❌ FAILURE
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "⚠️  SUCCESS WITH WARNINGS
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "🔄 EXECUTING
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "⏳ WAITING / QUEUED / READY
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "🚧 BLOCKED
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "✅​ SUCCESS
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "📦 FROM CACHE / SKIPPED
+",
+  },
+  Object {
+    "kind": "O",
     "text": "
-[gray]==[[default] [cyan]stdout+stderr[default] [gray]]================================================[[default] [white]1 of 1[default] [gray]]==[default]
+[gray]==[[default] [cyan]stdout+stderr[default] [gray]]====================================================[[default][white]🔄 1[default][gray]]==[default]
 ",
   },
   Object {
@@ -399,7 +519,7 @@ Array [
   },
   Object {
     "kind": "E",
-    "text": "[red]\\"stdout+stderr\\" failed to build.[default]
+    "text": "❌ [red]\\"stdout+stderr\\" failed to build.[default]
 ",
   },
   Object {
@@ -411,13 +531,13 @@ Array [
   },
   Object {
     "kind": "O",
-    "text": "[gray]==[[default] [red]FAILURE: 1 operation[default] [gray]]=====================================================[default]
+    "text": "[gray]==[[default]❌ [red]FAILURE: 1 operation[default] [gray]]====================================================[default]
 
 ",
   },
   Object {
     "kind": "O",
-    "text": "[gray]--[[default] [red]FAILURE: stdout+stderr[default] [gray]]---------------------------------[[default] [white]0.10 seconds[default] [gray]]--[default]
+    "text": "[gray]--[[default]❌ [red]FAILURE: stdout+stderr[default] [gray]]---------------------------------[[default] [white]0.10 seconds[default] [gray]]--[default]
 
 ",
   },
@@ -464,8 +584,48 @@ Array [
   },
   Object {
     "kind": "O",
+    "text": "Legend:
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "❌ FAILURE
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "⚠️  SUCCESS WITH WARNINGS
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "🔄 EXECUTING
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "⏳ WAITING / QUEUED / READY
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "🚧 BLOCKED
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "✅​ SUCCESS
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "📦 FROM CACHE / SKIPPED
+",
+  },
+  Object {
+    "kind": "O",
     "text": "
-[gray]==[[default] [cyan]stdout only[default] [gray]]==================================================[[default] [white]1 of 1[default] [gray]]==[default]
+[gray]==[[default] [cyan]stdout only[default] [gray]]======================================================[[default][white]🔄 1[default][gray]]==[default]
 ",
   },
   Object {
@@ -487,7 +647,7 @@ Array [
   },
   Object {
     "kind": "E",
-    "text": "[red]\\"stdout only\\" failed to build.[default]
+    "text": "❌ [red]\\"stdout only\\" failed to build.[default]
 ",
   },
   Object {
@@ -499,13 +659,13 @@ Array [
   },
   Object {
     "kind": "O",
-    "text": "[gray]==[[default] [red]FAILURE: 1 operation[default] [gray]]=====================================================[default]
+    "text": "[gray]==[[default]❌ [red]FAILURE: 1 operation[default] [gray]]====================================================[default]
 
 ",
   },
   Object {
     "kind": "O",
-    "text": "[gray]--[[default] [red]FAILURE: stdout only[default] [gray]]-----------------------------------[[default] [white]0.10 seconds[default] [gray]]--[default]
+    "text": "[gray]--[[default]❌ [red]FAILURE: stdout only[default] [gray]]-----------------------------------[[default] [white]0.10 seconds[default] [gray]]--[default]
 
 ",
   },
@@ -552,8 +712,48 @@ Array [
   },
   Object {
     "kind": "O",
+    "text": "Legend:
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "❌ FAILURE
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "⚠️  SUCCESS WITH WARNINGS
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "🔄 EXECUTING
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "⏳ WAITING / QUEUED / READY
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "🚧 BLOCKED
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "✅​ SUCCESS
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "📦 FROM CACHE / SKIPPED
+",
+  },
+  Object {
+    "kind": "O",
     "text": "
-[gray]==[[default] [cyan]success with warnings (failure)[default] [gray]]==============================[[default] [white]1 of 1[default] [gray]]==[default]
+[gray]==[[default] [cyan]success with warnings (failure)[default] [gray]]==================================[[default][white]🔄 1[default][gray]]==[default]
 ",
   },
   Object {
@@ -575,7 +775,7 @@ Array [
   },
   Object {
     "kind": "E",
-    "text": "[yellow]\\"success with warnings (failure)\\" completed with warnings in 0.10 seconds.[default]
+    "text": "⚠️  [yellow]\\"success with warnings (failure)\\" completed with warnings in 0.10 seconds.[default]
 ",
   },
   Object {
@@ -587,13 +787,13 @@ Array [
   },
   Object {
     "kind": "O",
-    "text": "[gray]==[[default] [yellow]SUCCESS WITH WARNINGS: 1 operation[default] [gray]]=======================================[default]
+    "text": "[gray]==[[default]⚠️  [yellow]SUCCESS WITH WARNINGS: 1 operation[default] [gray]]======================================[default]
 
 ",
   },
   Object {
     "kind": "O",
-    "text": "[gray]--[[default] [yellow]WARNING: success with warnings (failure)[default] [gray]]---------------[[default] [white]0.10 seconds[default] [gray]]--[default]
+    "text": "[gray]--[[default]⚠️  [yellow]WARNING: success with warnings (failure)[default] [gray]]---------------[[default] [white]0.10 seconds[default] [gray]]--[default]
 
 ",
   },
@@ -640,8 +840,48 @@ Array [
   },
   Object {
     "kind": "O",
+    "text": "Legend:
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "❌ FAILURE
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "⚠️  SUCCESS WITH WARNINGS
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "🔄 EXECUTING
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "⏳ WAITING / QUEUED / READY
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "🚧 BLOCKED
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "✅​ SUCCESS
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "📦 FROM CACHE / SKIPPED
+",
+  },
+  Object {
+    "kind": "O",
     "text": "
-[gray]==[[default] [cyan]success with warnings (success)[default] [gray]]==============================[[default] [white]1 of 1[default] [gray]]==[default]
+[gray]==[[default] [cyan]success with warnings (success)[default] [gray]]==================================[[default][white]🔄 1[default][gray]]==[default]
 ",
   },
   Object {
@@ -663,7 +903,7 @@ Array [
   },
   Object {
     "kind": "E",
-    "text": "[yellow]\\"success with warnings (success)\\" completed with warnings in 0.10 seconds.[default]
+    "text": "⚠️  [yellow]\\"success with warnings (success)\\" completed with warnings in 0.10 seconds.[default]
 ",
   },
   Object {
@@ -675,13 +915,13 @@ Array [
   },
   Object {
     "kind": "O",
-    "text": "[gray]==[[default] [yellow]SUCCESS WITH WARNINGS: 1 operation[default] [gray]]=======================================[default]
+    "text": "[gray]==[[default]⚠️  [yellow]SUCCESS WITH WARNINGS: 1 operation[default] [gray]]======================================[default]
 
 ",
   },
   Object {
     "kind": "O",
-    "text": "[gray]--[[default] [yellow]WARNING: success with warnings (success)[default] [gray]]---------------[[default] [white]0.10 seconds[default] [gray]]--[default]
+    "text": "[gray]--[[default]⚠️  [yellow]WARNING: success with warnings (success)[default] [gray]]---------------[[default] [white]0.10 seconds[default] [gray]]--[default]
 
 ",
   },
@@ -722,8 +962,48 @@ Array [
   },
   Object {
     "kind": "O",
+    "text": "Legend:
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "❌ FAILURE
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "⚠️  SUCCESS WITH WARNINGS
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "🔄 EXECUTING
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "⏳ WAITING / QUEUED / READY
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "🚧 BLOCKED
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "✅​ SUCCESS
+",
+  },
+  Object {
+    "kind": "O",
+    "text": "📦 FROM CACHE / SKIPPED
+",
+  },
+  Object {
+    "kind": "O",
     "text": "
-[gray]==[[default] [cyan]success with warnings (success)[default] [gray]]==============================[[default] [white]1 of 1[default] [gray]]==[default]
+[gray]==[[default] [cyan]success with warnings (success)[default] [gray]]==================================[[default][white]🔄 1[default][gray]]==[default]
 ",
   },
   Object {
@@ -745,7 +1025,7 @@ Array [
   },
   Object {
     "kind": "E",
-    "text": "[yellow]\\"success with warnings (success)\\" completed with warnings in 0.10 seconds.[default]
+    "text": "⚠️  [yellow]\\"success with warnings (success)\\" completed with warnings in 0.10 seconds.[default]
 ",
   },
   Object {
@@ -812,13 +1092,13 @@ Array [
   },
   Object {
     "kind": "O",
-    "text": "[gray]==[[default] [yellow]SUCCESS WITH WARNINGS: 1 operation[default] [gray]]=======================================[default]
+    "text": "[gray]==[[default]⚠️  [yellow]SUCCESS WITH WARNINGS: 1 operation[default] [gray]]======================================[default]
 
 ",
   },
   Object {
     "kind": "O",
-    "text": "[gray]--[[default] [yellow]WARNING: success with warnings (success)[default] [gray]]---------------[[default] [white]0.10 seconds[default] [gray]]--[default]
+    "text": "[gray]--[[default]⚠️  [yellow]WARNING: success with warnings (success)[default] [gray]]---------------[[default] [white]0.10 seconds[default] [gray]]--[default]
 
 ",
   },


### PR DESCRIPTION
## Summary
Fixes #5292 

## Details
Adds emoji status indicators 

## How it was tested
```
Executing a maximum of 16 simultaneous processes...
Legend:
❌ FAILURE
⚠️  SUCCESS WITH WARNINGS
🔄 EXECUTING
⏳ WAITING / QUEUED / READY
🚧 BLOCKED
✅​ SUCCESS
📦 FROM CACHE / SKIPPED

==[ decoupled-local-node-rig (build) ]=================================[⏳ 69]==
 "decoupled-local-node-rig (build)" did not define any work.

==[ @rushstack/eslint-patch (build) ]=============================[🔄 1 ⏳ 68]==
📦 "@rushstack/eslint-patch (build)" was restored from the build cache.

==[ decoupled-local-node-rig (test) ]========================[🔄 4 ⏳ 59 📦 5]==
 "decoupled-local-node-rig (test)" did not define any work.

==[ @rushstack/tree-pattern (build) ]========================[🔄 4 ⏳ 59 📦 5]==
📦 "@rushstack/tree-pattern (build)" was restored from the build cache.

==[ @rushstack/rig-package (build) ]=========================[🔄 4 ⏳ 59 📦 5]==
📦 "@rushstack/rig-package (build)" was restored from the build cache.

==[ @rushstack/node-core-library (build) ]===================[🔄 4 ⏳ 59 📦 5]==
📦 "@rushstack/node-core-library (build)" was restored from the build cache.

==[ @rushstack/eslint-patch (test) ]==============================[⏳ 58 📦 9]==
 "@rushstack/eslint-patch (test)" did not define any work.

==[ @rushstack/tree-pattern (test) ]==============================[⏳ 58 📦 9]==
📦 "@rushstack/tree-pattern (test)" was restored from the build cache.

==[ @rushstack/eslint-plugin (build) ]============================[⏳ 58 📦 9]==
📦 "@rushstack/eslint-plugin (build)" was restored from the build cache.

==[ @rushstack/eslint-plugin-security (build) ]==============[🔄 5 ⏳ 53 📦 9]==
📦 "@rushstack/eslint-plugin-security (build)" was restored from the build cache.

==[ @rushstack/rig-package (test) ]==========================[🔄 5 ⏳ 53 📦 9]==
📦 "@rushstack/rig-package (test)" was restored from the build cache.

==[ @rushstack/eslint-plugin-packlets (build) ]==============[🔄 5 ⏳ 53 📦 9]==
📦 "@rushstack/eslint-plugin-packlets (build)" was restored from the build cache.

==[ @microsoft/api-extractor-model (build) ]=================[🔄 5 ⏳ 53 📦 9]==
📦 "@microsoft/api-extractor-model (build)" was restored from the build cache.

==[ @rushstack/eslint-config (build) ]======================[🔄 5 ⏳ 45 📦 15]==
 "@rushstack/eslint-config (build)" did not define any work.

==[ @rushstack/eslint-config (test) ]=======================[🔄 5 ⏳ 45 📦 15]==
 "@rushstack/eslint-config (test)" did not define any work.

==[ @rushstack/eslint-plugin-security (test) ]==============[🔄 5 ⏳ 45 📦 15]==
📦 "@rushstack/eslint-plugin-security (test)" was restored from the build cache.

==[ @rushstack/eslint-plugin-packlets (test) ]==============[🔄 5 ⏳ 45 📦 15]==
📦 "@rushstack/eslint-plugin-packlets (test)" was restored from the build cache.

==[ @rushstack/node-core-library (test) ]===================[🔄 5 ⏳ 45 📦 15]==
📦 "@rushstack/node-core-library (test)" was restored from the build cache.

==[ @rushstack/eslint-plugin (test) ]=======================[🔄 5 ⏳ 45 📦 15]==
📦 "@rushstack/eslint-plugin (test)" was restored from the build cache.

==[ @rushstack/terminal (build) ]===========================[🔄 5 ⏳ 45 📦 15]==
📦 "@rushstack/terminal (build)" was restored from the build cache.

==[ local-eslint-config (build) ]===========================[🔄 5 ⏳ 45 📦 15]==
✅​ "local-eslint-config (build)" completed successfully in 0.38 seconds.

==[ @rushstack/terminal (test) ]============================[⏳ 41 ✅​ 1 📦 23]==
📦 "@rushstack/terminal (test)" was restored from the build cache.

==[ @rushstack/heft-config-file (build) ]===================[⏳ 41 ✅​ 1 📦 23]==
📦 "@rushstack/heft-config-file (build)" was restored from the build cache.

==[ @rushstack/operation-graph (build) ]====================[⏳ 41 ✅​ 1 📦 23]==
📦 "@rushstack/operation-graph (build)" was restored from the build cache.

==[ @rushstack/ts-command-line (build) ]====================[⏳ 41 ✅​ 1 📦 23]==
📦 "@rushstack/ts-command-line (build)" was restored from the build cache.

==[ @microsoft/api-extractor-model (test) ]=================[⏳ 41 ✅​ 1 📦 23]==
📦 "@microsoft/api-extractor-model (test)" was restored from the build cache.

==[ @rushstack/heft-config-file (test) ]====================[⏳ 41 ✅​ 1 📦 23]==
📦 "@rushstack/heft-config-file (test)" was restored from the build cache.

==[ @rushstack/operation-graph (test) ]=====================[⏳ 41 ✅​ 1 📦 23]==
📦 "@rushstack/operation-graph (test)" was restored from the build cache.

==[ @rushstack/ts-command-line (test) ]=====================[⏳ 41 ✅​ 1 📦 23]==
📦 "@rushstack/ts-command-line (test)" was restored from the build cache.

==[ @microsoft/api-extractor (build) ]=================[🔄 1 ⏳ 40 ✅​ 1 📦 23]==
📦 "@microsoft/api-extractor (build)" was restored from the build cache.

==[ local-eslint-config (test) ]============================[⏳ 39 ✅​ 1 📦 24]==
 "local-eslint-config (test)" did not define any work.

==[ @microsoft/api-extractor (test) ]==================[🔄 1 ⏳ 38 ✅​ 1 📦 24]==
📦 "@microsoft/api-extractor (test)" was restored from the build cache.

==[ @rushstack/heft (build) ]===============================[⏳ 37 ✅​ 1 📦 26]==
📦 "@rushstack/heft (build)" was restored from the build cache.

==[ @rushstack/heft (test) ]===========================[🔄 1 ⏳ 36 ✅​ 1 📦 26]==
📦 "@rushstack/heft (test)" was restored from the build cache.

==[ @rushstack/heft-api-extractor-plugin (build) ]=====[🔄 1 ⏳ 29 ✅​ 1 📦 31]==
📦 "@rushstack/heft-api-extractor-plugin (build)" was restored from the build cache.

==[ @rushstack/heft-api-extractor-plugin (test) ]======[🔄 1 ⏳ 29 ✅​ 1 📦 31]==
 "@rushstack/heft-api-extractor-plugin (test)" did not define any work.

==[ @rushstack/heft-typescript-plugin (build) ]========[🔄 1 ⏳ 29 ✅​ 1 📦 31]==
📦 "@rushstack/heft-typescript-plugin (build)" was restored from the build cache.

==[ @rushstack/heft-typescript-plugin (test) ]=========[🔄 1 ⏳ 29 ✅​ 1 📦 31]==
 "@rushstack/heft-typescript-plugin (test)" did not define any work.

==[ @rushstack/heft-jest-plugin (build) ]==============[🔄 1 ⏳ 29 ✅​ 1 📦 31]==
📦 "@rushstack/heft-jest-plugin (build)" was restored from the build cache.

==[ @rushstack/heft-lint-plugin (build) ]==============[🔄 1 ⏳ 29 ✅​ 1 📦 31]==
📦 "@rushstack/heft-lint-plugin (build)" was restored from the build cache.

==[ @rushstack/heft-jest-plugin (test) ]====================[⏳ 29 ✅​ 1 📦 32]==
📦 "@rushstack/heft-jest-plugin (test)" was restored from the build cache.

==[ @rushstack/heft-node-rig (build) ]=================[🔄 3 ⏳ 21 ✅​ 1 📦 33]==
 "@rushstack/heft-node-rig (build)" did not define any work.

==[ @rushstack/heft-node-rig (test) ]==================[🔄 3 ⏳ 21 ✅​ 1 📦 33]==
 "@rushstack/heft-node-rig (test)" did not define any work.

==[ local-node-rig (build) ]===========================[🔄 3 ⏳ 21 ✅​ 1 📦 33]==
 "local-node-rig (build)" did not define any work.

==[ local-node-rig (test) ]============================[🔄 3 ⏳ 21 ✅​ 1 📦 33]==
 "local-node-rig (test)" did not define any work.

==[ @rushstack/heft-lint-plugin (test) ]===============[🔄 3 ⏳ 21 ✅​ 1 📦 33]==
📦 "@rushstack/heft-lint-plugin (test)" was restored from the build cache.

==[ @rushstack/debug-certificate-manager (build) ]=====[🔄 5 ⏳ 15 ✅​ 1 📦 36]==
📦 "@rushstack/debug-certificate-manager (build)" was restored from the build cache.

==[ @rushstack/debug-certificate-manager (test) ]======[🔄 5 ⏳ 15 ✅​ 1 📦 36]==
 "@rushstack/debug-certificate-manager (test)" did not define any work.

==[ @rushstack/worker-pool (build) ]===================[🔄 5 ⏳ 15 ✅​ 1 📦 36]==
📦 "@rushstack/worker-pool (build)" was restored from the build cache.

==[ @rushstack/heft-sass-plugin (build) ]==============[🔄 5 ⏳ 15 ✅​ 1 📦 36]==
📦 "@rushstack/heft-sass-plugin (build)" was restored from the build cache.

==[ @rushstack/heft-webpack5-plugin (build) ]==========[🔄 5 ⏳ 15 ✅​ 1 📦 36]==
📦 "@rushstack/heft-webpack5-plugin (build)" was restored from the build cache.

==[ @rushstack/worker-pool (test) ]====================[🔄 3 ⏳ 13 ✅​ 1 📦 40]==
📦 "@rushstack/worker-pool (test)" was restored from the build cache.

==[ @rushstack/heft-sass-plugin (test) ]===============[🔄 3 ⏳ 13 ✅​ 1 📦 40]==
📦 "@rushstack/heft-sass-plugin (test)" was restored from the build cache.

==[ @rushstack/module-minifier (build) ]===============[🔄 3 ⏳ 13 ✅​ 1 📦 40]==
📦 "@rushstack/module-minifier (build)" was restored from the build cache.

==[ @rushstack/heft-webpack4-plugin (build) ]==========[🔄 3 ⏳ 13 ✅​ 1 📦 40]==
[build:lint] Warning: heft-plugins/heft-webpack4-plugin/src/WebpackConfigurationLoader.test.ts:19:1 - (no-console) Unexpected console statement. Only these console methods are allowed: debug, info, time, timeEnd, trace.
Encountered 1 warning
  [build:lint] heft-plugins/heft-webpack4-plugin/src/WebpackConfigurationLoader.test.ts:19:1 - (no-console) Unexpected console statement. Only these console methods are allowed: debug, info, time, timeEnd, trace.
⚠️  "@rushstack/heft-webpack4-plugin (build)" completed with warnings in 5.92 seconds.

==[ @rushstack/heft-web-rig (build) ]=========[❌ 1 ⚠️  1 ⏳ 1 🚧 5 ✅​ 1 📦 44]==
 "@rushstack/heft-web-rig (build)" did not define any work.

==[ @rushstack/heft-web-rig (test) ]==========[❌ 1 ⚠️  1 ⏳ 1 🚧 5 ✅​ 1 📦 44]==
 "@rushstack/heft-web-rig (test)" did not define any work.

==[ local-web-rig (build) ]===================[❌ 1 ⚠️  1 ⏳ 1 🚧 5 ✅​ 1 📦 44]==
 "local-web-rig (build)" did not define any work.

==[ local-web-rig (test) ]====================[❌ 1 ⚠️  1 ⏳ 1 🚧 5 ✅​ 1 📦 44]==
 "local-web-rig (test)" did not define any work.

==[ @rushstack/module-minifier (test) ]=======[❌ 1 ⚠️  1 ⏳ 1 🚧 5 ✅​ 1 📦 44]==
📦 "@rushstack/module-minifier (test)" was restored from the build cache.

==[ @rushstack/webpack4-module-minifier-plugin (build) ][❌ 1 ⚠️  1 ⏳ 1 🚧 5 ✅​ 1 📦 44]==
📦 "@rushstack/webpack4-module-minifier-plugin (build)" was restored from the build cache.

==[ @rushstack/heft-webpack5-plugin (test) ]==[❌ 1 ⚠️  1 ⏳ 1 🚧 5 ✅​ 1 📦 44]==
📦 "@rushstack/heft-webpack5-plugin (test)" was restored from the build cache.

==[ @rushstack/webpack4-module-minifier-plugin (test) ][❌ 1 ⚠️  1 ⏳ 1 🚧 5 ✅​ 1 📦 44]==
📦 "@rushstack/webpack4-module-minifier-plugin (test)" was restored from the build cache.

==[ @microsoft/load-themed-styles (build) ]===[❌ 1 ⚠️  1 ⏳ 1 🚧 5 ✅​ 1 📦 44]==
[build:typescript] Error: libraries/load-themed-styles/src/index.ts:10:1 - (TS2304) Cannot find name 'zzzz'.
Encountered 1 error
  [build:typescript] libraries/load-themed-styles/src/index.ts:10:1 - (TS2304) Cannot find name 'zzzz'.
Returned error code: 1
❌ "@microsoft/load-themed-styles (build)" failed to build.
🚧 "@microsoft/load-themed-styles (test)" is blocked by "@microsoft/load-themed-styles (build)".
🚧 "@rushstack/heft-sass-load-themed-styles-plugin (build)" is blocked by "@microsoft/load-themed-styles (build)".
🚧 "@rushstack/heft-sass-load-themed-styles-plugin (test)" is blocked by "@microsoft/load-themed-styles (build)".
🚧 "heft-sass-test (build)" is blocked by "@microsoft/load-themed-styles (build)".
🚧 "heft-sass-test (test)" is blocked by "@microsoft/load-themed-styles (build)".

==[ @rushstack/heft-webpack4-plugin (test) ]=[❌ 1 ⚠️  1 🔄 1 🚧 5 ✅​ 1 📦 44]==
📦 "@rushstack/heft-webpack4-plugin (test)" was restored from the build cache.



==[ NO OP: 17 operations ]====================================================

These operations did not define any work:
  @rushstack/debug-certificate-manager (test)
  @rushstack/eslint-config (build)
  @rushstack/eslint-config (test)
  @rushstack/eslint-patch (test)
  @rushstack/heft-api-extractor-plugin (test)
  @rushstack/heft-node-rig (build)
  @rushstack/heft-node-rig (test)
  @rushstack/heft-typescript-plugin (test)
  @rushstack/heft-web-rig (build)
  @rushstack/heft-web-rig (test)
  decoupled-local-node-rig (build)
  decoupled-local-node-rig (test)
  local-eslint-config (test)
  local-node-rig (build)
  local-node-rig (test)
  local-web-rig (build)
  local-web-rig (test)

==[📦 FROM CACHE: 45 operations ]===============================================

These operations were restored from the build cache:
  @microsoft/api-extractor (build)                      0.03 seconds
  @microsoft/api-extractor (test)                       0.03 seconds
  @microsoft/api-extractor-model (build)                0.05 seconds
  @microsoft/api-extractor-model (test)                 0.03 seconds
  @rushstack/debug-certificate-manager (build)          0.04 seconds
  @rushstack/eslint-patch (build)                       0.03 seconds
  @rushstack/eslint-plugin (build)                      0.09 seconds
  @rushstack/eslint-plugin (test)                       0.07 seconds
  @rushstack/eslint-plugin-packlets (build)             0.09 seconds
  @rushstack/eslint-plugin-packlets (test)              0.03 seconds
  @rushstack/eslint-plugin-security (build)             0.09 seconds
  @rushstack/eslint-plugin-security (test)              0.02 seconds
  @rushstack/heft (build)                               0.03 seconds
  @rushstack/heft (test)                                0.03 seconds
  @rushstack/heft-api-extractor-plugin (build)          0.02 seconds
  @rushstack/heft-config-file (build)                   0.06 seconds
  @rushstack/heft-config-file (test)                    0.02 seconds
  @rushstack/heft-jest-plugin (build)                   0.03 seconds
  @rushstack/heft-jest-plugin (test)                    0.01 seconds
  @rushstack/heft-lint-plugin (build)                   0.03 seconds
  @rushstack/heft-lint-plugin (test)                    0.03 seconds
  @rushstack/heft-sass-plugin (build)                   0.05 seconds
  @rushstack/heft-sass-plugin (test)                    0.02 seconds
  @rushstack/heft-typescript-plugin (build)             0.02 seconds
  @rushstack/heft-webpack4-plugin (test)                0.01 seconds
  @rushstack/heft-webpack5-plugin (build)               0.04 seconds
  @rushstack/heft-webpack5-plugin (test)                0.01 seconds
  @rushstack/module-minifier (build)                    0.03 seconds
  @rushstack/module-minifier (test)                     0.02 seconds
  @rushstack/node-core-library (build)                  0.07 seconds
  @rushstack/node-core-library (test)                   0.05 seconds
  @rushstack/operation-graph (build)                    0.05 seconds
  @rushstack/operation-graph (test)                     0.02 seconds
  @rushstack/rig-package (build)                        0.06 seconds
  @rushstack/rig-package (test)                         0.03 seconds
  @rushstack/terminal (build)                           0.05 seconds
  @rushstack/terminal (test)                            0.03 seconds
  @rushstack/tree-pattern (build)                       0.03 seconds
  @rushstack/tree-pattern (test)                        0.08 seconds
  @rushstack/ts-command-line (build)                    0.06 seconds
  @rushstack/ts-command-line (test)                     0.02 seconds
  @rushstack/webpack4-module-minifier-plugin (build)    0.02 seconds
  @rushstack/webpack4-module-minifier-plugin (test)     0.01 seconds
  @rushstack/worker-pool (build)                        0.04 seconds
  @rushstack/worker-pool (test)                         0.03 seconds

==[✅​ SUCCESS: 1 operation ]====================================================

These operations completed successfully:
  local-eslint-config (build)    0.38 seconds

==[⚠️  SUCCESS WITH WARNINGS: 1 operation ]======================================

--[⚠️  WARNING: @rushstack/heft-webpack4-plugin (build) ]-------[ 5.92 seconds ]--

[build:lint] Warning: heft-plugins/heft-webpack4-plugin/src/WebpackConfigurationLoader.test.ts:19:1 - (no-console) Unexpected console statement. Only these console methods are allowed: debug, info, time, timeEnd, trace.
Encountered 1 warning
  [build:lint] heft-plugins/heft-webpack4-plugin/src/WebpackConfigurationLoader.test.ts:19:1 - (no-console) Unexpected console statement. Only these console methods are allowed: debug, info, time, timeEnd, trace.

==[🚧 BLOCKED: 5 operations ]===================================================

These operations were blocked by dependencies that failed:
  @microsoft/load-themed-styles (test)
  @rushstack/heft-sass-load-themed-styles-plugin (build)
  @rushstack/heft-sass-load-themed-styles-plugin (test)
  heft-sass-test (build)
  heft-sass-test (test)

==[❌ FAILURE: 1 operation ]====================================================

--[❌ FAILURE: @microsoft/load-themed-styles (build) ]---------[ 2.01 seconds ]--

[build:typescript] Error: libraries/load-themed-styles/src/index.ts:10:1 - (TS2304) Cannot find name 'zzzz'.
Encountered 1 error
  [build:typescript] libraries/load-themed-styles/src/index.ts:10:1 - (TS2304) Cannot find name 'zzzz'.


Operations failed.

❌ rush test (7.12 seconds)
```

## Impacted documentation
None. Purely alters console output.