### PR TITLE
[playwright vscode extension] use `radio-tower` for the Waiting for Connection status

### DIFF
--- a/vscode-extensions/playwright-local-browser-server-vscode-extension/package.json
+++ b/vscode-extensions/playwright-local-browser-server-vscode-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-local-browser-server",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/rushstack.git",

--- a/vscode-extensions/playwright-local-browser-server-vscode-extension/src/extension.ts
+++ b/vscode-extensions/playwright-local-browser-server-vscode-extension/src/extension.ts
@@ -129,7 +129,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         statusBarItem.backgroundColor = undefined;
         break;
       case 'waiting-for-connection':
-        statusBarItem.text = '$(sync~spin) Playwright Tunnel';
+        statusBarItem.text = '$(radio-tower) Playwright Tunnel';
         statusBarItem.tooltip = 'Playwright Tunnel: Waiting for connection...';
         statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.warningBackground');
         break;


### PR DESCRIPTION
Got some feedback about the "Waiting for Connection" status icon that I liked:

> Yeah, a passive "Waiting" state shouldn't really use a spinner though

This PR addresses that by using a Radio tower icon instead: 
<img width="273" height="95" alt="image" src="https://github.com/user-attachments/assets/c09b1684-c305-4f0e-8316-21e7d45404b2" />

Also this PR bumps the extension as we've had at least one fix go in already and I forgot to bump the version since we haven't wroked on #5504 yet.  