### PR TITLE
[debug-certificate-manager] add homeDirectory config

### DIFF
--- a/vscode-extensions/debug-certificate-manager-vscode-extension/package.json
+++ b/vscode-extensions/debug-certificate-manager-vscode-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "debug-certificate-manager",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/rushstack.git",

--- a/vscode-extensions/debug-certificate-manager-vscode-extension/package.json
+++ b/vscode-extensions/debug-certificate-manager-vscode-extension/package.json
@@ -101,6 +101,11 @@
           "title": "Automatically Sync Certificates",
           "default": true,
           "description": "Check certificates when extension is activated. Extension is automatically activated when a `.vscode/debug-certificate-manager.json` file is present in the workspace."
+        },
+        "debugCertificateManager.homeDirectory": {
+          "type": "string",
+          "title": "Home Directory",
+          "description": "Absolute path to the home directory, used to resolve `~` in the workspace certificate store path. When set, this overrides the default behavior (`os.homedir()` for local workspaces, or running a command in a workspace terminal for remote workspaces like Codespaces, SSH, Dev Containers, WSL, or Tunnels). Note: this setting is recommended to be configured at the user level, not the workspace level."
         }
       }
     }

--- a/vscode-extensions/debug-certificate-manager-vscode-extension/src/config.ts
+++ b/vscode-extensions/debug-certificate-manager-vscode-extension/src/config.ts
@@ -11,12 +11,14 @@ import {
   CONFIG_CA_CERTIFICATE_FILENAME,
   CONFIG_CERTIFICATE_FILENAME,
   CONFIG_KEY_FILENAME,
+  CONFIG_HOME_DIRECTORY,
   CONFIG_STORE_PATH
 } from './constants';
 
 type StorePaths = Record<'windows' | 'linux' | 'osx', string>;
 export interface IExtensionConfig extends ICertificateStoreOptions {
   autoSync: boolean;
+  homeDirectory: string | undefined;
 }
 
 export function getConfig(terminal: ITerminal): IExtensionConfig {
@@ -27,6 +29,8 @@ export function getConfig(terminal: ITerminal): IExtensionConfig {
     config.get(CONFIG_CERTIFICATE_FILENAME) || 'rushstack-serve.pem';
   const keyFilename: string | undefined = config.get(CONFIG_KEY_FILENAME) || 'rushstack-serve.key';
   const autoSync: boolean = config.get(CONFIG_AUTOSYNC) ?? false;
+  const homeDirectory: string | undefined =
+    config.get<string>(CONFIG_HOME_DIRECTORY) || undefined;
   let storePath: string | undefined = undefined;
 
   const platformMap: Record<string, keyof StorePaths> = {
@@ -54,7 +58,8 @@ export function getConfig(terminal: ITerminal): IExtensionConfig {
     caCertificateFilename,
     certificateFilename,
     keyFilename,
-    autoSync
+    autoSync,
+    homeDirectory
   };
   terminal.writeLine(`Extension config: ${JSON.stringify(extensionConfig)}`);
   return extensionConfig;

--- a/vscode-extensions/debug-certificate-manager-vscode-extension/src/constants.ts
+++ b/vscode-extensions/debug-certificate-manager-vscode-extension/src/constants.ts
@@ -20,5 +20,6 @@ export const CONFIG_CA_CERTIFICATE_FILENAME: string = 'caCertificateFilename';
 export const CONFIG_CERTIFICATE_FILENAME: string = 'certificateFilename';
 export const CONFIG_KEY_FILENAME: string = 'keyFilename';
 export const CONFIG_STORE_PATH: string = 'storePath';
+export const CONFIG_HOME_DIRECTORY: string = 'homeDirectory';
 
 export const VSCODE_COMMAND_WORKSPACE_OPEN_SETTINGS: string = 'workbench.action.openSettings';

--- a/vscode-extensions/debug-certificate-manager-vscode-extension/src/extension.ts
+++ b/vscode-extensions/debug-certificate-manager-vscode-extension/src/extension.ts
@@ -206,7 +206,11 @@ export function activate(context: vscode.ExtensionContext): void {
       } else if (storePath.startsWith('~')) {
         let homeDir: string;
 
-        if (vscode.env.remoteName) {
+        const { homeDirectory } = getConfig(terminal);
+        if (homeDirectory) {
+          homeDir = homeDirectory;
+          terminal.writeLine(`Using configured home directory: ${homeDir}`);
+        } else if (vscode.env.remoteName) {
           const markerPrefix: string = '<<<HOMEDIR_START>>>';
           const markerSuffix: string = '<<<HOMEDIR_END>>>';
           const output: string = await runWorkspaceCommandAsync({


### PR DESCRIPTION
## Summary

Adds a new `debugCertificateManager.homeDirectory` setting to the Debug Certificate Manager VS Code extension. When set, this value is used to resolve a leading `~` in the workspace certificate store path, overriding both the local `os.homedir()` lookup and the terminal-based resolution used in remote workspaces.

This gives users a deterministic way to point the extension at the correct home directory in environments where the previous resolution mechanisms are unreliable.

## Details

- New string setting: `debugCertificateManager.homeDirectory`.
- Resolution order for `~` in the workspace store path:
  1. `homeDirectory` setting, if configured.
  2. Terminal-based resolution (existing behavior) when `vscode.env.remoteName` is set.
  3. `os.homedir()` (existing behavior) otherwise.
- The setting description recommends configuring it at the user level rather than per workspace.
- No backwards-compatibility break: when the setting is unset, behavior is unchanged.

## How it was tested

Manually:
- Built the extension via `rush build --to debug-certificate-manager`.
- Verified that with the new setting unset, existing local and remote resolution paths are preserved.
- Verified that with the new setting set, `~` expansion in the workspace store path uses the configured value directly without invoking the workspace terminal.

## Impacted documentation

None. Setting is self-describing via its `description` in `package.json`.
