### PR TITLE
[heft-swc] Reduce set of watched folders

### DIFF
--- a/common/changes/@rushstack/heft-isolated-typescript-transpile-plugin/main_2025-08-04-19-18.json
+++ b/common/changes/@rushstack/heft-isolated-typescript-transpile-plugin/main_2025-08-04-19-18.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-isolated-typescript-transpile-plugin",
+      "comment": "Manually process wildcard directories for watching instead of watching all read directories.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft-isolated-typescript-transpile-plugin"
+}

--- a/heft-plugins/heft-isolated-typescript-transpile-plugin/src/SwcIsolatedTranspilePlugin.ts
+++ b/heft-plugins/heft-isolated-typescript-transpile-plugin/src/SwcIsolatedTranspilePlugin.ts
@@ -171,7 +171,7 @@ async function transpileProjectAsync(
     // If the tsconfig has wildcard directories, we need to ensure that they are watched for file changes.
     const directoryQueue: Map<string, boolean> = new Map();
     for (const [wildcardDirectory, type] of Object.entries(parsedTsConfig.wildcardDirectories)) {
-      directoryQueue.set(path.normalize(wildcardDirectory), type !== 0);
+      directoryQueue.set(path.normalize(wildcardDirectory), type === ts.WatchDirectoryFlags.Recursive);
     }
 
     if (directoryQueue.size > 0) {


### PR DESCRIPTION
## Summary
Updates the watch logic to only watch folders that TypeScript has identified has having wildcard patterns for source files, rather than all folders enumerated during TSConfig parsing.

This avoids, for example, watching for changes to the project root folder.

## Details
The TSConfig parser returns a `wildcardDirectories` object that indicates folders that contained wildcards and if the wildcard is local (`*` or `?`) or recursive (`**`). This is used to determine the directories that should be watched by Heft's watcher.

## How it was tested
Local `heft run-watch --only build -- --clean` in `heft-swc-test` and creating/modifying/deleting files at various points in the directory hierarchy.
Linked the new version into a repository that was having infinite loop issues and verified that no such issues occur.

## Impacted documentation
None.