### PR TITLE
[debug-certificate-manager] Handle `~` in `storePath` when reading `debug-certifiacate-manager.json`

### DIFF
--- a/common/changes/@rushstack/debug-certificate-manager/bmiddha-certificatestore-homedir_2025-08-22-20-14.json
+++ b/common/changes/@rushstack/debug-certificate-manager/bmiddha-certificatestore-homedir_2025-08-22-20-14.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/debug-certificate-manager",
+      "comment": "Fix handling of home directory paths when reading debug-certificate-manager.json config file.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/debug-certificate-manager"
+}

--- a/libraries/debug-certificate-manager/src/CertificateStore.ts
+++ b/libraries/debug-certificate-manager/src/CertificateStore.ts
@@ -69,6 +69,9 @@ export class CertificateStore {
           debugCertificateManagerConfig = JSON.parse(configContent) as ICertificateStoreOptions;
           if (debugCertificateManagerConfig.storePath) {
             storePath = path.resolve(currentDir, debugCertificateManagerConfig.storePath);
+            if (storePath.startsWith('~')) {
+              storePath = path.join(homedir(), storePath.slice(2));
+            }
           }
         }
         const parentDir: string | undefined = path.dirname(currentDir);


### PR DESCRIPTION
## Summary

Handle `~` in `storePath` when reading `debug-certifiacate-manager.json`

## Details

Resolve homedir if `storePath` starts with `~`. `path.resolve` does not handle `~`

<img width="468" height="123" alt="image" src="https://github.com/user-attachments/assets/4b143f86-9465-4579-874a-dc3bc8e9e648" />

## How it was tested

Tested with `~` path in `debug-certificate-manager.json`
