### PR TITLE
[rush-lib] Update [dot]npmrc

### DIFF
--- a/libraries/rush-lib/assets/rush-init/common/config/rush/[dot]npmrc
+++ b/libraries/rush-lib/assets/rush-init/common/config/rush/[dot]npmrc
@@ -24,7 +24,7 @@
 #
 
 # Explicitly specify the NPM registry that "rush install" and "rush update" will use by default:
-registry=https://registry.npmjs.org/
+# registry=https://registry.npmjs.org/
 
 # Optionally provide an authentication token for the above registry URL (if it is a private registry):
 # //registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}


### PR DESCRIPTION
Since `https://registry.npmjs.org/` is already the default npm registry, there's no need to configure it explicitly. Otherwise, it will override the user's local configuration