### PR TITLE
[heft-rspack-plugin] Fix issue where ignoring ERR_MODULE_NOT_FOUND errors when importing the rspack config masks legitimate import issues

### DIFF
--- a/common/changes/@rushstack/heft-rspack-plugin/bmiddha-rspack-config-load_2025-11-21-22-35.json
+++ b/common/changes/@rushstack/heft-rspack-plugin/bmiddha-rspack-config-load_2025-11-21-22-35.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-rspack-plugin",
+      "comment": "Fix issue where ignoring ERR_MODULE_NOT_FOUND errors when importing the rspack config masks legitimate import issues.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft-rspack-plugin"
+}

--- a/heft-plugins/heft-rspack-plugin/src/RspackConfigurationLoader.ts
+++ b/heft-plugins/heft-rspack-plugin/src/RspackConfigurationLoader.ts
@@ -177,11 +177,6 @@ export async function _tryLoadRspackConfigurationFileInnerAsync(
       const configurationUri: string = pathToFileURL(configurationPath).href;
       return await import(configurationUri);
     } catch (e) {
-      const error: NodeJS.ErrnoException = e as NodeJS.ErrnoException;
-      if (error.code === 'ERR_MODULE_NOT_FOUND') {
-        // No configuration found, return undefined.
-        return undefined;
-      }
       throw new Error(`Error loading Rspack configuration at "${configurationPath}": ${e}`);
     }
   } else {


### PR DESCRIPTION
## Summary

Fix issue where ignoring ERR_MODULE_NOT_FOUND errors when importing the rspack config masks legitimate import issues

Fixes #5459

## Details

If there is a bad import in the rspack config. the issue is masked and the logs print "No Rspack configuration found"

<img width="731" height="199" alt="image" src="https://github.com/user-attachments/assets/4a2f587a-4abb-41f3-837c-93388476d828" />

Updated error handling to not ignore `ERR_MODULE_NOT_FOUND`

<img width="726" height="365" alt="image" src="https://github.com/user-attachments/assets/b94ae464-d397-401d-a629-8eff07f446c6" />

## How it was tested

Tested with `heft-rspack-everything-test`. To validate the error case, introduced a bad import.

## Impacted documentation


