### PR TITLE
detach playwright-core usage with imports

### DIFF
--- a/vscode-extensions/playwright-on-codespaces-vscode-extension/package.json
+++ b/vscode-extensions/playwright-on-codespaces-vscode-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-on-codespaces",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/rushstack.git",

--- a/vscode-extensions/playwright-on-codespaces-vscode-extension/src/extension.ts
+++ b/vscode-extensions/playwright-on-codespaces-vscode-extension/src/extension.ts
@@ -5,16 +5,21 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 
-import {
-  PlaywrightTunnel,
-  type TunnelStatus,
-  type IHandshake,
-  EXTENSION_INSTALLED_FILENAME,
-  LaunchOptionsValidator,
-  type ILaunchOptionsAllowlist,
-  type ILaunchOptionsValidationResult,
-  getNormalizedErrorString
+import type {
+  TunnelStatus,
+  IHandshake,
+  ILaunchOptionsAllowlist,
+  ILaunchOptionsValidationResult
 } from '@rushstack/playwright-browser-tunnel';
+
+import { PlaywrightTunnel } from '@rushstack/playwright-browser-tunnel/lib/PlaywrightBrowserTunnel';
+
+import {
+  EXTENSION_INSTALLED_FILENAME,
+  getNormalizedErrorString
+} from '@rushstack/playwright-browser-tunnel/lib/utilities';
+import { LaunchOptionsValidator } from '@rushstack/playwright-browser-tunnel/lib/LaunchOptionsValidator';
+
 import { Terminal, type ITerminal, type ITerminalProvider } from '@rushstack/terminal';
 
 import { runWorkspaceCommandAsync } from '@rushstack/vscode-shared/lib/runWorkspaceCommandAsync';

--- a/vscode-extensions/playwright-on-codespaces-vscode-extension/webpack.config.js
+++ b/vscode-extensions/playwright-on-codespaces-vscode-extension/webpack.config.js
@@ -20,7 +20,6 @@ function createConfig({ production, webpack }) {
 
   // Mark problematic modules as externals to avoid webpack bundling issues
   const externals = /** @type {Record<string, string>} */ (config.externals || {});
-  externals['playwright-core'] = 'commonjs playwright-core';
   externals['bufferutil'] = 'commonjs bufferutil';
   externals['utf-8-validate'] = 'commonjs utf-8-validate';
   config.externals = externals;


### PR DESCRIPTION
Playwright on Codespaces VS Code Extension fails because `playwright-core` was being accidentally bundled into the extension (even though its only used for its type import). 

This PR fixes the type imports so that playwright-core is not bundled into the vscode extension.