### PR TITLE
[rush-azure-storage-build-cache-plugin] Trim access token output in AdoCodespacesAuthCredential

### DIFF
--- a/common/changes/@microsoft/rush/bmiddha-azureauthhelpertrim_2025-10-01-20-20.json
+++ b/common/changes/@microsoft/rush/bmiddha-azureauthhelpertrim_2025-10-01-20-20.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "[rush-azure-storage-build-cache-plugin] Trim access token output in AdoCodespacesAuthCredential",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/rush-plugins/rush-azure-storage-build-cache-plugin/src/AdoCodespacesAuthCredential.ts
+++ b/rush-plugins/rush-azure-storage-build-cache-plugin/src/AdoCodespacesAuthCredential.ts
@@ -54,7 +54,10 @@ export class AdoCodespacesAuthCredential implements TokenCredential {
       }
       const azureAuthHelperExec: string = 'azure-auth-helper';
 
-      const token: string = Executable.spawnSync(azureAuthHelperExec, ['get-access-token', scope]).stdout.trim();
+      const token: string = Executable.spawnSync(azureAuthHelperExec, [
+        'get-access-token',
+        scope
+      ]).stdout.trim();
 
       let expiresOnTimestamp: number;
 

--- a/rush-plugins/rush-azure-storage-build-cache-plugin/src/AdoCodespacesAuthCredential.ts
+++ b/rush-plugins/rush-azure-storage-build-cache-plugin/src/AdoCodespacesAuthCredential.ts
@@ -54,7 +54,7 @@ export class AdoCodespacesAuthCredential implements TokenCredential {
       }
       const azureAuthHelperExec: string = 'azure-auth-helper';
 
-      const token: string = Executable.spawnSync(azureAuthHelperExec, ['get-access-token', scope]).stdout;
+      const token: string = Executable.spawnSync(azureAuthHelperExec, ['get-access-token', scope]).stdout.trim();
 
       let expiresOnTimestamp: number;
 


### PR DESCRIPTION
## Summary

Fix bug where there is a trailing `\n` character in tokens from `AdoCodespacesAuthCredential`

## Details

`stdout` from `azure-auth-helper` needs to be trimmed to remove the trailing newline from the token result.

token result:
```
{"token":"ey.....SwzQ\n","expiresOnTimestamp":1759351393000}
```

## How it was tested

Validated by using the built JS for AdoCodespacesAuthCredential.js in target repo.
