### PR TITLE
Bridge cache fix and adding cache key to terminal logs

### DIFF
--- a/common/changes/@microsoft/rush/benkeen-bridge-cache-updates_2025-08-29-15-37.json
+++ b/common/changes/@microsoft/rush/benkeen-bridge-cache-updates_2025-08-29-15-37.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix to allow Bridge Cache plugin be installed but not used when build cache disabled; add cache key to terminal logs",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/rush-plugins/rush-bridge-cache-plugin/src/BridgeCachePlugin.ts
+++ b/rush-plugins/rush-bridge-cache-plugin/src/BridgeCachePlugin.ts
@@ -83,14 +83,15 @@ export class BridgeCachePlugin implements IRushPlugin {
         ): Promise<void> => {
           const { buildCacheConfiguration } = context;
           const { terminal } = logger;
+
+          if (cacheAction === undefined) {
+            return;
+          }
+
           if (!buildCacheConfiguration?.buildCacheEnabled) {
             throw new Error(
               `The build cache must be enabled to use the "${this._actionParameterName}" parameter.`
             );
-          }
-
-          if (cacheAction === undefined) {
-            return;
           }
 
           const filteredOperations: Set<IOperationExecutionResult> = new Set();
@@ -122,6 +123,7 @@ export class BridgeCachePlugin implements IRushPlugin {
                   terminal.writeLine(
                     `Operation "${operation.name}": Outputs have been restored from the build cache."`
                   );
+                  terminal.writeLine(`Cache key: ${projectBuildCache.cacheId}`);
                 } else {
                   terminal.writeWarningLine(
                     `Operation "${operation.name}": Outputs could not be restored from the build cache.`
@@ -155,6 +157,7 @@ export class BridgeCachePlugin implements IRushPlugin {
                   terminal.writeLine(
                     `Operation "${operation.name}": Existing outputs have been successfully written to the build cache."`
                   );
+                  terminal.writeLine(`Cache key: ${projectBuildCache.cacheId}`);
                 } else {
                   terminal.writeErrorLine(
                     `Operation "${operation.name}": An error occurred while writing existing outputs to the build cache.`
@@ -179,6 +182,7 @@ export class BridgeCachePlugin implements IRushPlugin {
     const cacheActionParameter: CommandLineParameter | undefined = context.customParameters.get(
       this._actionParameterName
     );
+
     if (cacheActionParameter) {
       if (cacheActionParameter.kind !== CommandLineParameterKind.Choice) {
         throw new Error(


### PR DESCRIPTION
This PR fixes this issue: #5330 

And adds the cache key to the terminal logs to address this issue: #5340 

Example output:

<img width="755" height="206" alt="Screenshot 2025-08-29 at 8 30 31 AM" src="https://github.com/user-attachments/assets/820da27c-769a-4998-bbb9-4b906549953d" />
