### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/file-doc-tickets.yml
+++ b/.github/workflows/file-doc-tickets.yml
@@ -76,7 +76,7 @@ jobs:
           fi
       - name: File ticket
         if: ${{ env.FILE_TICKET == '1' }}
-        uses: peter-evans/create-issue-from-file@af31b99c72f9e91877aea8a2d96fd613beafac84 # @v4 (locked)
+        uses: peter-evans/create-issue-from-file@fca9117c27cdc29c6c4db3b86c48e4115a786710  # v6.0.0
         with:
           repository: microsoft/rushstack-websites
           token: '${{ secrets.RUSHSTACK_WEBSITES_PR_TOKEN }}'


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions for improved features, bug fixes, and security updates.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `peter-evans/create-issue-from-file` | [`af31b99`](https://github.com/peter-evans/create-issue-from-file/commit/af31b99c72f9e91877aea8a2d96fd613beafac84) | [`fca9117`](https://github.com/peter-evans/create-issue-from-file/commit/fca9117c27cdc29c6c4db3b86c48e4115a786710) | [Release](https://github.com/peter-evans/create-issue-from-file/releases/tag/v6.0.0) | file-doc-tickets.yml |

## Why upgrade?

Keeping GitHub Actions up to date ensures:
- **Security**: Latest security patches and fixes
- **Features**: Access to new functionality and improvements
- **Compatibility**: Better support for current GitHub features
- **Performance**: Optimizations and efficiency improvements

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
