### PR TITLE
[rush] Fix performance in findOrphanedProjects

### DIFF
--- a/common/changes/@microsoft/rush/tune-prepare-async_2025-08-20-01-11.json
+++ b/common/changes/@microsoft/rush/tune-prepare-async_2025-08-20-01-11.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix poor performance scaling during `rush install` when identifying projects in the lockfile that no longer exist.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}


### PR DESCRIPTION
## Summary
Fixes a performance issue encountered during `rush install`'s for lockfiles with many projects.

## Details
Switches the algorithm used when scanning the lockfile for projects that are no longer listed in `rush.json` from `Path.isUnder` to `LookupByPath`'s `findChildPath`.

## How it was tested
Using the rushstack repository:
Before:
<img width="1011" height="353" alt="image" src="https://github.com/user-attachments/assets/816580ca-0da8-4c1a-b443-feb5e5f5e8ac" />

After:
<img width="997" height="265" alt="image" src="https://github.com/user-attachments/assets/c0adfdab-6b95-48a2-b7f1-caf47a7381b4" />

## Impacted documentation
None.