### PR TITLE
[debug-certificate-manager] Fix homedir resolution bug in CertificateStore

### DIFF
--- a/common/changes/@rushstack/debug-certificate-manager/bmiddha-debug-certificate-manager-homedir-fix_2025-08-28-04-41.json
+++ b/common/changes/@rushstack/debug-certificate-manager/bmiddha-debug-certificate-manager-homedir-fix_2025-08-28-04-41.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/debug-certificate-manager",
+      "comment": "Fix homedir resolution in CertificateStore",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/debug-certificate-manager"
+}

--- a/libraries/debug-certificate-manager/src/CertificateStore.ts
+++ b/libraries/debug-certificate-manager/src/CertificateStore.ts
@@ -68,9 +68,11 @@ export class CertificateStore {
           const configContent: string = FileSystem.readFile(debugCertificateManagerConfigFile);
           debugCertificateManagerConfig = JSON.parse(configContent) as ICertificateStoreOptions;
           if (debugCertificateManagerConfig.storePath) {
-            storePath = path.resolve(currentDir, debugCertificateManagerConfig.storePath);
+            storePath = debugCertificateManagerConfig.storePath;
             if (storePath.startsWith('~')) {
               storePath = path.join(homedir(), storePath.slice(2));
+            } else {
+              storePath = path.resolve(currentDir, debugCertificateManagerConfig.storePath);
             }
           }
         }


### PR DESCRIPTION
## Summary

Fix home directory resolution in debug-certificate-manager

## Details

Home directory resolution for `debug-certificate-manager.json` was added in #5322.
This change fixes a logic error introduced in that change.

## How it was tested

Tested by using the built CertificateStore results and pnpm patching it into the target repo. Validated with debug logging that new codepath is working as expected.
