### PR TITLE
[debug-certificate-manager] add support for ipv6 loopback address

### DIFF
--- a/common/changes/@rushstack/debug-certificate-manager/bmiddha-debug-certificate-manager-ipv6_2025-10-07-05-01.json
+++ b/common/changes/@rushstack/debug-certificate-manager/bmiddha-debug-certificate-manager-ipv6_2025-10-07-05-01.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/debug-certificate-manager",
+      "comment": "add support for ipv6 localhost address",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/debug-certificate-manager"
+}

--- a/libraries/debug-certificate-manager/src/CertificateManager.ts
+++ b/libraries/debug-certificate-manager/src/CertificateManager.ts
@@ -28,7 +28,7 @@ export const DEFAULT_CERTIFICATE_SUBJECT_NAMES: ReadonlyArray<string> = ['localh
  * The set of ip addresses the certificate should be generated for, by default.
  * @public
  */
-export const DEFAULT_CERTIFICATE_SUBJECT_IP_ADDRESSES: ReadonlyArray<string> = ['127.0.0.1'];
+export const DEFAULT_CERTIFICATE_SUBJECT_IP_ADDRESSES: ReadonlyArray<string> = ['127.0.0.1', '::1'];
 
 const DISABLE_CERT_GENERATION_VARIABLE_NAME: 'RUSHSTACK_DISABLE_DEV_CERT_GENERATION' =
   'RUSHSTACK_DISABLE_DEV_CERT_GENERATION';


### PR DESCRIPTION
## Summary

add support for ipv6 loopback address

## Details

Add a subject alternative name for the ipv6 loopback address `::1`.

## How it was tested

Tested by creating new certificates and running `npm run start -- --serve` in `heft-webpack5-everything-test`.

## Impacted documentation

