### PR TITLE
[rush] Replace deprecated url.parse() with WHATWG URL API

### DIFF
--- a/common/changes/@microsoft/rush/fix-url-deprecation-warning_2026-02-21-01-15.json
+++ b/common/changes/@microsoft/rush/fix-url-deprecation-warning_2026-02-21-01-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "type": "none",
+      "packageName": "@microsoft/rush"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/libraries/rush-lib/src/logic/test/Git.test.ts
+++ b/libraries/rush-lib/src/logic/test/Git.test.ts
@@ -19,7 +19,7 @@ describe(Git.name, () => {
         'https://host.xz/path/to/repo'
       );
       expect(Git.normalizeGitUrlForComparison('http://host.xz:80/path/to/repo')).toEqual(
-        'https://host.xz:80/path/to/repo'
+        'https://host.xz/path/to/repo'
       );
       expect(Git.normalizeGitUrlForComparison('host.xz:path/to/repo.git/')).toEqual(
         'https://host.xz/path/to/repo'


### PR DESCRIPTION
## Summary

Node.js emits a `[DEP0169] DeprecationWarning` during rush-lib tests because `Git.normalizeGitUrlForComparison()` uses the deprecated `url.parse()` API. This PR replaces it with the WHATWG `URL` constructor to eliminate the warning.

## Details

- Replaced `url.parse()` with `new URL()` in `Git.normalizeGitUrlForComparison()`, wrapped in a try/catch to handle non-URL strings (local paths, SCP-like syntax already converted to HTTPS, etc.) that cause the `URL` constructor to throw.
- Removed the now-unused `import * as url from 'node:url'`.
- The WHATWG `URL` API normalizes default ports (e.g. port 80 for HTTP is stripped from `host`), which is actually more correct for URL comparison — `http://host.xz:80/path` and `http://host.xz/path` are equivalent. Updated the test expectation accordingly.
- No backwards compatibility concerns; `normalizeGitUrlForComparison()` is an internal API used for comparing Git remote URLs.

## How it was tested

Ran `rushx test` in the rush-lib project — all 583 tests pass with 0 failures, and the `[DEP0169] DeprecationWarning` no longer appears in test output.