### PR TITLE
[rush] Route lockfile-changed warning to stderr (fixes #5406)

### DIFF
--- a/common/changes/@microsoft/rush/fix-rush-list-json-stderr_2026-05-17-19-00.json
+++ b/common/changes/@microsoft/rush/fix-rush-list-json-stderr_2026-05-17-19-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Route the \"Lockfile was created or deleted\" warning to stderr so that machine-readable output (e.g. `rush list --json`) remains parseable when the lockfile was added or removed in the diff range.",
+      "type": "patch",
+      "packageName": "@microsoft/rush"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "sshaurya914@gmail.com"
+}

--- a/libraries/rush-lib/src/logic/ProjectChangeAnalyzer.ts
+++ b/libraries/rush-lib/src/logic/ProjectChangeAnalyzer.ts
@@ -220,11 +220,13 @@ export class ProjectChangeAnalyzer {
         if (shrinkwrapStatus) {
           if (shrinkwrapStatus.status !== 'M') {
             if (rushConfiguration.subspacesFeatureEnabled) {
-              terminal.writeLine(
+              terminal.writeWarningLine(
                 `"${subspace.subspaceName}" subspace lockfile was created or deleted. Assuming all projects are affected.`
               );
             } else {
-              terminal.writeLine(`Lockfile was created or deleted. Assuming all projects are affected.`);
+              terminal.writeWarningLine(
+                `Lockfile was created or deleted. Assuming all projects are affected.`
+              );
             }
             for (const project of subspaceProjects) {
               changedProjects.add(project);


### PR DESCRIPTION
### Summary

`rush list --json` corrupts its own JSON output when the lockfile was added or removed in the diff range:

```
$ rush list --json --impacted-by git:<sha_with_no_lockfile>
Lockfile was created or deleted. Assuming all projects are affected.
{
  "projects": [
     ...
  ]
}
```

The first line is written to **stdout**, so the output is no longer parseable by `jq` or any other tool consuming the JSON.

### Fix

Route both branches of the lockfile-status warning in `ProjectChangeAnalyzer.ts` through `terminal.writeWarningLine` (which writes to **stderr**) rather than `terminal.writeLine`. This is the standard CLI convention for warnings that should not pollute machine-readable stdout, and it matches how the rest of this file already emits non-fatal diagnostics (see existing `writeWarningLine` calls at lines 418, 446, 458 on `main`).

`iclanton` green-lit a PR in the issue thread ("Probably pretty simple to fix. Are you interested in putting together a PR?").

### Changeset

Added a `patch` changeset for `@microsoft/rush` under `common/changes/`.

### Verification

I do not have a Rush-managed monorepo set up locally to demonstrate the before/after pipe, but the diff is a one-method swap (`writeLine` → `writeWarningLine`) and the receiving terminal type already exposes the warning method (used elsewhere in the same file).

### Issue

Fixes #5406