### PR TITLE
[heft-web-rig] Add temp/image-typings to build clean folders

### DIFF
--- a/build-tests/heft-rspack-everything-test/config/heft.json
+++ b/build-tests/heft-rspack-everything-test/config/heft.json
@@ -7,7 +7,7 @@
   // TODO: Add comments
   "phasesByName": {
     "build": {
-      "cleanFiles": [{ "includeGlobs": ["dist", "lib", "lib-commonjs"] }],
+      "cleanFiles": [{ "includeGlobs": ["dist", "lib", "lib-commonjs", "temp/image-typings"] }],
 
       "tasksByName": {
         "image-typings": {

--- a/build-tests/heft-webpack5-everything-test/config/heft.json
+++ b/build-tests/heft-webpack5-everything-test/config/heft.json
@@ -7,7 +7,7 @@
   // TODO: Add comments
   "phasesByName": {
     "build": {
-      "cleanFiles": [{ "includeGlobs": ["dist", "lib", "lib-commonjs"] }],
+      "cleanFiles": [{ "includeGlobs": ["dist", "lib", "lib-commonjs", "temp/image-typings"] }],
 
       "tasksByName": {
         "image-typings": {

--- a/common/changes/@rushstack/heft-web-rig/main_2026-04-13-06-55.json
+++ b/common/changes/@rushstack/heft-web-rig/main_2026-04-13-06-55.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-web-rig",
+      "comment": "Include `temp/image-typings` in the build clean folders.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft-web-rig"
+}

--- a/rigs/heft-web-rig/profiles/app/config/heft.json
+++ b/rigs/heft-web-rig/profiles/app/config/heft.json
@@ -22,7 +22,17 @@
   "phasesByName": {
     "build": {
       "cleanFiles": [
-        { "includeGlobs": ["dist", "lib", "lib-amd", "lib-commonjs", "lib-es6", "temp/sass-ts"] }
+        {
+          "includeGlobs": [
+            "dist",
+            "lib",
+            "lib-amd",
+            "lib-commonjs",
+            "lib-es6",
+            "temp/sass-ts",
+            "temp/image-typings"
+          ]
+        }
       ],
 
       "tasksByName": {

--- a/rigs/heft-web-rig/profiles/library/config/heft.json
+++ b/rigs/heft-web-rig/profiles/library/config/heft.json
@@ -22,7 +22,17 @@
   "phasesByName": {
     "build": {
       "cleanFiles": [
-        { "includeGlobs": ["dist", "lib", "lib-amd", "lib-commonjs", "lib-es6", "temp/sass-ts"] }
+        {
+          "includeGlobs": [
+            "dist",
+            "lib",
+            "lib-amd",
+            "lib-commonjs",
+            "lib-es6",
+            "temp/sass-ts",
+            "temp/image-typings"
+          ]
+        }
       ],
 
       "tasksByName": {


### PR DESCRIPTION
## Summary

- Add `temp/image-typings` to the `cleanFiles` glob list in `heft-web-rig` rig profiles (`app` and `library`)
- Apply the same fix to the `heft-rspack-everything-test` and `heft-webpack5-everything-test` build test configs for consistency

## Test plan

- [ ] Verify that `rush build --clean` removes the `temp/image-typings` folder in projects using the `heft-web-rig`

🤖 Generated with [Claude Code](https://claude.com/claude-code)