### PR TITLE
[playwright vscode extension] Normalize temporary directory path handling for remote environments

### DIFF
--- a/vscode-extensions/playwright-local-browser-server-vscode-extension/src/extension.ts
+++ b/vscode-extensions/playwright-local-browser-server-vscode-extension/src/extension.ts
@@ -42,6 +42,7 @@ async function writeExtensionInstalledFileAsync(terminal: ITerminal): Promise<vo
     // If on a remote environment, write a file to os.tempdir() using workspace fs
 
     let fileUri: vscode.Uri;
+    let tempDir: string;
 
     if (vscode.env.remoteName) {
       const markerPrefix: string = '<<<TEMPDIR_START>>>';
@@ -52,10 +53,13 @@ async function writeExtensionInstalledFileAsync(terminal: ITerminal): Promise<vo
         terminal
       });
 
-      const tempDir: string = output.slice(
-        output.indexOf(markerPrefix) + markerPrefix.length,
-        output.indexOf(markerSuffix)
-      );
+      const startIndex: number = output.indexOf(markerPrefix);
+      const endIndex: number = output.indexOf(markerSuffix);
+      if (startIndex !== -1 && endIndex !== -1 && endIndex > startIndex) {
+        tempDir = output.substring(startIndex + markerPrefix.length, endIndex).trim();
+      } else {
+        throw new Error('Failed to parse temp directory from command output');
+      }
 
       // For remote environments, use the vscode-remote scheme
       // The workspace folder should have the correct scheme already


### PR DESCRIPTION
Fancy terminals like oh-my-zsh or oh-my-posh will add extra characters onto terminal output. Which isn't friendly with [runWorkspaceCommandAsync](https://github.com/microsoft/rushstack/blob/5d96c39cc3da215541fae0fd3f2c506792d30838/vscode-extensions/vscode-shared/src/runWorkspaceCommandAsync.ts#L8)

This PR uses the same functionality as [debug-cert-extension](https://github.com/microsoft/rushstack/blob/5d96c39cc3da215541fae0fd3f2c506792d30838/vscode-extensions/debug-certificate-manager-vscode-extension/src/extension.ts#L210-L218).

Example of the bug (see the URI in terminal)
<img width="1619" height="549" alt="image" src="https://github.com/user-attachments/assets/b4cadee9-86b1-49d3-9321-1aa1ef742b07" />
