### PR TITLE
Update CI Workflow to use 22.19 for the node 22 matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ jobs:
           - NodeVersion: 20.18.x
             NodeVersionDisplayName: 20
             OS: ubuntu-latest
-          - NodeVersion: 22.12.x
+          - NodeVersion: 22.19.x
             NodeVersionDisplayName: 22
             OS: ubuntu-latest
-          - NodeVersion: 22.12.x
+          - NodeVersion: 22.19.x
             NodeVersionDisplayName: 22
             OS: windows-latest
     name: Node.js v${{ matrix.NodeVersionDisplayName }} (${{ matrix.OS }})


### PR DESCRIPTION
Update CI Workflow to use 22.19 for the node 22 matrix