### PR TITLE
[rush-lib] Normalize plugin autoinstaller file line endings

### DIFF
--- a/common/changes/@microsoft/rush/fix-rush-lib-autoinstaller-loader_2026-03-02-22-12.json
+++ b/common/changes/@microsoft/rush/fix-rush-lib-autoinstaller-loader_2026-03-02-22-12.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix autoinstaller plugin loader behavior.",
+      "type": "none",
+      "packageName": "@microsoft/rush"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "61671317+kevin-y-ang@users.noreply.github.com"
+}

--- a/libraries/rush-lib/src/pluginFramework/PluginLoader/AutoinstallerPluginLoader.ts
+++ b/libraries/rush-lib/src/pluginFramework/PluginLoader/AutoinstallerPluginLoader.ts
@@ -6,6 +6,7 @@ import * as path from 'node:path';
 import {
   FileSystem,
   JsonFile,
+  NewlineKind,
   PosixModeBits,
   type JsonObject,
   type JsonSchema
@@ -68,9 +69,11 @@ export class AutoinstallerPluginLoader extends PluginLoaderBase<IRushPluginConfi
     );
 
     const destinationManifestPath: string = this._getManifestPath();
-    FileSystem.copyFile({
-      sourcePath: manifestPath,
-      destinationPath: destinationManifestPath
+
+    // Use read+write instead of copy to ensure line endings are normalized
+    const manifestContent: string = FileSystem.readFile(manifestPath);
+    FileSystem.writeFile(destinationManifestPath, manifestContent, {
+      convertLineEndings: NewlineKind.Lf
     });
     // Make permission consistent since it will be committed to Git
     FileSystem.changePosixModeBits(
@@ -98,9 +101,11 @@ export class AutoinstallerPluginLoader extends PluginLoaderBase<IRushPluginConfi
         );
       }
       const destinationCommandLineJsonFilePath: string = this._getCommandLineJsonFilePath();
-      FileSystem.copyFile({
-        sourcePath: commandLineJsonFullFilePath,
-        destinationPath: destinationCommandLineJsonFilePath
+
+      // Use read+write instead of copy to ensure line endings are normalized
+      const commandLineContent: string = FileSystem.readFile(commandLineJsonFullFilePath);
+      FileSystem.writeFile(destinationCommandLineJsonFilePath, commandLineContent, {
+        convertLineEndings: NewlineKind.Lf
       });
       // Make permission consistent since it will be committed to Git
       FileSystem.changePosixModeBits(


### PR DESCRIPTION
## Summary
- Update `AutoinstallerPluginLoader.ts` to read source JSON files and write them with `convertLineEndings: NewlineKind.Lf`.
- Apply this behavior to both the plugin manifest and optional command-line JSON file.

## Details
- At TikTok we develop on Mac. When running rush update, `AutoinstallerPluginLoader.ts` will the line endings of `rush-plugin-manifest.json` and `command-line.json`. This creates unstaged changes that causes confusion and inconvenience for developers.
- This behavior eists because `FileSystem.copyFile()` does not support the option `convertLineEndings: NewlineKind.Lf`. This problem can be resolved by reading the file into memory with `FileSystem.readFile()` and writing it with `FileSystem.writeFile()` with the `convertLineEndings: NewlineKind.Lf` option.

## How it was tested
- Testing it on TikTok repos, this removes the issue of Rush changing the line endings of `rush-plugin-manifest.json` and `command-line.json` when running rush update.

<img width="1229" height="96" alt="image" src="https://github.com/user-attachments/assets/36dc3ef2-c046-47b0-8d28-9cd03cd6a594" />