### PR TITLE
[api-extractor] Fix self-package import resolution in TypeScript compiler

### DIFF
--- a/apps/api-extractor/src/api/CompilerState.ts
+++ b/apps/api-extractor/src/api/CompilerState.ts
@@ -67,6 +67,15 @@ export class CompilerState {
       );
     }
 
+    // Delete outDir and declarationDir to prevent TypeScript from redirecting self-package
+    // imports to source files. When these options are set, TypeScript's module resolution
+    // tries to map output .d.ts files back to their source .ts files to avoid analyzing
+    // build outputs during compilation. However, API Extractor specifically wants to analyze
+    // the .d.ts build artifacts, not the source files. Since API Extractor doesn't emit any
+    // files, these options are unnecessary and interfere with correct module resolution.
+    delete commandLine.options.outDir;
+    delete commandLine.options.declarationDir;
+
     const inputFilePaths: string[] = commandLine.fileNames.concat(extractorConfig.mainEntryPointFilePath);
     if (options && options.additionalEntryPoints) {
       inputFilePaths.push(...options.additionalEntryPoints);

--- a/common/changes/@microsoft/api-extractor/fix-self-import-resolution_2025-08-07-10-22.json
+++ b/common/changes/@microsoft/api-extractor/fix-self-import-resolution_2025-08-07-10-22.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Fix self-package import resolution by removing outDir/declarationDir from compiler options",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor"
+}


### PR DESCRIPTION
## Summary
This PR fixes an issue where API Extractor incorrectly resolves self-package imports to source `.ts` files instead of the intended `.d.ts` build artifacts.

## Problem
When a `.d.ts` file imports the package itself by its name, TypeScript's module resolution redirects to source files instead of analyzing the build outputs. This occurs because TypeScript tries to avoid analyzing build outputs when `outDir` or `declarationDir` compiler options are set.

See the TypeScript compiler logic here: https://github.com/microsoft/TypeScript/blob/391616532d6827254a86dc266121fd5d1958ffb9/src/compiler/moduleNameResolver.ts#L2867

## Solution
Remove `outDir` and `declarationDir` from the compiler options in `CompilerState.ts`. This prevents TypeScript from redirecting imports and ensures API Extractor analyzes the correct `.d.ts` files. Since API Extractor only uses the compiler for analysis and doesn't emit any files, these options are unnecessary.

## Test Plan
- Built the project successfully with `rushx build`
- Verified that API Extractor still works correctly for analyzing `.d.ts` files
- Fixes build issues for me in [Alloy](https://github.com/alloy-framework/alloy/tree/main/packages/core)

### Alloy issue
I found this issue by trying to build [Alloy](https://github.com/alloy-framework/alloy/tree/main/packages/core) on a Windows machine. Strangely, this self-import issue causes cyclic dependency warnings only on Windows.

When you run `pnpm exec api-extractor run -v --diagnostics` in `packages/core` of the repository (regardless of the OS), you can see that the compiler is analyzing src directory.

```
============================================================
DIAGNOSTIC: Files analyzed by compiler
============================================================
...
/home/finalchild/projects/alloy/packages/core/src/symbols/symbol-slot.tsx
/home/finalchild/projects/alloy/packages/core/src/symbols/index.ts
/home/finalchild/projects/alloy/packages/core/src/tap.ts
/home/finalchild/projects/alloy/packages/core/src/write-output.ts
/home/finalchild/projects/alloy/packages/core/src/index.ts
/home/finalchild/projects/alloy/packages/core/src/jsx-runtime.ts
/home/finalchild/projects/alloy/packages/core/dist/src/components/MemberName.d.ts
/home/finalchild/projects/alloy/packages/core/dist/src/components/MemberScope.d.ts
...
```

After the fix, this changes:

```
============================================================
DIAGNOSTIC: Files analyzed by compiler
============================================================
...
/home/finalchild/projects/alloy/packages/core/dist/src/components/Declaration.d.ts
/home/finalchild/projects/alloy/packages/core/dist/src/components/List.d.ts
/home/finalchild/projects/alloy/packages/core/dist/src/components/For.d.ts
/home/finalchild/projects/alloy/packages/core/dist/src/components/Indent.d.ts
/home/finalchild/projects/alloy/packages/core/dist/src/components/MemberDeclaration.d.ts
/home/finalchild/projects/alloy/packages/core/dist/src/jsx-runtime.d.ts
/home/finalchild/projects/alloy/packages/core/dist/src/components/MemberName.d.ts
/home/finalchild/projects/alloy/packages/core/dist/src/components/MemberScope.d.ts
...
```

And the Windows issue is also gone.

### api.json impact

The members with self-dynamic-import are affected. Others are unaffected.

Before:
```
...
{
  "kind": "Reference",
  "text": "Children",
  "canonicalReference": "@alloy-js/core!~Children:type"
}
...
```
After:
```
...
{
  "kind": "Reference",
  "text": "Children",
  "canonicalReference": "@alloy-js/core!Children:type"
}
...
```

As you can see, `!~` is changed to `!`.

I don't completely understand what this change is, and which one is better. It seems `!~` means local and `!` means exported?Then `!` looks fine. The markdown generation was the same (both did not generate the link to `Children`).

# Generated Markdown
<!-- Do not edit this file. It is automatically generated by API Documenter. -->

[Home](./index.md) &gt; [@alloy-js/core](./core.md) &gt; [MemberName](./core.membername.md)

## MemberName() function

**Signature:**

```typescript
export declare function MemberName(): import("@alloy-js/core/jsx-runtime").Children;
```
**Returns:**

import("@alloy-js/core/jsx-runtime").Children