### PR TITLE
[rush] Optimize setPreferredVersions

### DIFF
--- a/common/changes/@microsoft/rush/tune-setPreferredVersions_2025-08-20-02-23.json
+++ b/common/changes/@microsoft/rush/tune-setPreferredVersions_2025-08-20-02-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Optimize `setPreferredVersions` in install setup.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}


### PR DESCRIPTION
## Summary
Optimizes the `setPreferredVersions` helper function that applies the `preferredVersions` information from `common-versions.json` to packages.

## Details
Avoids unnecessary range parsing for values that contain protocol specifiers, as they are not valid SemVer range specifiers. Caches range parsing results and ensures that the parsed values are used as-is by the `subset` function.

Avoids processing of the `devDependencies` field for any `package.json` that is not part of the workspace.

## How it was tested
Before:
<img width="998" height="344" alt="image" src="https://github.com/user-attachments/assets/db0cb157-8f9f-4722-acda-6bf3f417e0ad" />

After:
<img width="1000" height="346" alt="image" src="https://github.com/user-attachments/assets/905782b0-ba55-46e8-8da1-a7a4a51a2bbc" />

## Impacted documentation
None.