### PR TITLE
Update CI workflow: Run a second rush test step to verify build cache hits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,3 +95,7 @@ jobs:
       - name: Rush test (rush-lib)
         run: node ${{ github.workspace }}/repo-a/apps/rush/lib/start-dev.js test --verbose --production --timeline
         working-directory: repo-b
+
+      - name: Rush test (rush-lib) again to verify build cache hits
+        run: node ${{ github.workspace }}/repo-a/apps/rush/lib/start-dev.js test --verbose --production --timeline
+        working-directory: repo-b


### PR DESCRIPTION
Update CI workflow: Run a second rush test step to verify build cache hits