### PR TITLE
feat(heft-storybook-plugin): add `--quiet` opt-out and `--no-open` flag

### DIFF
--- a/common/changes/@rushstack/heft-storybook-plugin/main_2026-03-04-03-22.json
+++ b/common/changes/@rushstack/heft-storybook-plugin/main_2026-03-04-03-22.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-storybook-plugin",
+      "comment": "add option to control whether to pass --quiet flag",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft-storybook-plugin"
+}

--- a/common/changes/@rushstack/heft-storybook-plugin/main_2026-03-04-03-22.json
+++ b/common/changes/@rushstack/heft-storybook-plugin/main_2026-03-04-03-22.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@rushstack/heft-storybook-plugin",
-      "comment": "add option to control whether to pass --quiet flag",
+      "comment": "Add `quiet` option to control whether --quiet is passed to the Storybook CLI, and add `--no-open` flag to suppress automatic browser launch in serve mode",
       "type": "minor"
     }
   ],

--- a/heft-plugins/heft-storybook-plugin/heft-plugin.json
+++ b/heft-plugins/heft-storybook-plugin/heft-plugin.json
@@ -23,6 +23,11 @@
           "longName": "--docs",
           "description": "Execute storybook in docs mode.",
           "parameterKind": "flag"
+        },
+        {
+          "longName": "--no-open",
+          "description": "Pass --no-open to the storybook CLI so it does not automatically open a browser window in serve mode.",
+          "parameterKind": "flag"
         }
       ]
     }

--- a/heft-plugins/heft-storybook-plugin/src/StorybookPlugin.ts
+++ b/heft-plugins/heft-storybook-plugin/src/StorybookPlugin.ts
@@ -190,6 +190,7 @@ interface IPrepareStorybookOptions extends IStorybookPluginOptions {
   isServeMode: boolean;
   isTestMode: boolean;
   isDocsMode: boolean;
+  isNoOpenMode: boolean;
 }
 
 const DEFAULT_STORYBOOK_VERSION: StorybookCliVersion = StorybookCliVersion.STORYBOOK7;
@@ -227,6 +228,7 @@ const DEFAULT_STORYBOOK_CLI_CONFIG: Record<StorybookCliVersion, IStorybookCliCal
 const STORYBOOK_FLAG_NAME: '--storybook' = '--storybook';
 const STORYBOOK_TEST_FLAG_NAME: '--storybook-test' = '--storybook-test';
 const DOCS_FLAG_NAME: '--docs' = '--docs';
+const NO_OPEN_FLAG_NAME: '--no-open' = '--no-open';
 
 /** @public */
 export default class StorybookPlugin implements IHeftTaskPlugin<IStorybookPluginOptions> {
@@ -244,6 +246,8 @@ export default class StorybookPlugin implements IHeftTaskPlugin<IStorybookPlugin
     const storybookTestParameter: CommandLineFlagParameter =
       taskSession.parameters.getFlagParameter(STORYBOOK_TEST_FLAG_NAME);
     const docsParameter: CommandLineFlagParameter = taskSession.parameters.getFlagParameter(DOCS_FLAG_NAME);
+    const noOpenParameter: CommandLineFlagParameter =
+      taskSession.parameters.getFlagParameter(NO_OPEN_FLAG_NAME);
 
     const parseResult: IParsedPackageNameOrError = PackageName.tryParse(options.storykitPackageName);
     if (parseResult.error) {
@@ -307,6 +311,7 @@ export default class StorybookPlugin implements IHeftTaskPlugin<IStorybookPlugin
           isServeMode,
           isTestMode: storybookTestParameter.value,
           isDocsMode: docsParameter.value,
+          isNoOpenMode: noOpenParameter.value,
           ...options
         });
         await this._runStorybookAsync(runStorybookOptions, options);
@@ -465,7 +470,8 @@ export default class StorybookPlugin implements IHeftTaskPlugin<IStorybookPlugin
     runStorybookOptions: IRunStorybookOptions,
     options: IStorybookPluginOptions
   ): Promise<void> {
-    const { logger, resolvedModulePath, verbose, isServeMode, isTestMode, isDocsMode } = runStorybookOptions;
+    const { logger, resolvedModulePath, verbose, isServeMode, isTestMode, isDocsMode, isNoOpenMode } =
+      runStorybookOptions;
     let { workingDirectory, outputFolder } = runStorybookOptions;
     logger.terminal.writeLine('Running Storybook compilation');
     logger.terminal.writeVerboseLine(`Loading Storybook module "${resolvedModulePath}"`);
@@ -512,6 +518,10 @@ export default class StorybookPlugin implements IHeftTaskPlugin<IStorybookPlugin
       storybookArgs.push('--docs');
     }
 
+    if (isServeMode && isNoOpenMode) {
+      storybookArgs.push('--no-open');
+    }
+
     const storybookEnv: NodeJS.ProcessEnv = {
       ...process.env,
       // Prevent corepack from prompting to pin a package manager version
@@ -532,7 +542,13 @@ export default class StorybookPlugin implements IHeftTaskPlugin<IStorybookPlugin
         storybookCliVersion === StorybookCliVersion.STORYBOOK8
       );
     } else {
-      await this._invokeAsSubprocessAsync(logger, resolvedModulePath, storybookArgs, workingDirectory, storybookEnv);
+      await this._invokeAsSubprocessAsync(
+        logger,
+        resolvedModulePath,
+        storybookArgs,
+        workingDirectory,
+        storybookEnv
+      );
     }
   }
 

--- a/heft-plugins/heft-storybook-plugin/src/StorybookPlugin.ts
+++ b/heft-plugins/heft-storybook-plugin/src/StorybookPlugin.ts
@@ -164,6 +164,13 @@ export interface IStorybookPluginOptions {
    * which disables Storybook's telemetry data collection.
    */
   disableTelemetry?: boolean;
+
+  /**
+   * Specifies whether to run storybook in quiet mode (--quiet).
+   *
+   * @defaultValue `true`
+   */
+  quiet?: boolean;
 }
 
 interface IRunStorybookOptions extends IPrepareStorybookOptions {
@@ -493,7 +500,7 @@ export default class StorybookPlugin implements IHeftTaskPlugin<IStorybookPlugin
       storybookArgs.push('--webpack-stats-json');
     }
 
-    if (!verbose) {
+    if (options.quiet !== false && !verbose) {
       storybookArgs.push('--quiet');
     }
 

--- a/heft-plugins/heft-storybook-plugin/src/schemas/storybook.schema.json
+++ b/heft-plugins/heft-storybook-plugin/src/schemas/storybook.schema.json
@@ -42,6 +42,11 @@
       "title": "Specifies whether to disable Storybook telemetry.",
       "description": "If true, sets the STORYBOOK_DISABLE_TELEMETRY=1 environment variable when invoking the Storybook subprocess, which disables Storybook's telemetry data collection. Defaults to false.",
       "type": "boolean"
+    },
+    "quiet": {
+      "title": "Specifies whether to run storybook in quiet mode (--quiet).",
+      "description": "If this is true, then it will run storybook in quiet mode. Defaults to true.",
+      "type": "boolean"
     }
   }
 }


### PR DESCRIPTION
## Summary

Two new opt-in behaviours for `@rushstack/heft-storybook-plugin`:

- **`quiet` option** (plugin options in `heft.json`): controls whether `--quiet` is passed to the Storybook CLI. Defaults to `true` (existing behaviour). Set to `false` to suppress `--quiet`, which is useful when `--verbose` is not wanted but more Storybook output is needed.

- **`--no-open` CLI flag**: when passed alongside `--storybook` in serve mode, prevents Storybook from automatically opening a browser window. Useful for CI-adjacent tooling or daemon processes that start Storybook programmatically.

## Changes

- `heft-plugin.json` — registers the `--no-open` parameter on the storybook task
- `StorybookPlugin.ts` — wires up both behaviours
- `schemas/storybook.schema.json` — adds `quiet` to the options schema

## Test plan

- [ ] `heft build --storybook` — `--quiet` is passed by default (no change)
- [ ] `heft build --storybook` with `"quiet": false` in plugin options — `--quiet` is omitted
- [ ] `heft start --storybook --no-open` — Storybook starts without opening a browser tab
- [ ] `heft build --storybook --no-open` — `--no-open` is silently ignored in build mode (only applies to serve mode)