### PR TITLE
[rush] Fix version bump removing policy fields

### DIFF
--- a/common/changes/@microsoft/rush/version-policy-exempt_2025-08-19-21-32.json
+++ b/common/changes/@microsoft/rush/version-policy-exempt_2025-08-19-21-32.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Ensure that `rush version` and `rush publish` preserve all fields in `version-policies-json`.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -575,15 +575,15 @@ export interface ILogger {
 
 // @public
 export class IndividualVersionPolicy extends VersionPolicy {
-    // Warning: (ae-forgotten-export) The symbol "IIndividualVersionJson" needs to be exported by the entry point index.d.ts
-    //
     // @internal
     constructor(versionPolicyJson: IIndividualVersionJson);
     bump(bumpType?: BumpType, identifier?: string): void;
     ensure(project: IPackageJson, force?: boolean): IPackageJson | undefined;
-    // @internal
-    get _json(): IIndividualVersionJson;
-    readonly lockedMajor: number | undefined;
+    // Warning: (ae-forgotten-export) The symbol "IIndividualVersionJson" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    readonly _json: IIndividualVersionJson;
+    get lockedMajor(): number | undefined;
     validate(versionString: string, packageName: string): void;
 }
 
@@ -929,16 +929,16 @@ export interface _IYarnOptionsJson extends IPackageManagerOptionsJsonBase {
 
 // @public
 export class LockStepVersionPolicy extends VersionPolicy {
-    // Warning: (ae-forgotten-export) The symbol "ILockStepVersionJson" needs to be exported by the entry point index.d.ts
-    //
     // @internal
     constructor(versionPolicyJson: ILockStepVersionJson);
     bump(bumpType?: BumpType, identifier?: string): void;
     ensure(project: IPackageJson, force?: boolean): IPackageJson | undefined;
-    // @internal
-    get _json(): ILockStepVersionJson;
-    readonly mainProject: string | undefined;
-    readonly nextBump: BumpType | undefined;
+    // Warning: (ae-forgotten-export) The symbol "ILockStepVersionJson" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    _json: ILockStepVersionJson;
+    get mainProject(): string | undefined;
+    get nextBump(): BumpType | undefined;
     update(newVersionString: string): boolean;
     validate(versionString: string, packageName: string): void;
     get version(): string;
@@ -1603,21 +1603,21 @@ export class SubspacesConfiguration {
 
 // @public
 export abstract class VersionPolicy {
-    // Warning: (ae-forgotten-export) The symbol "IVersionPolicyJson" needs to be exported by the entry point index.d.ts
-    //
     // @internal
     constructor(versionPolicyJson: IVersionPolicyJson);
     abstract bump(bumpType?: BumpType, identifier?: string): void;
-    readonly definitionName: VersionPolicyDefinitionName;
+    get definitionName(): VersionPolicyDefinitionName;
     abstract ensure(project: IPackageJson, force?: boolean): IPackageJson | undefined;
-    readonly exemptFromRushChange: boolean;
-    readonly includeEmailInChangeFile: boolean;
+    get exemptFromRushChange(): boolean;
+    get includeEmailInChangeFile(): boolean;
     get isLockstepped(): boolean;
+    // Warning: (ae-forgotten-export) The symbol "IVersionPolicyJson" needs to be exported by the entry point index.d.ts
+    //
     // @internal
-    abstract get _json(): IVersionPolicyJson;
+    readonly _json: IVersionPolicyJson;
     // @internal
     static load(versionPolicyJson: IVersionPolicyJson): VersionPolicy | undefined;
-    readonly policyName: string;
+    get policyName(): string;
     setDependenciesBeforeCommit(packageName: string, configuration: RushConfiguration): void;
     setDependenciesBeforePublish(packageName: string, configuration: RushConfiguration): void;
     abstract validate(versionString: string, packageName: string): void;

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -538,6 +538,12 @@ export interface IGetChangedProjectsOptions {
 export interface IGlobalCommand extends IRushCommand {
 }
 
+// @public
+export interface IIndividualVersionJson extends IVersionPolicyJson {
+    // (undocumented)
+    lockedMajor?: number;
+}
+
 // @beta
 export interface IInputsSnapshot {
     getOperationOwnStateHash(project: IRushConfigurationProjectForSnapshot, operationName?: string): string;
@@ -554,6 +560,16 @@ export interface ILaunchOptions {
     builtInPluginConfigurations?: _IBuiltInPluginConfiguration[];
     isManaged: boolean;
     terminalProvider?: ITerminalProvider;
+}
+
+// @public
+export interface ILockStepVersionJson extends IVersionPolicyJson {
+    // (undocumented)
+    mainProject?: string;
+    // (undocumented)
+    nextBump?: string;
+    // (undocumented)
+    version: string;
 }
 
 // @alpha
@@ -579,9 +595,7 @@ export class IndividualVersionPolicy extends VersionPolicy {
     constructor(versionPolicyJson: IIndividualVersionJson);
     bump(bumpType?: BumpType, identifier?: string): void;
     ensure(project: IPackageJson, force?: boolean): IPackageJson | undefined;
-    // Warning: (ae-forgotten-export) The symbol "IIndividualVersionJson" needs to be exported by the entry point index.d.ts
-    //
-    // (undocumented)
+    // @internal (undocumented)
     readonly _json: IIndividualVersionJson;
     get lockedMajor(): number | undefined;
     validate(versionString: string, packageName: string): void;
@@ -922,6 +936,22 @@ export interface ITryFindRushJsonLocationOptions {
     startingFolder?: string;
 }
 
+// @public
+export interface IVersionPolicyJson {
+    // (undocumented)
+    definitionName: string;
+    // Warning: (ae-forgotten-export) The symbol "IVersionPolicyDependencyJson" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    dependencies?: IVersionPolicyDependencyJson;
+    // (undocumented)
+    exemptFromRushChange?: boolean;
+    // (undocumented)
+    includeEmailInChangeFile?: boolean;
+    // (undocumented)
+    policyName: string;
+}
+
 // @internal
 export interface _IYarnOptionsJson extends IPackageManagerOptionsJsonBase {
     ignoreEngines?: boolean;
@@ -933,10 +963,8 @@ export class LockStepVersionPolicy extends VersionPolicy {
     constructor(versionPolicyJson: ILockStepVersionJson);
     bump(bumpType?: BumpType, identifier?: string): void;
     ensure(project: IPackageJson, force?: boolean): IPackageJson | undefined;
-    // Warning: (ae-forgotten-export) The symbol "ILockStepVersionJson" needs to be exported by the entry point index.d.ts
-    //
-    // (undocumented)
-    _json: ILockStepVersionJson;
+    // @internal (undocumented)
+    readonly _json: ILockStepVersionJson;
     get mainProject(): string | undefined;
     get nextBump(): BumpType | undefined;
     update(newVersionString: string): boolean;
@@ -1611,8 +1639,6 @@ export abstract class VersionPolicy {
     get exemptFromRushChange(): boolean;
     get includeEmailInChangeFile(): boolean;
     get isLockstepped(): boolean;
-    // Warning: (ae-forgotten-export) The symbol "IVersionPolicyJson" needs to be exported by the entry point index.d.ts
-    //
     // @internal
     readonly _json: IVersionPolicyJson;
     // @internal

--- a/libraries/rush-lib/src/api/VersionPolicy.ts
+++ b/libraries/rush-lib/src/api/VersionPolicy.ts
@@ -4,10 +4,10 @@
 import * as semver from 'semver';
 import { type IPackageJson, Enum } from '@rushstack/node-core-library';
 
-import {
-  type IVersionPolicyJson,
-  type ILockStepVersionJson,
-  type IIndividualVersionJson,
+import type {
+  IVersionPolicyJson,
+  ILockStepVersionJson,
+  IIndividualVersionJson,
   VersionFormatForCommit,
   VersionFormatForPublish
 } from './VersionPolicyConfiguration';
@@ -64,11 +64,11 @@ export abstract class VersionPolicy {
   public readonly _json: IVersionPolicyJson;
 
   private get _versionFormatForCommit(): VersionFormatForCommit {
-    return this._json.dependencies?.versionFormatForCommit ?? VersionFormatForCommit.original;
+    return this._json.dependencies?.versionFormatForCommit ?? 'original';
   }
 
   private get _versionFormatForPublish(): VersionFormatForPublish {
-    return this._json.dependencies?.versionFormatForPublish ?? VersionFormatForPublish.original;
+    return this._json.dependencies?.versionFormatForPublish ?? 'original';
   }
 
   /**
@@ -164,7 +164,7 @@ export abstract class VersionPolicy {
    * to values used for publishing.
    */
   public setDependenciesBeforePublish(packageName: string, configuration: RushConfiguration): void {
-    if (this._versionFormatForPublish === VersionFormatForPublish.exact) {
+    if (this._versionFormatForPublish === 'exact') {
       const project: RushConfigurationProject = configuration.getProjectByName(packageName)!;
 
       const packageJsonEditor: PackageJsonEditor = project.packageJsonEditor;
@@ -190,7 +190,7 @@ export abstract class VersionPolicy {
    * to values used for checked-in source.
    */
   public setDependenciesBeforeCommit(packageName: string, configuration: RushConfiguration): void {
-    if (this._versionFormatForCommit === VersionFormatForCommit.wildcard) {
+    if (this._versionFormatForCommit === 'wildcard') {
       const project: RushConfigurationProject = configuration.getProjectByName(packageName)!;
 
       const packageJsonEditor: PackageJsonEditor = project.packageJsonEditor;
@@ -215,7 +215,10 @@ export abstract class VersionPolicy {
  * @public
  */
 export class LockStepVersionPolicy extends VersionPolicy {
-  public declare _json: ILockStepVersionJson;
+  /**
+   * @internal
+   */
+  public declare readonly _json: ILockStepVersionJson;
   private _version: semver.SemVer;
 
   /**
@@ -334,6 +337,9 @@ export class LockStepVersionPolicy extends VersionPolicy {
  * @public
  */
 export class IndividualVersionPolicy extends VersionPolicy {
+  /**
+   * @internal
+   */
   public declare readonly _json: IIndividualVersionJson;
 
   /**

--- a/libraries/rush-lib/src/api/VersionPolicyConfiguration.ts
+++ b/libraries/rush-lib/src/api/VersionPolicyConfiguration.ts
@@ -7,6 +7,12 @@ import { VersionPolicy, type BumpType, type LockStepVersionPolicy } from './Vers
 import type { RushConfigurationProject } from './RushConfigurationProject';
 import schemaJson from '../schemas/version-policies.schema.json';
 
+/**
+ * This interface represents the raw version policy JSON object which allows repo
+ * maintainers to define how different groups of projects will be published by Rush,
+ * and how their version numbers will be determined.
+ * @public
+ */
 export interface IVersionPolicyJson {
   policyName: string;
   definitionName: string;
@@ -15,26 +21,42 @@ export interface IVersionPolicyJson {
   includeEmailInChangeFile?: boolean;
 }
 
+/**
+ * This interface represents the raw lock-step version policy JSON object which extends the base version policy
+ * with additional fields specific to lock-step versioning.
+ * @public
+ */
 export interface ILockStepVersionJson extends IVersionPolicyJson {
   version: string;
   nextBump?: string;
   mainProject?: string;
 }
 
+/**
+ * This interface represents the raw individual version policy JSON object which extends the base version policy
+ * with additional fields specific to individual versioning.
+ * @public
+ */
 export interface IIndividualVersionJson extends IVersionPolicyJson {
   lockedMajor?: number;
 }
 
-export enum VersionFormatForPublish {
-  original = 'original',
-  exact = 'exact'
-}
+/**
+ * @public
+ */
+export type VersionFormatForPublish = 'original' | 'exact';
 
-export enum VersionFormatForCommit {
-  wildcard = 'wildcard',
-  original = 'original'
-}
+/**
+ * @public
+ */
+export type VersionFormatForCommit = 'wildcard' | 'original';
 
+/**
+ * This interface represents the `dependencies` field in a version policy JSON object,
+ * allowing repo maintainers to specify how dependencies' versions should be handled
+ * during publishing and committing.
+ * @public
+ */
 export interface IVersionPolicyDependencyJson {
   versionFormatForPublish?: VersionFormatForPublish;
   versionFormatForCommit?: VersionFormatForCommit;

--- a/libraries/rush-lib/src/api/test/VersionPolicy.test.ts
+++ b/libraries/rush-lib/src/api/test/VersionPolicy.test.ts
@@ -3,7 +3,13 @@
 
 import type { IPackageJson } from '@rushstack/node-core-library';
 
-import { VersionPolicyConfiguration } from '../VersionPolicyConfiguration';
+import {
+  type ILockStepVersionJson,
+  VersionFormatForCommit,
+  VersionFormatForPublish,
+  VersionPolicyConfiguration,
+  type IIndividualVersionJson
+} from '../VersionPolicyConfiguration';
 import { VersionPolicy, LockStepVersionPolicy, IndividualVersionPolicy, BumpType } from '../VersionPolicy';
 
 describe(VersionPolicy.name, () => {
@@ -113,6 +119,25 @@ describe(VersionPolicy.name, () => {
       lockStepVersionPolicy.update(newVersion);
       expect(lockStepVersionPolicy.version).toEqual(newVersion);
     });
+
+    it('preserves fields', () => {
+      const originalJson: ILockStepVersionJson = {
+        definitionName: 'lockStepVersion',
+        policyName: 'test',
+        dependencies: {
+          versionFormatForCommit: VersionFormatForCommit.original,
+          versionFormatForPublish: VersionFormatForPublish.original
+        },
+        exemptFromRushChange: true,
+        includeEmailInChangeFile: true,
+        version: '1.1.0',
+        mainProject: 'main-project',
+        nextBump: 'major'
+      };
+
+      const nextJson: ILockStepVersionJson = new LockStepVersionPolicy(originalJson)._json;
+      expect(nextJson).toMatchObject(originalJson);
+    });
   });
 
   describe(IndividualVersionPolicy.name, () => {
@@ -158,6 +183,23 @@ describe(VersionPolicy.name, () => {
       expect(() => {
         individualVersionPolicy.ensure(originalPackageJson);
       }).toThrow();
+    });
+
+    it('preserves fields', () => {
+      const originalJson: IIndividualVersionJson = {
+        definitionName: 'individualVersion',
+        policyName: 'test',
+        dependencies: {
+          versionFormatForCommit: VersionFormatForCommit.original,
+          versionFormatForPublish: VersionFormatForPublish.original
+        },
+        exemptFromRushChange: true,
+        includeEmailInChangeFile: true,
+        lockedMajor: 3
+      };
+
+      const nextJson: IIndividualVersionJson = new IndividualVersionPolicy(originalJson)._json;
+      expect(nextJson).toMatchObject(originalJson);
     });
   });
 });

--- a/libraries/rush-lib/src/api/test/VersionPolicy.test.ts
+++ b/libraries/rush-lib/src/api/test/VersionPolicy.test.ts
@@ -5,8 +5,6 @@ import type { IPackageJson } from '@rushstack/node-core-library';
 
 import {
   type ILockStepVersionJson,
-  VersionFormatForCommit,
-  VersionFormatForPublish,
   VersionPolicyConfiguration,
   type IIndividualVersionJson
 } from '../VersionPolicyConfiguration';
@@ -125,8 +123,8 @@ describe(VersionPolicy.name, () => {
         definitionName: 'lockStepVersion',
         policyName: 'test',
         dependencies: {
-          versionFormatForCommit: VersionFormatForCommit.original,
-          versionFormatForPublish: VersionFormatForPublish.original
+          versionFormatForCommit: 'original',
+          versionFormatForPublish: 'original'
         },
         exemptFromRushChange: true,
         includeEmailInChangeFile: true,
@@ -190,8 +188,8 @@ describe(VersionPolicy.name, () => {
         definitionName: 'individualVersion',
         policyName: 'test',
         dependencies: {
-          versionFormatForCommit: VersionFormatForCommit.original,
-          versionFormatForPublish: VersionFormatForPublish.original
+          versionFormatForCommit: 'wildcard',
+          versionFormatForPublish: 'exact'
         },
         exemptFromRushChange: true,
         includeEmailInChangeFile: true,

--- a/libraries/rush-lib/src/index.ts
+++ b/libraries/rush-lib/src/index.ts
@@ -107,7 +107,12 @@ export {
   VersionPolicy
 } from './api/VersionPolicy';
 
-export { VersionPolicyConfiguration } from './api/VersionPolicyConfiguration';
+export {
+  VersionPolicyConfiguration,
+  type ILockStepVersionJson,
+  type IIndividualVersionJson,
+  type IVersionPolicyJson
+} from './api/VersionPolicyConfiguration';
 
 export { type ILaunchOptions, Rush } from './api/Rush';
 export { RushInternals as _RushInternals } from './api/RushInternals';


### PR DESCRIPTION
## Summary
Fixes an issue where the fields `dependencies`, `exemptFromRushChange` and `includeEmailInChangeFile` were discarded from `version-policies.json` during `rush version --bump` or similar commands.

## Details
The version bump logic asked for a fresh serialization of the data in the version policies, and the serializer was missing fields.

The revised logic has the version policy track the original JSON and modify it in place so that the `version-policies.json` file will only have the necessary changes.

## How it was tested
Ran `rush version --bump` in the rushstack repository after adding `exemptFromRushChange: true` and `includeEmailInChangeFile: true` to the Rush version policy. Verified that in the old version these fields were discarded and in the new version they were preserved.

## Impacted documentation
Documentation is now correct, since it was neither stated nor implied that fields would be discarded during version bump.