### PR TITLE
Update issue template to ask package manager information

### DIFF
--- a/.github/ISSUE_TEMPLATE/rush.md
+++ b/.github/ISSUE_TEMPLATE/rush.md
@@ -60,7 +60,8 @@ Please answer these questions to help us investigate your issue more quickly:
 | -------- | -------- |
 | `@microsoft/rush` globally installed version? | <!-- X.Y.Z --> |
 | `rushVersion` from rush.json? | <!-- X.Y.Z --> |
-| `useWorkspaces` from rush.json? | <!-- X.Y.Z --> |
+| `pnpmVersion`, `npmVersion`, or `yarnVersion` from rush.json? | <!-- pnpm@X.Y.Z --> |
+| (if pnpm) `useWorkspaces` from pnpm-config.json? | <!-- X.Y.Z --> |
 | Operating system? | <!-- Windows / Mac / Linux --> |
 | Would you consider contributing a PR? | <!-- Yes / No --> |
 | Node.js version (`node -v`)? | <!-- X.Y.Z --> |


### PR DESCRIPTION
## Summary

Update issue template to ask package manager information. This may reduce a round trip or two when investigating compatibility issues with newer package manager releases.

## Details

Update issue template to ask about `pnpmVersion`, `npmVersion`, or `yarnVersion` from rush.json.

## How it was tested

## Impacted documentation

