### PR TITLE
[rush] Add a logging message after the TAR binary is found.

### DIFF
--- a/common/changes/@microsoft/rush/tar-logging_2025-10-02-19-02.json
+++ b/common/changes/@microsoft/rush/tar-logging_2025-10-02-19-02.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add a logging message after the 'Trying to find \"tar\" binary' message when the binary is found.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/utilities/TarExecutable.ts
+++ b/libraries/rush-lib/src/utilities/TarExecutable.ts
@@ -40,9 +40,10 @@ export class TarExecutable {
     if (!tarExecutablePath) {
       terminal.writeVerboseLine('"tar" was not found on the PATH');
       return undefined;
+    } else {
+      terminal.writeVerboseLine(`Using "tar" binary: ${tarExecutablePath}`);
+      return new TarExecutable(tarExecutablePath);
     }
-
-    return new TarExecutable(tarExecutablePath);
   }
 
   /**


### PR DESCRIPTION
During long cache pack/unpack operations, it can look like Rush gets stuck trying to find the `tar` binary. This PR adds a logging message after the `Trying to find "tar" binary` message.