### PR TITLE
[rush] Dedupe DependencySpecifier parsing

### DIFF
--- a/common/changes/@microsoft/rush/dependency-specifier-cache_2025-08-28-20-24.json
+++ b/common/changes/@microsoft/rush/dependency-specifier-cache_2025-08-28-20-24.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Deduplicate parsing of dependency specifiers.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/api/RushConfigurationProject.ts
+++ b/libraries/rush-lib/src/api/RushConfigurationProject.ts
@@ -411,7 +411,10 @@ export class RushConfigurationProject {
       ]) {
         if (dependencySet) {
           for (const [dependency, version] of Object.entries(dependencySet)) {
-            const dependencySpecifier: DependencySpecifier = new DependencySpecifier(dependency, version);
+            const dependencySpecifier: DependencySpecifier = DependencySpecifier.parseWithCache(
+              dependency,
+              version
+            );
             const dependencyName: string =
               dependencySpecifier.aliasTarget?.packageName ?? dependencySpecifier.packageName;
             // Skip if we can't find the local project or it's a cyclic dependency

--- a/libraries/rush-lib/src/logic/ApprovedPackagesChecker.ts
+++ b/libraries/rush-lib/src/logic/ApprovedPackagesChecker.ts
@@ -70,7 +70,7 @@ export class ApprovedPackagesChecker {
         // "dependencies": {
         //   "alias-name": "npm:target-name@^1.2.3"
         // }
-        const dependencySpecifier: DependencySpecifier = new DependencySpecifier(
+        const dependencySpecifier: DependencySpecifier = DependencySpecifier.parseWithCache(
           packageName,
           dependencies[packageName]
         );

--- a/libraries/rush-lib/src/logic/PublishUtilities.ts
+++ b/libraries/rush-lib/src/logic/PublishUtilities.ts
@@ -296,7 +296,7 @@ export class PublishUtilities {
     dependencyName: string,
     newProjectVersion: string
   ): string {
-    const currentDependencySpecifier: DependencySpecifier = new DependencySpecifier(
+    const currentDependencySpecifier: DependencySpecifier = DependencySpecifier.parseWithCache(
       dependencyName,
       dependencies[dependencyName]
     );
@@ -502,7 +502,7 @@ export class PublishUtilities {
             // TODO: treat prerelease version the same as non-prerelease version.
             // For prerelease, the newVersion needs to be appended with prerelease name.
             // And dependency should specify the specific prerelease version.
-            const currentSpecifier: DependencySpecifier = new DependencySpecifier(
+            const currentSpecifier: DependencySpecifier = DependencySpecifier.parseWithCache(
               depName,
               dependencies[depName]
             );
@@ -765,7 +765,7 @@ export class PublishUtilities {
       dependencies[change.packageName] &&
       !PublishUtilities._isCyclicDependency(allPackages, parentPackageName, change.packageName)
     ) {
-      const requiredVersion: DependencySpecifier = new DependencySpecifier(
+      const requiredVersion: DependencySpecifier = DependencySpecifier.parseWithCache(
         change.packageName,
         dependencies[change.packageName]
       );
@@ -863,7 +863,7 @@ export class PublishUtilities {
     // "*", "~", and "^" are special cases for workspace ranges, since it will publish using the exact
     // version of the local dependency, so we need to modify what we write for our change
     // comment
-    const currentDependencySpecifier: DependencySpecifier = new DependencySpecifier(
+    const currentDependencySpecifier: DependencySpecifier = DependencySpecifier.parseWithCache(
       dependencyName,
       currentDependencyVersion
     );
@@ -873,7 +873,7 @@ export class PublishUtilities {
         ? undefined
         : currentDependencySpecifier.versionSpecifier;
 
-    const newDependencySpecifier: DependencySpecifier = new DependencySpecifier(
+    const newDependencySpecifier: DependencySpecifier = DependencySpecifier.parseWithCache(
       dependencyName,
       newDependencyVersion
     );

--- a/libraries/rush-lib/src/logic/VersionManager.ts
+++ b/libraries/rush-lib/src/logic/VersionManager.ts
@@ -341,7 +341,7 @@ export class VersionManager {
     oldDependencyVersion: string,
     newDependencyVersion: string
   ): void {
-    const oldSpecifier: DependencySpecifier = new DependencySpecifier(
+    const oldSpecifier: DependencySpecifier = DependencySpecifier.parseWithCache(
       updatedDependentProject.name,
       oldDependencyVersion
     );

--- a/libraries/rush-lib/src/logic/installManager/RushInstallManager.ts
+++ b/libraries/rush-lib/src/logic/installManager/RushInstallManager.ts
@@ -132,7 +132,10 @@ export class RushInstallManager extends BaseInstallManager {
     if (shrinkwrapFile) {
       // Check any (explicitly) preferred dependencies first
       allExplicitPreferredVersions.forEach((version: string, dependency: string) => {
-        const dependencySpecifier: DependencySpecifier = new DependencySpecifier(dependency, version);
+        const dependencySpecifier: DependencySpecifier = DependencySpecifier.parseWithCache(
+          dependency,
+          version
+        );
 
         if (!shrinkwrapFile.hasCompatibleTopLevelDependency(dependencySpecifier)) {
           shrinkwrapWarnings.push(
@@ -230,7 +233,10 @@ export class RushInstallManager extends BaseInstallManager {
       Sort.sortMapKeys(tempDependencies);
 
       for (const [packageName, packageVersion] of tempDependencies.entries()) {
-        const dependencySpecifier: DependencySpecifier = new DependencySpecifier(packageName, packageVersion);
+        const dependencySpecifier: DependencySpecifier = DependencySpecifier.parseWithCache(
+          packageName,
+          packageVersion
+        );
 
         // Is there a locally built Rush project that could satisfy this dependency?
         // If so, then we will symlink to the project folder rather than to common/temp/node_modules.
@@ -391,7 +397,10 @@ export class RushInstallManager extends BaseInstallManager {
   }
 
   private _revertWorkspaceNotation(dependency: PackageJsonDependency): boolean {
-    const specifier: DependencySpecifier = new DependencySpecifier(dependency.name, dependency.version);
+    const specifier: DependencySpecifier = DependencySpecifier.parseWithCache(
+      dependency.name,
+      dependency.version
+    );
     if (specifier.specifierType !== DependencySpecifierType.Workspace) {
       return false;
     }

--- a/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
+++ b/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
@@ -220,7 +220,7 @@ export class WorkspaceInstallManager extends BaseInstallManager {
           continue;
         }
 
-        const dependencySpecifier: DependencySpecifier = new DependencySpecifier(name, version);
+        const dependencySpecifier: DependencySpecifier = DependencySpecifier.parseWithCache(name, version);
 
         // Is there a locally built Rush project that could satisfy this dependency?
         let referencedLocalProject: RushConfigurationProject | undefined =

--- a/libraries/rush-lib/src/logic/npm/NpmShrinkwrapFile.ts
+++ b/libraries/rush-lib/src/logic/npm/NpmShrinkwrapFile.ts
@@ -89,7 +89,7 @@ export class NpmShrinkwrapFile extends BaseShrinkwrapFile {
       return undefined;
     }
 
-    return new DependencySpecifier(dependencyName, dependencyJson.version);
+    return DependencySpecifier.parseWithCache(dependencyName, dependencyJson.version);
   }
 
   /**
@@ -121,7 +121,7 @@ export class NpmShrinkwrapFile extends BaseShrinkwrapFile {
       return this.getTopLevelDependencyVersion(dependencySpecifier.packageName);
     }
 
-    return new DependencySpecifier(dependencySpecifier.packageName, dependencyJson.version);
+    return DependencySpecifier.parseWithCache(dependencySpecifier.packageName, dependencyJson.version);
   }
 
   /** @override */

--- a/libraries/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
+++ b/libraries/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
@@ -151,7 +151,7 @@ export function parsePnpm9DependencyKey(
 
     // Example: 7.26.0
     if (semver.valid(key)) {
-      return new DependencySpecifier(dependencyName, key);
+      return DependencySpecifier.parseWithCache(dependencyName, key);
     }
   }
 
@@ -169,16 +169,16 @@ export function parsePnpm9DependencyKey(
   // Example: https://github.com/jonschlinkert/pad-left/tarball/2.1.0
   // Example: https://codeload.github.com/jonschlinkert/pad-left/tar.gz/7798d648225aa5d879660a37c408ab4675b65ac7
   if (/^https?:/.test(version)) {
-    return new DependencySpecifier(name, version);
+    return DependencySpecifier.parseWithCache(name, version);
   }
 
   // Is it an alias for a different package?
   if (name === dependencyName) {
     // No, it's a regular dependency
-    return new DependencySpecifier(name, version);
+    return DependencySpecifier.parseWithCache(name, version);
   } else {
     // If the parsed package name is different from the dependencyName, then this is an NPM package alias
-    return new DependencySpecifier(dependencyName, `npm:${name}@${version}`);
+    return DependencySpecifier.parseWithCache(dependencyName, `npm:${name}@${version}`);
   }
 }
 
@@ -266,7 +266,10 @@ export function parsePnpmDependencyKey(
     //     git@bitbucket.com+abc/def/188ed64efd5218beda276e02f2277bf3a6b745b2
     //     bitbucket.co.in/abc/def/188ed64efd5218beda276e02f2277bf3a6b745b2
     if (urlRegex.test(dependencyKey)) {
-      const dependencySpecifier: DependencySpecifier = new DependencySpecifier(dependencyName, dependencyKey);
+      const dependencySpecifier: DependencySpecifier = DependencySpecifier.parseWithCache(
+        dependencyName,
+        dependencyKey
+      );
       return dependencySpecifier;
     } else {
       return undefined;
@@ -276,10 +279,13 @@ export function parsePnpmDependencyKey(
   // Is it an alias for a different package?
   if (parsedPackageName === dependencyName) {
     // No, it's a regular dependency
-    return new DependencySpecifier(parsedPackageName, parsedVersionPart);
+    return DependencySpecifier.parseWithCache(parsedPackageName, parsedVersionPart);
   } else {
     // If the parsed package name is different from the dependencyName, then this is an NPM package alias
-    return new DependencySpecifier(dependencyName, `npm:${parsedPackageName}@${parsedVersionPart}`);
+    return DependencySpecifier.parseWithCache(
+      dependencyName,
+      `npm:${parsedPackageName}@${parsedVersionPart}`
+    );
   }
 }
 
@@ -673,7 +679,7 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
 
       const dependency: IPnpmShrinkwrapDependencyYaml | undefined = this.packages.get(value);
       if (dependency?.resolution?.tarball && value.startsWith(dependency.resolution.tarball)) {
-        return new DependencySpecifier(dependencyName, dependency.resolution.tarball);
+        return DependencySpecifier.parseWithCache(dependencyName, dependency.resolution.tarball);
       }
 
       if (this.shrinkwrapFileMajorVersion >= ShrinkwrapFileMajorVersion.V9) {
@@ -690,7 +696,7 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
         }
       }
 
-      return new DependencySpecifier(dependencyName, value);
+      return DependencySpecifier.parseWithCache(dependencyName, value);
     }
     return undefined;
   }

--- a/libraries/rush-lib/src/logic/test/DependencySpecifier.test.ts
+++ b/libraries/rush-lib/src/logic/test/DependencySpecifier.test.ts
@@ -4,6 +4,10 @@
 import { DependencySpecifier } from '../DependencySpecifier';
 
 describe(DependencySpecifier.name, () => {
+  afterEach(() => {
+    DependencySpecifier.clearCache();
+  });
+
   it('parses a simple version', () => {
     const specifier = new DependencySpecifier('dep', '1.2.3');
     expect(specifier).toMatchInlineSnapshot(`
@@ -133,6 +137,25 @@ DependencySpecifier {
   "versionSpecifier": "alias-target@*",
 }
 `);
+    });
+  });
+
+  describe(DependencySpecifier.parseWithCache.name, () => {
+    it('returns a cached instance for the same input', () => {
+      const specifier1 = DependencySpecifier.parseWithCache('dep', '1.2.3');
+      const specifier2 = DependencySpecifier.parseWithCache('dep', '1.2.3');
+      expect(specifier1).toBe(specifier2);
+    });
+    it('returns a cached instance for the same alias', () => {
+      const specifier1 = DependencySpecifier.parseWithCache('dep1', 'npm:dep@1.2.3');
+      const specifier2 = DependencySpecifier.parseWithCache('dep2', 'npm:dep@1.2.3');
+      expect(specifier1.aliasTarget).toBe(specifier2.aliasTarget);
+    });
+
+    it('returns different instances for different inputs', () => {
+      const specifier1 = DependencySpecifier.parseWithCache('dep', '1.2.3');
+      const specifier2 = DependencySpecifier.parseWithCache('dep', '1.2.4');
+      expect(specifier1).not.toBe(specifier2);
     });
   });
 });


### PR DESCRIPTION
## Summary
Adds a caching layer to the parsing of `DependencySpecifier` objects.

In large monorepos, it is very common to see the exact same dependency specifier in many packages, e.g. the dependency on `@rushstack/heft`.

## Details
Since dependency specifiers are immutable, dedupes at parse time based on the input strings. Alias targets share the same cache.

## How it was tested
Used the new version to run a `rush install` in a large monorepo.
Before:
<img width="1002" height="393" alt="image" src="https://github.com/user-attachments/assets/ab42c9ed-10e6-4151-8225-556fc5e0e442" />

After:
<img width="1002" height="370" alt="image" src="https://github.com/user-attachments/assets/ae673a7e-ba74-493b-bf03-d3b9cb640933" />


## Impacted documentation
None.