### PR TITLE
[rush] Optimize detecting local projects when collating versions

### DIFF
--- a/common/changes/@microsoft/rush/optimize-detect-local_2025-08-28-20-48.json
+++ b/common/changes/@microsoft/rush/optimize-detect-local_2025-08-28-20-48.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Optimize detection of local projects when collecting implicit preferred versions.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/logic/DependencyAnalyzer.ts
+++ b/libraries/rush-lib/src/logic/DependencyAnalyzer.ts
@@ -121,6 +121,11 @@ export class DependencyAnalyzer {
           continue;
         }
 
+        if (dependencyVersion.startsWith('workspace:')) {
+          // If this is a workspace protocol dependency, ignore it.
+          continue;
+        }
+
         // Is it a local project?
         const localProject: RushConfigurationProject | undefined =
           this._rushConfiguration.getProjectByName(dependencyName);


### PR DESCRIPTION
## Summary
Adds a fast path for `workspace:` protocol dependencies when analyzing common dependency versions.

## Details
The current detection algorithm for identifying local dependencies depended on semver matching; workspace protocol automatically requires the version to be satisfied locally.

## How it was tested
Ran in a large monorepo with the change.
Before:
<img width="1011" height="343" alt="image" src="https://github.com/user-attachments/assets/8e39f85a-47b1-4284-8021-d94b551b158a" />

After:
<img width="995" height="265" alt="image" src="https://github.com/user-attachments/assets/5ffa1424-c928-4e14-913c-f0a92134b558" />

## Impacted documentation
None