### PR TITLE
Update minimatch from 10.0.3 to 10.1.2 to address GHSA-7h2j-956f-4vf2

### DIFF
--- a/apps/api-extractor/package.json
+++ b/apps/api-extractor/package.json
@@ -46,7 +46,7 @@
     "@rushstack/ts-command-line": "workspace:*",
     "diff": "~8.0.2",
     "lodash": "~4.17.15",
-    "minimatch": "10.0.3",
+    "minimatch": "10.1.2",
     "resolve": "~1.22.1",
     "semver": "~7.5.4",
     "source-map": "~0.6.1",

--- a/common/changes/@microsoft/api-extractor/update-mismatch_2026-02-04-12-42.json
+++ b/common/changes/@microsoft/api-extractor/update-mismatch_2026-02-04-12-42.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Update minimatch dependency from 10.0.3 to 10.1.2",
+      "type": "patch",
+      "packageName": "@microsoft/api-extractor"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "example@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/package-extractor/update-mismatch_2026-02-04-12-42.json
+++ b/common/changes/@rushstack/package-extractor/update-mismatch_2026-02-04-12-42.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Update minimatch dependency from 10.0.3 to 10.1.2",
+      "type": "patch",
+      "packageName": "@rushstack/package-extractor"
+    }
+  ],
+  "packageName": "@rushstack/package-extractor",
+  "email": "example@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/webpack4-localization-plugin/update-mismatch_2026-02-04-12-42.json
+++ b/common/changes/@rushstack/webpack4-localization-plugin/update-mismatch_2026-02-04-12-42.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Update minimatch dependency from 10.0.3 to 10.1.2",
+      "type": "patch",
+      "packageName": "@rushstack/webpack4-localization-plugin"
+    }
+  ],
+  "packageName": "@rushstack/webpack4-localization-plugin",
+  "email": "example@users.noreply.github.com"
+}

--- a/common/config/subspaces/build-tests-subspace/pnpm-lock.yaml
+++ b/common/config/subspaces/build-tests-subspace/pnpm-lock.yaml
@@ -425,8 +425,8 @@ packages:
     resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==}
     engines: {node: 20 || >=22}
 
-  '@isaacs/brace-expansion@5.0.0':
-    resolution: {integrity: sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==}
+  '@isaacs/brace-expansion@5.0.1':
+    resolution: {integrity: sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==}
     engines: {node: 20 || >=22}
 
   '@isaacs/fs-minipass@4.0.1':
@@ -843,7 +843,7 @@ packages:
   '@rushstack/heft-api-extractor-plugin@file:../../../heft-plugins/heft-api-extractor-plugin':
     resolution: {directory: ../../../heft-plugins/heft-api-extractor-plugin, type: directory}
     peerDependencies:
-      '@rushstack/heft': 1.1.10
+      '@rushstack/heft': 1.1.11
 
   '@rushstack/heft-config-file@file:../../../libraries/heft-config-file':
     resolution: {directory: ../../../libraries/heft-config-file, type: directory}
@@ -852,7 +852,7 @@ packages:
   '@rushstack/heft-jest-plugin@file:../../../heft-plugins/heft-jest-plugin':
     resolution: {directory: ../../../heft-plugins/heft-jest-plugin, type: directory}
     peerDependencies:
-      '@rushstack/heft': ^1.1.10
+      '@rushstack/heft': ^1.1.11
       jest-environment-jsdom: ^29.5.0
       jest-environment-node: ^29.5.0
     peerDependenciesMeta:
@@ -864,17 +864,17 @@ packages:
   '@rushstack/heft-lint-plugin@file:../../../heft-plugins/heft-lint-plugin':
     resolution: {directory: ../../../heft-plugins/heft-lint-plugin, type: directory}
     peerDependencies:
-      '@rushstack/heft': 1.1.10
+      '@rushstack/heft': 1.1.11
 
   '@rushstack/heft-node-rig@file:../../../rigs/heft-node-rig':
     resolution: {directory: ../../../rigs/heft-node-rig, type: directory}
     peerDependencies:
-      '@rushstack/heft': ^1.1.10
+      '@rushstack/heft': ^1.1.11
 
   '@rushstack/heft-typescript-plugin@file:../../../heft-plugins/heft-typescript-plugin':
     resolution: {directory: ../../../heft-plugins/heft-typescript-plugin, type: directory}
     peerDependencies:
-      '@rushstack/heft': 1.1.10
+      '@rushstack/heft': 1.1.11
 
   '@rushstack/heft@file:../../../apps/heft':
     resolution: {directory: ../../../apps/heft, type: directory}
@@ -2674,8 +2674,8 @@ packages:
     resolution: {integrity: sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==}
     engines: {node: '>=8'}
 
-  minimatch@10.0.3:
-    resolution: {integrity: sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==}
+  minimatch@10.1.2:
+    resolution: {integrity: sha512-fu656aJ0n2kcXwsnwnv9g24tkU5uSmOlTjd6WyyaKm2Z+h1qmY6bAjrcaIxF/BslFqbZ8UBtbJi7KgQOZD2PTw==}
     engines: {node: 20 || >=22}
 
   minimatch@3.1.2:
@@ -3885,7 +3885,7 @@ snapshots:
 
   '@isaacs/balanced-match@4.0.1': {}
 
-  '@isaacs/brace-expansion@5.0.0':
+  '@isaacs/brace-expansion@5.0.1':
     dependencies:
       '@isaacs/balanced-match': 4.0.1
 
@@ -4170,7 +4170,7 @@ snapshots:
       '@rushstack/ts-command-line': file:../../../libraries/ts-command-line(@types/node@20.17.19)
       diff: 8.0.3
       lodash: 4.17.23
-      minimatch: 10.0.3
+      minimatch: 10.1.2
       resolve: 1.22.11
       semver: 7.5.4
       source-map: 0.6.1
@@ -4765,7 +4765,7 @@ snapshots:
       '@rushstack/ts-command-line': file:../../../libraries/ts-command-line(@types/node@20.17.19)
       ignore: 5.1.9
       jszip: 3.8.0
-      minimatch: 10.0.3
+      minimatch: 10.1.2
       npm-packlist: 5.1.3
       semver: 7.5.4
     transitivePeerDependencies:
@@ -7233,9 +7233,9 @@ snapshots:
 
   mimic-fn@3.1.0: {}
 
-  minimatch@10.0.3:
+  minimatch@10.1.2:
     dependencies:
-      '@isaacs/brace-expansion': 5.0.0
+      '@isaacs/brace-expansion': 5.0.1
 
   minimatch@3.1.2:
     dependencies:

--- a/common/config/subspaces/build-tests-subspace/repo-state.json
+++ b/common/config/subspaces/build-tests-subspace/repo-state.json
@@ -1,6 +1,6 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "5d9bc6eee5c9d99eb1d47a58664f6c7488199d42",
+  "pnpmShrinkwrapHash": "16050ece698e5d98fb8342e002b43246ea65f8d8",
   "preferredVersionsHash": "550b4cee0bef4e97db6c6aad726df5149d20e7d9",
-  "packageJsonInjectedDependenciesHash": "88585d29209a34b4908b0928fd68566f978c2bca"
+  "packageJsonInjectedDependenciesHash": "4c27699529576ee6f99d567318387412f007dbc7"
 }

--- a/common/config/subspaces/default/common-versions.json
+++ b/common/config/subspaces/default/common-versions.json
@@ -35,7 +35,7 @@
     "eslint": "~9.37.0",
 
     // Updated minimatch and its types to latest major version to resolve ReDoS vulnerability
-    "minimatch": "10.0.3"
+    "minimatch": "10.1.2"
   },
 
   /**

--- a/common/config/subspaces/default/pnpm-lock.yaml
+++ b/common/config/subspaces/default/pnpm-lock.yaml
@@ -88,8 +88,8 @@ importers:
         specifier: ~4.17.15
         version: 4.17.23
       minimatch:
-        specifier: 10.0.3
-        version: 10.0.3
+        specifier: 10.1.2
+        version: 10.1.2
       resolve:
         specifier: ~1.22.1
         version: 1.22.11
@@ -783,7 +783,7 @@ importers:
         version: 6.4.22(@types/react@17.0.74)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@storybook/cli':
         specifier: ~6.4.18
-        version: 6.4.22(eslint@9.37.0)(jest@29.3.1(@types/node@20.17.19))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.8.2)
+        version: 6.4.22(eslint@9.37.0)(jest@29.3.1(@types/node@20.17.19)(babel-plugin-macros@3.1.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.8.2)
       '@storybook/components':
         specifier: ~6.4.18
         version: 6.4.22(@types/react@17.0.74)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
@@ -819,7 +819,7 @@ importers:
         version: 5.2.7(webpack@4.47.0)
       jest:
         specifier: ~29.3.1
-        version: 29.3.1(@types/node@20.17.19)
+        version: 29.3.1(@types/node@20.17.19)(babel-plugin-macros@3.1.0)
       react:
         specifier: ~17.0.2
         version: 17.0.2
@@ -1005,7 +1005,7 @@ importers:
         version: 5.2.7(webpack@5.103.0)
       jest:
         specifier: ~29.3.1
-        version: 29.3.1(@types/node@20.17.19)
+        version: 29.3.1(@types/node@20.17.19)(babel-plugin-macros@3.1.0)
       react:
         specifier: ~19.2.3
         version: 19.2.4
@@ -3942,8 +3942,8 @@ importers:
         specifier: ~3.8.0
         version: 3.8.0
       minimatch:
-        specifier: 10.0.3
-        version: 10.0.3
+        specifier: 10.1.2
+        version: 10.1.2
       npm-packlist:
         specifier: ~5.1.3
         version: 5.1.3
@@ -5594,8 +5594,8 @@ importers:
         specifier: 1.4.2
         version: 1.4.2
       minimatch:
-        specifier: 10.0.3
-        version: 10.0.3
+        specifier: 10.1.2
+        version: 10.1.2
     devDependencies:
       '@rushstack/heft':
         specifier: workspace:*
@@ -7945,6 +7945,10 @@ packages:
 
   '@isaacs/brace-expansion@5.0.0':
     resolution: {integrity: sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==}
+    engines: {node: 20 || >=22}
+
+  '@isaacs/brace-expansion@5.0.1':
+    resolution: {integrity: sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==}
     engines: {node: 20 || >=22}
 
   '@isaacs/cliui@8.0.2':
@@ -15140,8 +15144,8 @@ packages:
     resolution: {integrity: sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==}
     engines: {node: 20 || >=22}
 
-  minimatch@10.1.1:
-    resolution: {integrity: sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==}
+  minimatch@10.1.2:
+    resolution: {integrity: sha512-fu656aJ0n2kcXwsnwnv9g24tkU5uSmOlTjd6WyyaKm2Z+h1qmY6bAjrcaIxF/BslFqbZ8UBtbJi7KgQOZD2PTw==}
     engines: {node: 20 || >=22}
 
   minimatch@3.1.2:
@@ -22309,6 +22313,10 @@ snapshots:
     dependencies:
       '@isaacs/balanced-match': 4.0.1
 
+  '@isaacs/brace-expansion@5.0.1':
+    dependencies:
+      '@isaacs/balanced-match': 4.0.1
+
   '@isaacs/cliui@8.0.2':
     dependencies:
       string-width: 5.1.2
@@ -22376,7 +22384,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/core@29.7.0':
+  '@jest/core@29.7.0(babel-plugin-macros@3.1.0)':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
@@ -22390,7 +22398,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@22.9.3)
+      jest-config: 29.7.0(@types/node@22.9.3)(babel-plugin-macros@3.1.0)
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -25101,7 +25109,7 @@ snapshots:
       ts-dedent: 2.2.0
       util-deprecate: 1.0.2
 
-  '@storybook/cli@6.4.22(eslint@9.37.0)(jest@29.3.1(@types/node@20.17.19))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.8.2)':
+  '@storybook/cli@6.4.22(eslint@9.37.0)(jest@29.3.1(@types/node@20.17.19)(babel-plugin-macros@3.1.0))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.8.2)':
     dependencies:
       '@babel/core': 7.20.12
       '@babel/preset-env': 7.28.6(@babel/core@7.20.12)
@@ -25121,7 +25129,7 @@ snapshots:
       fs-extra: 9.1.0
       get-port: 5.1.1
       globby: 11.1.0
-      jest: 29.3.1(@types/node@20.17.19)
+      jest: 29.3.1(@types/node@20.17.19)(babel-plugin-macros@3.1.0)
       jscodeshift: 0.13.1(@babel/preset-env@7.28.6(@babel/core@7.20.12))
       json5: 2.2.3
       leven: 3.1.0
@@ -26171,7 +26179,7 @@ snapshots:
 
   '@types/minimatch@6.0.0':
     dependencies:
-      minimatch: 10.0.3
+      minimatch: 10.1.2
 
   '@types/mocha@10.0.6': {}
 
@@ -28714,13 +28722,13 @@ snapshots:
       safe-buffer: 5.2.1
       sha.js: 2.4.12
 
-  create-jest@29.7.0(@types/node@20.17.19):
+  create-jest@29.7.0(@types/node@20.17.19)(babel-plugin-macros@3.1.0):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@20.17.19)
+      jest-config: 29.7.0(@types/node@20.17.19)(babel-plugin-macros@3.1.0)
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -31125,7 +31133,7 @@ snapshots:
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 4.1.1
-      minimatch: 10.1.1
+      minimatch: 10.1.2
       minipass: 7.1.2
       package-json-from-dist: 1.0.1
       path-scurry: 2.0.1
@@ -32086,16 +32094,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@20.17.19):
+  jest-cli@29.7.0(@types/node@20.17.19)(babel-plugin-macros@3.1.0):
     dependencies:
-      '@jest/core': 29.7.0
+      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)
       '@jest/test-result': 29.7.0(@types/node@20.17.19)
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@20.17.19)
+      create-jest: 29.7.0(@types/node@20.17.19)(babel-plugin-macros@3.1.0)
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@20.17.19)
+      jest-config: 29.7.0(@types/node@20.17.19)(babel-plugin-macros@3.1.0)
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -32165,7 +32173,7 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@29.7.0(@types/node@20.17.19):
+  jest-config@29.7.0(@types/node@20.17.19)(babel-plugin-macros@3.1.0):
     dependencies:
       '@babel/core': 7.20.12
       '@jest/test-sequencer': 29.7.0(@types/node@20.17.19)
@@ -32195,7 +32203,7 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@29.7.0(@types/node@22.9.3):
+  jest-config@29.7.0(@types/node@22.9.3)(babel-plugin-macros@3.1.0):
     dependencies:
       '@babel/core': 7.20.12
       '@jest/test-sequencer': 29.7.0(@types/node@22.9.3)
@@ -32583,12 +32591,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.3.1(@types/node@20.17.19):
+  jest@29.3.1(@types/node@20.17.19)(babel-plugin-macros@3.1.0):
     dependencies:
       '@jest/core': 29.5.0(babel-plugin-macros@3.1.0)
       '@jest/types': 29.5.0
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@20.17.19)
+      jest-cli: 29.7.0(@types/node@20.17.19)(babel-plugin-macros@3.1.0)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -33262,9 +33270,9 @@ snapshots:
     dependencies:
       '@isaacs/brace-expansion': 5.0.0
 
-  minimatch@10.1.1:
+  minimatch@10.1.2:
     dependencies:
-      '@isaacs/brace-expansion': 5.0.0
+      '@isaacs/brace-expansion': 5.0.1
 
   minimatch@3.1.2:
     dependencies:

--- a/common/config/subspaces/default/repo-state.json
+++ b/common/config/subspaces/default/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "b0dbc9dd6df6e790055edb199b9d85eb3a0f200f",
-  "preferredVersionsHash": "a9b67c38568259823f9cfb8270b31bf6d8470b27"
+  "pnpmShrinkwrapHash": "345b360cf73eecb3bc6fc478b7ed922496596845",
+  "preferredVersionsHash": "9ba05fe872434900a0b29c308a94015078f37c47"
 }

--- a/libraries/package-extractor/package.json
+++ b/libraries/package-extractor/package.json
@@ -23,7 +23,7 @@
     "@rushstack/ts-command-line": "workspace:*",
     "ignore": "~5.1.6",
     "jszip": "~3.8.0",
-    "minimatch": "10.0.3",
+    "minimatch": "10.1.2",
     "npm-packlist": "~5.1.3",
     "semver": "~7.5.4"
   },

--- a/webpack/webpack4-localization-plugin/package.json
+++ b/webpack/webpack4-localization-plugin/package.json
@@ -37,7 +37,7 @@
     "@rushstack/terminal": "workspace:*",
     "@types/tapable": "1.0.6",
     "loader-utils": "1.4.2",
-    "minimatch": "10.0.3"
+    "minimatch": "10.1.2"
   },
   "devDependencies": {
     "@rushstack/heft": "workspace:*",


### PR DESCRIPTION
## Summary

Updates the `minimatch` dependency from 10.0.3 to 10.1.2 across the monorepo to address a Regular Expression Denial of Service (ReDoS) vulnerability in the underlying `brace-expansion` dependency.

**Security Advisory:** https://github.com/advisories/GHSA-7h2j-956f-4vf2

## Details

Updated `minimatch` in the following packages:
- `@microsoft/api-extractor`
- `@rushstack/package-extractor`
- `@rushstack/webpack4-localization-plugin`
- `common-versions.json` (preferred version)

**Changes in minimatch 10.0.3 → 10.1.2:**
- Add `magicalBraces` option for `escape` function
- Fix `makeRe` when `partial: true` is set
- Fix `makeRe` when pattern ends in final `**` path part

**Breaking changes:** None. The API usage in the affected packages only uses the basic `minimatch(string, pattern)` function, which remains unchanged.

## How it was tested

- Ran `rush update` successfully
- Built all affected packages (`rush build -t @microsoft/api-extractor -t @rushstack/package-extractor -t @rushstack/webpack4-localization-plugin`) - 32 operations succeeded
- Ran api-extractor tests - 61 tests passed
- Ran package-extractor tests - 12 tests passed
