### PR TITLE
[debug-certificate-manager] add vs code extension info to log messages

### DIFF
--- a/common/changes/@rushstack/debug-certificate-manager/bmiddha-cert-store-path-fixup_2025-09-28-00-24.json
+++ b/common/changes/@rushstack/debug-certificate-manager/bmiddha-cert-store-path-fixup_2025-09-28-00-24.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/debug-certificate-manager",
+      "comment": "Add message to use VS Code extension to errors.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/debug-certificate-manager"
+}

--- a/libraries/debug-certificate-manager/src/CertificateManager.ts
+++ b/libraries/debug-certificate-manager/src/CertificateManager.ts
@@ -146,7 +146,7 @@ export interface ICertificateManagerOptions extends ICertificateStoreOptions {}
 const MAX_CERTIFICATE_VALIDITY_DAYS: 365 = 365;
 
 const VS_CODE_EXTENSION_FIX_MESSAGE: string =
-  'Use the "Debug Certificate Manager Extension" for VS Code and run the ' +
+  'Use the "Debug Certificate Manager" Extension for VS Code (ms-RushStack.debug-certificate-manager) and run the ' +
   '"Debug Certificate Manager: Ensure and Sync TLS Certificates" command to fix certificate issues. ';
 
 /**

--- a/libraries/debug-certificate-manager/src/CertificateManager.ts
+++ b/libraries/debug-certificate-manager/src/CertificateManager.ts
@@ -145,6 +145,10 @@ export interface ICertificateManagerOptions extends ICertificateStoreOptions {}
 
 const MAX_CERTIFICATE_VALIDITY_DAYS: 365 = 365;
 
+const VS_CODE_EXTENSION_FIX_MESSAGE: string =
+  'Use the "Debug Certificate Manager Extension" for VS Code and run the ' +
+  '"Debug Certificate Manager: Ensure and Sync TLS Certificates" command to fix certificate issues. ';
+
 /**
  * A utility class to handle generating, trusting, and untrustring a debug certificate.
  * Contains two public methods to `ensureCertificate` and `untrustCertificate`.
@@ -177,7 +181,8 @@ export class CertificateManager {
     if (process.env[DISABLE_CERT_GENERATION_VARIABLE_NAME] === '1') {
       // Allow the environment (e.g. GitHub codespaces) to forcibly disable dev cert generation
       terminal.writeLine(
-        `Found environment variable ${DISABLE_CERT_GENERATION_VARIABLE_NAME}=1, disabling certificate generation.`
+        `Found environment variable ${DISABLE_CERT_GENERATION_VARIABLE_NAME}=1, disabling certificate generation. ` +
+          VS_CODE_EXTENSION_FIX_MESSAGE
       );
       canGenerateNewCertificate = false;
     }
@@ -207,7 +212,8 @@ export class CertificateManager {
       } else {
         validationResult.validationMessages.push(
           'Untrust the certificate and generate a new one, or set the ' +
-            '`canGenerateNewCertificate` parameter to `true` when calling `ensureCertificateAsync`.'
+            '`canGenerateNewCertificate` parameter to `true` when calling `ensureCertificateAsync`. ' +
+            VS_CODE_EXTENSION_FIX_MESSAGE
         );
         throw new Error(validationResult.validationMessages.join(' '));
       }
@@ -216,7 +222,8 @@ export class CertificateManager {
     } else {
       throw new Error(
         'No development certificate found. Generate a new certificate manually, or set the ' +
-          '`canGenerateNewCertificate` parameter to `true` when calling `ensureCertificateAsync`.'
+          '`canGenerateNewCertificate` parameter to `true` when calling `ensureCertificateAsync`. ' +
+          VS_CODE_EXTENSION_FIX_MESSAGE
       );
     }
   }

--- a/libraries/debug-certificate-manager/src/CertificateStore.ts
+++ b/libraries/debug-certificate-manager/src/CertificateStore.ts
@@ -75,6 +75,7 @@ export class CertificateStore {
               storePath = path.resolve(currentDir, debugCertificateManagerConfig.storePath);
             }
           }
+          break; // found the config file, stop searching
         }
         const parentDir: string | undefined = path.dirname(currentDir);
         if (parentDir === currentDir) {


### PR DESCRIPTION
## Summary

Add information about the Debug Certificate Manager VS Code extension to log message strings in `debug-certificate-manager`. This is intended to make the log messages more actionable for users and help improve the experience when dealing with certificate issues.

## Details

- Add VS Code extension info to log message strings
- Break early when extension config is found
