### PR TITLE
[heft-sass-plugin] Fix an issue with generation of .scss.js files.

### DIFF
--- a/common/changes/@rushstack/heft-sass-plugin/fix-css-js_2025-08-31-00-57.json
+++ b/common/changes/@rushstack/heft-sass-plugin/fix-css-js_2025-08-31-00-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-sass-plugin",
+      "comment": "Fix an issue where generated `.scss.js` files can contain an incorrect path to the `.css` file.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft-sass-plugin"
+}

--- a/heft-plugins/heft-sass-plugin/src/SassProcessor.ts
+++ b/heft-plugins/heft-sass-plugin/src/SassProcessor.ts
@@ -781,7 +781,7 @@ export class SassProcessor {
 
     const filename: string = path.basename(relativeFilePath);
     const extensionStart: number = filename.lastIndexOf('.');
-    const cssPathFromJs: string = `./${relativeFilePath.slice(0, extensionStart)}.css`;
+    const cssPathFromJs: string = `./${filename.slice(0, extensionStart)}.css`;
     const relativeCssPath: string = `${relativeFilePath.slice(0, relativeFilePath.lastIndexOf('.'))}.css`;
 
     if (cssOutputFolders && cssOutputFolders.length > 0) {


### PR DESCRIPTION
## Summary

Fixes an issue with generation of .scss.js files in files that aren't in the root of the src folder.

## How it was tested

Tested in a repo that repros this issue.