### PR TITLE
[rush-lib] Add support for PNPM's minimumReleaseAge setting

### DIFF
--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -774,6 +774,7 @@ export interface _IPnpmOptionsJson extends IPackageManagerOptionsJsonBase {
     globalPatchedDependencies?: Record<string, string>;
     globalPeerDependencyRules?: IPnpmPeerDependencyRules;
     minimumReleaseAge?: number;
+    minimumReleaseAgeExclude?: string[];
     pnpmLockfilePolicies?: IPnpmLockfilePolicies;
     pnpmStore?: PnpmStoreLocation;
     preventManualShrinkwrapChanges?: boolean;
@@ -1190,6 +1191,7 @@ export class PnpmOptionsConfiguration extends PackageManagerOptionsConfiguration
     // @internal (undocumented)
     static loadFromJsonObject(json: _IPnpmOptionsJson, commonTempFolder: string): PnpmOptionsConfiguration;
     readonly minimumReleaseAge: number | undefined;
+    readonly minimumReleaseAgeExclude: string[] | undefined;
     readonly pnpmLockfilePolicies: IPnpmLockfilePolicies | undefined;
     readonly pnpmStore: PnpmStoreLocation;
     readonly pnpmStorePath: string;

--- a/libraries/rush-lib/assets/rush-init/common/config/rush/pnpm-config.json
+++ b/libraries/rush-lib/assets/rush-init/common/config/rush/pnpm-config.json
@@ -85,6 +85,21 @@
   /*[LINE "HYPOTHETICAL"]*/ "minimumReleaseAge": 1440,
 
   /**
+   * An array of package names or patterns to exclude from the minimumReleaseAge check.
+   * This allows certain trusted packages to be installed immediately after publication.
+   * Patterns are supported using glob syntax (e.g., "@myorg/*" to exclude all packages from an organization).
+   *
+   * For example:
+   *
+   * "minimumReleaseAgeExclude": ["webpack", "react", "@myorg/*"]
+   *
+   * (SUPPORTED ONLY IN PNPM 10.16.0 AND NEWER)
+   *
+   * PNPM documentation: https://pnpm.io/settings#minimumreleaseageexclude
+   */
+  /*[LINE "HYPOTHETICAL"]*/ "minimumReleaseAgeExclude": ["@myorg/*"],
+
+  /**
    * If true, then Rush will add the `--strict-peer-dependencies` command-line parameter when
    * invoking PNPM.  This causes `rush update` to fail if there are unsatisfied peer dependencies,
    * which is an invalid state that can cause build failures or incompatible dependency versions.

--- a/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
+++ b/libraries/rush-lib/src/logic/base/BaseInstallManager.ts
@@ -949,28 +949,6 @@ ${gitLfsHookHandling}
       }
 
       /*
-        If user set minimum-release-age in pnpm-config.json only, use the value in pnpm-config.json
-        If user set minimum-release-age in pnpm-config.json and .npmrc, use the value in pnpm-config.json
-        If user set minimum-release-age in .npmrc only, do nothing, let pnpm handle it
-      */
-      const isMinimumReleaseAgeInNpmrc: boolean = isVariableSetInNpmrcFile(
-        subspace.getSubspaceConfigFolderPath(),
-        'minimum-release-age',
-        this.rushConfiguration.isPnpm
-      );
-
-      const minimumReleaseAge: number | undefined = this.rushConfiguration.pnpmOptions.minimumReleaseAge;
-      if (minimumReleaseAge !== undefined) {
-        if (isMinimumReleaseAgeInNpmrc) {
-          this._terminal.writeWarningLine(
-            `Warning: PNPM's minimum-release-age is specified in both .npmrc and pnpm-config.json. ` +
-              `The value in pnpm-config.json will take precedence.`
-          );
-        }
-        args.push(`--config.minimumReleaseAge=${minimumReleaseAge}`);
-      }
-
-      /*
         If user set resolution-mode in pnpm-config.json only, use the value in pnpm-config.json
         If user set resolution-mode in pnpm-config.json and .npmrc, use the value in pnpm-config.json
         If user set resolution-mode in .npmrc only, do nothing, let pnpm handle it

--- a/libraries/rush-lib/src/logic/installManager/InstallHelpers.ts
+++ b/libraries/rush-lib/src/logic/installManager/InstallHelpers.ts
@@ -34,6 +34,8 @@ interface ICommonPackageJson extends IPackageJson {
     ignoredOptionalDependencies?: typeof PnpmOptionsConfiguration.prototype.globalIgnoredOptionalDependencies;
     allowedDeprecatedVersions?: typeof PnpmOptionsConfiguration.prototype.globalAllowedDeprecatedVersions;
     patchedDependencies?: typeof PnpmOptionsConfiguration.prototype.globalPatchedDependencies;
+    minimumReleaseAge?: typeof PnpmOptionsConfiguration.prototype.minimumReleaseAge;
+    minimumReleaseAgeExclude?: typeof PnpmOptionsConfiguration.prototype.minimumReleaseAgeExclude;
   };
 }
 
@@ -98,6 +100,30 @@ export class InstallHelpers {
 
       if (pnpmOptions.globalPatchedDependencies) {
         commonPackageJson.pnpm.patchedDependencies = pnpmOptions.globalPatchedDependencies;
+      }
+
+      if (pnpmOptions.minimumReleaseAge !== undefined || pnpmOptions.minimumReleaseAgeExclude) {
+        if (
+          rushConfiguration.rushConfigurationJson.pnpmVersion !== undefined &&
+          semver.lt(rushConfiguration.rushConfigurationJson.pnpmVersion, '10.16.0')
+        ) {
+          terminal.writeWarningLine(
+            Colorize.yellow(
+              `Your version of pnpm (${rushConfiguration.rushConfigurationJson.pnpmVersion}) ` +
+                `doesn't support the "minimumReleaseAge" or "minimumReleaseAgeExclude" fields in ` +
+                `${rushConfiguration.commonRushConfigFolder}/${RushConstants.pnpmConfigFilename}. ` +
+                'Remove these fields or upgrade to pnpm 10.16.0 or newer.'
+            )
+          );
+        }
+
+        if (pnpmOptions.minimumReleaseAge !== undefined) {
+          commonPackageJson.pnpm.minimumReleaseAge = pnpmOptions.minimumReleaseAge;
+        }
+
+        if (pnpmOptions.minimumReleaseAgeExclude) {
+          commonPackageJson.pnpm.minimumReleaseAgeExclude = pnpmOptions.minimumReleaseAgeExclude;
+        }
       }
 
       if (pnpmOptions.unsupportedPackageJsonSettings) {

--- a/libraries/rush-lib/src/logic/pnpm/PnpmOptionsConfiguration.ts
+++ b/libraries/rush-lib/src/logic/pnpm/PnpmOptionsConfiguration.ts
@@ -143,6 +143,10 @@ export interface IPnpmOptionsJson extends IPackageManagerOptionsJsonBase {
    */
   minimumReleaseAge?: number;
   /**
+   * {@inheritDoc PnpmOptionsConfiguration.minimumReleaseAgeExclude}
+   */
+  minimumReleaseAgeExclude?: string[];
+  /**
    * {@inheritDoc PnpmOptionsConfiguration.alwaysInjectDependenciesFromOtherSubspaces}
    */
   alwaysInjectDependenciesFromOtherSubspaces?: boolean;
@@ -275,6 +279,19 @@ export class PnpmOptionsConfiguration extends PackageManagerOptionsConfiguration
    * The default value is 0 (disabled).
    */
   public readonly minimumReleaseAge: number | undefined;
+
+  /**
+   * List of package names or patterns that are excluded from the minimumReleaseAge check.
+   * These packages will always install the newest version immediately, even if minimumReleaseAge is set.
+   *
+   * @remarks
+   * (SUPPORTED ONLY IN PNPM 10.16.0 AND NEWER)
+   *
+   * PNPM documentation: https://pnpm.io/settings#minimumreleaseageexclude
+   *
+   * Example: ["webpack", "react", "\@myorg/*"]
+   */
+  public readonly minimumReleaseAgeExclude: string[] | undefined;
 
   /**
    * If true, then `rush update` add injected install options for all cross-subspace
@@ -444,6 +461,7 @@ export class PnpmOptionsConfiguration extends PackageManagerOptionsConfiguration
     this.resolutionMode = json.resolutionMode;
     this.autoInstallPeers = json.autoInstallPeers;
     this.minimumReleaseAge = json.minimumReleaseAge;
+    this.minimumReleaseAgeExclude = json.minimumReleaseAgeExclude;
     this.alwaysInjectDependenciesFromOtherSubspaces = json.alwaysInjectDependenciesFromOtherSubspaces;
     this.alwaysFullInstall = json.alwaysFullInstall;
     this.pnpmLockfilePolicies = json.pnpmLockfilePolicies;

--- a/libraries/rush-lib/src/logic/pnpm/test/PnpmOptionsConfiguration.test.ts
+++ b/libraries/rush-lib/src/logic/pnpm/test/PnpmOptionsConfiguration.test.ts
@@ -81,5 +81,9 @@ describe(PnpmOptionsConfiguration.name, () => {
     );
 
     expect(pnpmConfiguration.minimumReleaseAge).toEqual(1440);
+    expect(TestUtilities.stripAnnotations(pnpmConfiguration.minimumReleaseAgeExclude)).toEqual([
+      'webpack',
+      '@myorg/*'
+    ]);
   });
 });

--- a/libraries/rush-lib/src/logic/pnpm/test/jsonFiles/pnpm-config-minimumReleaseAge.json
+++ b/libraries/rush-lib/src/logic/pnpm/test/jsonFiles/pnpm-config-minimumReleaseAge.json
@@ -1,3 +1,4 @@
 {
-  "minimumReleaseAge": 1440
+  "minimumReleaseAge": 1440,
+  "minimumReleaseAgeExclude": ["webpack", "@myorg/*"]
 }

--- a/libraries/rush-lib/src/schemas/pnpm-config.schema.json
+++ b/libraries/rush-lib/src/schemas/pnpm-config.schema.json
@@ -196,6 +196,15 @@
       "type": "number"
     },
 
+    "minimumReleaseAgeExclude": {
+      "description": "List of package names or patterns that are excluded from the minimumReleaseAge check. These packages will always install the newest version immediately, even if minimumReleaseAge is set. Supports glob patterns (e.g., \"@myorg/*\").\n\n(SUPPORTED ONLY IN PNPM 10.16.0 AND NEWER)\n\nPNPM documentation: https://pnpm.io/settings#minimumreleaseageexclude\n\nExample: [\"webpack\", \"react\", \"@myorg/*\"]",
+      "type": "array",
+      "items": {
+        "description": "Package name or pattern",
+        "type": "string"
+      }
+    },
+
     "alwaysFullInstall": {
       "description": "(EXPERIMENTAL) If 'true', then filtered installs ('rush install --to my-project') * will be disregarded, instead always performing a full installation of the lockfile.",
       "type": "boolean"


### PR DESCRIPTION
# Pull Request Summary - Add PNPM minimumReleaseAge and minimumReleaseAgeExclude Support

## PR Title
```
[rush-lib] Add support for PNPM's minimumReleaseAge setting
```

## Summary

This PR adds support for PNPM's `minimumReleaseAge` and `minimumReleaseAgeExclude` settings in Rush's `pnpm-config.json` file. These settings help mitigate supply chain attacks by requiring a minimum age (in minutes) for package versions before they can be installed, with the ability to exclude trusted packages from this restriction.

**Fixes #5372**

## Details

### Changes Implemented (Updated based on code review feedback):

1. **Added `minimumReleaseAge` and `minimumReleaseAgeExclude` properties**
   - Added to `IPnpmOptionsJson` interface and `PnpmOptionsConfiguration` class
   - Full JSDoc documentation with examples and version requirements
   - `minimumReleaseAge`: number (minutes to wait after package release)
   - `minimumReleaseAgeExclude`: string[] (package names/patterns to exclude from the check)

2. **Updated JSON schema** (`pnpm-config.schema.json`)
   - Added validation for `minimumReleaseAge` (type: number)
   - Added validation for `minimumReleaseAgeExclude` (type: array of strings)
   - Includes comprehensive descriptions and examples

3. **Settings written to workspace package.json** (refactored based on feedback)
   - Modified `InstallHelpers.generateCommonPackageJson()` to write both settings to `common/temp/package.json` in the `pnpm` section
   - This approach is more robust than passing CLI arguments
   - Follows the same pattern as other PNPM workspace settings

4. **Added PNPM version validation**
   - Warns users if PNPM version < 10.16.0
   - Clear messaging guides users to either remove the settings or upgrade PNPM
   - Follows the same pattern as `globalIgnoredOptionalDependencies`

5. **Removed CLI argument approach**
   - Removed command-line argument passing from `BaseInstallManager.ts`
   - Removed `.npmrc` duplicate detection (no longer needed with package.json approach)

6. **Updated API documentation** in `rush-lib.api.md`

7. **Added comprehensive template documentation**
   - Updated Rush initialization template with examples
   - Clear documentation about PNPM version requirements
   - Examples showing both settings working together

8. **Added test coverage**
   - Updated `PnpmOptionsConfiguration.test.ts` to verify both settings
   - Added test fixture with both `minimumReleaseAge` and `minimumReleaseAgeExclude`

### Design decisions:

- Both settings are **optional** and default to undefined when not specified
- **Requires PNPM 10.16.0 or newer** (documented and validated)
- Settings are written to workspace `package.json` instead of passed as CLI args (more reliable)
- `minimumReleaseAgeExclude` supports glob patterns (e.g., `@myorg/*`) per PNPM 10.17.0+

### Backwards compatibility:

✅ This change is **fully backwards compatible**. Both settings are optional, and existing configurations will continue to work unchanged.

### Performance impact:

- **No performance impact** when the settings are not configured
- When enabled, PNPM handles the filtering, with minimal impact during dependency resolution

## Code Review Updates

This PR has been updated based on feedback from @D4N14L and @iclanton:

- ✅ Added `minimumReleaseAgeExclude` support
- ✅ Refactored to write settings to workspace `package.json` instead of CLI args
- ✅ Added PNPM version validation (10.16.0+)
- ✅ Removed rush-lib change file (keeping only template change file)
- ✅ Fixed TSDoc warning for `@` character escaping