### PR TITLE
[rush-bridge-cache] Ensure that Rush waits for the cache operation to finish

### DIFF
--- a/common/changes/@microsoft/rush/bridge-cache-fix-wait_2025-08-06-20-42.json
+++ b/common/changes/@microsoft/rush/bridge-cache-fix-wait_2025-08-06-20-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix a bug in \"@rushstack/rush-bridge-cache-plugin\" where the cache replay did not block the normal execution process and instead was a floating promise.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/rush-plugins/rush-bridge-cache-plugin/src/BridgeCachePlugin.ts
+++ b/rush-plugins/rush-bridge-cache-plugin/src/BridgeCachePlugin.ts
@@ -75,7 +75,7 @@ export class BridgeCachePlugin implements IRushPlugin {
         }
       );
       // populate the cache for each operation
-      command.hooks.beforeExecuteOperations.tap(
+      command.hooks.beforeExecuteOperations.tapPromise(
         PLUGIN_NAME,
         async (
           recordByOperation: Map<Operation, IOperationExecutionResult>,
@@ -137,9 +137,9 @@ export class BridgeCachePlugin implements IRushPlugin {
                   const projectFolder: string = operation.associatedProject?.projectFolder;
                   const missingFolders: string[] = [];
                   operation.settings.outputFolderNames.forEach((outputFolderName: string) => {
-                      if (!FileSystem.exists(`${projectFolder}/${outputFolderName}`)) {
-                        missingFolders.push(outputFolderName);
-                      }
+                    if (!FileSystem.exists(`${projectFolder}/${outputFolderName}`)) {
+                      missingFolders.push(outputFolderName);
+                    }
                   });
                   if (missingFolders.length > 0) {
                     terminal.writeWarningLine(


### PR DESCRIPTION
## Summary
Fixes a bug where Rush would finish executing but the bridge-cache plugin's work would continue as a floating promise.

## Details
Incorrect tap action was used for an async function.

## How it was tested
Temporarily linked in the plugin to rushstack and ran `rush build --bridge-cache-action=read`. Verified that normal Rush logging for action completion occurs *after* the cache unpack finishes.

## Impacted documentation
None