### PR TITLE
[rush] Include seconds in generated change file names so repeated "rush change" runs do not collide

### DIFF
--- a/common/changes/@microsoft/rush/fix-change-file-timestamp-seconds_2026-06-03-00-00.json
+++ b/common/changes/@microsoft/rush/fix-change-file-timestamp-seconds_2026-06-03-00-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Include seconds in the generated change file name so that running \"rush change\" more than once in the same minute no longer silently overwrites the previously generated change file.",
+      "type": "patch",
+      "packageName": "@microsoft/rush"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "sshaurya914@gmail.com"
+}

--- a/common/changes/@microsoft/rush/fix-change-file-timestamp-seconds_2026-06-03-00-00.json
+++ b/common/changes/@microsoft/rush/fix-change-file-timestamp-seconds_2026-06-03-00-00.json
@@ -1,11 +1,11 @@
 {
   "changes": [
     {
-      "comment": "Include seconds in the generated change file name so that running \"rush change\" more than once in the same minute no longer silently overwrites the previously generated change file.",
+      "comment": "Include seconds in the generated change file name so that running `rush change` more than once in the same minute no longer silently overwrites the previously generated change file.",
       "type": "patch",
       "packageName": "@microsoft/rush"
     }
   ],
   "packageName": "@microsoft/rush",
-  "email": "sshaurya914@gmail.com"
+  "email": "LeSingh1@users.noreply.github.com"
 }

--- a/common/changes/@microsoft/rush/fix-change-file-timestamp-seconds_2026-06-03-00-00.json
+++ b/common/changes/@microsoft/rush/fix-change-file-timestamp-seconds_2026-06-03-00-00.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "comment": "Include seconds in the generated change file name so that running `rush change` more than once in the same minute no longer silently overwrites the previously generated change file.",
-      "type": "patch",
+      "type": "minor",
       "packageName": "@microsoft/rush"
     }
   ],

--- a/libraries/rush-lib/src/api/ChangeFile.ts
+++ b/libraries/rush-lib/src/api/ChangeFile.ts
@@ -84,10 +84,15 @@ export class ChangeFile {
       console.log('Could not automatically detect git branch name, using timestamp instead.');
     }
 
-    // example filename: yourbranchname_2017-05-01-20-20.json
+    // The timestamp includes seconds so that running "rush change" more than once
+    // in the same minute produces distinct filenames. Without this, the "--overwrite"
+    // flag rarely had any effect, and a second invocation would silently clobber the
+    // change file written by the first one. See GitHub issue #2195.
+    // example filename: yourbranchname_2017-05-01-20-20-30.json
+    const timestamp: string | undefined = this._getTimestamp(true);
     const filename: string = branch
-      ? this._escapeFilename(`${branch}_${this._getTimestamp()}.json`)
-      : `${this._getTimestamp()}.json`;
+      ? this._escapeFilename(`${branch}_${timestamp}.json`)
+      : `${timestamp}.json`;
     const filePath: string = path.join(
       this._rushConfiguration.changesFolder,
       ...this._changeFileData.packageName.split('/'),
@@ -98,7 +103,7 @@ export class ChangeFile {
 
   /**
    * Gets the current time, formatted as YYYY-MM-DD-HH-MM
-   * Optionally will include seconds
+   * When useSeconds is true, the seconds are appended as well: YYYY-MM-DD-HH-MM-SS
    */
   private _getTimestamp(useSeconds: boolean = false): string | undefined {
     // Create a date string with the current time
@@ -120,7 +125,7 @@ export class ChangeFile {
       let formattedTime: string;
       if (useSeconds) {
         // formattedTime === "22-47-49"
-        formattedTime = matches[2].replace(':', '-');
+        formattedTime = matches[2].replace(/:/g, '-');
       } else {
         // formattedTime === "22-47"
         const timeParts: string[] = matches[2].split(':');

--- a/libraries/rush-lib/src/api/test/ChangeFile.test.ts
+++ b/libraries/rush-lib/src/api/test/ChangeFile.test.ts
@@ -4,8 +4,47 @@
 import { ChangeFile } from '../ChangeFile';
 import { RushConfiguration } from '../RushConfiguration';
 import { ChangeType } from '../ChangeManagement';
+import { Git } from '../../logic/Git';
 
 describe(ChangeFile.name, () => {
+  it('generates a path that includes seconds so repeated invocations do not collide', () => {
+    const rushFilename: string = `${__dirname}/repo/rush-npm.json`;
+    const rushConfiguration: RushConfiguration = RushConfiguration.loadFromConfigurationFile(rushFilename);
+
+    // Pin the branch name so the generated filename is deterministic.
+    const getGitInfoSpy: jest.SpyInstance = jest
+      .spyOn(Git.prototype, 'getGitInfo')
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .mockReturnValue({ branch: 'my-branch' } as any);
+
+    // Pin the clock to 2017-05-01 20:20:30 UTC so the timestamp is deterministic.
+    const fixedDate: Date = new Date('2017-05-01T20:20:30.000Z');
+    const dateSpy: jest.SpyInstance = jest
+      .spyOn(global, 'Date')
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .mockImplementation(() => fixedDate as any);
+
+    try {
+      const changeFile: ChangeFile = new ChangeFile(
+        {
+          packageName: 'a',
+          changes: [],
+          email: 'fake@microsoft.com'
+        },
+        rushConfiguration
+      );
+
+      const generatedPath: string = changeFile.generatePath();
+
+      // The seconds must be present and every part must be dash-separated (no leftover colons).
+      expect(generatedPath.replace(/\\/g, '/')).toContain('my-branch_2017-05-01-20-20-30.json');
+      expect(generatedPath).not.toContain(':');
+    } finally {
+      dateSpy.mockRestore();
+      getGitInfoSpy.mockRestore();
+    }
+  });
+
   it('can add a change', () => {
     const rushFilename: string = `${__dirname}/repo/rush-npm.json`;
     const rushConfiguration: RushConfiguration = RushConfiguration.loadFromConfigurationFile(rushFilename);

--- a/libraries/rush-lib/src/api/test/ChangeFile.test.ts
+++ b/libraries/rush-lib/src/api/test/ChangeFile.test.ts
@@ -20,10 +20,11 @@ describe(ChangeFile.name, () => {
       .mockReturnValue({ branch: 'my-branch' } as any);
 
     // Pin the clock to 2017-05-01 20:20:30 UTC so the timestamp is deterministic.
-    // Use Jest fake timers so new Date() is intercepted at the engine level, which is
-    // more reliable than spying on the Date constructor (the spy approach is fragile on
-    // Windows with Node.js v24 because the V8 Date fast-path can bypass the spy).
-    jest.useFakeTimers().setSystemTime(new Date('2017-05-01T20:20:30.000Z'));
+    const fixedDate: Date = new Date('2017-05-01T20:20:30.000Z');
+    const dateSpy: jest.SpyInstance = jest
+      .spyOn(global, 'Date')
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .mockImplementation(() => fixedDate as any);
 
     try {
       const changeFile: ChangeFile = new ChangeFile(
@@ -46,7 +47,7 @@ describe(ChangeFile.name, () => {
       // includes a drive letter (e.g. "D:\...") which legitimately contains a colon.
       expect(filename).not.toContain(':');
     } finally {
-      jest.useRealTimers();
+      dateSpy.mockRestore();
       getGitInfoSpy.mockRestore();
     }
   });

--- a/libraries/rush-lib/src/api/test/ChangeFile.test.ts
+++ b/libraries/rush-lib/src/api/test/ChangeFile.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import * as path from 'node:path';
+import type { GitRepoInfo } from 'git-repo-info';
 
 import { ChangeFile } from '../ChangeFile';
 import { RushConfiguration } from '../RushConfiguration';
@@ -14,42 +14,27 @@ describe(ChangeFile.name, () => {
     const rushConfiguration: RushConfiguration = RushConfiguration.loadFromConfigurationFile(rushFilename);
 
     // Pin the branch name so the generated filename is deterministic.
-    const getGitInfoSpy: jest.SpyInstance = jest
-      .spyOn(Git.prototype, 'getGitInfo')
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      .mockReturnValue({ branch: 'my-branch' } as any);
+    jest.spyOn(Git.prototype, 'getGitInfo').mockReturnValue({ branch: 'my-branch' } as Readonly<GitRepoInfo>);
 
     // Pin the clock to 2017-05-01 20:20:30 UTC so the timestamp is deterministic.
-    const fixedDate: Date = new Date('2017-05-01T20:20:30.000Z');
-    const dateSpy: jest.SpyInstance = jest
-      .spyOn(global, 'Date')
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      .mockImplementation(() => fixedDate as any);
+    jest.useFakeTimers({
+      now: new Date('2017-05-01T20:20:30.000Z').getTime()
+    });
 
-    try {
-      const changeFile: ChangeFile = new ChangeFile(
-        {
-          packageName: 'a',
-          changes: [],
-          email: 'fake@microsoft.com'
-        },
-        rushConfiguration
-      );
+    const changeFile: ChangeFile = new ChangeFile(
+      {
+        packageName: 'a',
+        changes: [],
+        email: 'fake@microsoft.com'
+      },
+      rushConfiguration
+    );
 
-      const generatedPath: string = changeFile.generatePath();
-      const filename: string = path.basename(generatedPath);
-
-      // The seconds must be present and the filename must be fully dash-separated
-      // (no leftover colons from the time portion).
-      // Check toContain on the forward-slash-normalised path so it works on Windows too.
-      expect(generatedPath.replace(/\\/g, '/')).toContain('my-branch_2017-05-01-20-20-30.json');
-      // Only check the filename for colons, not the full path: on Windows the path
-      // includes a drive letter (e.g. "D:\...") which legitimately contains a colon.
-      expect(filename).not.toContain(':');
-    } finally {
-      dateSpy.mockRestore();
-      getGitInfoSpy.mockRestore();
-    }
+    const generatedPath: string = changeFile.generatePath();
+    // The seconds must be present and the filename must be fully dash-separated
+    // (no leftover colons from the time portion).
+    // Check toContain on the forward-slash-normalised path so it works on Windows too.
+    expect(generatedPath.replace(/\\/g, '/').endsWith('my-branch_2017-05-01-20-20-30.json')).toBe(true);
   });
 
   it('can add a change', () => {

--- a/libraries/rush-lib/src/api/test/ChangeFile.test.ts
+++ b/libraries/rush-lib/src/api/test/ChangeFile.test.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+import * as path from 'node:path';
+
 import { ChangeFile } from '../ChangeFile';
 import { RushConfiguration } from '../RushConfiguration';
 import { ChangeType } from '../ChangeManagement';
@@ -18,11 +20,10 @@ describe(ChangeFile.name, () => {
       .mockReturnValue({ branch: 'my-branch' } as any);
 
     // Pin the clock to 2017-05-01 20:20:30 UTC so the timestamp is deterministic.
-    const fixedDate: Date = new Date('2017-05-01T20:20:30.000Z');
-    const dateSpy: jest.SpyInstance = jest
-      .spyOn(global, 'Date')
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      .mockImplementation(() => fixedDate as any);
+    // Use Jest fake timers so new Date() is intercepted at the engine level, which is
+    // more reliable than spying on the Date constructor (the spy approach is fragile on
+    // Windows with Node.js v24 because the V8 Date fast-path can bypass the spy).
+    jest.useFakeTimers().setSystemTime(new Date('2017-05-01T20:20:30.000Z'));
 
     try {
       const changeFile: ChangeFile = new ChangeFile(
@@ -35,12 +36,17 @@ describe(ChangeFile.name, () => {
       );
 
       const generatedPath: string = changeFile.generatePath();
+      const filename: string = path.basename(generatedPath);
 
-      // The seconds must be present and every part must be dash-separated (no leftover colons).
+      // The seconds must be present and the filename must be fully dash-separated
+      // (no leftover colons from the time portion).
+      // Check toContain on the forward-slash-normalised path so it works on Windows too.
       expect(generatedPath.replace(/\\/g, '/')).toContain('my-branch_2017-05-01-20-20-30.json');
-      expect(generatedPath).not.toContain(':');
+      // Only check the filename for colons, not the full path: on Windows the path
+      // includes a drive letter (e.g. "D:\...") which legitimately contains a colon.
+      expect(filename).not.toContain(':');
     } finally {
-      dateSpy.mockRestore();
+      jest.useRealTimers();
       getGitInfoSpy.mockRestore();
     }
   });

--- a/libraries/rush-lib/src/api/test/ChangeFile.test.ts
+++ b/libraries/rush-lib/src/api/test/ChangeFile.test.ts
@@ -25,7 +25,7 @@ describe(ChangeFile.name, () => {
       {
         packageName: 'a',
         changes: [],
-        email: 'fake@microsoft.com'
+        email: 'fake@example.com'
       },
       rushConfiguration
     );


### PR DESCRIPTION
Fixes #2195

When you run "rush change" twice within the same minute, the second run silently overwrites the change file written by the first one, so one of your messages gets lost. The generated filename only has minute-level granularity, which means both runs resolve to the same path. The issue thread confirms this: waiting a minute between invocations makes it behave correctly.

The cause is in ChangeFile.generatePath(), which called _getTimestamp() with no arguments. That formats the time as YYYY-MM-DD-HH-MM. The method already accepted a useSeconds parameter, but nothing ever passed it. This change passes true so the filename includes seconds (YYYY-MM-DD-HH-MM-SS), which is enough to keep separate invocations from colliding in normal usage.

While turning that on I noticed the useSeconds branch was itself broken. It used matches[2].replace(:, -), which only replaces the first colon, so it produced strings like 20-20:30 with a leftover colon. A colon is not even a valid filename character on Windows. I changed it to a global replace so every colon is converted.

I added a unit test in ChangeFile.test.ts that pins the branch name and the clock, then asserts the generated path contains the seconds and has no leftover colons. I confirmed the test fails against the previous behavior and passes with this change. I also added a change file under common/changes.