### PR TITLE
[module-minifier] Allow disabling result cache

### DIFF
--- a/common/changes/@rushstack/module-minifier/module-minifier-no-cache_2025-10-23-21-27.json
+++ b/common/changes/@rushstack/module-minifier/module-minifier-no-cache_2025-10-23-21-27.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/module-minifier",
+      "comment": "Add the ability to disable the minifier result cache to \"LocalMinifier\" and \"WorkerPoolMinifier\".",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/module-minifier"
+}

--- a/common/reviews/api/module-minifier.api.md
+++ b/common/reviews/api/module-minifier.api.md
@@ -16,6 +16,7 @@ export function getIdentifier(ordinal: number): string;
 
 // @public
 export interface ILocalMinifierOptions {
+    cache?: boolean;
     // (undocumented)
     terserOptions?: MinifyOptions;
 }
@@ -77,6 +78,7 @@ export interface IModuleMinifierFunction {
 
 // @public
 export interface IWorkerPoolMinifierOptions {
+    cache?: boolean;
     maxThreads?: number;
     terserOptions?: MinifyOptions;
     verbose?: boolean;

--- a/libraries/module-minifier/src/test/LocalMinifier.test.ts
+++ b/libraries/module-minifier/src/test/LocalMinifier.test.ts
@@ -2,6 +2,7 @@
 // See LICENSE in the project root for license information.
 
 import type { IMinifierConnection } from '../types';
+import type { minifySingleFileAsync } from '../MinifySingleFile';
 
 let terserVersion: string = '1.0.0';
 jest.mock('terser/package.json', () => {
@@ -12,7 +13,25 @@ jest.mock('terser/package.json', () => {
   };
 });
 
+const mockMinifySingleFileAsync: jest.MockedFunction<typeof minifySingleFileAsync> = jest.fn();
+jest.mock('../MinifySingleFile', () => {
+  return {
+    minifySingleFileAsync: mockMinifySingleFileAsync
+  };
+});
+
 describe('LocalMinifier', () => {
+  beforeEach(() => {
+    mockMinifySingleFileAsync.mockReset().mockImplementation(async (req) => {
+      return {
+        code: `minified(${req.code})`,
+        map: undefined,
+        hash: req.hash,
+        error: undefined
+      };
+    });
+  });
+
   it('Includes terserOptions in config hash', async () => {
     const { LocalMinifier } = await import('../LocalMinifier');
     // eslint-disable-next-line @typescript-eslint/no-redeclare
@@ -57,5 +76,59 @@ describe('LocalMinifier', () => {
     expect(connection1.configHash).toMatchSnapshot('terser-5.9.1');
     expect(connection2.configHash).toMatchSnapshot('terser-5.16.1');
     expect(connection1.configHash !== connection2.configHash);
+  });
+
+  it('Deduplicates when cache is enabled', async () => {
+    const { LocalMinifier } = await import('../LocalMinifier');
+    // eslint-disable-next-line @typescript-eslint/no-redeclare
+    type LocalMinifier = typeof LocalMinifier.prototype;
+
+    const minifier1: LocalMinifier = new LocalMinifier({});
+
+    let completedRequests: number = 0;
+    function onRequestComplete(): void {
+      completedRequests++;
+    }
+
+    const connection1: IMinifierConnection = await minifier1.connectAsync();
+    await minifier1.minify(
+      { hash: 'hash1', code: 'code1', nameForMap: undefined, externals: undefined },
+      onRequestComplete
+    );
+    await minifier1.minify(
+      { hash: 'hash1', code: 'code1', nameForMap: undefined, externals: undefined },
+      onRequestComplete
+    );
+    await connection1.disconnectAsync();
+
+    expect(completedRequests).toBe(2);
+    expect(mockMinifySingleFileAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it('Does not deduplicate when cache is disabled', async () => {
+    const { LocalMinifier } = await import('../LocalMinifier');
+    // eslint-disable-next-line @typescript-eslint/no-redeclare
+    type LocalMinifier = typeof LocalMinifier.prototype;
+
+    const minifier1: LocalMinifier = new LocalMinifier({ cache: false });
+
+    let completedRequests: number = 0;
+    function onRequestComplete(): void {
+      completedRequests++;
+    }
+
+    const connection1: IMinifierConnection = await minifier1.connectAsync();
+    await minifier1.minify(
+      { hash: 'hash1', code: 'code1', nameForMap: undefined, externals: undefined },
+      onRequestComplete
+    );
+    await minifier1.minify(
+      { hash: 'hash1', code: 'code1', nameForMap: undefined, externals: undefined },
+      onRequestComplete
+    );
+    await connection1.disconnectAsync();
+
+    expect(completedRequests).toBe(2);
+    expect(mockMinifySingleFileAsync).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
## Summary
Adds an option to `@rushstack/module-minifier` to disable caching of results.

## Details
Supported for `LocalMinifier` and `WorkerPoolMinifier`

## How it was tested
Unit tests for `LocalMinifier`.

## Impacted documentation
API Doc for the package.