### PR TITLE
[rush] Support aborting phased command execution

### DIFF
--- a/common/changes/@microsoft/rush/rush-abort_2025-09-16-01-25.json
+++ b/common/changes/@microsoft/rush/rush-abort_2025-09-16-01-25.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Support aborting execution in phased commands. The CLI allows aborting via the \"a\" key in watch mode, and it is available to plugin authors for more advanced scenarios.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -477,6 +477,7 @@ export interface IEnvironmentConfigurationInitializeOptions {
 
 // @alpha
 export interface IExecuteOperationsContext extends ICreateOperationsContext {
+    readonly abortController: AbortController;
     readonly inputsSnapshot?: IInputsSnapshot;
 }
 
@@ -742,6 +743,8 @@ export type IPhaseBehaviorForMissingScript = 'silent' | 'log' | 'error';
 
 // @beta
 export interface IPhasedCommand extends IRushCommand {
+    // @alpha
+    readonly abortController: AbortController;
     // @alpha
     readonly hooks: PhasedCommandHooks;
 }
@@ -1053,6 +1056,7 @@ export class _OperationStateFile {
 
 // @beta
 export enum OperationStatus {
+    Aborted = "ABORTED",
     Blocked = "BLOCKED",
     Executing = "EXECUTING",
     Failure = "FAILURE",

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -744,9 +744,9 @@ export type IPhaseBehaviorForMissingScript = 'silent' | 'log' | 'error';
 // @beta
 export interface IPhasedCommand extends IRushCommand {
     // @alpha
-    readonly abortController: AbortController;
-    // @alpha
     readonly hooks: PhasedCommandHooks;
+    // @alpha
+    readonly sessionAbortController: AbortController;
 }
 
 // @public

--- a/libraries/rush-lib/src/logic/ProjectWatcher.ts
+++ b/libraries/rush-lib/src/logic/ProjectWatcher.ts
@@ -156,6 +156,13 @@ export class ProjectWatcher {
    * `waitForChange` is not allowed to be called multiple times concurrently.
    */
   public async waitForChangeAsync(onWatchingFiles?: () => void): Promise<IProjectChangeResult> {
+    if (this.isPaused) {
+      this._setStatus(`Project watcher paused.`);
+      await new Promise<void>((resolve) => {
+        this._resolveIfChanged = async () => resolve();
+      });
+    }
+
     const initialChangeResult: IProjectChangeResult = await this._computeChangedAsync();
     // Ensure that the new state is recorded so that we don't loop infinitely
     this._commitChanges(initialChangeResult.inputsSnapshot);

--- a/libraries/rush-lib/src/logic/operations/AsyncOperationQueue.ts
+++ b/libraries/rush-lib/src/logic/operations/AsyncOperationQueue.ts
@@ -104,7 +104,8 @@ export class AsyncOperationQueue
         record.status === OperationStatus.SuccessWithWarning ||
         record.status === OperationStatus.FromCache ||
         record.status === OperationStatus.NoOp ||
-        record.status === OperationStatus.Failure
+        record.status === OperationStatus.Failure ||
+        record.status === OperationStatus.Aborted
       ) {
         // It shouldn't be on the queue, remove it
         queue.splice(i, 1);

--- a/libraries/rush-lib/src/logic/operations/ConsoleTimelinePlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/ConsoleTimelinePlugin.ts
@@ -86,7 +86,8 @@ const TIMELINE_CHART_SYMBOLS: Record<OperationStatus, string> = {
   [OperationStatus.Blocked]: '.',
   [OperationStatus.Skipped]: '%',
   [OperationStatus.FromCache]: '%',
-  [OperationStatus.NoOp]: '%'
+  [OperationStatus.NoOp]: '%',
+  [OperationStatus.Aborted]: '@'
 };
 
 const COBUILD_REPORTABLE_STATUSES: Set<OperationStatus> = new Set([
@@ -110,7 +111,8 @@ const TIMELINE_CHART_COLORIZER: Record<OperationStatus, (string: string) => stri
   [OperationStatus.Blocked]: Colorize.red,
   [OperationStatus.Skipped]: Colorize.green,
   [OperationStatus.FromCache]: Colorize.green,
-  [OperationStatus.NoOp]: Colorize.gray
+  [OperationStatus.NoOp]: Colorize.gray,
+  [OperationStatus.Aborted]: Colorize.gray
 };
 
 interface ITimelineRecord {

--- a/libraries/rush-lib/src/logic/operations/ConsoleTimelinePlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/ConsoleTimelinePlugin.ts
@@ -112,7 +112,7 @@ const TIMELINE_CHART_COLORIZER: Record<OperationStatus, (string: string) => stri
   [OperationStatus.Skipped]: Colorize.green,
   [OperationStatus.FromCache]: Colorize.green,
   [OperationStatus.NoOp]: Colorize.gray,
-  [OperationStatus.Aborted]: Colorize.gray
+  [OperationStatus.Aborted]: Colorize.red
 };
 
 interface ITimelineRecord {

--- a/libraries/rush-lib/src/logic/operations/OperationExecutionManager.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationExecutionManager.ts
@@ -90,6 +90,7 @@ export class OperationExecutionManager {
   // Variables for current status
   private _hasAnyFailures: boolean;
   private _hasAnyNonAllowedWarnings: boolean;
+  private _hasAnyAborted: boolean;
   private _completedOperations: number;
   private _executionQueue: AsyncOperationQueue;
 
@@ -109,6 +110,7 @@ export class OperationExecutionManager {
     this._quietMode = quietMode;
     this._hasAnyFailures = false;
     this._hasAnyNonAllowedWarnings = false;
+    this._hasAnyAborted = false;
     this._parallelism = parallelism;
 
     this._beforeExecuteOperation = beforeExecuteOperation;
@@ -232,9 +234,10 @@ export class OperationExecutionManager {
    * Executes all operations which have been registered, returning a promise which is resolved when all the
    * operations are completed successfully, or rejects when any operation fails.
    */
-  public async executeAsync(): Promise<IExecutionResult> {
+  public async executeAsync(abortController: AbortController): Promise<IExecutionResult> {
     this._completedOperations = 0;
     const totalOperations: number = this._totalOperations;
+    const abortSignal: AbortSignal = abortController.signal;
 
     if (!this._quietMode) {
       const plural: string = totalOperations === 1 ? '' : 's';
@@ -287,10 +290,15 @@ export class OperationExecutionManager {
     await Async.forEachAsync(
       this._executionQueue,
       async (record: OperationExecutionRecord) => {
-        await record.executeAsync({
-          onStart: onOperationStartAsync,
-          onResult: onOperationCompleteAsync
-        });
+        if (abortSignal.aborted) {
+          record.status = OperationStatus.Aborted;
+          this._onOperationComplete(record);
+        } else {
+          await record.executeAsync({
+            onStart: onOperationStartAsync,
+            onResult: onOperationCompleteAsync
+          });
+        }
       },
       {
         concurrency: maxParallelism,
@@ -300,9 +308,11 @@ export class OperationExecutionManager {
 
     const status: OperationStatus = this._hasAnyFailures
       ? OperationStatus.Failure
-      : this._hasAnyNonAllowedWarnings
-        ? OperationStatus.SuccessWithWarning
-        : OperationStatus.Success;
+      : this._hasAnyAborted
+        ? OperationStatus.Aborted
+        : this._hasAnyNonAllowedWarnings
+          ? OperationStatus.SuccessWithWarning
+          : OperationStatus.Success;
 
     return {
       operationResults: this._executionRecords,
@@ -434,6 +444,11 @@ export class OperationExecutionManager {
           );
         }
         this._hasAnyNonAllowedWarnings = this._hasAnyNonAllowedWarnings || !runner.warningsAreAllowed;
+        break;
+      }
+
+      case OperationStatus.Aborted: {
+        this._hasAnyAborted ||= true;
         break;
       }
 

--- a/libraries/rush-lib/src/logic/operations/OperationExecutionManager.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationExecutionManager.ts
@@ -292,7 +292,10 @@ export class OperationExecutionManager {
       async (record: OperationExecutionRecord) => {
         if (abortSignal.aborted) {
           record.status = OperationStatus.Aborted;
-          this._onOperationComplete(record);
+          // Bypass the normal completion handler, directly mark the operation as aborted and unblock the queue.
+          // We do this to ensure that we aren't messing with the stopwatch or terminal.
+          this._hasAnyAborted = true;
+          this._executionQueue.complete(record);
         } else {
           await record.executeAsync({
             onStart: onOperationStartAsync,

--- a/libraries/rush-lib/src/logic/operations/OperationResultSummarizerPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationResultSummarizerPlugin.ts
@@ -132,7 +132,7 @@ export function _printOperationStatus(terminal: ITerminal, result: IExecutionRes
     terminal,
     OperationStatus.Aborted,
     operationsByStatus,
-    Colorize.gray,
+    Colorize.white,
     'These operations were aborted:'
   );
 

--- a/libraries/rush-lib/src/logic/operations/OperationResultSummarizerPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationResultSummarizerPlugin.ts
@@ -69,6 +69,7 @@ export function _printOperationStatus(terminal: ITerminal, result: IExecutionRes
       case OperationStatus.Blocked:
       case OperationStatus.Failure:
       case OperationStatus.NoOp:
+      case OperationStatus.Aborted:
         break;
       default:
         // This should never happen
@@ -125,6 +126,14 @@ export function _printOperationStatus(terminal: ITerminal, result: IExecutionRes
     operationsByStatus,
     Colorize.yellow,
     'WARNING'
+  );
+
+  writeCondensedSummary(
+    terminal,
+    OperationStatus.Aborted,
+    operationsByStatus,
+    Colorize.gray,
+    'These operations were aborted:'
   );
 
   writeCondensedSummary(

--- a/libraries/rush-lib/src/logic/operations/OperationStatus.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationStatus.ts
@@ -49,7 +49,11 @@ export enum OperationStatus {
   /**
    * The Operation was a no-op (for example, it had an empty script)
    */
-  NoOp = 'NO OP'
+  NoOp = 'NO OP',
+  /**
+   * The Operation was aborted before it could execute.
+   */
+  Aborted = 'ABORTED'
 }
 
 /**
@@ -63,5 +67,6 @@ export const TERMINAL_STATUSES: Set<OperationStatus> = new Set([
   OperationStatus.Blocked,
   OperationStatus.FromCache,
   OperationStatus.Failure,
-  OperationStatus.NoOp
+  OperationStatus.NoOp,
+  OperationStatus.Aborted
 ]);

--- a/libraries/rush-lib/src/logic/operations/test/OperationExecutionManager.test.ts
+++ b/libraries/rush-lib/src/logic/operations/test/OperationExecutionManager.test.ts
@@ -117,7 +117,8 @@ describe(OperationExecutionManager.name, () => {
         })
       );
 
-      const result: IExecutionResult = await executionManager.executeAsync();
+      const abortController = new AbortController();
+      const result: IExecutionResult = await executionManager.executeAsync(abortController);
       _printOperationStatus(mockTerminal, result);
       expect(result.status).toEqual(OperationStatus.Failure);
       expect(result.operationResults.size).toEqual(1);
@@ -141,7 +142,8 @@ describe(OperationExecutionManager.name, () => {
         })
       );
 
-      const result: IExecutionResult = await executionManager.executeAsync();
+      const abortController = new AbortController();
+      const result: IExecutionResult = await executionManager.executeAsync(abortController);
       _printOperationStatus(mockTerminal, result);
       expect(result.status).toEqual(OperationStatus.Failure);
       expect(result.operationResults.size).toEqual(1);
@@ -154,6 +156,48 @@ describe(OperationExecutionManager.name, () => {
       expect(allOutput).toMatch(/Build step 1/);
       expect(allOutput).toMatch(/Error: step 1 failed/);
       expect(mockWritable.getFormattedChunks()).toMatchSnapshot();
+    });
+  });
+
+  describe('Aborting', () => {
+    it('Aborted operations abort', async () => {
+      const mockRun: jest.Mock = jest.fn();
+
+      const firstOperation = new Operation({
+        runner: new MockOperationRunner('1', mockRun),
+        phase: mockPhase,
+        project: getOrCreateProject('1'),
+        logFilenameIdentifier: '1'
+      });
+
+      const secondOperation = new Operation({
+        runner: new MockOperationRunner('2', mockRun),
+        phase: mockPhase,
+        project: getOrCreateProject('2'),
+        logFilenameIdentifier: '2'
+      });
+
+      secondOperation.addDependency(firstOperation);
+
+      const manager: OperationExecutionManager = new OperationExecutionManager(
+        new Set([firstOperation, secondOperation]),
+        {
+          quietMode: false,
+          debugMode: false,
+          parallelism: 1,
+          destination: mockWritable
+        }
+      );
+
+      const abortController = new AbortController();
+      abortController.abort();
+
+      const result = await manager.executeAsync(abortController);
+      expect(result.status).toEqual(OperationStatus.Aborted);
+      expect(mockRun).not.toHaveBeenCalled();
+      expect(result.operationResults.size).toEqual(2);
+      expect(result.operationResults.get(firstOperation)?.status).toEqual(OperationStatus.Aborted);
+      expect(result.operationResults.get(secondOperation)?.status).toEqual(OperationStatus.Aborted);
     });
   });
 
@@ -189,7 +233,8 @@ describe(OperationExecutionManager.name, () => {
         }
       );
 
-      const result = await manager.executeAsync();
+      const abortController = new AbortController();
+      const result = await manager.executeAsync(abortController);
       expect(result.status).toEqual(OperationStatus.Failure);
       expect(blockedRunFn).not.toHaveBeenCalled();
       expect(result.operationResults.size).toEqual(2);
@@ -219,7 +264,8 @@ describe(OperationExecutionManager.name, () => {
           })
         );
 
-        const result: IExecutionResult = await executionManager.executeAsync();
+        const abortController = new AbortController();
+        const result: IExecutionResult = await executionManager.executeAsync(abortController);
         _printOperationStatus(mockTerminal, result);
         expect(result.status).toEqual(OperationStatus.SuccessWithWarning);
         expect(result.operationResults.size).toEqual(1);
@@ -259,7 +305,8 @@ describe(OperationExecutionManager.name, () => {
           )
         );
 
-        const result: IExecutionResult = await executionManager.executeAsync();
+        const abortController = new AbortController();
+        const result: IExecutionResult = await executionManager.executeAsync(abortController);
         _printOperationStatus(mockTerminal, result);
         expect(result.status).toEqual(OperationStatus.Success);
         expect(result.operationResults.size).toEqual(1);
@@ -287,7 +334,8 @@ describe(OperationExecutionManager.name, () => {
           )
         );
 
-        const result: IExecutionResult = await executionManager.executeAsync();
+        const abortController = new AbortController();
+        const result: IExecutionResult = await executionManager.executeAsync(abortController);
         _printTimeline({ terminal: mockTerminal, result, cobuildConfiguration: undefined });
         _printOperationStatus(mockTerminal, result);
         const allMessages: string = mockWritable.getAllOutput();
@@ -359,7 +407,8 @@ describe(OperationExecutionManager.name, () => {
         {} as unknown as RushConfigurationProject
       );
 
-      const result: IExecutionResult = await executionManager.executeAsync();
+      const abortController = new AbortController();
+      const result: IExecutionResult = await executionManager.executeAsync(abortController);
       _printTimeline({
         terminal: mockTerminal,
         result,
@@ -384,7 +433,8 @@ describe(OperationExecutionManager.name, () => {
         {} as unknown as RushConfigurationProject
       );
 
-      const result: IExecutionResult = await executionManager.executeAsync();
+      const abortController = new AbortController();
+      const result: IExecutionResult = await executionManager.executeAsync(abortController);
       _printTimeline({
         terminal: mockTerminal,
         result,

--- a/libraries/rush-lib/src/pluginFramework/PhasedCommandHooks.ts
+++ b/libraries/rush-lib/src/pluginFramework/PhasedCommandHooks.ts
@@ -131,6 +131,11 @@ export interface IExecuteOperationsContext extends ICreateOperationsContext {
    * Not part of the creation context to avoid the overhead of Git calls when initializing the graph.
    */
   readonly inputsSnapshot?: IInputsSnapshot;
+
+  /**
+   * An abort controller that can be used to abort the current set of queued operations.
+   */
+  readonly abortController: AbortController;
 }
 
 /**

--- a/libraries/rush-lib/src/pluginFramework/RushLifeCycle.ts
+++ b/libraries/rush-lib/src/pluginFramework/RushLifeCycle.ts
@@ -42,7 +42,7 @@ export interface IPhasedCommand extends IRushCommand {
    * Long-lived plugins should listen to the signal to handle any cleanup logic.
    * @alpha
    */
-  readonly abortController: AbortController;
+  readonly sessionAbortController: AbortController;
 }
 
 /**

--- a/libraries/rush-lib/src/pluginFramework/RushLifeCycle.ts
+++ b/libraries/rush-lib/src/pluginFramework/RushLifeCycle.ts
@@ -36,6 +36,13 @@ export interface IPhasedCommand extends IRushCommand {
    * @alpha
    */
   readonly hooks: PhasedCommandHooks;
+
+  /**
+   * An abort controller that can be used to abort the command.
+   * Long-lived plugins should listen to the signal to handle any cleanup logic.
+   * @alpha
+   */
+  readonly abortController: AbortController;
 }
 
 /**

--- a/rush-plugins/rush-bridge-cache-plugin/src/BridgeCachePlugin.ts
+++ b/rush-plugins/rush-bridge-cache-plugin/src/BridgeCachePlugin.ts
@@ -55,7 +55,8 @@ export class BridgeCachePlugin implements IRushPlugin {
       command.hooks.createOperations.tap(
         { name: PLUGIN_NAME, stage: Number.MAX_SAFE_INTEGER },
         (operations: Set<Operation>, context: ICreateOperationsContext): Set<Operation> => {
-          cacheAction = this._getCacheAction(context);
+          const { customParameters } = context;
+          cacheAction = this._getCacheAction(customParameters);
 
           if (cacheAction !== undefined) {
             if (!context.buildCacheConfiguration?.buildCacheEnabled) {
@@ -68,7 +69,7 @@ export class BridgeCachePlugin implements IRushPlugin {
               operation.enabled = false;
             }
 
-            requireOutputFolders = this._isRequireOutputFoldersFlagSet(context);
+            requireOutputFolders = this._isRequireOutputFoldersFlagSet(customParameters);
           }
 
           return operations;
@@ -178,8 +179,10 @@ export class BridgeCachePlugin implements IRushPlugin {
     });
   }
 
-  private _getCacheAction(context: IExecuteOperationsContext): CacheAction | undefined {
-    const cacheActionParameter: CommandLineParameter | undefined = context.customParameters.get(
+  private _getCacheAction(
+    customParameters: ReadonlyMap<string, CommandLineParameter>
+  ): CacheAction | undefined {
+    const cacheActionParameter: CommandLineParameter | undefined = customParameters.get(
       this._actionParameterName
     );
 
@@ -217,12 +220,14 @@ export class BridgeCachePlugin implements IRushPlugin {
     return undefined;
   }
 
-  private _isRequireOutputFoldersFlagSet(context: IExecuteOperationsContext): boolean {
+  private _isRequireOutputFoldersFlagSet(
+    customParameters: ReadonlyMap<string, CommandLineParameter>
+  ): boolean {
     if (!this._requireOutputFoldersParameterName) {
       return false;
     }
 
-    const requireOutputFoldersParam: CommandLineParameter | undefined = context.customParameters.get(
+    const requireOutputFoldersParam: CommandLineParameter | undefined = customParameters.get(
       this._requireOutputFoldersParameterName
     );
 

--- a/rush-plugins/rush-serve-plugin/src/phasedCommandHandler.ts
+++ b/rush-plugins/rush-serve-plugin/src/phasedCommandHandler.ts
@@ -243,7 +243,7 @@ export async function phasedCommandHandler(options: IPhasedCommandHandlerOptions
       webSocketServerUpgrader?.(server);
 
       server.listen(requestedPort);
-      command.abortController.signal.addEventListener(
+      command.sessionAbortController.signal.addEventListener(
         'abort',
         () => {
           server.close();


### PR DESCRIPTION
## Summary
Allows watch-mode phased commands abort queued operations via the `a` key. Aborting execution does not stop any operations that are currently executing, but any that are waiting will be aborted and automatically marked as invalid for the next iteration.

## Details
Aborting is supported at two levels:
- `IPhasedCommand` now has a `sessionAbortController` property, which can be used to completely abort the session (i.e. in watch mode, kill the watcher), and its `signal` should be listened to by any plugins that have long-lived state (like the `rush-serve-plugin`).
- `IExecuteOperationsContext` also has an `abortController` property, which is bound only to the current execution pass. This can be used to abort the currently queued operations.

Also fixes an issue where when the watcher is "paused", it still will do an immediate recheck for changes. This check now also gets paused.

## How it was tested
Unit tests handling the abort status reporting.
Manual invocation of the rushstack `rush start` command and toggling abort.

## Impacted documentation
Phased command plugin documentation. The CLI prompt.