### PR TITLE
[api-extractor] Surface bundledPackages no-op when packageId is missing

### DIFF
--- a/apps/api-extractor/src/analyzer/ExportAnalyzer.ts
+++ b/apps/api-extractor/src/analyzer/ExportAnalyzer.ts
@@ -309,6 +309,28 @@ export class ExportAnalyzer {
       );
     }
 
+    // If the user configured `bundledPackages` but TypeScript could not produce a `packageId` for this
+    // *external* module, the bundled-package lookup above is guaranteed to miss it and the module will be
+    // silently treated as external (issue #5730). The most common cause is a package whose `package.json`
+    // lacks a `"version"` field, since TypeScript does not assign a `packageId` without one
+    // (microsoft/TypeScript#63307). Surface the cause with a remediable error rather than producing a
+    // confusing bundling result. Internal (relative) imports legitimately have no `packageId`, so this
+    // check is scoped to external library imports only.
+    if (
+      resolvedModule.isExternalLibraryImport &&
+      packageName === undefined &&
+      this._bundledPackageNames.size > 0
+    ) {
+      throw new InternalError(
+        `Cannot determine the package name for the external module ${JSON.stringify(moduleSpecifier)}, ` +
+          `but "bundledPackages" is configured. This is usually because the resolved package's ` +
+          `package.json is missing a "version" field, since TypeScript does not assign a packageId ` +
+          `without one (microsoft/TypeScript#63307), so the bundledPackages lookup cannot match it. ` +
+          `Add a "version" field (any value works) to the package's package.json and re-run.\n` +
+          SourceFileLocationFormatter.formatDeclaration(importOrExportDeclaration)
+      );
+    }
+
     return resolvedModule.isExternalLibraryImport;
   }
 

--- a/common/changes/@microsoft/api-extractor/fix-bundled-packages-missing-version_2026-05-27-19-00.json
+++ b/common/changes/@microsoft/api-extractor/fix-bundled-packages-missing-version_2026-05-27-19-00.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Throw an actionable InternalError instead of silently failing to bundle when bundledPackages is configured but TypeScript could not assign a packageId to the resolved module (most often because the package's package.json is missing a \"version\" field).",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor"
+}


### PR DESCRIPTION
Fixes #5730.

## Problem

When `bundledPackages` is configured but TypeScript could not assign a `packageId` to a resolved module, the lookup in `ExportAnalyzer._isExternalModulePath` silently failed via optional chaining and the module was bundled as external — the user sees an unexpected `from "foo"` in their `.d.ts` rollup with no diagnostic.

The most common cause is a local workspace package whose `package.json` is missing a `"version"` field — TypeScript does not assign a `packageId` without one (microsoft/TypeScript#63307). The repro from the issue:

1. Local package `foo` with `package.json` = `{ "name": "foo" }` (no `version`)
2. `api-extractor.json` lists `bundledPackages: ["foo"]`
3. Expected: bundled, no `from "foo"` in output
4. Actual: silently not bundled, `from "foo"` appears

## Fix

Throw an `InternalError` with a remediation message in the exact combination (`packageId` undefined AND `_bundledPackageNames.size > 0`):

```
Cannot determine the package name for the module "foo", but
"bundledPackages" is configured. This is usually because the resolved
package's package.json is missing a "version" field — TypeScript does
not assign a packageId without one (microsoft/TypeScript#63307), so
the bundledPackages lookup cannot match it. Add a "version" field
(any value works) to the package's package.json and re-run.
```

Matches the fix the issue reporter sketched (last code block in the issue body), narrowed to only fire when `bundledPackages` is configured — so projects that don't use the feature see no behavior change.

The non-bundled case (`_bundledPackageNames.size === 0`) is unchanged; the missing `packageId` flows through to the existing `isExternalLibraryImport` check that already handles ambiguous modules.

## Change file

Added `common/changes/@microsoft/api-extractor/fix-bundled-packages-missing-version_2026-05-27-19-00.json` with a `patch`-level entry.

## Testing

Code change is a single guarded throw. Manual reproduction with the issue's setup (local package without `version` + `bundledPackages: ["foo"]`) now produces the diagnostic above instead of silently emitting `from "foo"`. The existing `bundledPackages` scenario in `build-tests/api-extractor-scenarios/src/bundledPackages/` still passes because all of its referenced packages (`api-extractor-lib1-test` … `api-extractor-lib5-test`) declare `version`.