### PR TITLE
[debug-certificate-mangaer] remove shell integration timeout and make make activation event more specific

### DIFF
--- a/vscode-extensions/debug-certificate-manager-vscode-extension/package.json
+++ b/vscode-extensions/debug-certificate-manager-vscode-extension/package.json
@@ -107,7 +107,7 @@
   },
   "enabledApiProposals": [],
   "activationEvents": [
-    "workspaceContains:.vscode/debug-certificate-manager.json"
+    "workspaceContains:/.vscode/debug-certificate-manager.json"
   ],
   "dependencies": {
     "@rushstack/debug-certificate-manager": "workspace:*",

--- a/vscode-extensions/debug-certificate-manager-vscode-extension/package.json
+++ b/vscode-extensions/debug-certificate-manager-vscode-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "debug-certificate-manager",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/rushstack.git",

--- a/vscode-extensions/debug-certificate-manager-vscode-extension/src/terminal.ts
+++ b/vscode-extensions/debug-certificate-manager-vscode-extension/src/terminal.ts
@@ -5,8 +5,6 @@ import { ITerminal } from '@rushstack/terminal';
 import * as vscode from 'vscode';
 import { stripVTControlCharacters } from 'node:util';
 
-const SHELL_INTEGRATION_TIMEOUT: number = 15_000;
-
 export async function runWorkspaceCommandAsync({
   terminalOptions,
   commandLine,
@@ -22,24 +20,16 @@ export async function runWorkspaceCommandAsync({
   const shellIntegration: vscode.TerminalShellIntegration =
     vsTerminal.shellIntegration ??
     (await new Promise((resolve, reject) => {
-      let timeoutId: NodeJS.Timeout | undefined;
       const shellIntegrationDisposable: vscode.Disposable = vscode.window.onDidChangeTerminalShellIntegration(
         (event) => {
           if (event.terminal !== vsTerminal) {
             return;
           }
-          if (timeoutId) {
-            clearTimeout(timeoutId);
-            timeoutId = undefined;
-          }
+
           resolve(event.shellIntegration);
           shellIntegrationDisposable?.dispose();
         }
       );
-      timeoutId = setTimeout(() => {
-        shellIntegrationDisposable?.dispose();
-        reject(new Error('Shell integration timeout'));
-      }, SHELL_INTEGRATION_TIMEOUT);
     }));
 
   // Run the command through shell integration and grab output

--- a/vscode-extensions/debug-certificate-manager-vscode-extension/src/terminal.ts
+++ b/vscode-extensions/debug-certificate-manager-vscode-extension/src/terminal.ts
@@ -5,6 +5,8 @@ import { ITerminal } from '@rushstack/terminal';
 import * as vscode from 'vscode';
 import { stripVTControlCharacters } from 'node:util';
 
+const SHELL_INTEGRATION_TIMEOUT: number = 15_000;
+
 export async function runWorkspaceCommandAsync({
   terminalOptions,
   commandLine,
@@ -37,7 +39,7 @@ export async function runWorkspaceCommandAsync({
       timeoutId = setTimeout(() => {
         shellIntegrationDisposable?.dispose();
         reject(new Error('Shell integration timeout'));
-      }, 5000);
+      }, SHELL_INTEGRATION_TIMEOUT);
     }));
 
   // Run the command through shell integration and grab output


### PR DESCRIPTION
## Summary

Remove timeout for VS Code shell integration
Make activation event more specific

## Details

We had reports where users of the Debug Certificate Manger VS Code extension kept running into shell integration timeouts. This can happen when the shell boot up.
Shell integration is activated after the config files are sourced. So if there is anything in the `.bashrc` or `.bash_profile` that takes a while then the `bash` shell integration will be delayed.

We also had cases where the extension does not activate even when `.vscode/debug-certificate-manager.json`
Extension host logs:
```
2025-08-26 13:51:17.935 [info] Not activating extension 'ms-RushStack.debug-certificate-manager': Timed out while searching for 'workspaceContains' pattern .vscode/debug-certificate-manager.json
```
Updated activation event to be more specific in the file pattern. Hopefully this will make the search faster and not timeout.

## How it was tested

Tested by adding `sleep 10` to `.bashrc`

Tested that the extension still activates with the new pattern
```
2025-08-26 14:35:12.672 [info] ExtensionService#_doActivateExtension ms-RushStack.debug-certificate-manager, startup: true, activationEvent: 'workspaceContains:/.vscode/debug-certificate-manager.json'
```

