### PR TITLE
[package-deps-hash] Fix build cache failures in git linked worktrees caused by GIT_DIR set by pre-commit hooks

### DIFF
--- a/common/changes/@microsoft/rush/fix-git-dir-worktree-hook-repo-root_2026-06-08-19-02.json
+++ b/common/changes/@microsoft/rush/fix-git-dir-worktree-hook-repo-root_2026-06-08-19-02.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "No-op change to trigger changeset for rush publish for package-deps-hash changes.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/fix-git-dir-worktree-hook-repo-root_2026-06-08-19-02.json
+++ b/common/changes/@microsoft/rush/fix-git-dir-worktree-hook-repo-root_2026-06-08-19-02.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "No-op change to trigger changeset for rush publish for package-deps-hash changes.",
+      "comment": "Fix build cache failures when running inside a git linked worktree via a pre-commit hook, caused by GIT_DIR being set to the per-worktree metadata directory",
       "type": "none"
     }
   ],

--- a/common/changes/@rushstack/package-deps-hash/fix-git-dir-worktree-hook_2026-06-03-00-00.json
+++ b/common/changes/@rushstack/package-deps-hash/fix-git-dir-worktree-hook_2026-06-03-00-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix build cache failures when running inside a git linked worktree via a pre-commit hook, caused by GIT_DIR being set to the per-worktree metadata directory",
+      "type": "patch",
+      "packageName": "@rushstack/package-deps-hash"
+    }
+  ],
+  "packageName": "@rushstack/package-deps-hash",
+  "email": "kfleischman@squarespace.com"
+}

--- a/common/changes/@rushstack/package-deps-hash/fix-git-dir-worktree-hook_2026-06-03-00-00.json
+++ b/common/changes/@rushstack/package-deps-hash/fix-git-dir-worktree-hook_2026-06-03-00-00.json
@@ -7,5 +7,5 @@
     }
   ],
   "packageName": "@rushstack/package-deps-hash",
-  "email": "kfleischman@squarespace.com"
+  "email": "istateside@users.noreply.github.com"
 }

--- a/common/changes/@rushstack/package-deps-hash/fix-git-dir-worktree-hook_2026-06-03-00-00.json
+++ b/common/changes/@rushstack/package-deps-hash/fix-git-dir-worktree-hook_2026-06-03-00-00.json
@@ -1,7 +1,7 @@
 {
   "changes": [
     {
-      "comment": "Fix build cache failures when running inside a git linked worktree via a pre-commit hook, caused by GIT_DIR being set to the per-worktree metadata directory",
+      "comment": "Strip GIT_DIR and GIT_WORK_TREE Node env variables to fix issues with miscalculating the git repo root when working in a linked worktree",
       "type": "patch",
       "packageName": "@rushstack/package-deps-hash"
     }

--- a/libraries/package-deps-hash/src/getRepoState.ts
+++ b/libraries/package-deps-hash/src/getRepoState.ts
@@ -275,9 +275,6 @@ const repoRootCache: Map<string, string> = new Map();
 
 // Strip GIT_DIR/GIT_WORK_TREE: git hooks in linked worktrees set GIT_DIR to the per-worktree metadata dir, causing rev-parse --show-toplevel to return CWD instead of the worktree root.
 function getCleanGitEnvironment(): NodeJS.ProcessEnv {
-  const env: NodeJS.ProcessEnv = { ...process.env };
-  delete env.GIT_DIR;
-  delete env.GIT_WORK_TREE;
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { GIT_DIR, GIT_WORK_TREE, ...trimmedEnv } = process.env;
   return trimmedEnv;

--- a/libraries/package-deps-hash/src/getRepoState.ts
+++ b/libraries/package-deps-hash/src/getRepoState.ts
@@ -33,9 +33,28 @@ const STANDARD_GIT_OPTIONS: readonly string[] = [
 // `git hash-object` aborts the process. Such files are typically untracked artifacts left behind
 // by tooling (e.g. stray `nul` from a shell redirect).
 const WINDOWS_RESERVED_BASENAMES: ReadonlySet<string> = new Set([
-  'CON', 'PRN', 'AUX', 'NUL',
-  'COM1', 'COM2', 'COM3', 'COM4', 'COM5', 'COM6', 'COM7', 'COM8', 'COM9',
-  'LPT1', 'LPT2', 'LPT3', 'LPT4', 'LPT5', 'LPT6', 'LPT7', 'LPT8', 'LPT9'
+  'CON',
+  'PRN',
+  'AUX',
+  'NUL',
+  'COM1',
+  'COM2',
+  'COM3',
+  'COM4',
+  'COM5',
+  'COM6',
+  'COM7',
+  'COM8',
+  'COM9',
+  'LPT1',
+  'LPT2',
+  'LPT3',
+  'LPT4',
+  'LPT5',
+  'LPT6',
+  'LPT7',
+  'LPT8',
+  'LPT9'
 ]);
 
 /**
@@ -254,6 +273,14 @@ export function parseGitStatus(output: string): Map<string, boolean> {
 
 const repoRootCache: Map<string, string> = new Map();
 
+// Strip GIT_DIR/GIT_WORK_TREE: git hooks in linked worktrees set GIT_DIR to the per-worktree metadata dir, causing rev-parse --show-toplevel to return CWD instead of the worktree root.
+function getCleanGitEnvironment(): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...process.env };
+  delete env.GIT_DIR;
+  delete env.GIT_WORK_TREE;
+  return env;
+}
+
 /**
  * Finds the root of the current Git repository
  *
@@ -270,7 +297,8 @@ export function getRepoRoot(currentWorkingDirectory: string, gitPath?: string): 
       gitPath || 'git',
       ['--no-optional-locks', 'rev-parse', '--show-toplevel'],
       {
-        currentWorkingDirectory
+        currentWorkingDirectory,
+        environment: getCleanGitEnvironment()
       }
     );
 
@@ -305,7 +333,8 @@ async function spawnGitAsync(
 ): Promise<string> {
   const spawnOptions: IExecutableSpawnOptions = {
     currentWorkingDirectory,
-    stdio: ['pipe', 'pipe', 'pipe']
+    stdio: ['pipe', 'pipe', 'pipe'],
+    environment: getCleanGitEnvironment()
   };
 
   let stdout: string = '';
@@ -591,7 +620,8 @@ export function getRepoChanges(
       '--'
     ]),
     {
-      currentWorkingDirectory: rootDirectory
+      currentWorkingDirectory: rootDirectory,
+      environment: getCleanGitEnvironment()
     }
   );
 

--- a/libraries/package-deps-hash/src/getRepoState.ts
+++ b/libraries/package-deps-hash/src/getRepoState.ts
@@ -278,7 +278,9 @@ function getCleanGitEnvironment(): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = { ...process.env };
   delete env.GIT_DIR;
   delete env.GIT_WORK_TREE;
-  return env;
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { GIT_DIR, GIT_WORK_TREE, ...trimmedEnv } = process.env;
+  return trimmedEnv;
 }
 
 /**

--- a/libraries/package-deps-hash/src/test/getRepoDeps.test.ts
+++ b/libraries/package-deps-hash/src/test/getRepoDeps.test.ts
@@ -2,7 +2,7 @@
 // See LICENSE in the project root for license information.
 
 import * as path from 'node:path';
-import { execSync } from 'node:child_process';
+import { execSync, type SpawnSyncReturns } from 'node:child_process';
 
 import {
   getDetailedRepoStateAsync,
@@ -12,7 +12,7 @@ import {
   parseGitHashObject
 } from '../getRepoState';
 
-import { FileSystem } from '@rushstack/node-core-library';
+import { Executable, FileSystem } from '@rushstack/node-core-library';
 
 const SOURCE_PATH: string = path
   .join(__dirname)
@@ -46,20 +46,55 @@ describe(getRepoRoot.name, () => {
     expect(root).toEqual(expectedRoot);
   });
 
-  it(`ignores GIT_DIR set by git hooks in linked worktrees`, () => {
-    // GIT_DIR pointing to a non-existent path causes git rev-parse to fail unless stripped.
+  it(`strips GIT_DIR and GIT_WORK_TREE before invoking git`, () => {
+    // Regression test for the linked-worktree bug. When git runs a hook it injects GIT_DIR (and
+    // sometimes GIT_WORK_TREE) into the environment; in a linked worktree GIT_DIR points at the
+    // per-worktree metadata directory, which makes `git rev-parse --show-toplevel` resolve against
+    // the current directory instead of the true repository root. getRepoRoot must therefore invoke
+    // git with those variables removed, so the root is derived solely from currentWorkingDirectory.
+    //
+    // This is asserted at the spawn boundary rather than by mutating process.env and shelling out for
+    // real: the Jest environment does not propagate in-process process.env writes to child processes,
+    // so an end-to-end variant would pass whether or not the stripping actually happens.
+    const fakeRoot: string = '/fake/repo/root';
+    const mockResult: SpawnSyncReturns<string> = {
+      pid: 0,
+      output: [],
+      stdout: fakeRoot,
+      stderr: '',
+      status: 0,
+      signal: null
+    };
+    const spawnSyncSpy: jest.SpyInstance = jest.spyOn(Executable, 'spawnSync').mockReturnValue(mockResult);
+
     const originalGitDir: string | undefined = process.env.GIT_DIR;
+    const originalGitWorkTree: string | undefined = process.env.GIT_WORK_TREE;
     try {
-      process.env.GIT_DIR = '/nonexistent-fake-gitdir-worktrees-for-testing';
-      const testCwd: string = path.resolve(SOURCE_PATH, '..');
-      const root: string = getRepoRoot(testCwd);
-      const expectedRoot: string = path.resolve(__dirname, '../../../..').replace(/\\/g, '/');
-      expect(root).toEqual(expectedRoot);
+      process.env.GIT_DIR = '/repo/.git/worktrees/feature';
+      process.env.GIT_WORK_TREE = '/repo/work/tree';
+
+      // A unique cwd that no other test resolves, so getRepoRoot's module-level cache can't satisfy
+      // this from a previous call and skip the spawn.
+      getRepoRoot('/nonexistent/getRepoRoot-strips-git-env');
+
+      expect(spawnSyncSpy).toHaveBeenCalledTimes(1);
+      const passedEnvironment: NodeJS.ProcessEnv | undefined = spawnSyncSpy.mock.calls[0][2]?.environment;
+      // The fix passes an explicit environment (pre-fix code passed none) that omits both variables,
+      // while leaving the rest of process.env intact.
+      expect(passedEnvironment).toBeDefined();
+      expect(passedEnvironment).not.toHaveProperty('GIT_DIR');
+      expect(passedEnvironment).not.toHaveProperty('GIT_WORK_TREE');
     } finally {
+      spawnSyncSpy.mockRestore();
       if (originalGitDir === undefined) {
         delete process.env.GIT_DIR;
       } else {
         process.env.GIT_DIR = originalGitDir;
+      }
+      if (originalGitWorkTree === undefined) {
+        delete process.env.GIT_WORK_TREE;
+      } else {
+        process.env.GIT_WORK_TREE = originalGitWorkTree;
       }
     }
   });

--- a/libraries/package-deps-hash/src/test/getRepoDeps.test.ts
+++ b/libraries/package-deps-hash/src/test/getRepoDeps.test.ts
@@ -45,6 +45,24 @@ describe(getRepoRoot.name, () => {
     const expectedRoot: string = path.resolve(__dirname, '../../../..').replace(/\\/g, '/');
     expect(root).toEqual(expectedRoot);
   });
+
+  it(`ignores GIT_DIR set by git hooks in linked worktrees`, () => {
+    // GIT_DIR pointing to a non-existent path causes git rev-parse to fail unless stripped.
+    const originalGitDir: string | undefined = process.env.GIT_DIR;
+    try {
+      process.env.GIT_DIR = '/nonexistent-fake-gitdir-worktrees-for-testing';
+      const testCwd: string = path.resolve(SOURCE_PATH, '..');
+      const root: string = getRepoRoot(testCwd);
+      const expectedRoot: string = path.resolve(__dirname, '../../../..').replace(/\\/g, '/');
+      expect(root).toEqual(expectedRoot);
+    } finally {
+      if (originalGitDir === undefined) {
+        delete process.env.GIT_DIR;
+      } else {
+        process.env.GIT_DIR = originalGitDir;
+      }
+    }
+  });
 });
 
 describe(parseGitLsTree.name, () => {


### PR DESCRIPTION
## Summary

Fixes build cache failures when Rush commands that trigger incremental build analysis run inside a git linked worktree via a pre-commit hook.

Fixes #5479

When git invokes a pre-commit hook in a linked worktree, it sets `GIT_DIR` to the per-worktree metadata directory (e.g. `.git/worktrees/{name}`) but does **not** set `GIT_WORK_TREE`. Child processes inherit this environment. `getRepoRoot()` calls `git rev-parse --show-toplevel` and inherits this `GIT_DIR`, causing git to return the `currentWorkingDirectory` argument (e.g. the `rushJsonFolder` subdirectory) instead of the actual worktree root. All subsequent git calls use this wrong root, causing `git status -u` to miss the top-level `.gitignore`, surfacing `node_modules/` symlinks as untracked files, which `git hash-object` cannot hash — ultimately reported as "Build cache is only supported if running in a Git repository."

## Details

The fix strips `GIT_DIR` and `GIT_WORK_TREE` from the environment before spawning any git subprocess in `getRepoState.ts`. This lets git auto-discover the correct repo root by scanning up from `currentWorkingDirectory`, which correctly resolves to the linked worktree root regardless of the hook-injected environment. Three call sites are patched: `getRepoRoot`, `spawnGitAsync` (used by `getDetailedRepoStateAsync` and `hashFilesAsync`), and `getRepoChanges`.

This regression was introduced in #5500, which switched from `git ls-tree -r HEAD` (reads committed objects, never surfaces `node_modules/`) to `git ls-files --cached` + `git status -u` (scans the work tree, exposing the broken `.gitignore` context).

The diff also includes prettier reformatting the `WINDOWS_RESERVED_BASENAMES` array from a compact multi-line form to one-entry-per-line — this is an unrelated side effect of the project's pre-commit hook. Happy to add a `// prettier-ignore` comment to suppress it if preferred.

## How it was tested

Added a unit test to `getRepoDeps.test.ts` that sets `GIT_DIR` to a nonexistent path (simulating hook interference) and verifies that `getRepoRoot` still returns the correct repo root. Without the fix, `git rev-parse` exits 128 ("not a git repository") and the function throws; with the fix, `GIT_DIR` is stripped and git auto-discovers the root correctly.

Also manually reproduced the original failure by running a Rush build command from within a git linked worktree via a pre-commit hook and confirmed the build cache error no longer occurs with this fix applied.

## Reproduction

The bug can be reproduced with this shell script: https://gist.github.com/istateside/e8b0c5f694424a423ae29fe9203ec895

The script bootstraps a Rush monorepo with all of the requisite contributing factors to recreate the bug:
1. The repo is a Rush monorepo
2. The base directory for the Rush monorepo is *not* the base directory of the git repo (`rush.json` is not in the root directory of the git repo)
3. The build cache is enabled
4. A pre-commit hook runs a Rush command

In that environment, the bug is triggered if you are in a linked worktree and make a commit, to trigger the pre-commit rush command.