### PR TITLE
[rush-serve] Unref server

### DIFF
--- a/common/changes/@microsoft/rush/rush-serve-unref_2025-08-26-21-30.json
+++ b/common/changes/@microsoft/rush/rush-serve-unref_2025-08-26-21-30.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "[rush-serve-plugin] Allow the Rush process to exit if the server is the only active handle.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/rush-plugins/rush-serve-plugin/src/phasedCommandHandler.ts
+++ b/rush-plugins/rush-serve-plugin/src/phasedCommandHandler.ts
@@ -243,6 +243,9 @@ export async function phasedCommandHandler(options: IPhasedCommandHandlerOptions
       webSocketServerUpgrader?.(server);
 
       server.listen(requestedPort);
+      // Don't let the HTTP/2 server keep the process alive if the user asks to quit.
+      // TODO: use some "user wants to exit" event to close the server.
+      server.unref();
       await once(server, 'listening');
 
       const address: AddressInfo | undefined = server.address() as AddressInfo;


### PR DESCRIPTION
## Summary
Calls `unref()` on the HTTP/2 server owned by `rush-serve-plugin` so that if the user presses `q` to terminate watch mode, the process will actually exit.

## Details
Possible this could leak a socket, but it's better than forcing the user to press Ctrl+C to terminate. In the future this should tap some hook indicating that the user is trying to shut down the process.

## How it was tested
Ran a watch mode command with `rush-serve-plugin` enabled and verified that pressing `q` causes the process to gracefully exit.

## Impacted documentation
None.