### PR TITLE
[rush] Fix an issue with running npm commands.

### DIFF
--- a/common/changes/@microsoft/rush/fix-rush-publish_2026-01-12-19-17.json
+++ b/common/changes/@microsoft/rush/fix-rush-publish_2026-01-12-19-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@microsoft/rush"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/libraries/rush-lib/src/utilities/Npm.ts
+++ b/libraries/rush-lib/src/utilities/Npm.ts
@@ -19,7 +19,7 @@ async function runNpmCommandAndCaptureOutputAsync(
     captureExitCodeAndSignal: true
   });
 
-  if (signal !== undefined) {
+  if (signal) {
     throw new Error(`The npm command was terminated by signal: ${signal}. Output: ${stdout} ${stderr}`);
   } else if (exitCode !== 0) {
     throw new Error(`The npm command failed with exit code: ${exitCode}. Output: ${stdout} ${stderr}`);


### PR DESCRIPTION
## Summary

In the current prerelease of Rush, `rush publish` is broken when npm commands are run because `signal` is set to `null`, not `undefined`.

## How it was tested

Will be tested by another prerelease.

## Impacted documentation

None.