### PR TITLE
[debug-certificate-manager] remove workspace folder error notification

### DIFF
--- a/vscode-extensions/debug-certificate-manager-vscode-extension/package.json
+++ b/vscode-extensions/debug-certificate-manager-vscode-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "debug-certificate-manager",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/rushstack.git",

--- a/vscode-extensions/debug-certificate-manager-vscode-extension/src/extension.ts
+++ b/vscode-extensions/debug-certificate-manager-vscode-extension/src/extension.ts
@@ -164,9 +164,6 @@ export function activate(context: vscode.ExtensionContext): void {
       const workspaceUri: vscode.Uri | undefined = vscode.workspace.workspaceFolders?.[0].uri;
       if (!workspaceUri) {
         terminal.writeLine('No workspace folder found. Synchronization aborted.');
-        void vscode.window.showErrorMessage(
-          'No workspace folder found. Open the project folder to sync TLS certificates.'
-        );
         return;
       }
 


### PR DESCRIPTION
## Summary

Remove workspace folder error notification.

## Details

Users reported they don't find the workspace folder error notification useful. Error is still available in the log window for debugging and issue reporting purposes.

Removing the notification to make VS Code boot up less noisy.

## How it was tested

Tested that the error notification does not show up when opening loose files instead of a workspace folder.
