### PR TITLE
[rush] Use AsyncRecycler for autoinstaller cleanup

### DIFF
--- a/common/changes/@microsoft/rush/autoinstaller-move-node-modules-to-recycler_2026-04-07-18-05.json
+++ b/common/changes/@microsoft/rush/autoinstaller-move-node-modules-to-recycler_2026-04-07-18-05.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Move stale autoinstaller node_modules folders into Rush's recycler before deleting them, instead of clearing them in place.",
+      "comment": "Move stale autoinstaller `node_modules` folders into Rush's recycler before asynchronously deleting them, instead of synchronously deleting them in place.",
       "type": "none"
     }
   ],

--- a/common/changes/@microsoft/rush/autoinstaller-move-node-modules-to-recycler_2026-04-07-18-05.json
+++ b/common/changes/@microsoft/rush/autoinstaller-move-node-modules-to-recycler_2026-04-07-18-05.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Move stale autoinstaller node_modules folders into Rush's recycler before deleting them, instead of clearing them in place.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/cli/test/Autoinstaller.test.ts
+++ b/libraries/rush-lib/src/cli/test/Autoinstaller.test.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import * as path from 'node:path';
-
 import './mockRushCommandLineParser';
 
 import { FileSystem } from '@rushstack/node-core-library';
@@ -34,23 +32,21 @@ describe(Autoinstaller.name, () => {
       'pluginWithBuildCommandRepo',
       'update'
     );
-  const autoinstallerPath: string = `${repoPath}/common/autoinstallers/plugins`;
-  const nodeModulesFolder: string = `${autoinstallerPath}/${RushConstants.nodeModulesFolderName}`;
-  const staleFilePath: string = `${nodeModulesFolder}/stale-package/index.js`;
-  const recyclerFolder: string = `${parser.rushConfiguration.commonTempFolder}/${RushConstants.rushRecyclerFolderName}`;
+    const autoinstallerPath: string = `${repoPath}/common/autoinstallers/plugins`;
+    const nodeModulesFolder: string = `${autoinstallerPath}/${RushConstants.nodeModulesFolderName}`;
+    const staleFilePath: string = `${nodeModulesFolder}/stale-package/index.js`;
+    const recyclerFolder: string = `${parser.rushConfiguration.commonTempFolder}/${RushConstants.rushRecyclerFolderName}`;
 
     await FileSystem.writeFileAsync(staleFilePath, 'stale', {
       ensureFolderExists: true
     });
 
-    const recyclerEntriesBefore: Set<string> = FileSystem.exists(recyclerFolder)
-      ? new Set(FileSystem.readFolderItemNames(recyclerFolder))
     let recyclerEntriesBefore: Set<string>;
     try {
-      recyclerEntriesBefore =new Set(await FileSystem.readFolderItemNamesAsync(recyclerFolder));
+      recyclerEntriesBefore = new Set(await FileSystem.readFolderItemNamesAsync(recyclerFolder));
     } catch (error) {
       if (FileSystem.isNotExistError(error)) {
-        recyclerEntriesBefore= new Set();
+        recyclerEntriesBefore = new Set();
       } else {
         throw error;
       }
@@ -61,7 +57,9 @@ describe(Autoinstaller.name, () => {
     jest
       .spyOn(Utilities, 'executeCommandAsync')
       .mockImplementation(async (options: Parameters<typeof Utilities.executeCommandAsync>[0]) => {
-        await FileSystem.ensureFolderAsync(`${options.workingDirectory}/${RushConstants.nodeModulesFolderName}`);
+        await FileSystem.ensureFolderAsync(
+          `${options.workingDirectory}/${RushConstants.nodeModulesFolderName}`
+        );
       });
 
     const autoinstaller: Autoinstaller = new Autoinstaller({

--- a/libraries/rush-lib/src/cli/test/Autoinstaller.test.ts
+++ b/libraries/rush-lib/src/cli/test/Autoinstaller.test.ts
@@ -1,0 +1,101 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import * as path from 'node:path';
+
+import './mockRushCommandLineParser';
+
+import { FileSystem } from '@rushstack/node-core-library';
+
+import { Autoinstaller } from '../../logic/Autoinstaller';
+import { InstallHelpers } from '../../logic/installManager/InstallHelpers';
+import { RushConstants } from '../../logic/RushConstants';
+import { Utilities } from '../../utilities/Utilities';
+import {
+  getCommandLineParserInstanceAsync,
+  isolateEnvironmentConfigurationForTests,
+  type IEnvironmentConfigIsolation
+} from './TestUtils';
+
+describe('Autoinstaller', () => {
+  let _envIsolation: IEnvironmentConfigIsolation;
+
+  beforeEach(() => {
+    _envIsolation = isolateEnvironmentConfigurationForTests();
+  });
+
+  afterEach(() => {
+    _envIsolation.restore();
+    jest.restoreAllMocks();
+  });
+
+  it('moves an existing node_modules folder into the Rush recycler before reinstalling', async () => {
+    const { parser, repoPath, spawnMock } = await getCommandLineParserInstanceAsync(
+      'pluginWithBuildCommandRepo',
+      'update'
+    );
+    const autoinstallerPath: string = path.join(repoPath, 'common/autoinstallers/plugins');
+    const nodeModulesFolder: string = path.join(autoinstallerPath, RushConstants.nodeModulesFolderName);
+    const staleFilePath: string = path.join(nodeModulesFolder, 'stale-package/index.js');
+    const recyclerFolder: string = path.join(
+      parser.rushConfiguration.commonTempFolder,
+      RushConstants.rushRecyclerFolderName
+    );
+
+    FileSystem.writeFile(staleFilePath, 'stale', {
+      ensureFolderExists: true
+    });
+
+    const recyclerEntriesBefore: Set<string> = FileSystem.exists(recyclerFolder)
+      ? new Set(FileSystem.readFolderItemNames(recyclerFolder))
+      : new Set();
+
+    jest.spyOn(InstallHelpers, 'ensureLocalPackageManagerAsync').mockResolvedValue(undefined);
+    jest.spyOn(Utilities, 'syncNpmrc').mockImplementation(() => undefined);
+    jest
+      .spyOn(Utilities, 'executeCommandAsync')
+      .mockImplementation(async (options: Parameters<typeof Utilities.executeCommandAsync>[0]) => {
+        FileSystem.ensureFolder(path.join(options.workingDirectory, RushConstants.nodeModulesFolderName));
+      });
+
+    const autoinstaller: Autoinstaller = new Autoinstaller({
+      autoinstallerName: 'plugins',
+      rushConfiguration: parser.rushConfiguration,
+      rushGlobalFolder: parser.rushGlobalFolder
+    });
+
+    await autoinstaller.prepareAsync();
+
+    const recyclerEntriesAfter: string[] = FileSystem.readFolderItemNames(recyclerFolder).filter(
+      (entry: string) => !recyclerEntriesBefore.has(entry)
+    );
+
+    expect(recyclerEntriesAfter).toHaveLength(1);
+    expect(
+      FileSystem.exists(path.join(recyclerFolder, recyclerEntriesAfter[0], 'stale-package/index.js'))
+    ).toBe(true);
+    expect(FileSystem.exists(staleFilePath)).toBe(false);
+    expect(FileSystem.exists(path.join(nodeModulesFolder, 'rush-autoinstaller.flag'))).toBe(true);
+
+    if (process.platform === 'win32') {
+      expect(spawnMock).toHaveBeenCalledWith(
+        'cmd.exe',
+        expect.arrayContaining(['/c']),
+        expect.objectContaining({
+          detached: true,
+          stdio: 'ignore',
+          windowsVerbatimArguments: true
+        })
+      );
+    } else {
+      expect(spawnMock).toHaveBeenCalledWith(
+        'rm',
+        expect.arrayContaining(['-rf']),
+        expect.objectContaining({
+          detached: true,
+          stdio: 'ignore'
+        })
+      );
+    }
+  });
+});

--- a/libraries/rush-lib/src/cli/test/Autoinstaller.test.ts
+++ b/libraries/rush-lib/src/cli/test/Autoinstaller.test.ts
@@ -17,7 +17,7 @@ import {
   type IEnvironmentConfigIsolation
 } from './TestUtils';
 
-describe('Autoinstaller', () => {
+describe(Autoinstaller.name, () => {
   let _envIsolation: IEnvironmentConfigIsolation;
 
   beforeEach(() => {
@@ -34,28 +34,34 @@ describe('Autoinstaller', () => {
       'pluginWithBuildCommandRepo',
       'update'
     );
-    const autoinstallerPath: string = path.join(repoPath, 'common/autoinstallers/plugins');
-    const nodeModulesFolder: string = path.join(autoinstallerPath, RushConstants.nodeModulesFolderName);
-    const staleFilePath: string = path.join(nodeModulesFolder, 'stale-package/index.js');
-    const recyclerFolder: string = path.join(
-      parser.rushConfiguration.commonTempFolder,
-      RushConstants.rushRecyclerFolderName
-    );
+  const autoinstallerPath: string = `${repoPath}/common/autoinstallers/plugins`;
+  const nodeModulesFolder: string = `${autoinstallerPath}/${RushConstants.nodeModulesFolderName}`;
+  const staleFilePath: string = `${nodeModulesFolder}/stale-package/index.js`;
+  const recyclerFolder: string = `${parser.rushConfiguration.commonTempFolder}/${RushConstants.rushRecyclerFolderName}`;
 
-    FileSystem.writeFile(staleFilePath, 'stale', {
+    await FileSystem.writeFileAsync(staleFilePath, 'stale', {
       ensureFolderExists: true
     });
 
     const recyclerEntriesBefore: Set<string> = FileSystem.exists(recyclerFolder)
       ? new Set(FileSystem.readFolderItemNames(recyclerFolder))
-      : new Set();
+    let recyclerEntriesBefore: Set<string>;
+    try {
+      recyclerEntriesBefore =new Set(await FileSystem.readFolderItemNamesAsync(recyclerFolder));
+    } catch (error) {
+      if (FileSystem.isNotExistError(error)) {
+        recyclerEntriesBefore= new Set();
+      } else {
+        throw error;
+      }
+    }
 
     jest.spyOn(InstallHelpers, 'ensureLocalPackageManagerAsync').mockResolvedValue(undefined);
     jest.spyOn(Utilities, 'syncNpmrc').mockImplementation(() => undefined);
     jest
       .spyOn(Utilities, 'executeCommandAsync')
       .mockImplementation(async (options: Parameters<typeof Utilities.executeCommandAsync>[0]) => {
-        FileSystem.ensureFolder(path.join(options.workingDirectory, RushConstants.nodeModulesFolderName));
+        await FileSystem.ensureFolderAsync(`${options.workingDirectory}/${RushConstants.nodeModulesFolderName}`);
       });
 
     const autoinstaller: Autoinstaller = new Autoinstaller({
@@ -66,16 +72,16 @@ describe('Autoinstaller', () => {
 
     await autoinstaller.prepareAsync();
 
-    const recyclerEntriesAfter: string[] = FileSystem.readFolderItemNames(recyclerFolder).filter(
+    const recyclerEntriesAfter: string[] = (await FileSystem.readFolderItemNamesAsync(recyclerFolder)).filter(
       (entry: string) => !recyclerEntriesBefore.has(entry)
     );
 
     expect(recyclerEntriesAfter).toHaveLength(1);
-    expect(
-      FileSystem.exists(path.join(recyclerFolder, recyclerEntriesAfter[0], 'stale-package/index.js'))
-    ).toBe(true);
-    expect(FileSystem.exists(staleFilePath)).toBe(false);
-    expect(FileSystem.exists(path.join(nodeModulesFolder, 'rush-autoinstaller.flag'))).toBe(true);
+    await expect(
+      FileSystem.existsAsync(`${recyclerFolder}/${recyclerEntriesAfter[0]}/stale-package/index.js`)
+    ).resolves.toBe(true);
+    await expect(FileSystem.existsAsync(staleFilePath)).resolves.toBe(false);
+    await expect(FileSystem.existsAsync(`${nodeModulesFolder}/rush-autoinstaller.flag`)).resolves.toBe(true);
 
     if (process.platform === 'win32') {
       expect(spawnMock).toHaveBeenCalledWith(

--- a/libraries/rush-lib/src/logic/Autoinstaller.ts
+++ b/libraries/rush-lib/src/logic/Autoinstaller.ts
@@ -133,7 +133,7 @@ export class Autoinstaller {
         if (FileSystem.exists(nodeModulesFolder)) {
           this._logIfConsoleOutputIsNotRestricted('Deleting old files from ' + nodeModulesFolder);
           const recycler: AsyncRecycler = new AsyncRecycler(
-            path.join(this._rushConfiguration.commonTempFolder, RushConstants.rushRecyclerFolderName)
+            `${this._rushConfiguration.commonTempFolder}/${RushConstants.rushRecyclerFolderName}`
           );
           recycler.moveFolder(nodeModulesFolder);
           await recycler.startDeleteAllAsync();

--- a/libraries/rush-lib/src/logic/Autoinstaller.ts
+++ b/libraries/rush-lib/src/logic/Autoinstaller.ts
@@ -132,7 +132,7 @@ export class Autoinstaller {
       if (isLastInstallFlagDirty || lock.dirtyWhenAcquired) {
         if (FileSystem.exists(nodeModulesFolder)) {
           this._logIfConsoleOutputIsNotRestricted('Deleting old files from ' + nodeModulesFolder);
-          const recycler = new AsyncRecycler(
+          const recycler: AsyncRecycler = new AsyncRecycler(
             path.join(this._rushConfiguration.commonTempFolder, RushConstants.rushRecyclerFolderName)
           );
           recycler.moveFolder(nodeModulesFolder);

--- a/libraries/rush-lib/src/logic/Autoinstaller.ts
+++ b/libraries/rush-lib/src/logic/Autoinstaller.ts
@@ -14,6 +14,7 @@ import {
 } from '@rushstack/node-core-library';
 import { Colorize } from '@rushstack/terminal';
 
+import { AsyncRecycler } from '../utilities/AsyncRecycler';
 import { Utilities } from '../utilities/Utilities';
 import type { RushConfiguration } from '../api/RushConfiguration';
 import { PackageJsonEditor } from '../api/PackageJsonEditor';
@@ -131,7 +132,11 @@ export class Autoinstaller {
       if (isLastInstallFlagDirty || lock.dirtyWhenAcquired) {
         if (FileSystem.exists(nodeModulesFolder)) {
           this._logIfConsoleOutputIsNotRestricted('Deleting old files from ' + nodeModulesFolder);
-          FileSystem.ensureEmptyFolder(nodeModulesFolder);
+          const recycler = new AsyncRecycler(
+            path.join(this._rushConfiguration.commonTempFolder, RushConstants.rushRecyclerFolderName)
+          );
+          recycler.moveFolder(nodeModulesFolder);
+          await recycler.startDeleteAllAsync();
         }
 
         // Copy: .../common/autoinstallers/my-task/.npmrc


### PR DESCRIPTION
## Summary

`Deleting old files from **/node_modules` is a process invoked for every autoinstaller install.

For large rush repos, this takes a lot of time. On my computer this process can take half a minute.

This fixes autoinstaller cleanup so stale `node_modules` folders are moved into Rush's recycler before deletion instead of being cleared in place.

## Details

When an autoinstaller install is invalidated, Rush previously called `FileSystem.ensureEmptyFolder()` on the autoinstaller `node_modules` folder. This change switches that path to `AsyncRecycler`, which first renames the folder into `common/temp/rush-recycler` and then starts asynchronous deletion. That keeps the cleanup path cross-platform and consistent with other Rush cleanup flows.

I also added a targeted unit test that seeds an autoinstaller `node_modules` tree, runs `prepareAsync()`, and verifies the old tree was moved into the recycler before reinstall.

This does not change public APIs.

## How it was tested

- `pnpm --dir libraries/rush-lib exec heft build --clean`
- `pnpm --dir libraries/rush-lib exec heft test --clean --test-path-pattern Autoinstaller.test`
