### PR TITLE
[rush-resolver-cache] Improve performance of scan for nested package.json files

### DIFF
--- a/common/changes/@microsoft/rush/tune-resolver-cache_2025-08-20-01-41.json
+++ b/common/changes/@microsoft/rush/tune-resolver-cache_2025-08-20-01-41.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "[resolver-cache-plugin] Improve performance of scan for nested package.json files in external packages.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}


### PR DESCRIPTION
## Summary
Improves performance `@rushstack/rush-resolver-cache-plugin` when scanning for nested package.json files in packages.

## Details
Skips the JSON parse and instead manually scans for the token `/package.json":`, which marks the end of a file name key for a nested package.json file.

## How it was tested
Before:
<img width="1008" height="364" alt="image" src="https://github.com/user-attachments/assets/23e278bc-29e1-46ca-92d9-244c5e683699" />

After:
<img width="1008" height="368" alt="image" src="https://github.com/user-attachments/assets/54cc9d7e-44ec-4711-b213-ef04fac1e674" />

Manually verified that nested package.json entries were still found using some projects that were known to contain them.

## Impacted documentation
None