### PR TITLE
[rush-resolver-cache] Fix rush-lib reference

### DIFF
--- a/common/changes/@microsoft/rush/fix-rush-lib-external_2025-09-17-20-55.json
+++ b/common/changes/@microsoft/rush/fix-rush-lib-external_2025-09-17-20-55.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "[rush-resolver-cache] Ensure that the correct version of rush-lib is loaded when the global version doesn't match the repository version.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/rush-plugins/rush-resolver-cache-plugin/src/afterInstallAsync.ts
+++ b/rush-plugins/rush-resolver-cache-plugin/src/afterInstallAsync.ts
@@ -41,7 +41,7 @@ function getPlatformInfo(): IPlatformInfo {
 }
 
 const END_TOKEN: string = '/package.json":';
-const RESOLVER_CACHE_FILE_VERSION: 1 = 1;
+const RESOLVER_CACHE_FILE_VERSION: 2 = 2;
 
 interface IExtendedResolverCacheFile extends IResolverCacheFile {
   /**
@@ -92,6 +92,12 @@ export async function afterInstallAsync(
   });
   if (!lockFile) {
     throw new Error(`Failed to load shrinkwrap file: ${lockFilePath}`);
+  }
+
+  if (!lockFile.hash) {
+    throw new Error(
+      `Shrinkwrap file does not have a hash. This indicates linking to an old version of Rush.`
+    );
   }
 
   try {

--- a/rush-plugins/rush-resolver-cache-plugin/src/externals.ts
+++ b/rush-plugins/rush-resolver-cache-plugin/src/externals.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import type Module from 'node:module';
-
 import type { Operation as OperationType, OperationStatus as OperationStatusType } from '@rushstack/rush-sdk';
 import type { PnpmShrinkwrapFile as PnpmShrinkwrapFileType } from '@rushstack/rush-sdk/lib/logic/pnpm/PnpmShrinkwrapFile';
 import type * as rushSdkType from '@rushstack/rush-sdk';
@@ -22,27 +20,30 @@ export { Operation, OperationStatus };
 // Support this plugin being webpacked.
 const req: typeof require = typeof __non_webpack_require__ === 'function' ? __non_webpack_require__ : require;
 
-const entryModule: Module | undefined = req.main;
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function getExternal<TResult = any>(name: string): TResult {
+const rushLibPath: string | undefined = process.env._RUSH_LIB_PATH;
+
+function importDependency<TResult>(name: string): TResult {
+  if (!rushLibPath) {
+    throw new Error(`_RUSH_LIB_PATH variable is not set, cannot resolve rush-lib.`);
+  }
   const externalPath: string = req.resolve(name, {
-    paths: entryModule?.paths
+    paths: [rushLibPath]
   });
 
   return req(externalPath);
 }
 
 // Private Rush APIs
-export const { PnpmShrinkwrapFile } = getExternal<
+export const { PnpmShrinkwrapFile } = importDependency<
   typeof import('@rushstack/rush-sdk/lib/logic/pnpm/PnpmShrinkwrapFile')
 >('@microsoft/rush-lib/lib/logic/pnpm/PnpmShrinkwrapFile');
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export type PnpmShrinkwrapFile = PnpmShrinkwrapFileType;
 
 // Avoid bundling expensive stuff that's already part of Rush.
-export const { Async } = getExternal<typeof import('@rushstack/node-core-library/lib/Async')>(
+export const { Async } = importDependency<typeof import('@rushstack/node-core-library/lib/Async')>(
   `@rushstack/node-core-library/lib/Async`
 );
-export const { FileSystem } = getExternal<typeof import('@rushstack/node-core-library/lib/FileSystem')>(
+export const { FileSystem } = importDependency<typeof import('@rushstack/node-core-library/lib/FileSystem')>(
   `@rushstack/node-core-library/lib/FileSystem`
 );


### PR DESCRIPTION
## Summary
Fix an incorrect path for `rush-lib` inside of `@rushstack/rush-resolver-cache-plugin`.

## Details
The existing code path loaded the version of `@microsoft/rush-lib` linked to the globally installed version of `@microsoft/rush`, rather than the version installed for the current repository.

## How it was tested
The alternate logic is already in use in other Rush plugins that don't have this problem. Also tested by modifying a local installation.

## Impacted documentation
None.