### PR TITLE
[api-extractor] refactor import() type support, to support more cases

### DIFF
--- a/apps/api-extractor/src/analyzer/AstImport.ts
+++ b/apps/api-extractor/src/analyzer/AstImport.ts
@@ -27,12 +27,7 @@ export enum AstImportKind {
   /**
    * An import statement such as `import x = require("y");`.
    */
-  EqualsImport,
-
-  /**
-   * An import statement such as `interface foo { foo: import("bar").a.b.c }`.
-   */
-  ImportType
+  EqualsImport
 }
 
 /**
@@ -150,14 +145,6 @@ export class AstImport extends AstSyntheticEntity {
         return `${options.modulePath}:*`;
       case AstImportKind.EqualsImport:
         return `${options.modulePath}:=`;
-      case AstImportKind.ImportType: {
-        const subKey: string = !options.exportName
-          ? '*' // Equivalent to StarImport
-          : options.exportName.includes('.') // Equivalent to a named export
-            ? options.exportName.split('.')[0]
-            : options.exportName;
-        return `${options.modulePath}:${subKey}`;
-      }
       default:
         throw new InternalError('Unknown AstImportKind');
     }

--- a/apps/api-extractor/src/analyzer/AstSubPathImport.ts
+++ b/apps/api-extractor/src/analyzer/AstSubPathImport.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+import { InternalError } from '@rushstack/node-core-library';
 import { AstEntity, AstSyntheticEntity } from './AstEntity';
 
 export interface IAstSubPathImportOptions {
@@ -8,16 +9,52 @@ export interface IAstSubPathImportOptions {
   readonly exportPath: string[];
 }
 
+/**
+ * `AstSubPathImport` represents a sub-path import, such as `import("foo").X.Y.Z` will import Y.Z from X of "foo".
+ *
+ * @remarks
+ *
+ * The base AstEntity can be either local or external entity.
+ *
+ * ```ts
+ * // import from AstImport (NamedImport, modulePath="foo", exportName="X"), with exportPath ["Y", "Z"]
+ * const foo: import("foo").X.Y.Z;
+ *
+ * // import from AstImport (DefaultImport, modulePath="foo"), with exportPath ["X", "Y", "Z"]
+ * const bar: import("foo").default.X.Y.Z;
+ *
+ * // import from AstEntity of X, with exportPath ["Y", "Z"]
+ * const baz: import("./foo").X.Y.Z;
+ * ```
+ */
 export class AstSubPathImport extends AstSyntheticEntity {
-  public readonly astEntity: AstEntity;
+  /**
+   * The AstEntity that is imported from.
+   *
+   * @remarks
+   *
+   * The AstEntity can be either local or external entity.
+   */
+  public readonly baseAstEntity: AstEntity;
 
+  /**
+   * The path to the entity within the `baseAstEntity`.
+   */
   public readonly exportPath: string[];
 
+  /**
+   * Whether it is referenced only by import type syntax, e.g. `import("foo").Bar`.
+   */
   public isImportTypeEverywhere: boolean = true;
 
   public constructor(options: IAstSubPathImportOptions) {
     super();
-    this.astEntity = options.astEntity;
+
+    if (options.exportPath.length === 0) {
+      throw new InternalError('AstSubPathImport.exportPath cannot be empty');
+    }
+
+    this.baseAstEntity = options.astEntity;
     this.exportPath = options.exportPath;
   }
 

--- a/apps/api-extractor/src/analyzer/AstSubPathImport.ts
+++ b/apps/api-extractor/src/analyzer/AstSubPathImport.ts
@@ -42,11 +42,6 @@ export class AstSubPathImport extends AstSyntheticEntity {
    */
   public readonly exportPath: string[];
 
-  /**
-   * Whether it is referenced only by import type syntax, e.g. `import("foo").Bar`.
-   */
-  public isImportTypeEverywhere: boolean = true;
-
   public constructor(options: IAstSubPathImportOptions) {
     super();
 

--- a/apps/api-extractor/src/analyzer/AstSubPathImport.ts
+++ b/apps/api-extractor/src/analyzer/AstSubPathImport.ts
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { AstEntity, AstSyntheticEntity } from './AstEntity';
+
+export interface IAstSubPathImportOptions {
+  readonly astEntity: AstEntity;
+  readonly exportPath: string[];
+}
+
+export class AstSubPathImport extends AstSyntheticEntity {
+  public readonly astEntity: AstEntity;
+
+  public readonly exportPath: string[];
+
+  public isImportTypeEverywhere: boolean = true;
+
+  public constructor(options: IAstSubPathImportOptions) {
+    super();
+    this.astEntity = options.astEntity;
+    this.exportPath = options.exportPath;
+  }
+
+  /** {@inheritdoc} */
+  public get localName(): string {
+    // abstract
+    return this.exportPath[this.exportPath.length - 1];
+  }
+}

--- a/apps/api-extractor/src/analyzer/AstSymbolTable.ts
+++ b/apps/api-extractor/src/analyzer/AstSymbolTable.ts
@@ -333,7 +333,7 @@ export class AstSymbolTable {
         }
 
         if (referencedAstEntity instanceof AstSubPathImport) {
-          analyzeReferencedLocalAstEntity(referencedAstEntity.astEntity);
+          analyzeReferencedLocalAstEntity(referencedAstEntity.baseAstEntity);
         }
       };
 

--- a/apps/api-extractor/src/analyzer/AstSymbolTable.ts
+++ b/apps/api-extractor/src/analyzer/AstSymbolTable.ts
@@ -18,6 +18,7 @@ import type { MessageRouter } from '../collector/MessageRouter';
 import { TypeScriptInternals, type IGlobalVariableAnalyzer } from './TypeScriptInternals';
 import { SyntaxHelpers } from './SyntaxHelpers';
 import { SourceFileLocationFormatter } from './SourceFileLocationFormatter';
+import { AstSubPathImport } from './AstSubPathImport';
 
 /**
  * Options for `AstSymbolTable._fetchAstSymbol()`
@@ -318,20 +319,28 @@ export class AstSymbolTable {
       // If this symbol is non-external (i.e. it belongs to the working package), then we also analyze any
       // referencedAstSymbols that are non-external.  For example, this ensures that forgotten exports
       // get analyzed.
+      const analyzeReferencedLocalAstEntity = (referencedAstEntity: AstEntity) => {
+        if (referencedAstEntity instanceof AstSymbol) {
+          if (!referencedAstEntity.isExternal) {
+            this._analyzeAstSymbol(referencedAstEntity);
+          }
+        }
+
+        if (referencedAstEntity instanceof AstNamespaceImport) {
+          if (!referencedAstEntity.astModule.isExternal) {
+            this._analyzeAstNamespaceImport(referencedAstEntity);
+          }
+        }
+
+        if (referencedAstEntity instanceof AstSubPathImport) {
+          analyzeReferencedLocalAstEntity(referencedAstEntity.astEntity);
+        }
+      };
+
       rootAstSymbol.forEachDeclarationRecursive((astDeclaration: AstDeclaration) => {
         for (const referencedAstEntity of astDeclaration.referencedAstEntities) {
           // Walk up to the root of the tree, looking for any imports along the way
-          if (referencedAstEntity instanceof AstSymbol) {
-            if (!referencedAstEntity.isExternal) {
-              this._analyzeAstSymbol(referencedAstEntity);
-            }
-          }
-
-          if (referencedAstEntity instanceof AstNamespaceImport) {
-            if (!referencedAstEntity.astModule.isExternal) {
-              this._analyzeAstNamespaceImport(referencedAstEntity);
-            }
-          }
+          analyzeReferencedLocalAstEntity(referencedAstEntity);
         }
       });
     }

--- a/apps/api-extractor/src/analyzer/ExportAnalyzer.ts
+++ b/apps/api-extractor/src/analyzer/ExportAnalyzer.ts
@@ -995,6 +995,8 @@ export class ExportAnalyzer {
 
   private _fetchAstSubPathImport(astEntity: AstEntity, exportPath: string[]): AstEntity {
     if (exportPath.length === 0) {
+      // If the exportPath is empty, just use the AstEntity directly instead of creating an unnecessary AstSubPathImport.
+      // e.g. return AstImport for `import("foo").Bar`, return AstEntity of Bar for `import("./foo").Bar`.
       return astEntity;
     }
 

--- a/apps/api-extractor/src/analyzer/ExportAnalyzer.ts
+++ b/apps/api-extractor/src/analyzer/ExportAnalyzer.ts
@@ -469,7 +469,7 @@ export class ExportAnalyzer {
           exportAstEntity = this._fetchAstImport(exportSymbol, {
             importKind: AstImportKind.DefaultImport,
             modulePath: externalModulePath,
-            exportName: exportSymbol?.name ?? exportName,
+            exportName: SyntaxHelpers.makeCamelCaseIdentifier(externalModulePath),
             isTypeOnly: true
           });
         } else {

--- a/apps/api-extractor/src/collector/Collector.ts
+++ b/apps/api-extractor/src/collector/Collector.ts
@@ -581,9 +581,9 @@ export class Collector {
     }
 
     if (astEntity instanceof AstSubPathImport) {
-      this._createCollectorEntity(astEntity.astEntity);
+      this._createCollectorEntity(astEntity.baseAstEntity);
       this._createCollectorEntity(astEntity);
-      this._recursivelyCreateEntities(astEntity.astEntity, alreadySeenAstEntities);
+      this._recursivelyCreateEntities(astEntity.baseAstEntity, alreadySeenAstEntities);
     }
   }
 

--- a/apps/api-extractor/src/collector/Collector.ts
+++ b/apps/api-extractor/src/collector/Collector.ts
@@ -34,6 +34,7 @@ import { ExtractorConfig } from '../api/ExtractorConfig';
 import { AstNamespaceImport } from '../analyzer/AstNamespaceImport';
 import { AstImport } from '../analyzer/AstImport';
 import type { SourceMapper } from './SourceMapper';
+import { AstSubPathImport } from '../analyzer/AstSubPathImport';
 
 /**
  * Options for Collector constructor.
@@ -577,6 +578,12 @@ export class Collector {
         this._createCollectorEntity(localAstEntity, localExportName, parentEntity);
         this._recursivelyCreateEntities(localAstEntity, alreadySeenAstEntities);
       }
+    }
+
+    if (astEntity instanceof AstSubPathImport) {
+      this._createCollectorEntity(astEntity.astEntity);
+      this._createCollectorEntity(astEntity);
+      this._recursivelyCreateEntities(astEntity.astEntity, alreadySeenAstEntities);
     }
   }
 

--- a/build-tests/api-extractor-scenarios/etc/dynamicImportType/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/dynamicImportType/api-extractor-scenarios.api.json
@@ -190,6 +190,36 @@
           "members": [
             {
               "kind": "Property",
+              "canonicalReference": "api-extractor-scenarios!Item#externalModule:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "externalModule: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "typeof import('api-extractor-lib3-test')"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "externalModule",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              },
+              "isStatic": false,
+              "isProtected": false,
+              "isAbstract": false
+            },
+            {
+              "kind": "Property",
               "canonicalReference": "api-extractor-scenarios!Item#lib1:member",
               "docComment": "",
               "excerptTokens": [
@@ -330,12 +360,47 @@
             },
             {
               "kind": "Property",
-              "canonicalReference": "api-extractor-scenarios!Item#reExport:member",
+              "canonicalReference": "api-extractor-scenarios!Item#reExportExternal:member",
               "docComment": "",
               "excerptTokens": [
                 {
                   "kind": "Content",
-                  "text": "reExport: "
+                  "text": "reExportExternal: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "import('./re-export')."
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Lib3Class",
+                  "canonicalReference": "api-extractor-lib3-test!Lib3Class:class"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "reExportExternal",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 3
+              },
+              "isStatic": false,
+              "isProtected": false,
+              "isAbstract": false
+            },
+            {
+              "kind": "Property",
+              "canonicalReference": "api-extractor-scenarios!Item#reExportLocal:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "reExportLocal: "
                 },
                 {
                   "kind": "Content",
@@ -354,7 +419,77 @@
               "isReadonly": false,
               "isOptional": false,
               "releaseTag": "Public",
-              "name": "reExport",
+              "name": "reExportLocal",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 3
+              },
+              "isStatic": false,
+              "isProtected": false,
+              "isAbstract": false
+            },
+            {
+              "kind": "Property",
+              "canonicalReference": "api-extractor-scenarios!Item#typeofImportExternal:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "typeofImportExternal: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "typeof import('api-extractor-lib3-test')."
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Lib1Class",
+                  "canonicalReference": "api-extractor-lib1-test!Lib1Class:class"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "typeofImportExternal",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 3
+              },
+              "isStatic": false,
+              "isProtected": false,
+              "isAbstract": false
+            },
+            {
+              "kind": "Property",
+              "canonicalReference": "api-extractor-scenarios!Item#typeofImportLocal:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "typeofImportLocal: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "typeof import('./Options')."
+                },
+                {
+                  "kind": "Reference",
+                  "text": "OptionsClass",
+                  "canonicalReference": "api-extractor-scenarios!~OptionsClass:class"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "typeofImportLocal",
               "propertyTypeTokenRange": {
                 "startIndex": 1,
                 "endIndex": 3

--- a/build-tests/api-extractor-scenarios/etc/dynamicImportType/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/dynamicImportType/api-extractor-scenarios.api.json
@@ -190,6 +190,41 @@
           "members": [
             {
               "kind": "Property",
+              "canonicalReference": "api-extractor-scenarios!Item#defaultImport:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "defaultImport: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "import('api-extractor-lib2-test')."
+                },
+                {
+                  "kind": "Reference",
+                  "text": "default",
+                  "canonicalReference": "api-extractor-lib2-test!DefaultClass:class"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "defaultImport",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 3
+              },
+              "isStatic": false,
+              "isProtected": false,
+              "isAbstract": false
+            },
+            {
+              "kind": "Property",
               "canonicalReference": "api-extractor-scenarios!Item#externalModule:member",
               "docComment": "",
               "excerptTokens": [

--- a/build-tests/api-extractor-scenarios/etc/dynamicImportType/api-extractor-scenarios.api.md
+++ b/build-tests/api-extractor-scenarios/etc/dynamicImportType/api-extractor-scenarios.api.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import { apiExtractorLib3Test } from 'api-extractor-lib3-test';
 import * as Lib1 from 'api-extractor-lib1-test';
 import { Lib1Class } from 'api-extractor-lib3-test';
 import { Lib1Interface } from 'api-extractor-lib1-test';
@@ -12,6 +13,8 @@ import { Lib2Interface } from 'api-extractor-lib2-test';
 
 // @public (undocumented)
 export class Item {
+    // (undocumented)
+    externalModule: apiExtractorLib3Test;
     // (undocumented)
     lib1: Lib1Interface;
     // (undocumented)
@@ -22,8 +25,18 @@ export class Item {
     //
     // (undocumented)
     options: Options;
+    // Warning: (ae-forgotten-export) The symbol "Lib3Class" needs to be exported by the entry point index.d.ts
+    //
     // (undocumented)
-    reExport: Lib2Class;
+    reExportExternal: Lib3Class;
+    // (undocumented)
+    reExportLocal: Lib2Class;
+    // (undocumented)
+    typeofImportExternal: Lib1Class;
+    // Warning: (ae-forgotten-export) The symbol "OptionsClass" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    typeofImportLocal: OptionsClass;
 }
 
 export { Lib1 }

--- a/build-tests/api-extractor-scenarios/etc/dynamicImportType/api-extractor-scenarios.api.md
+++ b/build-tests/api-extractor-scenarios/etc/dynamicImportType/api-extractor-scenarios.api.md
@@ -4,17 +4,18 @@
 
 ```ts
 
-import { apiExtractorLib3Test } from 'api-extractor-lib3-test';
+import * as apiExtractorLib3Test from 'api-extractor-lib3-test';
 import * as Lib1 from 'api-extractor-lib1-test';
-import { Lib1Class } from 'api-extractor-lib3-test';
-import { Lib1Interface } from 'api-extractor-lib1-test';
+import type { Lib1Class } from 'api-extractor-lib3-test';
+import type { Lib1Interface } from 'api-extractor-lib1-test';
 import { Lib2Class } from 'api-extractor-lib2-test';
 import { Lib2Interface } from 'api-extractor-lib2-test';
+import { Lib3Class } from 'api-extractor-lib3-test';
 
 // @public (undocumented)
 export class Item {
     // (undocumented)
-    externalModule: apiExtractorLib3Test;
+    externalModule: typeof apiExtractorLib3Test;
     // (undocumented)
     lib1: Lib1Interface;
     // (undocumented)
@@ -25,18 +26,16 @@ export class Item {
     //
     // (undocumented)
     options: Options;
-    // Warning: (ae-forgotten-export) The symbol "Lib3Class" needs to be exported by the entry point index.d.ts
-    //
     // (undocumented)
     reExportExternal: Lib3Class;
     // (undocumented)
     reExportLocal: Lib2Class;
     // (undocumented)
-    typeofImportExternal: Lib1Class;
+    typeofImportExternal: typeof Lib1Class;
     // Warning: (ae-forgotten-export) The symbol "OptionsClass" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    typeofImportLocal: OptionsClass;
+    typeofImportLocal: typeof OptionsClass;
 }
 
 export { Lib1 }

--- a/build-tests/api-extractor-scenarios/etc/dynamicImportType/api-extractor-scenarios.api.md
+++ b/build-tests/api-extractor-scenarios/etc/dynamicImportType/api-extractor-scenarios.api.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import type apiExtractorLib2Test from 'api-extractor-lib2-test';
 import * as apiExtractorLib3Test from 'api-extractor-lib3-test';
 import * as Lib1 from 'api-extractor-lib1-test';
 import type { Lib1Class } from 'api-extractor-lib3-test';
@@ -14,6 +15,8 @@ import { Lib3Class } from 'api-extractor-lib3-test';
 
 // @public (undocumented)
 export class Item {
+    // (undocumented)
+    defaultImport: apiExtractorLib2Test;
     // (undocumented)
     externalModule: typeof apiExtractorLib3Test;
     // (undocumented)

--- a/build-tests/api-extractor-scenarios/etc/dynamicImportType/rollup.d.ts
+++ b/build-tests/api-extractor-scenarios/etc/dynamicImportType/rollup.d.ts
@@ -1,3 +1,4 @@
+import type apiExtractorLib2Test from 'api-extractor-lib2-test';
 import * as apiExtractorLib3Test from 'api-extractor-lib3-test';
 import * as Lib1 from 'api-extractor-lib1-test';
 import type { Lib1Class } from 'api-extractor-lib3-test';
@@ -12,6 +13,7 @@ export declare class Item {
     lib1: Lib1Interface;
     lib2: Lib2Interface;
     lib3: Lib1Class;
+    defaultImport: apiExtractorLib2Test;
     externalModule: typeof apiExtractorLib3Test;
     typeofImportLocal: typeof OptionsClass;
     typeofImportExternal: typeof Lib1Class;

--- a/build-tests/api-extractor-scenarios/etc/dynamicImportType/rollup.d.ts
+++ b/build-tests/api-extractor-scenarios/etc/dynamicImportType/rollup.d.ts
@@ -1,9 +1,10 @@
-import { apiExtractorLib3Test } from 'api-extractor-lib3-test';
+import * as apiExtractorLib3Test from 'api-extractor-lib3-test';
 import * as Lib1 from 'api-extractor-lib1-test';
-import { Lib1Class } from 'api-extractor-lib3-test';
-import { Lib1Interface } from 'api-extractor-lib1-test';
+import type { Lib1Class } from 'api-extractor-lib3-test';
+import type { Lib1Interface } from 'api-extractor-lib1-test';
 import { Lib2Class } from 'api-extractor-lib2-test';
 import { Lib2Interface } from 'api-extractor-lib2-test';
+import { Lib3Class } from 'api-extractor-lib3-test';
 
 /** @public */
 export declare class Item {
@@ -11,9 +12,9 @@ export declare class Item {
     lib1: Lib1Interface;
     lib2: Lib2Interface;
     lib3: Lib1Class;
-    externalModule: apiExtractorLib3Test;
-    typeofImportLocal: OptionsClass;
-    typeofImportExternal: Lib1Class;
+    externalModule: typeof apiExtractorLib3Test;
+    typeofImportLocal: typeof OptionsClass;
+    typeofImportExternal: typeof Lib1Class;
     reExportLocal: Lib2Class;
     reExportExternal: Lib3Class;
 }
@@ -21,19 +22,6 @@ export declare class Item {
 export { Lib1 }
 
 export { Lib2Interface }
-
-/**
- * @internalRemarks Internal remarks
- * @public
- */
-declare class Lib3Class {
-    /**
-     * I am a documented property!
-     * @betaDocumentation My docs include a custom block tag!
-     * @virtual @override
-     */
-    prop: boolean;
-}
 
 declare interface Options {
     name: string;

--- a/build-tests/api-extractor-scenarios/etc/dynamicImportType/rollup.d.ts
+++ b/build-tests/api-extractor-scenarios/etc/dynamicImportType/rollup.d.ts
@@ -1,3 +1,4 @@
+import { apiExtractorLib3Test } from 'api-extractor-lib3-test';
 import * as Lib1 from 'api-extractor-lib1-test';
 import { Lib1Class } from 'api-extractor-lib3-test';
 import { Lib1Interface } from 'api-extractor-lib1-test';
@@ -10,16 +11,36 @@ export declare class Item {
     lib1: Lib1Interface;
     lib2: Lib2Interface;
     lib3: Lib1Class;
-    reExport: Lib2Class;
+    externalModule: apiExtractorLib3Test;
+    typeofImportLocal: OptionsClass;
+    typeofImportExternal: Lib1Class;
+    reExportLocal: Lib2Class;
+    reExportExternal: Lib3Class;
 }
 
 export { Lib1 }
 
 export { Lib2Interface }
 
+/**
+ * @internalRemarks Internal remarks
+ * @public
+ */
+declare class Lib3Class {
+    /**
+     * I am a documented property!
+     * @betaDocumentation My docs include a custom block tag!
+     * @virtual @override
+     */
+    prop: boolean;
+}
+
 declare interface Options {
     name: string;
     color: 'red' | 'blue';
+}
+
+declare class OptionsClass {
 }
 
 export { }

--- a/build-tests/api-extractor-scenarios/etc/dynamicImportType2/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/dynamicImportType2/api-extractor-scenarios.api.json
@@ -275,7 +275,7 @@
                 {
                   "kind": "Reference",
                   "text": "LocalModule.LocalClass",
-                  "canonicalReference": "api-extractor-scenarios!~LocalClass:class"
+                  "canonicalReference": "api-extractor-scenarios!~LocalClass_2:class"
                 },
                 {
                   "kind": "Content",

--- a/build-tests/api-extractor-scenarios/etc/dynamicImportType2/api-extractor-scenarios.api.json
+++ b/build-tests/api-extractor-scenarios/etc/dynamicImportType2/api-extractor-scenarios.api.json
@@ -258,6 +258,98 @@
                 "startIndex": 1,
                 "endIndex": 4
               }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "api-extractor-scenarios!IExample#localDottedImportType:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "localDottedImportType: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "import('./namespace-export')."
+                },
+                {
+                  "kind": "Reference",
+                  "text": "LocalModule.LocalClass",
+                  "canonicalReference": "api-extractor-scenarios!~LocalClass:class"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "localDottedImportType",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 3
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "api-extractor-scenarios!IExample#localDottedImportType2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "localDottedImportType2: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "import('./namespace-export')."
+                },
+                {
+                  "kind": "Reference",
+                  "text": "LocalNS.LocalNSClass",
+                  "canonicalReference": "api-extractor-scenarios!~LocalNS.LocalNSClass:class"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "localDottedImportType2",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 3
+              }
+            },
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "api-extractor-scenarios!IExample#predefinedNamedImport:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "predefinedNamedImport: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "Lib1Namespace.Inner.X",
+                  "canonicalReference": "api-extractor-lib1-test!Lib1Namespace.Inner.X:class"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "isReadonly": false,
+              "isOptional": false,
+              "releaseTag": "Public",
+              "name": "predefinedNamedImport",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
             }
           ],
           "extendsTokenRanges": []

--- a/build-tests/api-extractor-scenarios/etc/dynamicImportType2/api-extractor-scenarios.api.md
+++ b/build-tests/api-extractor-scenarios/etc/dynamicImportType2/api-extractor-scenarios.api.md
@@ -9,17 +9,13 @@ import { Lib1Namespace } from 'api-extractor-lib1-test';
 // @public (undocumented)
 export interface IExample {
     // (undocumented)
-    dottedImportType: Lib1Namespace | undefined;
+    dottedImportType: Lib1Namespace.Inner.X | undefined;
     // (undocumented)
-    dottedImportType2: Lib1Namespace | undefined;
-    // Warning: (ae-forgotten-export) The symbol "LocalClass" needs to be exported by the entry point index.d.ts
-    //
+    dottedImportType2: Lib1Namespace.Y | undefined;
     // (undocumented)
-    localDottedImportType: LocalClass;
-    // Warning: (ae-forgotten-export) The symbol "LocalNS" needs to be exported by the entry point index.d.ts
-    //
+    localDottedImportType: LocalModule.LocalClass;
     // (undocumented)
-    localDottedImportType2: import('./namespace-export').LocalNS.LocalNSClass;
+    localDottedImportType2: LocalNS.LocalNSClass;
     // (undocumented)
     predefinedNamedImport: Lib1Namespace.Inner.X;
 }

--- a/build-tests/api-extractor-scenarios/etc/dynamicImportType2/api-extractor-scenarios.api.md
+++ b/build-tests/api-extractor-scenarios/etc/dynamicImportType2/api-extractor-scenarios.api.md
@@ -9,9 +9,19 @@ import { Lib1Namespace } from 'api-extractor-lib1-test';
 // @public (undocumented)
 export interface IExample {
     // (undocumented)
-    dottedImportType: Lib1Namespace.Inner.X | undefined;
+    dottedImportType: Lib1Namespace | undefined;
     // (undocumented)
-    dottedImportType2: Lib1Namespace.Y | undefined;
+    dottedImportType2: Lib1Namespace | undefined;
+    // Warning: (ae-forgotten-export) The symbol "LocalClass" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    localDottedImportType: LocalClass;
+    // Warning: (ae-forgotten-export) The symbol "LocalNS" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    localDottedImportType2: import('./namespace-export').LocalNS.LocalNSClass;
+    // (undocumented)
+    predefinedNamedImport: Lib1Namespace.Inner.X;
 }
 
 // (No @packageDocumentation comment for this package)

--- a/build-tests/api-extractor-scenarios/etc/dynamicImportType2/rollup.d.ts
+++ b/build-tests/api-extractor-scenarios/etc/dynamicImportType2/rollup.d.ts
@@ -3,13 +3,30 @@ import { Lib1Namespace } from 'api-extractor-lib1-test';
 /** @public */
 export declare interface IExample {
     predefinedNamedImport: Lib1Namespace.Inner.X;
-    dottedImportType: Lib1Namespace | undefined;
-    dottedImportType2: Lib1Namespace | undefined;
-    localDottedImportType: LocalClass;
-    localDottedImportType2: import('./namespace-export').LocalNS.LocalNSClass;
+    dottedImportType: Lib1Namespace.Inner.X | undefined;
+    dottedImportType2: Lib1Namespace.Y | undefined;
+    localDottedImportType: LocalModule.LocalClass;
+    localDottedImportType2: LocalNS.LocalNSClass;
 }
 
-declare class LocalClass {
+declare class LocalClass_2 {
+}
+
+declare interface LocalInterface {
+}
+
+declare namespace LocalModule {
+    export {
+        LocalClass_2 as LocalClass,
+        LocalInterface
+    }
+}
+
+declare namespace LocalNS {
+    class LocalNSClass {
+    }
+    interface LocalNSInterface {
+    }
 }
 
 export { }

--- a/build-tests/api-extractor-scenarios/etc/dynamicImportType2/rollup.d.ts
+++ b/build-tests/api-extractor-scenarios/etc/dynamicImportType2/rollup.d.ts
@@ -2,8 +2,14 @@ import { Lib1Namespace } from 'api-extractor-lib1-test';
 
 /** @public */
 export declare interface IExample {
-    dottedImportType: Lib1Namespace.Inner.X | undefined;
-    dottedImportType2: Lib1Namespace.Y | undefined;
+    predefinedNamedImport: Lib1Namespace.Inner.X;
+    dottedImportType: Lib1Namespace | undefined;
+    dottedImportType2: Lib1Namespace | undefined;
+    localDottedImportType: LocalClass;
+    localDottedImportType2: import('./namespace-export').LocalNS.LocalNSClass;
+}
+
+declare class LocalClass {
 }
 
 export { }

--- a/build-tests/api-extractor-scenarios/etc/dynamicImportType3/api-extractor-scenarios.api.md
+++ b/build-tests/api-extractor-scenarios/etc/dynamicImportType3/api-extractor-scenarios.api.md
@@ -4,8 +4,8 @@
 
 ```ts
 
-import { Lib1GenericType } from 'api-extractor-lib1-test';
-import { Lib1Interface } from 'api-extractor-lib1-test';
+import type { Lib1GenericType } from 'api-extractor-lib1-test';
+import type { Lib1Interface } from 'api-extractor-lib1-test';
 
 // @public (undocumented)
 export interface IExample {

--- a/build-tests/api-extractor-scenarios/etc/dynamicImportType3/rollup.d.ts
+++ b/build-tests/api-extractor-scenarios/etc/dynamicImportType3/rollup.d.ts
@@ -1,5 +1,5 @@
-import { Lib1GenericType } from 'api-extractor-lib1-test';
-import { Lib1Interface } from 'api-extractor-lib1-test';
+import type { Lib1GenericType } from 'api-extractor-lib1-test';
+import type { Lib1Interface } from 'api-extractor-lib1-test';
 
 /** @public */
 export declare interface IExample {

--- a/build-tests/api-extractor-scenarios/etc/namedDefaultImport/api-extractor-scenarios.api.md
+++ b/build-tests/api-extractor-scenarios/etc/namedDefaultImport/api-extractor-scenarios.api.md
@@ -4,12 +4,13 @@
 
 ```ts
 
+import type apiExtractorLib2Test from 'api-extractor-lib2-test';
 import { default as default_2 } from 'api-extractor-lib2-test';
 
 // @public (undocumented)
 export interface DefaultImportTypes {
     // (undocumented)
-    dynamicImport: default_2;
+    dynamicImport: apiExtractorLib2Test;
     // (undocumented)
     namedImport: default_2;
     // (undocumented)

--- a/build-tests/api-extractor-scenarios/etc/namedDefaultImport/rollup.d.ts
+++ b/build-tests/api-extractor-scenarios/etc/namedDefaultImport/rollup.d.ts
@@ -1,10 +1,11 @@
+import type apiExtractorLib2Test from 'api-extractor-lib2-test';
 import { default as default_2 } from 'api-extractor-lib2-test';
 
 /** @public */
 export declare interface DefaultImportTypes {
     namedImport: default_2;
     reExport: default_2;
-    dynamicImport: default_2;
+    dynamicImport: apiExtractorLib2Test;
 }
 
 export { }

--- a/build-tests/api-extractor-scenarios/src/dynamicImportType/Item.ts
+++ b/build-tests/api-extractor-scenarios/src/dynamicImportType/Item.ts
@@ -7,6 +7,7 @@ export class Item {
   lib1: import('api-extractor-lib1-test').Lib1Interface;
   lib2: import('api-extractor-lib2-test').Lib2Interface;
   lib3: import('api-extractor-lib3-test').Lib1Class;
+  defaultImport: import('api-extractor-lib2-test').default;
   externalModule: typeof import('api-extractor-lib3-test');
   typeofImportLocal: typeof import('./Options').OptionsClass;
   typeofImportExternal: typeof import('api-extractor-lib3-test').Lib1Class;

--- a/build-tests/api-extractor-scenarios/src/dynamicImportType/Item.ts
+++ b/build-tests/api-extractor-scenarios/src/dynamicImportType/Item.ts
@@ -7,5 +7,9 @@ export class Item {
   lib1: import('api-extractor-lib1-test').Lib1Interface;
   lib2: import('api-extractor-lib2-test').Lib2Interface;
   lib3: import('api-extractor-lib3-test').Lib1Class;
-  reExport: import('./re-export').Lib2Class;
+  externalModule: typeof import('api-extractor-lib3-test');
+  typeofImportLocal: typeof import('./Options').OptionsClass;
+  typeofImportExternal: typeof import('api-extractor-lib3-test').Lib1Class;
+  reExportLocal: import('./re-export').Lib2Class;
+  reExportExternal: import('./re-export').Lib3Class;
 }

--- a/build-tests/api-extractor-scenarios/src/dynamicImportType/Options.ts
+++ b/build-tests/api-extractor-scenarios/src/dynamicImportType/Options.ts
@@ -5,3 +5,5 @@ export interface Options {
   name: string;
   color: 'red' | 'blue';
 }
+
+export class OptionsClass {}

--- a/build-tests/api-extractor-scenarios/src/dynamicImportType/re-export.ts
+++ b/build-tests/api-extractor-scenarios/src/dynamicImportType/re-export.ts
@@ -1,4 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+export * from 'api-extractor-lib3-test';
+
 export { Lib2Class } from 'api-extractor-lib2-test';

--- a/build-tests/api-extractor-scenarios/src/dynamicImportType2/index.ts
+++ b/build-tests/api-extractor-scenarios/src/dynamicImportType2/index.ts
@@ -1,8 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
+import { Lib1Namespace } from 'api-extractor-lib1-test';
 
 /** @public */
 export interface IExample {
+  predefinedNamedImport: Lib1Namespace.Inner.X;
   dottedImportType: import('api-extractor-lib1-test').Lib1Namespace.Inner.X | undefined;
   dottedImportType2: import('api-extractor-lib1-test').Lib1Namespace.Y | undefined;
+  localDottedImportType: import('./namespace-export').LocalModule.LocalClass;
+  localDottedImportType2: import('./namespace-export').LocalNS.LocalNSClass;
 }

--- a/build-tests/api-extractor-scenarios/src/dynamicImportType2/local-module.ts
+++ b/build-tests/api-extractor-scenarios/src/dynamicImportType2/local-module.ts
@@ -1,0 +1,3 @@
+export class LocalClass {}
+
+export interface LocalInterface {}

--- a/build-tests/api-extractor-scenarios/src/dynamicImportType2/namespace-export.ts
+++ b/build-tests/api-extractor-scenarios/src/dynamicImportType2/namespace-export.ts
@@ -1,0 +1,7 @@
+import * as LocalModule from './local-module';
+export { LocalModule };
+
+export namespace LocalNS {
+  export class LocalNSClass {}
+  export interface LocalNSInterface {}
+}

--- a/common/changes/@microsoft/api-extractor/feat-api-extractor-import-type_2025-08-28-05-55.json
+++ b/common/changes/@microsoft/api-extractor/feat-api-extractor-import-type_2025-08-28-05-55.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "refactor import() type support, to support more cases",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor"
+}


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

Refactor `import()` type syntax support. Fixes cases in #5326 (except for one very rare case that requires more code changes: typeof import("./foo")").

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

## Details

For `import("foo").X.Y.Z` import type syntax, instead of create a new `ImportType` kind of `AstImport`, creating a new synthetic entity `AstSubPathImport` to represent "importing nested part from an AstEntity".

Some detail changes:
- `import()` is handled as a `type-only` import to an AstImport entity
- for local `import()`, simplify code to parse the local `AstModule` and its first export, instead of parsing the right-most symbol.
- for `DtsEmitHelper`, decouple code to modify import type node only by related entity info. (no assumption that always importing from top namespace. that may changes in some optimization cases which is not implemented yet.)

I also plan to use `AstSubPathImport` (or a better name?) to support import equal syntax `import Foo = X.Y.Z` (which implemented in another way in https://github.com/adventure-yunfei/web-build-tools/pull/4.)

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

Add more test cases for dymanic import type.

## Impacted documentation

<!--------------------------------------------------------------------------
👉 STEP 7: Does your PR affect anything that is discussed in the website docs?
     If so, please paste the URL of each affected web page, so we will
     remember to update the documentation after your PR is merged.
     (Updating the website is appreciated but not required.)
     If no docs are impacted, delete the "Impacted documentation" section.

     If you modified a JSON schema, remember to update init templates such as:
     rush-lib/assets/rush-init/*.json
     api-extractor/src/schemas/api-extractor-template.json
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 8: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
