### PR TITLE
[rush] Fix an issue with validation of packageExtensionsChecksum.

### DIFF
--- a/common/changes/@microsoft/rush/fix-package-extensions-hash_2025-10-03-17-31.json
+++ b/common/changes/@microsoft/rush/fix-package-extensions-hash_2025-10-03-17-31.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix an issue with validation of the `pnpm-lock.yaml` `packageExtensionsChecksum` field in pnpm v10.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/config/rush/nonbrowser-approved-packages.json
+++ b/common/config/rush/nonbrowser-approved-packages.json
@@ -847,6 +847,10 @@
       "allowedCategories": [ "libraries" ]
     },
     {
+      "name": "object-hash",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
       "name": "open",
       "allowedCategories": [ "libraries" ]
     },

--- a/common/config/subspaces/build-tests-subspace/pnpm-lock.yaml
+++ b/common/config/subspaces/build-tests-subspace/pnpm-lock.yaml
@@ -5100,6 +5100,10 @@ packages:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
+  /object-hash@3.0.0:
+    resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
+    engines: {node: '>= 6'}
+
   /object-inspect@1.13.3:
     resolution: {integrity: sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==}
     engines: {node: '>= 0.4'}
@@ -7241,6 +7245,7 @@ packages:
       js-yaml: 4.1.0
       npm-check: 6.0.1
       npm-package-arg: 6.1.1
+      object-hash: 3.0.0
       pnpm-sync-lib: 0.3.2
       read-package-tree: 5.1.6
       rxjs: 6.6.7

--- a/common/config/subspaces/build-tests-subspace/repo-state.json
+++ b/common/config/subspaces/build-tests-subspace/repo-state.json
@@ -1,6 +1,6 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "9eaf55ba29de8d94e17af33463f3b6ce0480400b",
+  "pnpmShrinkwrapHash": "f2c06df75a96061e31624e1a556e34660a569623",
   "preferredVersionsHash": "550b4cee0bef4e97db6c6aad726df5149d20e7d9",
-  "packageJsonInjectedDependenciesHash": "5f2a311100f4ad0bc6735377670f5d7cfd664127"
+  "packageJsonInjectedDependenciesHash": "408abb46a6057c11ab1f54350cc17675cd0767bd"
 }

--- a/common/config/subspaces/build-tests-subspace/repo-state.json
+++ b/common/config/subspaces/build-tests-subspace/repo-state.json
@@ -2,5 +2,5 @@
 {
   "pnpmShrinkwrapHash": "f2c06df75a96061e31624e1a556e34660a569623",
   "preferredVersionsHash": "550b4cee0bef4e97db6c6aad726df5149d20e7d9",
-  "packageJsonInjectedDependenciesHash": "408abb46a6057c11ab1f54350cc17675cd0767bd"
+  "packageJsonInjectedDependenciesHash": "14f4881943e5d03a361f079944eb76e1501b3e18"
 }

--- a/common/config/subspaces/default/pnpm-lock.yaml
+++ b/common/config/subspaces/default/pnpm-lock.yaml
@@ -3684,6 +3684,9 @@ importers:
       npm-package-arg:
         specifier: ~6.1.0
         version: 6.1.1
+      object-hash:
+        specifier: 3.0.0
+        version: 3.0.0
       pnpm-sync-lib:
         specifier: 0.3.2
         version: 0.3.2
@@ -3745,6 +3748,9 @@ importers:
       '@types/npm-package-arg':
         specifier: 6.1.0
         version: 6.1.0
+      '@types/object-hash':
+        specifier: ~3.0.6
+        version: 3.0.6
       '@types/read-package-tree':
         specifier: 5.1.0
         version: 5.1.0
@@ -14082,6 +14088,10 @@ packages:
     resolution: {integrity: sha512-0l3z16vnlJGl2Mi/rgJFrdwfLZ4jfNYgE6ZShEpjqhHuGTqdEzNles03NpYHwUMVYZa+Tj46UxKIEpE78lQ3DQ==}
     dependencies:
       '@types/node': 17.0.41
+    dev: true
+
+  /@types/object-hash@3.0.6:
+    resolution: {integrity: sha512-fOBV8C1FIu2ELinoILQ+ApxcUKz4ngq+IWUYrxSGjXzzjUALijilampwkMgEtJ+h2njAW3pi853QpzNVCHB73w==}
     dev: true
 
   /@types/overlayscrollbars@1.12.5:
@@ -25072,6 +25082,11 @@ packages:
       copy-descriptor: 0.1.1
       define-property: 0.2.5
       kind-of: 3.2.2
+
+  /object-hash@3.0.0:
+    resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
+    engines: {node: '>= 6'}
+    dev: false
 
   /object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}

--- a/common/config/subspaces/default/repo-state.json
+++ b/common/config/subspaces/default/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "b14e05fb6e67142fd6a574fe462bee93cb828511",
+  "pnpmShrinkwrapHash": "c643d2cc7e2c60ef034a6557fc89760140d42f66",
   "preferredVersionsHash": "61cd419c533464b580f653eb5f5a7e27fe7055ca"
 }

--- a/libraries/rush-lib/package.json
+++ b/libraries/rush-lib/package.json
@@ -57,6 +57,7 @@
     "js-yaml": "~4.1.0",
     "npm-check": "~6.0.1",
     "npm-package-arg": "~6.1.0",
+    "object-hash": "3.0.0",
     "pnpm-sync-lib": "0.3.2",
     "read-package-tree": "~5.1.5",
     "rxjs": "~6.6.7",
@@ -70,8 +71,6 @@
   "devDependencies": {
     "@pnpm/lockfile.types": "~1.0.3",
     "@pnpm/logger": "4.0.0",
-    "eslint": "~9.25.1",
-    "local-node-rig": "workspace:*",
     "@rushstack/heft-webpack5-plugin": "workspace:*",
     "@rushstack/heft": "workspace:*",
     "@rushstack/operation-graph": "workspace:*",
@@ -81,12 +80,15 @@
     "@types/inquirer": "7.3.1",
     "@types/js-yaml": "4.0.9",
     "@types/npm-package-arg": "6.1.0",
+    "@types/object-hash": "~3.0.6",
     "@types/read-package-tree": "5.1.0",
     "@types/semver": "7.5.0",
     "@types/ssri": "~7.1.0",
     "@types/strict-uri-encode": "2.0.0",
     "@types/tar": "6.1.6",
     "@types/webpack-env": "1.18.8",
+    "eslint": "~9.25.1",
+    "local-node-rig": "workspace:*",
     "webpack": "~5.98.0"
   },
   "publishOnlyDependencies": {

--- a/libraries/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
+++ b/libraries/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
@@ -580,7 +580,7 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
    */
   private _parseDependencyPath(packagePath: string): string {
     let depPath: string = packagePath;
-    if (this.shrinkwrapFileMajorVersion >= 6) {
+    if (this.shrinkwrapFileMajorVersion >= ShrinkwrapFileMajorVersion.V6) {
       depPath = this._convertLockfileV6DepPathToV5DepPath(packagePath);
     }
     const pkgInfo: ReturnType<typeof dependencyPathLockfilePreV9.parse> =
@@ -998,7 +998,7 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
 
     const allDependencies: PackageJsonDependency[] = [...dependencyList, ...devDependencyList];
 
-    if (this.shrinkwrapFileMajorVersion < 6) {
+    if (this.shrinkwrapFileMajorVersion < ShrinkwrapFileMajorVersion.V6) {
       // PNPM <= v7
 
       // Then get the unique package names and map them to package versions.


### PR DESCRIPTION
## Summary

In pnpm v10, the `packageExtensionsChecksum` hash format was changed from a MD5 hex digest to a SHA256 base64 digest. This PR adds support for the latter.

## How it was tested

Tested in a repo with package extensions that is being upgraded to pnpm v10.