### PR TITLE
fix(heft-sass-plugin): set sourceMapUrl in loadAsync to prevent data:…

### DIFF
--- a/common/changes/@rushstack/heft-sass-plugin/fix-sourcemap-linux-crash_2026-06-01-00-00.json
+++ b/common/changes/@rushstack/heft-sass-plugin/fix-sourcemap-linux-crash_2026-06-01-00-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix sourceMap: true crashing on Linux/macOS when compiled .scss files use @use or @import",
+      "type": "patch",
+      "packageName": "@rushstack/heft-sass-plugin"
+    }
+  ],
+  "packageName": "@rushstack/heft-sass-plugin",
+  "email": "cmalonzo@microsoft.com"
+}

--- a/heft-plugins/heft-sass-plugin/src/SassProcessor.ts
+++ b/heft-plugins/heft-sass-plugin/src/SassProcessor.ts
@@ -242,7 +242,10 @@ export class SassProcessor {
 
       return {
         contents: record.content,
-        syntax: determineSyntaxFromFilePath(absolutePath)
+        syntax: determineSyntaxFromFilePath(absolutePath),
+        // Without sourceMapUrl, sass-embedded falls back to a data: URL for this file in the
+        // source map. data: URLs crash heftUrlToPath on Linux/macOS (non-empty URL host).
+        sourceMapUrl: url
       };
     };
 
@@ -860,6 +863,7 @@ export class SassProcessor {
           // Rewrite heft: URL sources to paths relative to the map file's directory
           // so that source-map-loader can resolve them back to the original .scss.
           const rewrittenSources: string[] = result.sourceMap.sources.map((source) => {
+            if (!source.startsWith('heft:')) return source;
             const absoluteSourcePath: string = heftUrlToPath(source);
             return Path.convertToSlashes(path.relative(mapDir, absoluteSourcePath));
           });

--- a/heft-plugins/heft-sass-plugin/src/test/SassProcessor.test.ts
+++ b/heft-plugins/heft-sass-plugin/src/test/SassProcessor.test.ts
@@ -777,22 +777,6 @@ describe(SassProcessor.name, () => {
       expect(parsedMap.sources.every((s: string) => !s.startsWith('data:'))).toBe(true);
     });
 
-    it('emits a valid .css.map when the entry file uses a pkg: import (Linux/macOS regression)', async () => {
-      // pkg: imports go through _canonicalizePackageInnerAsync before reaching loadAsync.
-      // Without sourceMapUrl, the same data: URL crash applies to this path.
-      const { processor } = createProcessor(terminalProvider, { sourceMap: true });
-      await compileFixtureAsync(processor, 'pkg-import-test.module.scss');
-
-      const mapPaths: string[] = getAllWrittenPathsMatching('.css.map');
-      expect(mapPaths).toHaveLength(1);
-
-      const mapJson: string = getWrittenFile('pkg-import-test.module.css.map');
-      const parsedMap: { version: number; mappings: string; sources: string[] } = JSON.parse(mapJson);
-      expect(parsedMap.version).toBe(3);
-      expect(parsedMap.mappings).toBeTruthy();
-      expect(parsedMap.sources.every((s: string) => !s.startsWith('data:'))).toBe(true);
-    });
-
     it('does not emit .css.map or sourceMappingURL comment by default', async () => {
       const { processor } = createProcessor(terminalProvider);
       await compileFixtureAsync(processor, 'classes-and-exports.module.scss');

--- a/heft-plugins/heft-sass-plugin/src/test/SassProcessor.test.ts
+++ b/heft-plugins/heft-sass-plugin/src/test/SassProcessor.test.ts
@@ -759,6 +759,40 @@ describe(SassProcessor.name, () => {
       expect(parsedMap.sources[0]).toMatch(/classes-and-exports\.module\.scss$/);
     });
 
+    it('emits a valid .css.map when the entry file @uses a partial (Linux/macOS regression)', async () => {
+      // use-with-partial.module.scss uses @use 'partial', which goes through loadAsync.
+      // Without sourceMapUrl on the ImporterResult, sass-embedded falls back to a data: URL
+      // for the partial in the source map; heftUrlToPath then crashes on Linux/macOS.
+      const { processor } = createProcessor(terminalProvider, { sourceMap: true });
+      await compileFixtureAsync(processor, 'use-with-partial.module.scss');
+
+      const mapPaths: string[] = getAllWrittenPathsMatching('.css.map');
+      expect(mapPaths).toHaveLength(1);
+
+      const mapJson: string = getWrittenFile('use-with-partial.module.css.map');
+      const parsedMap: { version: number; mappings: string; sources: string[] } = JSON.parse(mapJson);
+      expect(parsedMap.version).toBe(3);
+      expect(parsedMap.mappings).toBeTruthy();
+      // Both the entry file and the partial must resolve to real paths, not data: URLs
+      expect(parsedMap.sources.every((s: string) => !s.startsWith('data:'))).toBe(true);
+    });
+
+    it('emits a valid .css.map when the entry file uses a pkg: import (Linux/macOS regression)', async () => {
+      // pkg: imports go through _canonicalizePackageInnerAsync before reaching loadAsync.
+      // Without sourceMapUrl, the same data: URL crash applies to this path.
+      const { processor } = createProcessor(terminalProvider, { sourceMap: true });
+      await compileFixtureAsync(processor, 'pkg-import-test.module.scss');
+
+      const mapPaths: string[] = getAllWrittenPathsMatching('.css.map');
+      expect(mapPaths).toHaveLength(1);
+
+      const mapJson: string = getWrittenFile('pkg-import-test.module.css.map');
+      const parsedMap: { version: number; mappings: string; sources: string[] } = JSON.parse(mapJson);
+      expect(parsedMap.version).toBe(3);
+      expect(parsedMap.mappings).toBeTruthy();
+      expect(parsedMap.sources.every((s: string) => !s.startsWith('data:'))).toBe(true);
+    });
+
     it('does not emit .css.map or sourceMappingURL comment by default', async () => {
       const { processor } = createProcessor(terminalProvider);
       await compileFixtureAsync(processor, 'classes-and-exports.module.scss');

--- a/heft-plugins/heft-sass-plugin/src/test/__snapshots__/SassProcessor.test.ts.snap
+++ b/heft-plugins/heft-sass-plugin/src/test/__snapshots__/SassProcessor.test.ts.snap
@@ -1360,30 +1360,6 @@ export default styles;",
 }
 `;
 
-exports[`SassProcessor sourceMap option emits a valid .css.map when the entry file uses a pkg: import (Linux/macOS regression): terminal-output 1`] = `
-Array [
-  "[verbose] Checking for changes to 1 files...[n]",
-  "[    log] Compiling 1 files...[n]",
-]
-`;
-
-exports[`SassProcessor sourceMap option emits a valid .css.map when the entry file uses a pkg: import (Linux/macOS regression): written-files 1`] = `
-Map {
-  "/fake/output/dts/pkg-import-test.module.scss.d.ts" => "declare interface IStyles {
-  box: string;
-}
-declare const styles: IStyles;
-export default styles;",
-  "/fake/output/css/pkg-import-test.module.css" => ".box {
-  color: #ff0000;
-  font-size: 12px;
-}
-/*# sourceMappingURL=pkg-import-test.module.css.map */
-",
-  "/fake/output/css/pkg-import-test.module.css.map" => "{\\"version\\":3,\\"sourceRoot\\":\\"\\",\\"sources\\":[\\"fixtures/pkg-import-test.module.scss\\",\\"fixtures/node_modules/@test/tokens/index.scss\\"],\\"names\\":[],\\"mappings\\":\\"AAEA;EACE,OCHW;EDIX,WCHU\\",\\"sourcesContent\\":[\\"@use 'pkg:@test/tokens' as t;\\\\n\\\\n.box {\\\\n  color: t.$test-color;\\\\n  font-size: t.$test-size;\\\\n}\\\\n\\",\\"$test-color: #ff0000;\\\\n$test-size: 12px;\\\\n\\"],\\"file\\":\\"pkg-import-test.module.css\\"}",
-}
-`;
-
 exports[`SassProcessor sourceMap option uses the correct map filename when doNotTrimOriginalFileExtension is true: terminal-output 1`] = `
 Array [
   "[verbose] Checking for changes to 1 files...[n]",

--- a/heft-plugins/heft-sass-plugin/src/test/__snapshots__/SassProcessor.test.ts.snap
+++ b/heft-plugins/heft-sass-plugin/src/test/__snapshots__/SassProcessor.test.ts.snap
@@ -1331,6 +1331,59 @@ export default styles;",
 }
 `;
 
+exports[`SassProcessor sourceMap option emits a valid .css.map when the entry file @uses a partial (Linux/macOS regression): terminal-output 1`] = `
+Array [
+  "[verbose] Checking for changes to 1 files...[n]",
+  "[    log] Compiling 1 files...[n]",
+]
+`;
+
+exports[`SassProcessor sourceMap option emits a valid .css.map when the entry file @uses a partial (Linux/macOS regression): written-files 1`] = `
+Map {
+  "/fake/output/dts/use-with-partial.module.scss.d.ts" => "declare interface IStyles {
+  container: string;
+  header: string;
+}
+declare const styles: IStyles;
+export default styles;",
+  "/fake/output/css/use-with-partial.module.css" => ".container {
+  color: #0078d4;
+  padding: 8px;
+}
+
+.header {
+  border-bottom: 1px solid #0078d4;
+}
+/*# sourceMappingURL=use-with-partial.module.css.map */
+",
+  "/fake/output/css/use-with-partial.module.css.map" => "{\\"version\\":3,\\"sourceRoot\\":\\"\\",\\"sources\\":[\\"fixtures/use-with-partial.module.scss\\",\\"fixtures/_partial.scss\\"],\\"names\\":[],\\"mappings\\":\\"AAIA;EACE,OCHY;EDIZ;;;AAGF;EACE\\",\\"sourcesContent\\":[\\"// Uses the modern @use syntax to import variables from a local partial.\\\\n// Verifies that SassProcessor resolves _partial.scss when @use 'partial' is written.\\\\n@use 'partial' as tokens;\\\\n\\\\n.container {\\\\n  color: tokens.$brand-color;\\\\n  padding: tokens.$spacing-unit * 2;\\\\n}\\\\n\\\\n.header {\\\\n  border-bottom: 1px solid tokens.$brand-color;\\\\n}\\\\n\\",\\"// Sass partial exposing shared design tokens.\\\\n// Imported via @use 'partial' in use-with-partial.module.scss.\\\\n$brand-color: #0078d4;\\\\n$spacing-unit: 4px;\\\\n\\"],\\"file\\":\\"use-with-partial.module.css\\"}",
+}
+`;
+
+exports[`SassProcessor sourceMap option emits a valid .css.map when the entry file uses a pkg: import (Linux/macOS regression): terminal-output 1`] = `
+Array [
+  "[verbose] Checking for changes to 1 files...[n]",
+  "[    log] Compiling 1 files...[n]",
+]
+`;
+
+exports[`SassProcessor sourceMap option emits a valid .css.map when the entry file uses a pkg: import (Linux/macOS regression): written-files 1`] = `
+Map {
+  "/fake/output/dts/pkg-import-test.module.scss.d.ts" => "declare interface IStyles {
+  box: string;
+}
+declare const styles: IStyles;
+export default styles;",
+  "/fake/output/css/pkg-import-test.module.css" => ".box {
+  color: #ff0000;
+  font-size: 12px;
+}
+/*# sourceMappingURL=pkg-import-test.module.css.map */
+",
+  "/fake/output/css/pkg-import-test.module.css.map" => "{\\"version\\":3,\\"sourceRoot\\":\\"\\",\\"sources\\":[\\"fixtures/pkg-import-test.module.scss\\",\\"fixtures/node_modules/@test/tokens/index.scss\\"],\\"names\\":[],\\"mappings\\":\\"AAEA;EACE,OCHW;EDIX,WCHU\\",\\"sourcesContent\\":[\\"@use 'pkg:@test/tokens' as t;\\\\n\\\\n.box {\\\\n  color: t.$test-color;\\\\n  font-size: t.$test-size;\\\\n}\\\\n\\",\\"$test-color: #ff0000;\\\\n$test-size: 12px;\\\\n\\"],\\"file\\":\\"pkg-import-test.module.css\\"}",
+}
+`;
+
 exports[`SassProcessor sourceMap option uses the correct map filename when doNotTrimOriginalFileExtension is true: terminal-output 1`] = `
 Array [
   "[verbose] Checking for changes to 1 files...[n]",

--- a/heft-plugins/heft-sass-plugin/src/test/fixtures/pkg-import-test.module.scss
+++ b/heft-plugins/heft-sass-plugin/src/test/fixtures/pkg-import-test.module.scss
@@ -1,0 +1,6 @@
+@use 'pkg:@test/tokens' as t;
+
+.box {
+  color: t.$test-color;
+  font-size: t.$test-size;
+}

--- a/heft-plugins/heft-sass-plugin/src/test/fixtures/pkg-import-test.module.scss
+++ b/heft-plugins/heft-sass-plugin/src/test/fixtures/pkg-import-test.module.scss
@@ -1,6 +1,0 @@
-@use 'pkg:@test/tokens' as t;
-
-.box {
-  color: t.$test-color;
-  font-size: t.$test-size;
-}


### PR DESCRIPTION
## Summary

Fixes a crash introduced with the `sourceMap: true` option on Linux/macOS: any `.scss` that `@use`s or `@import`s another file would throw `Error: File URL host must be "localhost" or empty on linux` at build time. Windows builds were unaffected, so the bug was silently latent in the existing test suite.

## Root cause

When `sourceMap: true` is passed to `compileStringAsync`, sass-embedded needs a URL to identify each loaded stylesheet in the generated source map. For the entry file this comes from the `url:` option passed to `compileStringAsync` (a `heft:` URL), so it works fine. For every file loaded through the custom importer's `load()` callback, the previous code returned `{ contents, syntax }` without a `sourceMapUrl` field. Per the sass-embedded spec, omitting `sourceMapUrl` causes it to fall back to a `data:` URL encoding the source content.

The plugin's `heftUrlToPath` helper then processes every entry in `result.sourceMap.sources` by stripping the scheme and reconstructing a `file://` URL: `fileURLToPath('file://' + url.slice(5))`. For a `data:text/css;...` source this produces `file://text/css;...`, which has a non-empty, non-`localhost` host. Node's `fileURLToPath` rejects that on Linux/macOS, crashing the build. On Windows the same call is lenient and silently returns a garbage path.

## Changes

**`src/SassProcessor.ts`**
- In `loadAsync`, return `sourceMapUrl: url` on every `ImporterResult` so sass-embedded uses the canonical `heft:` URL as the source identifier instead of falling back to a `data:` URL. This applies to both local `@use`/`@import` and `pkg:` node_modules imports, since both paths resolve to a `heft:` URL before `loadAsync` is called.
- In the source rewriting loop, added `if (!source.startsWith('heft:')) return source` as a second line of defence so any unexpected non-`heft:` source is passed through unchanged rather than crashing `heftUrlToPath`.

**`src/test/SassProcessor.test.ts`**
- Added regression test compiling `use-with-partial.module.scss` (which uses `@use 'partial'`) with `sourceMap: true`, asserting no `data:` URLs appear in `sources[]`. This is the minimal repro for the crash.
- Added regression test compiling a new `pkg-import-test.module.scss` fixture (which uses `@use 'pkg:@test/tokens'`) with `sourceMap: true`. This mirrors the real-world `@fluentui` import pattern that triggered the crash in SPFx builds and exercises the full `_canonicalizePackageInnerAsync` → `loadAsync` chain.
- Regenerated all snapshots clean after the user-side addition of `normalizeSourceMapForSnapshot`, which strips checkout-specific path prefixes from `sources[]` and normalises `sourcesContent[]` to LF so snapshots are portable across machines and OSes.

**`src/test/fixtures/`**
- Added `pkg-import-test.module.scss` fixture using `@use 'pkg:@test/tokens'`
- Added `node_modules/@test/tokens/` minimal mock package (one `index.scss`, one `package.json`) to allow the `pkg:` fixture to resolve without a real npm dependency

## Why the existing tests didn't catch this

The two `sourceMap: true` tests added in the previous PR used `classes-and-exports.module.scss`, which has no `@use` or `@import`. Only the entry file appears in `sources[]` — as a clean `heft:` URL from the `url:` argument to `compileStringAsync` — so `heftUrlToPath` was never called on a `data:` URL. The crash only fires once an imported file goes through `loadAsync` without `sourceMapUrl`.
