### PR TITLE
[rush] Add an option to make the Rush operation hash depend on the NodeJS version.

### DIFF
--- a/common/changes/@microsoft/rush-lib/rush-project-dependsOnNodeVersion_2026-02-17-00-00.json
+++ b/common/changes/@microsoft/rush-lib/rush-project-dependsOnNodeVersion_2026-02-17-00-00.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Add a new `dependsOnNodeVersion` setting for operation entries in rush-project.json. When set to `true`, the Node.js version is included in the build cache hash, ensuring that cached outputs are invalidated when the Node.js version changes.",
+      "comment": "Add a new `dependsOnNodeVersion` setting for operation entries in rush-project.json. When enabled, the Node.js version is included in the build cache hash, ensuring that cached outputs are invalidated when the Node.js version changes. Accepts `true` (alias for `\"patch\"`), `\"major\"`, `\"minor\"`, or `\"patch\"` to control the granularity of version matching.",
       "type": "none"
     }
   ],

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -669,7 +669,7 @@ export interface IOperationSettings {
     allowCobuildWithoutCache?: boolean;
     dependsOnAdditionalFiles?: string[];
     dependsOnEnvVars?: string[];
-    dependsOnNodeVersion?: boolean;
+    dependsOnNodeVersion?: boolean | NodeVersionGranularity;
     disableBuildCacheForOperation?: boolean;
     ignoreChangedProjectsOnlyFlag?: boolean;
     operationName: string;
@@ -961,6 +961,9 @@ export class LockStepVersionPolicy extends VersionPolicy {
 }
 
 export { LookupByPath }
+
+// @alpha
+export type NodeVersionGranularity = 'major' | 'minor' | 'patch';
 
 // @public
 export class NpmOptionsConfiguration extends PackageManagerOptionsConfigurationBase {

--- a/libraries/rush-lib/src/api/RushProjectConfiguration.ts
+++ b/libraries/rush-lib/src/api/RushProjectConfiguration.ts
@@ -73,6 +73,17 @@ export interface IRushPhaseSharding {
 }
 
 /**
+ * The granularity at which the Node.js version is included in the build cache hash.
+ *
+ * - `"major"` — includes only the major version (e.g. `18`)
+ * - `"minor"` — includes the major and minor version (e.g. `18.17`)
+ * - `"patch"` — includes the full version (e.g. `18.17.1`)
+ *
+ * @alpha
+ */
+export type NodeVersionGranularity = 'major' | 'minor' | 'patch';
+
+/**
  * @alpha
  */
 export interface IOperationSettings {
@@ -113,12 +124,18 @@ export interface IOperationSettings {
   dependsOnEnvVars?: string[];
 
   /**
-   * If set to true, the Node.js version (process.version) will be included in the hash used for the
-   * build cache. This ensures that if the Node.js version changes, cached outputs will be invalidated
-   * and the operation will be re-executed. This is useful for projects that produce
-   * Node.js-version-specific outputs, such as native module builds.
+   * Specifies whether and at what granularity the Node.js version should be included in the hash
+   * used for the build cache. When enabled, changing the Node.js version at the specified granularity
+   * will invalidate cached outputs and cause the operation to be re-executed. This is useful for
+   * projects that produce Node.js-version-specific outputs, such as native module builds.
+   *
+   * Allowed values:
+   * - `true` — alias for `"patch"`, includes the full version (e.g. `18.17.1`)
+   * - `"major"` — includes only the major version (e.g. `18`)
+   * - `"minor"` — includes the major and minor version (e.g. `18.17`)
+   * - `"patch"` — includes the full version (e.g. `18.17.1`)
    */
-  dependsOnNodeVersion?: boolean;
+  dependsOnNodeVersion?: boolean | NodeVersionGranularity;
 
   /**
    * An optional list of glob (minimatch) patterns pointing to files that can affect this operation.

--- a/libraries/rush-lib/src/index.ts
+++ b/libraries/rush-lib/src/index.ts
@@ -79,6 +79,7 @@ export { RushConfigurationProject } from './api/RushConfigurationProject';
 export {
   type IRushProjectJson as _IRushProjectJson,
   type IOperationSettings,
+  type NodeVersionGranularity,
   RushProjectConfiguration,
   type IRushPhaseSharding
 } from './api/RushProjectConfiguration';

--- a/libraries/rush-lib/src/logic/incremental/test/InputsSnapshot.test.ts
+++ b/libraries/rush-lib/src/logic/incremental/test/InputsSnapshot.test.ts
@@ -467,6 +467,153 @@ describe(InputsSnapshot.name, () => {
       expect(result2).not.toEqual(result1);
     });
 
+    it('Respects dependsOnNodeVersion with major granularity', () => {
+      const { project, options } = getTestConfig();
+
+      const projectConfig: Pick<RushProjectConfiguration, 'operationSettingsByOperationName'> = {
+        operationSettingsByOperationName: new Map([
+          [
+            '_phase:build',
+            {
+              operationName: '_phase:build',
+              dependsOnNodeVersion: 'major'
+            }
+          ]
+        ])
+      };
+
+      // Same major, different minor — should produce the same hash
+      const input1: InputsSnapshot = new InputsSnapshot({
+        ...options,
+        projectMap: new Map([[project, { projectConfig: projectConfig as RushProjectConfiguration }]]),
+        nodeVersion: 'v18.17.0'
+      });
+
+      const input2: InputsSnapshot = new InputsSnapshot({
+        ...options,
+        projectMap: new Map([[project, { projectConfig: projectConfig as RushProjectConfiguration }]]),
+        nodeVersion: 'v18.20.3'
+      });
+
+      const result1: string = input1.getOperationOwnStateHash(project, '_phase:build');
+      const result2: string = input2.getOperationOwnStateHash(project, '_phase:build');
+
+      expect(result1).toEqual(result2);
+
+      // Different major — should produce a different hash
+      const input3: InputsSnapshot = new InputsSnapshot({
+        ...options,
+        projectMap: new Map([[project, { projectConfig: projectConfig as RushProjectConfiguration }]]),
+        nodeVersion: 'v20.10.0'
+      });
+
+      const result3: string = input3.getOperationOwnStateHash(project, '_phase:build');
+
+      expect(result3).not.toEqual(result1);
+    });
+
+    it('Respects dependsOnNodeVersion with minor granularity', () => {
+      const { project, options } = getTestConfig();
+
+      const projectConfig: Pick<RushProjectConfiguration, 'operationSettingsByOperationName'> = {
+        operationSettingsByOperationName: new Map([
+          [
+            '_phase:build',
+            {
+              operationName: '_phase:build',
+              dependsOnNodeVersion: 'minor'
+            }
+          ]
+        ])
+      };
+
+      // Same major.minor, different patch — should produce the same hash
+      const input1: InputsSnapshot = new InputsSnapshot({
+        ...options,
+        projectMap: new Map([[project, { projectConfig: projectConfig as RushProjectConfiguration }]]),
+        nodeVersion: 'v18.17.0'
+      });
+
+      const input2: InputsSnapshot = new InputsSnapshot({
+        ...options,
+        projectMap: new Map([[project, { projectConfig: projectConfig as RushProjectConfiguration }]]),
+        nodeVersion: 'v18.17.5'
+      });
+
+      const result1: string = input1.getOperationOwnStateHash(project, '_phase:build');
+      const result2: string = input2.getOperationOwnStateHash(project, '_phase:build');
+
+      expect(result1).toEqual(result2);
+
+      // Different minor — should produce a different hash
+      const input3: InputsSnapshot = new InputsSnapshot({
+        ...options,
+        projectMap: new Map([[project, { projectConfig: projectConfig as RushProjectConfiguration }]]),
+        nodeVersion: 'v18.20.0'
+      });
+
+      const result3: string = input3.getOperationOwnStateHash(project, '_phase:build');
+
+      expect(result3).not.toEqual(result1);
+    });
+
+    it('Respects dependsOnNodeVersion with patch granularity', () => {
+      const { project, options } = getTestConfig();
+
+      const projectConfig: Pick<RushProjectConfiguration, 'operationSettingsByOperationName'> = {
+        operationSettingsByOperationName: new Map([
+          [
+            '_phase:build',
+            {
+              operationName: '_phase:build',
+              dependsOnNodeVersion: 'patch'
+            }
+          ]
+        ])
+      };
+
+      // true and 'patch' should produce identical hashes
+      const projectConfigTrue: Pick<RushProjectConfiguration, 'operationSettingsByOperationName'> = {
+        operationSettingsByOperationName: new Map([
+          [
+            '_phase:build',
+            {
+              operationName: '_phase:build',
+              dependsOnNodeVersion: true
+            }
+          ]
+        ])
+      };
+
+      const inputPatch: InputsSnapshot = new InputsSnapshot({
+        ...options,
+        projectMap: new Map([[project, { projectConfig: projectConfig as RushProjectConfiguration }]]),
+        nodeVersion: 'v18.17.1'
+      });
+
+      const inputTrue: InputsSnapshot = new InputsSnapshot({
+        ...options,
+        projectMap: new Map([[project, { projectConfig: projectConfigTrue as RushProjectConfiguration }]]),
+        nodeVersion: 'v18.17.1'
+      });
+
+      const resultPatch: string = inputPatch.getOperationOwnStateHash(project, '_phase:build');
+      const resultTrue: string = inputTrue.getOperationOwnStateHash(project, '_phase:build');
+
+      expect(resultPatch).toEqual(resultTrue);
+
+      // Different patch — should produce a different hash
+      const input2: InputsSnapshot = new InputsSnapshot({
+        ...options,
+        projectMap: new Map([[project, { projectConfig: projectConfig as RushProjectConfiguration }]]),
+        nodeVersion: 'v18.17.2'
+      });
+
+      const result2: string = input2.getOperationOwnStateHash(project, '_phase:build');
+
+      expect(result2).not.toEqual(resultPatch);
+    });
+
     it('Does not include node version when dependsOnNodeVersion is not set', () => {
       const { project, options } = getTestConfig();
 

--- a/libraries/rush-lib/src/logic/incremental/test/__snapshots__/InputsSnapshot.test.ts.snap
+++ b/libraries/rush-lib/src/logic/incremental/test/__snapshots__/InputsSnapshot.test.ts.snap
@@ -10,9 +10,9 @@ exports[`InputsSnapshot getOperationOwnStateHash Respects dependsOnEnvVars 1`] =
 
 exports[`InputsSnapshot getOperationOwnStateHash Respects dependsOnEnvVars 2`] = `"2c68d56fc9278b6495496070a6a992b929c37a83"`;
 
-exports[`InputsSnapshot getOperationOwnStateHash Respects dependsOnNodeVersion 1`] = `"df8e519b405d7deca932c0085c1c6b48b57ae4fc"`;
+exports[`InputsSnapshot getOperationOwnStateHash Respects dependsOnNodeVersion 1`] = `"bdfb861c2d1106b68b604b74e13f1c3f95095df6"`;
 
-exports[`InputsSnapshot getOperationOwnStateHash Respects dependsOnNodeVersion 2`] = `"8323bdc4729024e6f0e4b4378f0f3e6bef96dce2"`;
+exports[`InputsSnapshot getOperationOwnStateHash Respects dependsOnNodeVersion 2`] = `"cc182bde6aa81c0410ede7db22f3af2f0a24d3e3"`;
 
 exports[`InputsSnapshot getOperationOwnStateHash Respects globalAdditionalFiles 1`] = `"0e0437ad1941bacd098b22da15dc673f86ca6003"`;
 

--- a/libraries/rush-lib/src/schemas/rush-project.schema.json
+++ b/libraries/rush-lib/src/schemas/rush-project.schema.json
@@ -99,8 +99,11 @@
             }
           },
           "dependsOnNodeVersion": {
-            "description": "If set to true, the Node.js version (process.version) will be included in the hash used for the build cache. This ensures that if the Node.js version changes, cached outputs will be invalidated and the operation will be re-executed. This is useful for projects that produce Node.js-version-specific outputs, such as native module builds.",
-            "type": "boolean"
+            "description": "Specifies whether and at what granularity the Node.js version should be included in the hash used for the build cache. When enabled, changing the Node.js version at the specified granularity will invalidate cached outputs and cause the operation to be re-executed. This is useful for projects that produce Node.js-version-specific outputs, such as native module builds. Allowed values: true (alias for 'patch'), 'major' (e.g. '18'), 'minor' (e.g. '18.17'), or 'patch' (e.g. '18.17.1').",
+            "oneOf": [
+              { "type": "boolean", "enum": [true] },
+              { "type": "string", "enum": ["major", "minor", "patch"] }
+            ]
           },
           "weight": {
             "description": "The number of concurrency units that this operation should take up. The maximum concurrency units is determined by the -p flag.",


### PR DESCRIPTION
## Summary

Add a `dependsOnNodeVersion` setting to `config/rush-project.json` that allows a project's build cache hash to incorporate the Node.js version. This ensures that projects whose build output varies by Node version get correct cache hits/misses.

Two motivating scenarios:
1. **Projects with Node-version-dependent behavior** - e.g. [heft-storybook-v9-react-tutorial](https://github.com/microsoft/rushstack/tree/main/build-tests-samples/heft-storybook-v9-react-tutorial) conditionally disables Storybook under Node 18.
2. **Repos that validate builds across multiple Node versions in CI** - e.g. this repo's CI runs build across Node 18/20/22/24. Without Node version in the cache key, a cloud cache entry written by one Node version can be incorrectly restored by another.

## Details

A new `dependsOnNodeVersion` property is added to `operationSettings` in `rush-project.json`. It accepts:
- `true` - include the full patch version (e.g. `24.13.0`) in the cache hash (alias for `"patch"`)
- `"major"` - include only the major version (e.g. `24`)
- `"minor"` - include the major.minor version (e.g. `24.13`)
- `"patch"` - include the full major.minor.patch version (e.g. `24.13.0`)

The granularity options let teams choose the right cache invalidation tradeoff. For example, `"major"` avoids unnecessary rebuilds between patch or minor Node versions, while `"patch"` ensures exact reproducibility.

Implementation:
- Updated `rush-project.schema.json` with a `oneOf` accepting `true` or a string enum
- Added `NodeVersionGranularity` type alias (`'major' | 'minor' | 'patch'`) to `IOperationSettings` and exported it from `rush-lib`
- Extended `InputsSnapshot` to pre-compute Node version strings for all granularities once in the constructor, and include the appropriate string in `getOperationOwnStateHash()` when the setting is present
- No backwards compatibility concerns - the setting is optional and defaults to not including Node version (preserving existing behavior)

## How it was tested

Added unit tests to `InputsSnapshot.test.ts` covering: `dependsOnNodeVersion: true`, each granularity level (`"major"`, `"minor"`, `"patch"`), equivalence of `true` and `"patch"`, and the default case (no Node version in hash)

## Impacted documentation

- https://rushjs.io/pages/configs/rush-project_json/ (new `dependsOnNodeVersion` property in `operationSettings`)
- JSON schema: `rush-lib/src/schemas/rush-project.schema.json`