### PR TITLE
Fix extension publish pipeline

### DIFF
--- a/common/config/azure-pipelines/templates/build.yaml
+++ b/common/config/azure-pipelines/templates/build.yaml
@@ -25,6 +25,6 @@ steps:
   - script: 'node common/scripts/install-run-rush.js retest --verbose --production ${{ parameters.BuildParameters }}'
     displayName: 'Rush retest (install-run-rush)'
 
-  - script: 'node common/scripts/install-run-rush.js retest --verbose --production -t package-manager-integration-test'
+  - script: 'npm run test'
     workingDirectory: 'build-tests/rush-package-manager-integration-test'
     displayName: 'Run package manager integration tests'

--- a/common/config/azure-pipelines/vscode-extension-publish.yaml
+++ b/common/config/azure-pipelines/vscode-extension-publish.yaml
@@ -63,9 +63,6 @@ extends:
               - template: /common/config/azure-pipelines/templates/install-node.yaml@self
 
               - template: /common/config/azure-pipelines/templates/build.yaml@self
-                parameters:
-                  BuildParameters: >
-                    --to tag:vsix
 
               - ${{ if parameters.shouldPublish }}:
                   - task: AzureCLI@2


### PR DESCRIPTION
After #5573 a new pipeline step was introduced in publish that seems busted for the extension pipeline. This fixes that. 