### PR TITLE
[rush-resolver-cache] Fix subpackage cache optimization

### DIFF
--- a/common/changes/@microsoft/rush/resolver-cache-fixes_2025-08-28-19-56.json
+++ b/common/changes/@microsoft/rush/resolver-cache-fixes_2025-08-28-19-56.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Dedupe shrinkwrap parsing by content hash.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/resolver-cache-fixes_2025-08-28-19-57.json
+++ b/common/changes/@microsoft/rush/resolver-cache-fixes_2025-08-28-19-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "[resolver-cache] Use shrinkwrap hash to skip resolver cache regeneration.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
+++ b/libraries/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
@@ -364,6 +364,13 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
     return dependencyPath.removeSuffix(version).includes('@', 1) ? version : `${name}@${version}`;
   }
 
+  /**
+   * Clears the cache of PnpmShrinkwrapFile instances to free up memory.
+   */
+  public static clearCache(): void {
+    cacheByLockfileHash.clear();
+  }
+
   public static loadFromFile(
     shrinkwrapYamlFilePath: string,
     options: ILoadFromFileOptions = {}

--- a/rush-plugins/rush-resolver-cache-plugin/src/afterInstallAsync.ts
+++ b/rush-plugins/rush-resolver-cache-plugin/src/afterInstallAsync.ts
@@ -271,5 +271,8 @@ export async function afterInstallAsync(
     })
   ]);
 
+  // Free the memory used by the lockfiles, since nothing should read the lockfile from this point on.
+  PnpmShrinkwrapFile.clearCache();
+
   terminal.writeLine(`Resolver cache written.`);
 }

--- a/rush-plugins/rush-resolver-cache-plugin/src/computeResolverCacheFromLockfileAsync.ts
+++ b/rush-plugins/rush-resolver-cache-plugin/src/computeResolverCacheFromLockfileAsync.ts
@@ -49,11 +49,12 @@ function extractBundledDependencies(
   contexts: Map<string, IResolverContext>,
   context: IResolverContext
 ): void {
-  const { nestedPackageDirs } = context;
+  let { nestedPackageDirs } = context;
   if (!nestedPackageDirs) {
     return;
   }
 
+  let foundBundledDependencies: boolean = false;
   for (let i: number = nestedPackageDirs.length - 1; i >= 0; i--) {
     const nestedDir: string = nestedPackageDirs[i];
     if (!nestedDir.startsWith('node_modules/')) {
@@ -71,6 +72,10 @@ function extractBundledDependencies(
       continue;
     }
 
+    if (!foundBundledDependencies) {
+      foundBundledDependencies = true;
+      nestedPackageDirs = nestedPackageDirs.slice(0);
+    }
     // Remove this nested package from the list
     nestedPackageDirs.splice(i, 1);
 

--- a/rush-plugins/rush-resolver-cache-plugin/src/computeResolverCacheFromLockfileAsync.ts
+++ b/rush-plugins/rush-resolver-cache-plugin/src/computeResolverCacheFromLockfileAsync.ts
@@ -74,6 +74,8 @@ function extractBundledDependencies(
 
     if (!foundBundledDependencies) {
       foundBundledDependencies = true;
+      // Make a copy of the nestedPackageDirs array so that we don't mutate the version being
+      // saved into the subpackage index cache.
       context.nestedPackageDirs = nestedPackageDirs = nestedPackageDirs.slice(0);
     }
     // Remove this nested package from the list

--- a/rush-plugins/rush-resolver-cache-plugin/src/computeResolverCacheFromLockfileAsync.ts
+++ b/rush-plugins/rush-resolver-cache-plugin/src/computeResolverCacheFromLockfileAsync.ts
@@ -74,7 +74,7 @@ function extractBundledDependencies(
 
     if (!foundBundledDependencies) {
       foundBundledDependencies = true;
-      nestedPackageDirs = nestedPackageDirs.slice(0);
+      context.nestedPackageDirs = nestedPackageDirs = nestedPackageDirs.slice(0);
     }
     // Remove this nested package from the list
     nestedPackageDirs.splice(i, 1);


### PR DESCRIPTION
## Summary
Fixes an issue where the subpackage cache file was accidentally written empty.

## Details
The previous fix wrote the file before the data had been populated, making the optimization produce correct results but be useless.

Updates the caching layer in PnpmShrinkwrapFile to be based on a content hash of the raw shrinkwrap text instead of file path, so that writing a new file will never have caching issues.

Added an explicit API to clear the shrinkwrap cache.

## How it was tested
Built and copied into a repository using the feature. Validated resolver cache created correctly.

## Impacted documentation
Only the API documentation for PnpmShrinkwrapFile, which doesn't seem to be part of the API.md.