### PR TITLE
[rush] Fix sync-back when dependencies move to devDependencies

### DIFF
--- a/common/changes/@microsoft/rush/fix-rush-update-devDependency-sync_2026-05-29-12-00.json
+++ b/common/changes/@microsoft/rush/fix-rush-update-devDependency-sync_2026-05-29-12-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix `rush update` not syncing pnpm-lock.yaml when a workspace dependency moves from `dependencies` to `devDependencies`.",
+      "type": "patch",
+      "packageName": "@microsoft/rush"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "eric.prestemon@reve.art"
+}

--- a/common/changes/@microsoft/rush/fix-rush-update-devDependency-sync_2026-05-29-12-00.json
+++ b/common/changes/@microsoft/rush/fix-rush-update-devDependency-sync_2026-05-29-12-00.json
@@ -7,5 +7,5 @@
     }
   ],
   "packageName": "@microsoft/rush",
-  "email": "eric.prestemon@reve.art"
+  "email": "ericprestemon@users.noreply.github.com"
 }

--- a/common/changes/@microsoft/rush/fix-rush-update-devDependency-sync_2026-05-29-12-00.json
+++ b/common/changes/@microsoft/rush/fix-rush-update-devDependency-sync_2026-05-29-12-00.json
@@ -1,7 +1,7 @@
 {
   "changes": [
     {
-      "comment": "Fix `rush update` not syncing pnpm-lock.yaml when a workspace dependency moves from `dependencies` to `devDependencies`.",
+      "comment": "Fix `rush update` not syncing `pnpm-lock.yaml` when a workspace dependency moves from `dependencies` to `devDependencies`.",
       "type": "patch",
       "packageName": "@microsoft/rush"
     }

--- a/libraries/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
+++ b/libraries/rush-lib/src/logic/pnpm/PnpmShrinkwrapFile.ts
@@ -1124,6 +1124,8 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
       const importerDevDependencies: Set<string> = new Set(Object.keys(importer.devDependencies ?? {}));
       const importerDependenciesMeta: Set<string> = new Set(Object.keys(importer.dependenciesMeta ?? {}));
 
+      const regularDependencyNames: Set<string> = new Set(dependencyList.map(({ name }) => name));
+
       for (const { dependencyType, name, version } of allDependencies) {
         let isOptional: boolean = false;
         let specifierFromLockfile: IPnpmVersionSpecifier | undefined;
@@ -1147,6 +1149,10 @@ export class PnpmShrinkwrapFile extends BaseShrinkwrapFile {
               // so fall through
               importerDevDependencies.delete(name);
               break;
+            }
+            // If not a peer and not also a regular dependency, the lockfile is stale.
+            if (!isOptional && !regularDependencyNames.has(name)) {
+              return true;
             }
             // If fall through, there is a chance the package declares an inconsistent version, ignore it.
             isDevDepFallThrough = true;

--- a/libraries/rush-lib/src/logic/pnpm/test/PnpmShrinkwrapFile.test.ts
+++ b/libraries/rush-lib/src/logic/pnpm/test/PnpmShrinkwrapFile.test.ts
@@ -487,6 +487,22 @@ snapshots:
         ).resolves.toBe(false);
       });
 
+      it('can detect a devDependency that is still listed under dependencies in the importer', async () => {
+        // Regression: moving a dep from dependencies to devDependencies should be detected as modified.
+        const project = getMockRushProject();
+        const pnpmShrinkwrapFile = getPnpmShrinkwrapFileFromFile(
+          `${__dirname}/yamlFiles/pnpm-lock-v9/stale-dev-in-dependencies.yaml`,
+          project.rushConfiguration.defaultSubspace
+        );
+        await expect(
+          pnpmShrinkwrapFile.isWorkspaceProjectModifiedAsync(
+            project,
+            project.rushConfiguration.defaultSubspace,
+            undefined
+          )
+        ).resolves.toBe(true);
+      });
+
       it('sha1 integrity can be handled when disallowInsecureSha1', async () => {
         const project = getMockRushProject();
         const pnpmShrinkwrapFile = getPnpmShrinkwrapFileFromFile(

--- a/libraries/rush-lib/src/logic/pnpm/test/yamlFiles/pnpm-lock-v9/stale-dev-in-dependencies.yaml
+++ b/libraries/rush-lib/src/logic/pnpm/test/yamlFiles/pnpm-lock-v9/stale-dev-in-dependencies.yaml
@@ -1,0 +1,37 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+  .: {}
+
+  ../../apps/foo:
+    dependencies:
+      tslib:
+        specifier: ~2.3.1
+        version: 2.3.1
+      typescript:
+        specifier: ~5.0.4
+        version: 5.0.4
+
+packages:
+  tslib@2.3.1:
+    resolution:
+      {
+        integrity: sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
+      }
+
+  typescript@5.0.4:
+    resolution:
+      {
+        integrity: sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==
+      }
+    engines: { node: '>=12.20' }
+    hasBin: true
+
+snapshots:
+  tslib@2.3.1: {}
+
+  typescript@5.0.4: {}


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->
<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary
  When a project dependency is moved from `dependencies` to `devDependencies`, `rush update` would correctly update the temporary lockfile but fail to sync it back to `common/config/rush/`. This left the repository with a stale committed lockfile despite the install appearing to succeed.
<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

## Details
  The root cause was an unconditional fall-through in `isWorkspaceProjectModifiedAsync` (the PNPM v8+ logic path). When checking a project's `devDependencies`, if a package was missing from the lockfile's `devDependencies` section, the code would automatically check the `dependencies` section instead.

  While this fall-through is necessary to support dual-declarations (which PNPM collapses into the `dependencies` section of the lockfile), it was also masking the case where a package had been moved out of the regular `dependencies` section entirely.

  The fix introduces a `regularDependencyNames` set for the project and gates the fall-through on membership in that set. This preserves support for dual-declared packages while correctly identifying a stale lockfile when a package has been moved to `devDependencies`.
<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

## How it was tested
  - Added a regression test in `PnpmShrinkwrapFile.test.ts`.
  - Created a new test fixture `stale-dev-in-dependencies.yaml` that simulates a lockfile where a moved dependency is still incorrectly listed in the `dependencies` section.
  - Verified that the new test fails without the fix and passes with it.
  - Ran the full `rush-lib` test suite to ensure no regressions in other lockfile sync scenarios.
<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 7: Does your PR affect anything that is discussed in the website docs?
     If so, please paste the URL of each affected web page, so we will
     remember to update the documentation after your PR is merged.
     (Updating the website is appreciated but not required.)
     If no docs are impacted, delete the "Impacted documentation" section.

     If you modified a JSON schema, remember to update init templates such as:
     rush-lib/assets/rush-init/*.json
     api-extractor/src/schemas/api-extractor-template.json
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 8: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
