### PR TITLE
[vsix publish] fix pipeline artifact path

### DIFF
--- a/common/config/azure-pipelines/vscode-extension-publish.yaml
+++ b/common/config/azure-pipelines/vscode-extension-publish.yaml
@@ -48,7 +48,7 @@ extends:
                 - ${{ each extension in parameters.ExtensionPublishConfig }}:
                     - output: pipelineArtifact
                       artifactName: ${{ extension.key }}
-                      targetPath: ${{ extension.projectPath }}/${{ extension.vsixPath }}
+                      targetPath: ${{ extension.projectPath }}/${{ extension.projectRelativeAssetsDir }}/${{ extension.vsixPath }}
                       displayName: 'Publish Artifact: ${{ extension.key }}'
 
             steps:


### PR DESCRIPTION
## Summary

Fix bug where vsix pipeline artifact is not published because of a bad path
