### PR TITLE
Add repo config for rushstack debug certificate manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,7 @@ jspm_packages/
 .vscode/
 !.vscode/tasks.json
 !.vscode/launch.json
+!.vscode/debug-certificate-manager.json
 
 # Rush temporary files
 common/deploy/

--- a/debug-certificate-manager.json
+++ b/debug-certificate-manager.json
@@ -1,0 +1,3 @@
+{
+  "storePath": "common/temp/debug-certificates"
+}


### PR DESCRIPTION
## Summary

Add repo config for rushstack debug certificate manager

## Details

This config is read by

- "Debug Certificate Manager" VS Code extension (`vscode-extensions/debug-certificate-manager`): Config file is used to sync user's debug certificates to the workspace.

- `@rushstack/debug-certificate-manager` package: Config file is used to read/write certificates from/to the filesystem in `CertificateStore`.

## How it was tested

Tested by running `npm run start -- --serve` in `heft-webpack5-everything-test` in a codespace. The localhost server through `@rushstack/debug-certificate-manager` on the codespace. The certificates were synced with the codespace by the VS Code extension.

## Impacted documentation

