### PR TITLE
feat: read `trustPolicy`, `trustPolicyExclude`, and `trustPolicyIgnoreAfter` from pnpm-config.json

### DIFF
--- a/common/changes/@microsoft/rush/feature-add-trust-policy-support_2026-04-07-00-00.json
+++ b/common/changes/@microsoft/rush/feature-add-trust-policy-support_2026-04-07-00-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add support for pnpm trustPolicy, trustPolicyExclude, and trustPolicyIgnoreAfter settings in pnpm-config.json",
+      "type": "minor",
+      "packageName": "@microsoft/rush"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "user@example.com"
+}

--- a/common/changes/@microsoft/rush/feature-add-trust-policy-support_2026-04-07-00-00.json
+++ b/common/changes/@microsoft/rush/feature-add-trust-policy-support_2026-04-07-00-00.json
@@ -7,5 +7,5 @@
     }
   ],
   "packageName": "@microsoft/rush",
-  "email": "user@example.com"
+  "email": "fpapado@users.noreply.github.com"
 }

--- a/common/changes/@microsoft/rush/feature-add-trust-policy-support_2026-04-07-00-00.json
+++ b/common/changes/@microsoft/rush/feature-add-trust-policy-support_2026-04-07-00-00.json
@@ -1,7 +1,7 @@
 {
   "changes": [
     {
-      "comment": "Add support for pnpm trustPolicy, trustPolicyExclude, and trustPolicyIgnoreAfter settings in pnpm-config.json",
+      "comment": "Add support for pnpm `trustPolicy`, `trustPolicyExclude`, and `trustPolicyIgnoreAfter` settings in `pnpm-config.json`.",
       "type": "minor",
       "packageName": "@microsoft/rush"
     }

--- a/common/changes/@microsoft/rush/feature-add-trust-policy-support_2026-04-07-00-00.json
+++ b/common/changes/@microsoft/rush/feature-add-trust-policy-support_2026-04-07-00-00.json
@@ -1,7 +1,7 @@
 {
   "changes": [
     {
-      "comment": "Add support for pnpm `trustPolicy`, `trustPolicyExclude`, and `trustPolicyIgnoreAfter` settings in `pnpm-config.json`.",
+      "comment": "Add support for pnpm `trustPolicy`, `trustPolicyExclude`, and `trustPolicyIgnoreAfterMinutes` settings in `pnpm-config.json`.",
       "type": "minor",
       "packageName": "@microsoft/rush"
     }

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -767,6 +767,9 @@ export interface _IPnpmOptionsJson extends IPackageManagerOptionsJsonBase {
     preventManualShrinkwrapChanges?: boolean;
     resolutionMode?: PnpmResolutionMode;
     strictPeerDependencies?: boolean;
+    trustPolicy?: PnpmTrustPolicy;
+    trustPolicyExclude?: string[];
+    trustPolicyIgnoreAfter?: number;
     unsupportedPackageJsonSettings?: unknown;
     useWorkspaces?: boolean;
 }
@@ -1194,6 +1197,9 @@ export class PnpmOptionsConfiguration extends PackageManagerOptionsConfiguration
     readonly preventManualShrinkwrapChanges: boolean;
     readonly resolutionMode: PnpmResolutionMode | undefined;
     readonly strictPeerDependencies: boolean;
+    readonly trustPolicy: PnpmTrustPolicy | undefined;
+    readonly trustPolicyExclude: string[] | undefined;
+    readonly trustPolicyIgnoreAfter: number | undefined;
     readonly unsupportedPackageJsonSettings: unknown | undefined;
     updateGlobalOnlyBuiltDependencies(onlyBuiltDependencies: string[] | undefined): void;
     updateGlobalPatchedDependencies(patchedDependencies: Record<string, string> | undefined): void;
@@ -1208,6 +1214,9 @@ export type PnpmStoreLocation = 'local' | 'global';
 
 // @public @deprecated (undocumented)
 export type PnpmStoreOptions = PnpmStoreLocation;
+
+// @public
+export type PnpmTrustPolicy = 'no-downgrade' | 'off';
 
 // @beta (undocumented)
 export class ProjectChangeAnalyzer {

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -769,7 +769,7 @@ export interface _IPnpmOptionsJson extends IPackageManagerOptionsJsonBase {
     strictPeerDependencies?: boolean;
     trustPolicy?: PnpmTrustPolicy;
     trustPolicyExclude?: string[];
-    trustPolicyIgnoreAfter?: number;
+    trustPolicyIgnoreAfterMinutes?: number;
     unsupportedPackageJsonSettings?: unknown;
     useWorkspaces?: boolean;
 }
@@ -1199,7 +1199,7 @@ export class PnpmOptionsConfiguration extends PackageManagerOptionsConfiguration
     readonly strictPeerDependencies: boolean;
     readonly trustPolicy: PnpmTrustPolicy | undefined;
     readonly trustPolicyExclude: string[] | undefined;
-    readonly trustPolicyIgnoreAfter: number | undefined;
+    readonly trustPolicyIgnoreAfterMinutes: number | undefined;
     readonly unsupportedPackageJsonSettings: unknown | undefined;
     updateGlobalOnlyBuiltDependencies(onlyBuiltDependencies: string[] | undefined): void;
     updateGlobalPatchedDependencies(patchedDependencies: Record<string, string> | undefined): void;

--- a/libraries/rush-lib/assets/rush-init/common/config/rush/pnpm-config.json
+++ b/libraries/rush-lib/assets/rush-init/common/config/rush/pnpm-config.json
@@ -100,6 +100,49 @@
   /*[LINE "HYPOTHETICAL"]*/ "minimumReleaseAgeExclude": ["@myorg/*"],
 
   /**
+   * The trust policy controls whether pnpm should block installation of package versions where
+   * the trust level has decreased (e.g., a package previously published with provenance is now
+   * published without it). Setting this to `"no-downgrade"` enables the protection.
+   *
+   * (SUPPORTED ONLY IN PNPM 10.21.0 AND NEWER)
+   *
+   * PNPM documentation: https://pnpm.io/settings#trustpolicy
+   */
+  /*[LINE "HYPOTHETICAL"]*/ "trustPolicy": "no-downgrade",
+
+  /**
+   * An array of package names or patterns to exclude from the trust policy check.
+   * These packages will be allowed to install even if their trust level has decreased.
+   * Patterns are supported using glob syntax (e.g., "@myorg/*" to exclude all packages
+   * from an organization).
+   *
+   * For example:
+   *
+   * "trustPolicyExclude": ["webpack", "react", "@myorg/*"]
+   *
+   * (SUPPORTED ONLY IN PNPM 10.22.0 AND NEWER)
+   *
+   * PNPM documentation: https://pnpm.io/settings#trustpolicyexclude
+   */
+  /*[LINE "HYPOTHETICAL"]*/ "trustPolicyExclude": ["@myorg/*"],
+
+  /**
+   * The number of minutes after which pnpm will ignore trust level downgrades. Packages
+   * published longer ago than this threshold will not be blocked even if their trust level
+   * has decreased.
+   *
+   * For example, the following setting ignores trust level changes for packages published
+   * more than one day ago:
+   *
+   * "trustPolicyIgnoreAfter": 1440
+   *
+   * (SUPPORTED ONLY IN PNPM 10.27.0 AND NEWER)
+   *
+   * PNPM documentation: https://pnpm.io/settings#trustpolicyignoreafter
+   */
+  /*[LINE "HYPOTHETICAL"]*/ "trustPolicyIgnoreAfter": 1440,
+
+  /**
    * If true, then Rush will add the `--strict-peer-dependencies` command-line parameter when
    * invoking PNPM.  This causes `rush update` to fail if there are unsatisfied peer dependencies,
    * which is an invalid state that can cause build failures or incompatible dependency versions.

--- a/libraries/rush-lib/assets/rush-init/common/config/rush/pnpm-config.json
+++ b/libraries/rush-lib/assets/rush-init/common/config/rush/pnpm-config.json
@@ -107,6 +107,9 @@
    * (SUPPORTED ONLY IN PNPM 10.21.0 AND NEWER)
    *
    * PNPM documentation: https://pnpm.io/settings#trustpolicy
+   *
+   * Possible values are: `off` and `no-downgrade`.
+   * The default is `off`.
    */
   /*[LINE "HYPOTHETICAL"]*/ "trustPolicy": "no-downgrade",
 
@@ -118,29 +121,35 @@
    *
    * For example:
    *
-   * "trustPolicyExclude": ["webpack", "react", "@myorg/*"]
+   * "trustPolicyExclude": ["@babel/core@7.28.5", "chokidar@4.0.3", "@myorg/*"]
    *
    * (SUPPORTED ONLY IN PNPM 10.22.0 AND NEWER)
    *
    * PNPM documentation: https://pnpm.io/settings#trustpolicyexclude
+   *
+   * The default value is [].
    */
   /*[LINE "HYPOTHETICAL"]*/ "trustPolicyExclude": ["@myorg/*"],
 
   /**
    * The number of minutes after which pnpm will ignore trust level downgrades. Packages
    * published longer ago than this threshold will not be blocked even if their trust level
-   * has decreased.
+   * has decreased. This is useful when enabling strict trust policies, as it allows older versions
+   * of packages (which may lack a process for publishing with signatures or provenance) to be
+   * installed without manual exclusion, assuming they are safe due to their age.
    *
    * For example, the following setting ignores trust level changes for packages published
-   * more than one day ago:
+   * more than 14 days ago:
    *
-   * "trustPolicyIgnoreAfter": 1440
+   * "trustPolicyIgnoreAfter": 20160
    *
    * (SUPPORTED ONLY IN PNPM 10.27.0 AND NEWER)
    *
    * PNPM documentation: https://pnpm.io/settings#trustpolicyignoreafter
+   *
+   * The default value is undefined (no exclusion).
    */
-  /*[LINE "HYPOTHETICAL"]*/ "trustPolicyIgnoreAfter": 1440,
+  /*[LINE "HYPOTHETICAL"]*/ "trustPolicyIgnoreAfter": 20160,
 
   /**
    * If true, then Rush will add the `--strict-peer-dependencies` command-line parameter when

--- a/libraries/rush-lib/assets/rush-init/common/config/rush/pnpm-config.json
+++ b/libraries/rush-lib/assets/rush-init/common/config/rush/pnpm-config.json
@@ -141,7 +141,7 @@
    * For example, the following setting ignores trust level changes for packages published
    * more than 14 days ago:
    *
-   * "trustPolicyIgnoreAfter": 20160
+   * "trustPolicyIgnoreAfterMinutes": 20160
    *
    * (SUPPORTED ONLY IN PNPM 10.27.0 AND NEWER)
    *
@@ -149,7 +149,7 @@
    *
    * The default value is undefined (no exclusion).
    */
-  /*[LINE "HYPOTHETICAL"]*/ "trustPolicyIgnoreAfter": 20160,
+  /*[LINE "HYPOTHETICAL"]*/ "trustPolicyIgnoreAfterMinutes": 20160,
 
   /**
    * If true, then Rush will add the `--strict-peer-dependencies` command-line parameter when

--- a/libraries/rush-lib/src/index.ts
+++ b/libraries/rush-lib/src/index.ts
@@ -48,7 +48,8 @@ export {
   type IPnpmPeerDependenciesMeta,
   type PnpmStoreOptions,
   PnpmOptionsConfiguration,
-  type PnpmResolutionMode
+  type PnpmResolutionMode,
+  type PnpmTrustPolicy
 } from './logic/pnpm/PnpmOptionsConfiguration';
 
 export { BuildCacheConfiguration } from './api/BuildCacheConfiguration';

--- a/libraries/rush-lib/src/logic/installManager/InstallHelpers.ts
+++ b/libraries/rush-lib/src/logic/installManager/InstallHelpers.ts
@@ -37,6 +37,9 @@ interface ICommonPackageJson extends IPackageJson {
     patchedDependencies?: typeof PnpmOptionsConfiguration.prototype.globalPatchedDependencies;
     minimumReleaseAge?: typeof PnpmOptionsConfiguration.prototype.minimumReleaseAge;
     minimumReleaseAgeExclude?: typeof PnpmOptionsConfiguration.prototype.minimumReleaseAgeExclude;
+    trustPolicy?: typeof PnpmOptionsConfiguration.prototype.trustPolicy;
+    trustPolicyExclude?: typeof PnpmOptionsConfiguration.prototype.trustPolicyExclude;
+    trustPolicyIgnoreAfter?: typeof PnpmOptionsConfiguration.prototype.trustPolicyIgnoreAfter;
   };
 }
 
@@ -143,6 +146,60 @@ export class InstallHelpers {
         if (pnpmOptions.minimumReleaseAgeExclude) {
           commonPackageJson.pnpm.minimumReleaseAgeExclude = pnpmOptions.minimumReleaseAgeExclude;
         }
+      }
+
+      if (pnpmOptions.trustPolicy !== undefined) {
+        if (
+          rushConfiguration.rushConfigurationJson.pnpmVersion !== undefined &&
+          semver.lt(rushConfiguration.rushConfigurationJson.pnpmVersion, '10.21.0')
+        ) {
+          terminal.writeWarningLine(
+            Colorize.yellow(
+              `Your version of pnpm (${rushConfiguration.rushConfigurationJson.pnpmVersion}) ` +
+                `doesn't support the "trustPolicy" field in ` +
+                `${rushConfiguration.commonRushConfigFolder}/${RushConstants.pnpmConfigFilename}. ` +
+                'Remove this field or upgrade to pnpm 10.21.0 or newer.'
+            )
+          );
+        }
+
+        commonPackageJson.pnpm.trustPolicy = pnpmOptions.trustPolicy;
+      }
+
+      if (pnpmOptions.trustPolicyExclude) {
+        if (
+          rushConfiguration.rushConfigurationJson.pnpmVersion !== undefined &&
+          semver.lt(rushConfiguration.rushConfigurationJson.pnpmVersion, '10.22.0')
+        ) {
+          terminal.writeWarningLine(
+            Colorize.yellow(
+              `Your version of pnpm (${rushConfiguration.rushConfigurationJson.pnpmVersion}) ` +
+                `doesn't support the "trustPolicyExclude" field in ` +
+                `${rushConfiguration.commonRushConfigFolder}/${RushConstants.pnpmConfigFilename}. ` +
+                'Remove this field or upgrade to pnpm 10.22.0 or newer.'
+            )
+          );
+        }
+
+        commonPackageJson.pnpm.trustPolicyExclude = pnpmOptions.trustPolicyExclude;
+      }
+
+      if (pnpmOptions.trustPolicyIgnoreAfter !== undefined) {
+        if (
+          rushConfiguration.rushConfigurationJson.pnpmVersion !== undefined &&
+          semver.lt(rushConfiguration.rushConfigurationJson.pnpmVersion, '10.27.0')
+        ) {
+          terminal.writeWarningLine(
+            Colorize.yellow(
+              `Your version of pnpm (${rushConfiguration.rushConfigurationJson.pnpmVersion}) ` +
+                `doesn't support the "trustPolicyIgnoreAfter" field in ` +
+                `${rushConfiguration.commonRushConfigFolder}/${RushConstants.pnpmConfigFilename}. ` +
+                'Remove this field or upgrade to pnpm 10.27.0 or newer.'
+            )
+          );
+        }
+
+        commonPackageJson.pnpm.trustPolicyIgnoreAfter = pnpmOptions.trustPolicyIgnoreAfter;
       }
 
       if (pnpmOptions.unsupportedPackageJsonSettings) {

--- a/libraries/rush-lib/src/logic/installManager/InstallHelpers.ts
+++ b/libraries/rush-lib/src/logic/installManager/InstallHelpers.ts
@@ -39,7 +39,7 @@ interface ICommonPackageJson extends IPackageJson {
     minimumReleaseAgeExclude?: typeof PnpmOptionsConfiguration.prototype.minimumReleaseAgeExclude;
     trustPolicy?: typeof PnpmOptionsConfiguration.prototype.trustPolicy;
     trustPolicyExclude?: typeof PnpmOptionsConfiguration.prototype.trustPolicyExclude;
-    trustPolicyIgnoreAfter?: typeof PnpmOptionsConfiguration.prototype.trustPolicyIgnoreAfter;
+    trustPolicyIgnoreAfter?: typeof PnpmOptionsConfiguration.prototype.trustPolicyIgnoreAfterMinutes;
   };
 }
 
@@ -184,7 +184,7 @@ export class InstallHelpers {
         commonPackageJson.pnpm.trustPolicyExclude = pnpmOptions.trustPolicyExclude;
       }
 
-      if (pnpmOptions.trustPolicyIgnoreAfter !== undefined) {
+      if (pnpmOptions.trustPolicyIgnoreAfterMinutes !== undefined) {
         if (
           rushConfiguration.rushConfigurationJson.pnpmVersion !== undefined &&
           semver.lt(rushConfiguration.rushConfigurationJson.pnpmVersion, '10.27.0')
@@ -192,14 +192,15 @@ export class InstallHelpers {
           terminal.writeWarningLine(
             Colorize.yellow(
               `Your version of pnpm (${rushConfiguration.rushConfigurationJson.pnpmVersion}) ` +
-                `doesn't support the "trustPolicyIgnoreAfter" field in ` +
+                `doesn't support the "trustPolicyIgnoreAfterMinutes" field in ` +
                 `${rushConfiguration.commonRushConfigFolder}/${RushConstants.pnpmConfigFilename}. ` +
                 'Remove this field or upgrade to pnpm 10.27.0 or newer.'
             )
           );
         }
 
-        commonPackageJson.pnpm.trustPolicyIgnoreAfter = pnpmOptions.trustPolicyIgnoreAfter;
+        // NOTE: the pnpm setting is `trustPolicyIgnoreAfter`, but the rush pnpm setting is `trustPolicyIgnoreAfterMinutes`
+        commonPackageJson.pnpm.trustPolicyIgnoreAfter = pnpmOptions.trustPolicyIgnoreAfterMinutes;
       }
 
       if (pnpmOptions.unsupportedPackageJsonSettings) {

--- a/libraries/rush-lib/src/logic/pnpm/PnpmOptionsConfiguration.ts
+++ b/libraries/rush-lib/src/logic/pnpm/PnpmOptionsConfiguration.ts
@@ -171,7 +171,7 @@ export interface IPnpmOptionsJson extends IPackageManagerOptionsJsonBase {
   /**
    * {@inheritDoc PnpmOptionsConfiguration.trustPolicyIgnoreAfter}
    */
-  trustPolicyIgnoreAfter?: number;
+  trustPolicyIgnoreAfterMinutes?: number;
   /**
    * {@inheritDoc PnpmOptionsConfiguration.alwaysInjectDependenciesFromOtherSubspaces}
    */
@@ -357,7 +357,7 @@ export class PnpmOptionsConfiguration extends PackageManagerOptionsConfiguration
    *
    * PNPM documentation: https://pnpm.io/settings#trustpolicyignoreafter
    */
-  public readonly trustPolicyIgnoreAfter: number | undefined;
+  public readonly trustPolicyIgnoreAfterMinutes: number | undefined;
 
   /**
    * If true, then `rush update` add injected install options for all cross-subspace
@@ -555,7 +555,7 @@ export class PnpmOptionsConfiguration extends PackageManagerOptionsConfiguration
     this.minimumReleaseAgeExclude = json.minimumReleaseAgeExclude;
     this.trustPolicy = json.trustPolicy;
     this.trustPolicyExclude = json.trustPolicyExclude;
-    this.trustPolicyIgnoreAfter = json.trustPolicyIgnoreAfter;
+    this.trustPolicyIgnoreAfterMinutes = json.trustPolicyIgnoreAfterMinutes;
     this.alwaysInjectDependenciesFromOtherSubspaces = json.alwaysInjectDependenciesFromOtherSubspaces;
     this.alwaysFullInstall = json.alwaysFullInstall;
     this.pnpmLockfilePolicies = json.pnpmLockfilePolicies;

--- a/libraries/rush-lib/src/logic/pnpm/PnpmOptionsConfiguration.ts
+++ b/libraries/rush-lib/src/logic/pnpm/PnpmOptionsConfiguration.ts
@@ -169,7 +169,7 @@ export interface IPnpmOptionsJson extends IPackageManagerOptionsJsonBase {
    */
   trustPolicyExclude?: string[];
   /**
-   * {@inheritDoc PnpmOptionsConfiguration.trustPolicyIgnoreAfter}
+   * {@inheritDoc PnpmOptionsConfiguration.trustPolicyIgnoreAfterMinutes}
    */
   trustPolicyIgnoreAfterMinutes?: number;
   /**

--- a/libraries/rush-lib/src/logic/pnpm/PnpmOptionsConfiguration.ts
+++ b/libraries/rush-lib/src/logic/pnpm/PnpmOptionsConfiguration.ts
@@ -35,6 +35,16 @@ export type PnpmStoreOptions = PnpmStoreLocation;
 export type PnpmResolutionMode = 'highest' | 'time-based' | 'lowest-direct';
 
 /**
+ * Possible values for the `trustPolicy` setting in Rush's pnpm-config.json file.
+ * @remarks
+ * These values correspond to PNPM's `trust-policy` setting, which is documented here:
+ * {@link https://pnpm.io/settings#trustpolicy}
+ *
+ * @public
+ */
+export type PnpmTrustPolicy = 'no-downgrade' | 'off';
+
+/**
  * Possible values for the `pnpmLockfilePolicies` setting in Rush's pnpm-config.json file.
  * @public
  */
@@ -150,6 +160,18 @@ export interface IPnpmOptionsJson extends IPackageManagerOptionsJsonBase {
    * {@inheritDoc PnpmOptionsConfiguration.minimumReleaseAgeExclude}
    */
   minimumReleaseAgeExclude?: string[];
+  /**
+   * {@inheritDoc PnpmOptionsConfiguration.trustPolicy}
+   */
+  trustPolicy?: PnpmTrustPolicy;
+  /**
+   * {@inheritDoc PnpmOptionsConfiguration.trustPolicyExclude}
+   */
+  trustPolicyExclude?: string[];
+  /**
+   * {@inheritDoc PnpmOptionsConfiguration.trustPolicyIgnoreAfter}
+   */
+  trustPolicyIgnoreAfter?: number;
   /**
    * {@inheritDoc PnpmOptionsConfiguration.alwaysInjectDependenciesFromOtherSubspaces}
    */
@@ -300,6 +322,42 @@ export class PnpmOptionsConfiguration extends PackageManagerOptionsConfiguration
    * Example: ["webpack", "react", "\@myorg/*"]
    */
   public readonly minimumReleaseAgeExclude: string[] | undefined;
+
+  /**
+   * The trust policy controls whether pnpm should block installation of package versions where the
+   * trust level has decreased (e.g., a package previously published with provenance is now published
+   * without it). Setting this to `"no-downgrade"` enables the protection.
+   *
+   * @remarks
+   * (SUPPORTED ONLY IN PNPM 10.21.0 AND NEWER)
+   *
+   * PNPM documentation: https://pnpm.io/settings#trustpolicy
+   */
+  public readonly trustPolicy: PnpmTrustPolicy | undefined;
+
+  /**
+   * List of package names or patterns that are excluded from the trust policy check.
+   * These packages will be allowed to install even if their trust level has decreased.
+   *
+   * @remarks
+   * (SUPPORTED ONLY IN PNPM 10.22.0 AND NEWER)
+   *
+   * PNPM documentation: https://pnpm.io/settings#trustpolicyexclude
+   *
+   * Example: ["webpack", "react", "\@myorg/*"]
+   */
+  public readonly trustPolicyExclude: string[] | undefined;
+
+  /**
+   * The number of minutes after which pnpm will ignore trust level downgrades. Packages published
+   * longer ago than this threshold will not be blocked even if their trust level has decreased.
+   *
+   * @remarks
+   * (SUPPORTED ONLY IN PNPM 10.27.0 AND NEWER)
+   *
+   * PNPM documentation: https://pnpm.io/settings#trustpolicyignoreafter
+   */
+  public readonly trustPolicyIgnoreAfter: number | undefined;
 
   /**
    * If true, then `rush update` add injected install options for all cross-subspace
@@ -495,6 +553,9 @@ export class PnpmOptionsConfiguration extends PackageManagerOptionsConfiguration
     this.autoInstallPeers = json.autoInstallPeers;
     this.minimumReleaseAge = json.minimumReleaseAge;
     this.minimumReleaseAgeExclude = json.minimumReleaseAgeExclude;
+    this.trustPolicy = json.trustPolicy;
+    this.trustPolicyExclude = json.trustPolicyExclude;
+    this.trustPolicyIgnoreAfter = json.trustPolicyIgnoreAfter;
     this.alwaysInjectDependenciesFromOtherSubspaces = json.alwaysInjectDependenciesFromOtherSubspaces;
     this.alwaysFullInstall = json.alwaysFullInstall;
     this.pnpmLockfilePolicies = json.pnpmLockfilePolicies;

--- a/libraries/rush-lib/src/logic/pnpm/test/PnpmOptionsConfiguration.test.ts
+++ b/libraries/rush-lib/src/logic/pnpm/test/PnpmOptionsConfiguration.test.ts
@@ -108,10 +108,12 @@ describe(PnpmOptionsConfiguration.name, () => {
 
     expect(pnpmConfiguration.trustPolicy).toEqual('no-downgrade');
     expect(TestUtilities.stripAnnotations(pnpmConfiguration.trustPolicyExclude)).toEqual([
-      'webpack',
-      '@myorg/*'
+      '@myorg/*',
+      'chokidar@4.0.3',
+      'webpack@4.47.0 || 5.102.1',
+      '@babel/core@7.28.5'
     ]);
-    expect(pnpmConfiguration.trustPolicyIgnoreAfter).toEqual(1440);
+    expect(pnpmConfiguration.trustPolicyIgnoreAfter).toEqual(20160);
   });
 
   it('loads catalog and catalogs', () => {

--- a/libraries/rush-lib/src/logic/pnpm/test/PnpmOptionsConfiguration.test.ts
+++ b/libraries/rush-lib/src/logic/pnpm/test/PnpmOptionsConfiguration.test.ts
@@ -100,6 +100,20 @@ describe(PnpmOptionsConfiguration.name, () => {
     ]);
   });
 
+  it('loads trustPolicy', () => {
+    const pnpmConfiguration: PnpmOptionsConfiguration = PnpmOptionsConfiguration.loadFromJsonFileOrThrow(
+      `${__dirname}/jsonFiles/pnpm-config-trustPolicy.json`,
+      fakeCommonTempFolder
+    );
+
+    expect(pnpmConfiguration.trustPolicy).toEqual('no-downgrade');
+    expect(TestUtilities.stripAnnotations(pnpmConfiguration.trustPolicyExclude)).toEqual([
+      'webpack',
+      '@myorg/*'
+    ]);
+    expect(pnpmConfiguration.trustPolicyIgnoreAfter).toEqual(1440);
+  });
+
   it('loads catalog and catalogs', () => {
     const pnpmConfiguration: PnpmOptionsConfiguration = PnpmOptionsConfiguration.loadFromJsonFileOrThrow(
       `${__dirname}/jsonFiles/pnpm-config-catalog.json`,

--- a/libraries/rush-lib/src/logic/pnpm/test/PnpmOptionsConfiguration.test.ts
+++ b/libraries/rush-lib/src/logic/pnpm/test/PnpmOptionsConfiguration.test.ts
@@ -113,7 +113,7 @@ describe(PnpmOptionsConfiguration.name, () => {
       'webpack@4.47.0 || 5.102.1',
       '@babel/core@7.28.5'
     ]);
-    expect(pnpmConfiguration.trustPolicyIgnoreAfter).toEqual(20160);
+    expect(pnpmConfiguration.trustPolicyIgnoreAfterMinutes).toEqual(20160);
   });
 
   it('loads catalog and catalogs', () => {

--- a/libraries/rush-lib/src/logic/pnpm/test/jsonFiles/pnpm-config-trustPolicy.json
+++ b/libraries/rush-lib/src/logic/pnpm/test/jsonFiles/pnpm-config-trustPolicy.json
@@ -1,5 +1,5 @@
 {
   "trustPolicy": "no-downgrade",
-  "trustPolicyExclude": ["webpack", "@myorg/*"],
-  "trustPolicyIgnoreAfter": 1440
+  "trustPolicyExclude": ["@myorg/*", "chokidar@4.0.3", "webpack@4.47.0 || 5.102.1", "@babel/core@7.28.5"],
+  "trustPolicyIgnoreAfter": 20160
 }

--- a/libraries/rush-lib/src/logic/pnpm/test/jsonFiles/pnpm-config-trustPolicy.json
+++ b/libraries/rush-lib/src/logic/pnpm/test/jsonFiles/pnpm-config-trustPolicy.json
@@ -1,5 +1,5 @@
 {
   "trustPolicy": "no-downgrade",
   "trustPolicyExclude": ["@myorg/*", "chokidar@4.0.3", "webpack@4.47.0 || 5.102.1", "@babel/core@7.28.5"],
-  "trustPolicyIgnoreAfter": 20160
+  "trustPolicyIgnoreAfterMinutes": 20160
 }

--- a/libraries/rush-lib/src/logic/pnpm/test/jsonFiles/pnpm-config-trustPolicy.json
+++ b/libraries/rush-lib/src/logic/pnpm/test/jsonFiles/pnpm-config-trustPolicy.json
@@ -1,0 +1,5 @@
+{
+  "trustPolicy": "no-downgrade",
+  "trustPolicyExclude": ["webpack", "@myorg/*"],
+  "trustPolicyIgnoreAfter": 1440
+}

--- a/libraries/rush-lib/src/schemas/pnpm-config.schema.json
+++ b/libraries/rush-lib/src/schemas/pnpm-config.schema.json
@@ -214,6 +214,26 @@
       }
     },
 
+    "trustPolicy": {
+      "description": "The trust policy controls whether pnpm should block installation of package versions where the trust level has decreased (e.g., a package previously published with provenance is now published without it). Setting this to \"no-downgrade\" enables the protection.\n\n(SUPPORTED ONLY IN PNPM 10.21.0 AND NEWER)\n\nPNPM documentation: https://pnpm.io/settings#trustpolicy",
+      "type": "string",
+      "enum": ["no-downgrade", "off"]
+    },
+
+    "trustPolicyExclude": {
+      "description": "List of package names or patterns that are excluded from the trust policy check. These packages will be allowed to install even if their trust level has decreased. Supports glob patterns (e.g., \"@myorg/*\").\n\n(SUPPORTED ONLY IN PNPM 10.22.0 AND NEWER)\n\nPNPM documentation: https://pnpm.io/settings#trustpolicyexclude\n\nExample: [\"webpack\", \"react\", \"@myorg/*\"]",
+      "type": "array",
+      "items": {
+        "description": "Package name or pattern",
+        "type": "string"
+      }
+    },
+
+    "trustPolicyIgnoreAfter": {
+      "description": "The number of minutes after which pnpm will ignore trust level downgrades. Packages published longer ago than this threshold will not be blocked even if their trust level has decreased.\n\n(SUPPORTED ONLY IN PNPM 10.27.0 AND NEWER)\n\nPNPM documentation: https://pnpm.io/settings#trustpolicyignoreafter",
+      "type": "number"
+    },
+
     "alwaysFullInstall": {
       "description": "(EXPERIMENTAL) If 'true', then filtered installs ('rush install --to my-project') * will be disregarded, instead always performing a full installation of the lockfile.",
       "type": "boolean"

--- a/libraries/rush-lib/src/schemas/pnpm-config.schema.json
+++ b/libraries/rush-lib/src/schemas/pnpm-config.schema.json
@@ -229,7 +229,7 @@
       }
     },
 
-    "trustPolicyIgnoreAfter": {
+    "trustPolicyIgnoreAfterMinutes": {
       "description": "The number of minutes after which pnpm will ignore trust level downgrades. Packages published longer ago than this threshold will not be blocked even if their trust level has decreased.\n\n(SUPPORTED ONLY IN PNPM 10.27.0 AND NEWER)\n\nPNPM documentation: https://pnpm.io/settings#trustpolicyignoreafter",
       "type": "number"
     },


### PR DESCRIPTION
## Summary

This PR closes https://github.com/microsoft/rushstack/issues/5750, by adding support for these options in `pnpm-config.json`. 

From a user's perspective, they can now adopt a stricter trust policy, providing defence-in-depth for supply chain vulnerabilities, particularly hijacking of dependency maintainers' tokens and publishing outside of CI. The `trustPolicyExclude` and `trustPolicyIgnoreAfter` options provide a migration path for adopting the setting, by avoiding errors on known-good (or assumed-good) versions of packages.

## Details

I largely followed the implementation for `minimumRelease` and `minimumReleaseAgeExclude`, adding the setting to `PnpmOptionsConfiguration` and any of the related interfaces. I also updated the docs, largely matching what pnpm describes.

This should not have backwards compatibility issues, since these properties are optional (though I suppose if a repo was specifying them assuming they worked, they will now be enforced; I forget if pnpm-config.json is permissive about unknown properties)

## How it was tested

I added unit tests to ensure that the config gets passed on.

I'm now looking through the docs about the current recommendation for linking locally, so I can test this on our monorepo at DoorDash.

## Impacted documentation

The docs at https://rushjs.io/pages/configs/pnpm-config_json/ are affected, though if I understood the process right, they are covered by the docs changes here? Let me know if not, and I can update the site manually or in whichever process :relieved:

(Note to self to double-check the api-extractor result, now that I've edited some of the comments)
