### PR TITLE
[rush] Fix .npmrc syncing cache bug that strips pnpm hoisting properties

### DIFF
--- a/common/changes/@microsoft/rush-lib/fix-npmrc-syncing_2026-02-19-02-14.json
+++ b/common/changes/@microsoft/rush-lib/fix-npmrc-syncing_2026-02-19-02-14.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix .npmrc syncing to common/temp incorrectly caching results, which caused pnpm-specific properties like hoist-pattern to be stripped when the same .npmrc was processed with different options.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/utilities/npmrcUtilities.ts
+++ b/libraries/rush-lib/src/utilities/npmrcUtilities.ts
@@ -19,9 +19,6 @@ export interface ILogger {
  * The text of the the .npmrc.
  */
 
-// create a global _combinedNpmrc for cache purpose
-const _combinedNpmrcMap: Map<string, string> = new Map();
-
 function _trimNpmrcFile(
   options: Pick<
     INpmrcTrimOptions,
@@ -41,10 +38,6 @@ function _trimNpmrcFile(
     filterNpmIncompatibleProperties,
     env = process.env
   } = options;
-  const combinedNpmrcFromCache: string | undefined = _combinedNpmrcMap.get(sourceNpmrcPath);
-  if (combinedNpmrcFromCache !== undefined) {
-    return combinedNpmrcFromCache;
-  }
 
   let npmrcFileLines: string[] = [];
   if (linesToPrepend) {
@@ -69,9 +62,6 @@ function _trimNpmrcFile(
   );
 
   const combinedNpmrc: string = resultLines.join('\n');
-
-  //save the cache
-  _combinedNpmrcMap.set(sourceNpmrcPath, combinedNpmrc);
 
   return combinedNpmrc;
 }


### PR DESCRIPTION
## Summary

Fixes #5641.

The `.npmrc` file synced to temp in pnpm repos was having pnpm-specific properties (like `hoist`, `hoist-pattern`, `public-hoist-pattern`, `shamefully-hoist`) incorrectly stripped, causing packages to be hoisted with pnpm's default behavior instead of the configured behavior.

## Details

The `_trimNpmrcFile()` function in npmrcUtilities.ts had a cache (`_combinedNpmrcMap`) keyed **only** by `sourceNpmrcPath`, ignoring all other parameters (`filterNpmIncompatibleProperties`, `linesToPrepend`, `supportEnvVarFallbackSyntax`, `env`).

In a pnpm repo without subspaces, both calls resolve to the same source path (`common/config/rush/.npmrc`), but are called with different options:

1. **`ensureLocalPackageManagerAsync`** calls `syncNpmrc` with `filterNpmIncompatibleProperties: true` — this correctly comments out pnpm-specific hoisting properties because npm is used to install the package manager itself. **This result gets cached.**

2. **`BaseInstallManager`** then calls `syncNpmrc` with `filterNpmIncompatibleProperties: false` (since pnpm should keep these properties) — but the stale cached result from step 1 is returned, with hoisting properties already stripped.

The fix removes the broken cache entirely. The I/O cost of re-reading a small `.npmrc` config file a few times during install is negligible, and correctness is critical.

No alternate approaches like fixing the cache key were pursued because the cache provides marginal benefit (the file is only read a small number of times during an install operation) and a correct composite cache key would need to account for many parameters including `env` (a large object), making it complex and fragile.

## How it was tested

Ran the existing `npmrcUtilities` unit tests via `heft test --test-path-pattern npmrcUtilities` — all 17 tests pass.

## Impacted documentation

None.