### PR TITLE
[rush-lib] Add subspaceName information to the output of the rush list command

### DIFF
--- a/common/changes/@microsoft/rush/feature-add-subspace-name-for-rush-list-command_2025-11-24-12-44.json
+++ b/common/changes/@microsoft/rush/feature-add-subspace-name-for-rush-list-command_2025-11-24-12-44.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add subspaceName to the output of the `rush list` command",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/cli/actions/ListAction.ts
+++ b/libraries/rush-lib/src/cli/actions/ListAction.ts
@@ -45,6 +45,10 @@ export interface IJsonEntry {
    * @see {@link ../../api/RushConfigurationProject#RushConfigurationProject.tags | RushConfigurationProject.tags}
    */
   tags: string[];
+  /**
+   * @see {@link ../../api/Subspace#Subspace.subspaceName | Subspace.subspaceName}
+   */
+  subspaceName: string | undefined;
 }
 
 export interface IJsonOutput {
@@ -145,6 +149,7 @@ export class ListAction extends BaseRushAction {
       let shouldPublish: undefined | boolean;
       let versionPolicy: undefined | string;
       let versionPolicyName: undefined | string;
+      let subspaceName: undefined | string;
       if (config.versionPolicy !== undefined) {
         const definitionName: string = VersionPolicyDefinitionName[config.versionPolicy.definitionName];
         versionPolicy = `${definitionName}`;
@@ -157,6 +162,10 @@ export class ListAction extends BaseRushAction {
         reviewCategory = config.reviewCategory;
       }
 
+      if (this.rushConfiguration.subspacesFeatureEnabled) {
+        subspaceName = config.subspace.subspaceName;
+      }
+
       return {
         name: config.packageName,
         version: config.packageJson.version,
@@ -166,7 +175,8 @@ export class ListAction extends BaseRushAction {
         versionPolicyName,
         shouldPublish,
         reviewCategory,
-        tags: Array.from(config.tags)
+        tags: Array.from(config.tags),
+        subspaceName
       };
     });
 
@@ -186,6 +196,10 @@ export class ListAction extends BaseRushAction {
 
   private async _printListTableAsync(selection: Set<RushConfigurationProject>): Promise<void> {
     const tableHeader: string[] = ['Project'];
+    if (this.rushConfiguration.subspacesFeatureEnabled) {
+      tableHeader.push('Subspace');
+    }
+
     if (this._version.value || this._detailedFlag.value) {
       tableHeader.push('Version');
     }
@@ -218,6 +232,10 @@ export class ListAction extends BaseRushAction {
       }
 
       appendToPackageRow(project.packageName);
+
+      if (this.rushConfiguration.subspacesFeatureEnabled) {
+        appendToPackageRow(project.subspace.subspaceName);
+      }
 
       if (this._version.value || this._detailedFlag.value) {
         appendToPackageRow(project.packageJson.version);


### PR DESCRIPTION
## Summary

Add subspaceName information to the output of the rush list command when the subspace feature is enabled. So that `subspaceName` can be used as a filter criterion in [jq](https://jqlang.org/).


## Details

- add subspaceName in `IJsonEntry`
- add subspaceName in `_printJson` and `_printListTableAsync`

## How it was tested

- build rush-lib
- run `node libraries/rush-lib/lib/start.js --json`
  > Below is some excerpted output
  ```json
    {
      "name": "rush-project-change-analyzer-test",
      "version": "1.0.0",
      "path": "build-tests/rush-project-change-analyzer-test",
      "fullPath": "/Users/majunchen/lp/rushstack/build-tests/rush-project-change-analyzer-test",
      "shouldPublish": false,
      "reviewCategory": "tests",
      "tags": [],
      "subspaceName": "default"
    },
    {
      "name": "rush-redis-cobuild-plugin-integration-test",
      "version": "1.0.0",
      "path": "build-tests/rush-redis-cobuild-plugin-integration-test",
      "fullPath": "/Users/majunchen/lp/rushstack/build-tests/rush-redis-cobuild-plugin-integration-test",
      "shouldPublish": false,
      "reviewCategory": "tests",
      "tags": [],
      "subspaceName": "default"
    },
  ```

- run `node libraries/rush-lib/lib/start.js --detailed`
  > Below is a screenshot of detailed output
  <img width="3010" height="878" alt="image" src="https://github.com/user-attachments/assets/5508ead3-c4d3-4170-b276-63c6d5df69ea" />

## Impacted documentation

None
