### PR TITLE
[heft-rspack-plugin] implement `DeferredWatchFileSystem`

### DIFF
--- a/common/changes/@rushstack/heft-webpack5-plugin/bmiddha-rspack-watchpack_2025-11-19-00-23.json
+++ b/common/changes/@rushstack/heft-webpack5-plugin/bmiddha-rspack-watchpack_2025-11-19-00-23.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-webpack5-plugin",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/heft-webpack5-plugin"
+}

--- a/common/config/subspaces/default/pnpm-lock.yaml
+++ b/common/config/subspaces/default/pnpm-lock.yaml
@@ -3081,6 +3081,9 @@ importers:
       tapable:
         specifier: 2.3.0
         version: 2.3.0
+      watchpack:
+        specifier: 2.4.0
+        version: 2.4.0
       webpack:
         specifier: ~5.98.0
         version: 5.98.0
@@ -3094,6 +3097,9 @@ importers:
       '@rushstack/terminal':
         specifier: workspace:*
         version: link:../../libraries/terminal
+      '@types/watchpack':
+        specifier: 2.4.0
+        version: 2.4.0
       eslint:
         specifier: ~9.37.0
         version: 9.37.0(supports-color@8.1.1)

--- a/heft-plugins/heft-rspack-plugin/package.json
+++ b/heft-plugins/heft-rspack-plugin/package.json
@@ -26,11 +26,13 @@
     "@rushstack/node-core-library": "workspace:*",
     "tapable": "2.3.0",
     "@rspack/dev-server": "^1.1.4",
+    "watchpack": "2.4.0",
     "webpack": "~5.98.0"
   },
   "devDependencies": {
     "@rushstack/heft": "workspace:*",
     "@rushstack/terminal": "workspace:*",
+    "@types/watchpack": "2.4.0",
     "eslint": "~9.37.0",
     "local-node-rig": "workspace:*",
     "@rspack/core": "~1.6.0-beta.0"

--- a/heft-plugins/heft-rspack-plugin/src/DeferredWatchFileSystem.ts
+++ b/heft-plugins/heft-rspack-plugin/src/DeferredWatchFileSystem.ts
@@ -1,0 +1,235 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import Watchpack, { type WatchOptions } from 'watchpack';
+import type { Compiler, RspackPluginInstance, WatchFileSystem } from '@rspack/core';
+
+// InputFileSystem type is defined inline since it's not exported from @rspack/core
+// missing re-export here: https://github.com/web-infra-dev/rspack/blob/9542b49ad43f91ecbcb37ff277e0445e67b99967/packages/rspack/src/exports.ts#L133
+// type definition here: https://github.com/web-infra-dev/rspack/blob/9542b49ad43f91ecbcb37ff277e0445e67b99967/packages/rspack/src/util/fs.ts#L496
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export interface InputFileSystem {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  readFile: (...args: any[]) => void;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  readlink: (...args: any[]) => void;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  readdir: (...args: any[]) => void;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  stat: (...args: any[]) => void;
+  purge?: (files?: string | string[] | Set<string>) => void;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: any;
+}
+
+export type WatchCallback = Parameters<WatchFileSystem['watch']>[5];
+export type WatchUndelayedCallback = Parameters<WatchFileSystem['watch']>[6];
+export type Watcher = ReturnType<WatchFileSystem['watch']>;
+export type WatcherInfo = ReturnType<Required<Watcher>['getInfo']>;
+type FileSystemMap = ReturnType<NonNullable<Watcher['getFileTimeInfoEntries']>>;
+
+interface IWatchState {
+  changes: Set<string>;
+  removals: Set<string>;
+
+  callback: WatchCallback;
+}
+
+interface ITimeEntry {
+  timestamp: number;
+  safeTime: number;
+}
+
+type IRawFileSystemMap = Map<string, ITimeEntry>;
+
+interface ITimeInfoEntries {
+  fileTimeInfoEntries: FileSystemMap;
+  contextTimeInfoEntries: FileSystemMap;
+}
+
+export class DeferredWatchFileSystem implements WatchFileSystem {
+  public readonly inputFileSystem: InputFileSystem;
+  public readonly watcherOptions: WatchOptions;
+  public watcher: Watchpack | undefined;
+
+  private readonly _onChange: () => void;
+  private _state: IWatchState | undefined;
+
+  public constructor(inputFileSystem: InputFileSystem, onChange: () => void) {
+    this.inputFileSystem = inputFileSystem;
+    this.watcherOptions = {
+      aggregateTimeout: 0
+    };
+    this.watcher = new Watchpack(this.watcherOptions);
+    this._onChange = onChange;
+  }
+
+  public flush(): boolean {
+    const state: IWatchState | undefined = this._state;
+
+    if (!state) {
+      return false;
+    }
+
+    const { changes, removals, callback } = state;
+
+    // Force flush the aggregation callback
+    const { changes: newChanges, removals: newRemovals } = this.watcher!.getAggregated();
+
+    // Rspack (like Webpack 5) treats changes and removals as separate things
+    if (newRemovals) {
+      for (const removal of newRemovals) {
+        changes.delete(removal);
+        removals.add(removal);
+      }
+    }
+    if (newChanges) {
+      for (const change of newChanges) {
+        removals.delete(change);
+        changes.add(change);
+      }
+    }
+
+    if (changes.size > 0 || removals.size > 0) {
+      this._purge(removals, changes);
+
+      const { fileTimeInfoEntries, contextTimeInfoEntries } = this._fetchTimeInfo();
+
+      callback(null, fileTimeInfoEntries, contextTimeInfoEntries, changes, removals);
+
+      changes.clear();
+      removals.clear();
+
+      return true;
+    }
+
+    return false;
+  }
+
+  public watch(
+    files: Iterable<string>,
+    directories: Iterable<string>,
+    missing: Iterable<string>,
+    startTime: number,
+    options: WatchOptions,
+    callback: WatchCallback,
+    callbackUndelayed: WatchUndelayedCallback
+  ): Watcher {
+    const oldWatcher: Watchpack | undefined = this.watcher;
+    this.watcher = new Watchpack(options);
+
+    const changes: Set<string> = new Set();
+    const removals: Set<string> = new Set();
+
+    this._state = {
+      changes,
+      removals,
+
+      callback
+    };
+
+    this.watcher.on('aggregated', (newChanges: Set<string>, newRemovals: Set<string>) => {
+      for (const change of newChanges) {
+        removals.delete(change);
+        changes.add(change);
+      }
+      for (const removal of newRemovals) {
+        changes.delete(removal);
+        removals.add(removal);
+      }
+
+      this._onChange();
+    });
+
+    this.watcher.watch({
+      files,
+      directories,
+      missing,
+      startTime
+    });
+
+    if (oldWatcher) {
+      oldWatcher.close();
+    }
+
+    return {
+      close: () => {
+        if (this.watcher) {
+          this.watcher.close();
+          this.watcher = undefined;
+        }
+      },
+      pause: () => {
+        if (this.watcher) {
+          this.watcher.pause();
+        }
+      },
+      getInfo: () => {
+        const newRemovals: Set<string> | undefined = this.watcher?.aggregatedRemovals;
+        const newChanges: Set<string> | undefined = this.watcher?.aggregatedChanges;
+        this._purge(newRemovals, newChanges);
+        const { fileTimeInfoEntries, contextTimeInfoEntries } = this._fetchTimeInfo();
+        return {
+          changes: newChanges!,
+          removals: newRemovals!,
+          fileTimeInfoEntries,
+          contextTimeInfoEntries
+        };
+      },
+      getContextTimeInfoEntries: () => {
+        const { contextTimeInfoEntries } = this._fetchTimeInfo();
+        return contextTimeInfoEntries;
+      },
+      getFileTimeInfoEntries: () => {
+        const { fileTimeInfoEntries } = this._fetchTimeInfo();
+        return fileTimeInfoEntries;
+      }
+    };
+  }
+
+  private _fetchTimeInfo(): ITimeInfoEntries {
+    const fileTimeInfoEntries: IRawFileSystemMap = new Map();
+    const contextTimeInfoEntries: IRawFileSystemMap = new Map();
+    this.watcher?.collectTimeInfoEntries(fileTimeInfoEntries, contextTimeInfoEntries);
+    return { fileTimeInfoEntries, contextTimeInfoEntries };
+  }
+
+  private _purge(removals: Set<string> | undefined, changes: Set<string> | undefined): void {
+    const fs: InputFileSystem = this.inputFileSystem;
+    if (fs.purge) {
+      if (removals) {
+        for (const removal of removals) {
+          fs.purge(removal);
+        }
+      }
+      if (changes) {
+        for (const change of changes) {
+          fs.purge(change);
+        }
+      }
+    }
+  }
+}
+
+export class OverrideNodeWatchFSPlugin implements RspackPluginInstance {
+  public readonly fileSystems: Set<DeferredWatchFileSystem> = new Set();
+  private readonly _onChange: () => void;
+
+  public constructor(onChange: () => void) {
+    this._onChange = onChange;
+  }
+
+  public apply(compiler: Compiler): void {
+    const { inputFileSystem } = compiler;
+    if (!inputFileSystem) {
+      throw new Error(`compiler.inputFileSystem is not defined`);
+    }
+
+    const watchFileSystem: DeferredWatchFileSystem = new DeferredWatchFileSystem(
+      inputFileSystem,
+      this._onChange
+    );
+    this.fileSystems.add(watchFileSystem);
+    compiler.watchFileSystem = watchFileSystem;
+  }
+}

--- a/heft-plugins/heft-webpack5-plugin/src/Webpack5Plugin.ts
+++ b/heft-plugins/heft-webpack5-plugin/src/Webpack5Plugin.ts
@@ -232,7 +232,7 @@ export default class Webpack5Plugin implements IHeftTaskPlugin<IWebpackPluginOpt
       this._validateEnvironmentVariable(taskSession);
       if (!taskSession.parameters.watch) {
         // Should never happen, but just in case
-        throw new InternalError('Cannot run Rspack in watch mode when watch mode is not enabled');
+        throw new InternalError('Cannot run Webpack in watch mode when watch mode is not enabled');
       }
 
       // Load the config and compiler, and return if there is no config found


### PR DESCRIPTION
## Summary

Copy the `DeferredWatchFileSystem` implementation for `heft-webpack5-plugin` and make it work with `heft-rspack-plugin`

Fixes #5452

## Details

An issue was reported where the rspack plugin gets stuck with `Cancelling incremental build...` message when an incremental build is running. This reproduces consistently when a change is made while a compilation is running.

This PR adds the `DeferredWatchFileSystem` from `heft-webpack5-plugin` which mitigates the issue.

This PR also has a change in `heft-webpack5-plugin` to update a logging message which incorrectly says "Rspack" instead of "Webpack"

## How it was tested

Tested that `heft build-watch` and `heft build-watch --serve` work when files are changed while a compilation is running.

## Impacted documentation
