### PR TITLE
[rush-resolver-cache] Cache nested package info

### DIFF
--- a/common/changes/@microsoft/rush/resolver-cache-cache_2025-08-25-20-30.json
+++ b/common/changes/@microsoft/rush/resolver-cache-cache_2025-08-25-20-30.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "[resolver-cache-plugin] Optimize search for nested package.json files with persistent cache file keyed by integrity hash.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}


### PR DESCRIPTION
## Summary
Improves the performance of `@rushstack/rush-resolver-cache-plugin` by caching information about nested package.json files in packages across installs based on package integrity hashes.

## Details
Persists an additional file into common/temp that stores the results of the scan for each package integrity hash.

## How it was tested
Local runs on a repository using this plugin. Reduced time spent in the rush-resolver-cache plugin from 2647ms to 443ms (most of which is loading the shrinkwrap file).

This could be further reduced if the `afterInstall` hook was passed the shrinkwrap file used for installation, skipped if no install occurred, or at least passed an indicator if an install occurred.

## Impacted documentation
None.