### PR TITLE
Make the next release of Rush a patch

### DIFF
--- a/common/config/rush/version-policies.json
+++ b/common/config/rush/version-policies.json
@@ -103,7 +103,7 @@
     "policyName": "rush",
     "definitionName": "lockStepVersion",
     "version": "5.158.0",
-    "nextBump": "minor",
+    "nextBump": "patch",
     "mainProject": "@microsoft/rush"
   }
 ]


### PR DESCRIPTION
## Summary
Sets the version policy to have the next Rush bump be a patch release.

## Details
N/A