### PR TITLE
[api-extractor] Upgrade bundled TypeScript to 6.0.3

### DIFF
--- a/apps/api-extractor/package.json
+++ b/apps/api-extractor/package.json
@@ -74,7 +74,7 @@
     "resolve": "~1.22.1",
     "semver": "~7.7.4",
     "source-map": "~0.6.1",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   },
   "devDependencies": {
     "@rushstack/heft": "1.2.17",

--- a/apps/api-extractor/src/analyzer/TypeScriptInternals.ts
+++ b/apps/api-extractor/src/analyzer/TypeScriptInternals.ts
@@ -17,7 +17,7 @@ export interface IGlobalVariableAnalyzer {
 export class TypeScriptInternals {
   public static getImmediateAliasedSymbol(symbol: ts.Symbol, typeChecker: ts.TypeChecker): ts.Symbol {
     // Compiler internal:
-    // https://github.com/microsoft/TypeScript/blob/v5.9.3/src/compiler/checker.ts
+    // https://github.com/microsoft/TypeScript/blob/v6.0.3/src/compiler/checker.ts
     return (typeChecker as any).getImmediateAliasedSymbol(symbol);
   }
 
@@ -61,7 +61,7 @@ export class TypeScriptInternals {
    */
   public static getJSDocCommentRanges(node: ts.Node, text: string): ts.CommentRange[] | undefined {
     // Compiler internal:
-    // https://github.com/microsoft/TypeScript/blob/v5.9.3/src/compiler/utilities.ts#L2710
+    // https://github.com/microsoft/TypeScript/blob/v6.0.3/src/compiler/utilities.ts#L2763
 
     return (ts as any).getJSDocCommentRanges.apply(this, arguments);
   }
@@ -73,7 +73,7 @@ export class TypeScriptInternals {
     node: ts.Identifier | ts.StringLiteralLike | ts.NumericLiteral
   ): string {
     // Compiler internal:
-    // https://github.com/microsoft/TypeScript/blob/v5.9.3/src/compiler/utilities.ts#L5368
+    // https://github.com/microsoft/TypeScript/blob/v6.0.3/src/compiler/utilities.ts#L5439
 
     return (ts as any).getTextOfIdentifierOrLiteral(node);
   }
@@ -89,7 +89,7 @@ export class TypeScriptInternals {
     mode: ts.ModuleKind.CommonJS | ts.ModuleKind.ESNext | undefined
   ): ts.ResolvedModuleFull | undefined {
     // Compiler internal:
-    // https://github.com/microsoft/TypeScript/blob/v5.9.3/src/compiler/types.ts#L5064
+    // https://github.com/microsoft/TypeScript/blob/v6.0.3/src/compiler/types.ts#L5056
     const result: ts.ResolvedModuleWithFailedLookupLocations | undefined = (program as any).getResolvedModule(
       sourceFile,
       moduleNameText,
@@ -107,7 +107,7 @@ export class TypeScriptInternals {
     compilerOptions: ts.CompilerOptions
   ): ts.ModuleKind.CommonJS | ts.ModuleKind.ESNext | undefined {
     // Compiler internal:
-    // https://github.com/microsoft/TypeScript/blob/v5.9.3/src/compiler/program.ts#L932
+    // https://github.com/microsoft/TypeScript/blob/v6.0.3/src/compiler/program.ts#L932
 
     return ts.getModeForUsageLocation?.(file, usage, compilerOptions);
   }

--- a/build-tests/api-extractor-test-05/dist/tsdoc-metadata.json
+++ b/build-tests/api-extractor-test-05/dist/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.58.2"
+      "packageVersion": "7.58.7"
     }
   ]
 }

--- a/common/changes/@microsoft/api-extractor/api-extractor-ts-6_2026-04-21-11-57.json
+++ b/common/changes/@microsoft/api-extractor/api-extractor-ts-6_2026-04-21-11-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Upgrade the bundled compiler engine to TypeScript 6.0.3",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor"
+}

--- a/common/config/subspaces/build-tests-subspace/pnpm-lock.yaml
+++ b/common/config/subspaces/build-tests-subspace/pnpm-lock.yaml
@@ -911,7 +911,7 @@ packages:
   '@rushstack/heft-api-extractor-plugin@file:../../../heft-plugins/heft-api-extractor-plugin':
     resolution: {directory: ../../../heft-plugins/heft-api-extractor-plugin, type: directory}
     peerDependencies:
-      '@rushstack/heft': 1.2.16
+      '@rushstack/heft': 1.2.17
 
   '@rushstack/heft-config-file@file:../../../libraries/heft-config-file':
     resolution: {directory: ../../../libraries/heft-config-file, type: directory}
@@ -920,7 +920,7 @@ packages:
   '@rushstack/heft-jest-plugin@file:../../../heft-plugins/heft-jest-plugin':
     resolution: {directory: ../../../heft-plugins/heft-jest-plugin, type: directory}
     peerDependencies:
-      '@rushstack/heft': ^1.2.16
+      '@rushstack/heft': ^1.2.17
       '@types/jest': ^30.0.0
       jest-environment-jsdom: ^30.3.0
       jest-environment-node: ^30.3.0
@@ -935,17 +935,17 @@ packages:
   '@rushstack/heft-lint-plugin@file:../../../heft-plugins/heft-lint-plugin':
     resolution: {directory: ../../../heft-plugins/heft-lint-plugin, type: directory}
     peerDependencies:
-      '@rushstack/heft': 1.2.16
+      '@rushstack/heft': 1.2.17
 
   '@rushstack/heft-node-rig@file:../../../rigs/heft-node-rig':
     resolution: {directory: ../../../rigs/heft-node-rig, type: directory}
     peerDependencies:
-      '@rushstack/heft': ^1.2.16
+      '@rushstack/heft': ^1.2.17
 
   '@rushstack/heft-typescript-plugin@file:../../../heft-plugins/heft-typescript-plugin':
     resolution: {directory: ../../../heft-plugins/heft-typescript-plugin, type: directory}
     peerDependencies:
-      '@rushstack/heft': 1.2.16
+      '@rushstack/heft': 1.2.17
 
   '@rushstack/heft@file:../../../apps/heft':
     resolution: {directory: ../../../apps/heft, type: directory}
@@ -3533,8 +3533,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -4296,7 +4296,7 @@ snapshots:
       resolve: 1.22.11
       semver: 7.7.4
       source-map: 0.6.1
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - '@types/node'
 
@@ -8127,7 +8127,7 @@ snapshots:
 
   typescript@5.8.3: {}
 
-  typescript@5.9.3: {}
+  typescript@6.0.3: {}
 
   unbox-primitive@1.1.0:
     dependencies:

--- a/common/config/subspaces/build-tests-subspace/repo-state.json
+++ b/common/config/subspaces/build-tests-subspace/repo-state.json
@@ -1,6 +1,6 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "25af5cc1d5f5868a28c72452f26f989b79a633fa",
+  "pnpmShrinkwrapHash": "4589dcbd2f0b9ddb3e72852e16ef504154da6bd2",
   "preferredVersionsHash": "550b4cee0bef4e97db6c6aad726df5149d20e7d9",
-  "packageJsonInjectedDependenciesHash": "4882fe56328604fcfe4c0ee5f0bd20ff86e48a18"
+  "packageJsonInjectedDependenciesHash": "d54b214b99147653017ea4cd79bcc24e9a47b8e4"
 }

--- a/common/config/subspaces/default/common-versions.json
+++ b/common/config/subspaces/default/common-versions.json
@@ -107,8 +107,9 @@
       "~4.9.5",
 
       "5.8.2",
+      "5.9.3",
       // API Extractor bundles a specific TypeScript version because it calls internal APIs
-      "5.9.3"
+      "6.0.3"
     ],
     "source-map": [
       "~0.6.1" // API Extractor is using an older version of source-map because newer versions are async

--- a/common/config/subspaces/default/pnpm-lock.yaml
+++ b/common/config/subspaces/default/pnpm-lock.yaml
@@ -99,8 +99,8 @@ importers:
         specifier: ~0.6.1
         version: 0.6.1
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
     devDependencies:
       '@rushstack/heft':
         specifier: 1.2.17
@@ -18346,6 +18346,11 @@ packages:
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -37485,6 +37490,8 @@ snapshots:
   typescript@5.8.2: {}
 
   typescript@5.9.3: {}
+
+  typescript@6.0.3: {}
 
   uc.micro@2.1.0: {}
 

--- a/common/config/subspaces/default/repo-state.json
+++ b/common/config/subspaces/default/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "80172ae4736f423efc43c5fb63defdf8229a8ef8",
+  "pnpmShrinkwrapHash": "25cdd40bf0e35e44b48d4072fcb1c8378f14b120",
   "preferredVersionsHash": "029c99bd6e65c5e1f25e2848340509811ff9753c"
 }


### PR DESCRIPTION
 ## Summary
 
 Upgrade the bundled compiler engine from TypeScript 5.9.3 to 6.0.3.
 
 ## Details
 
In our packages, we extend a shared tsconfig (using lib/target of ES2025) which now fails api-extractor. As a current workaround, we use a separate tsconfig just for api-extractor (setting lib/target back to ES2024).

NOTE: I used copilot for this PR
 
 ## How it was tested
 
 `rushx _phase:test` — all 61 tests pass
 
 ## Impacted documentation
 
 Updated code comments in `TypeScriptInternals.ts` to point to updated version and correct lines.