### PR TITLE
[heft-storybook-plugin] Add --port flag to set the Storybook dev server port in serve mode

### DIFF
--- a/common/changes/@rushstack/heft-storybook-plugin/heft-storybook-plugin-port-flag_2026-06-05-15-54.json
+++ b/common/changes/@rushstack/heft-storybook-plugin/heft-storybook-plugin-port-flag_2026-06-05-15-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-storybook-plugin",
+      "comment": "Add `--port` flag to pass a specific dev server port through to the Storybook CLI in serve mode",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/heft-storybook-plugin"
+}

--- a/heft-plugins/heft-storybook-plugin/heft-plugin.json
+++ b/heft-plugins/heft-storybook-plugin/heft-plugin.json
@@ -28,6 +28,12 @@
           "longName": "--no-open",
           "description": "Pass --no-open to the storybook CLI so it does not automatically open a browser window in serve mode.",
           "parameterKind": "flag"
+        },
+        {
+          "longName": "--port",
+          "description": "Pass --port to the storybook CLI to bind the dev server to a specific port in serve mode.",
+          "parameterKind": "string",
+          "argumentName": "PORT"
         }
       ]
     }

--- a/heft-plugins/heft-storybook-plugin/src/StorybookPlugin.ts
+++ b/heft-plugins/heft-storybook-plugin/src/StorybookPlugin.ts
@@ -23,6 +23,7 @@ import type {
   IScopedLogger,
   IHeftTaskPlugin,
   CommandLineFlagParameter,
+  CommandLineStringParameter,
   IHeftTaskRunHookOptions
 } from '@rushstack/heft';
 import type {
@@ -191,6 +192,7 @@ interface IPrepareStorybookOptions extends IStorybookPluginOptions {
   isTestMode: boolean;
   isDocsMode: boolean;
   isNoOpenMode: boolean;
+  port: string | undefined;
 }
 
 const DEFAULT_STORYBOOK_VERSION: StorybookCliVersion = StorybookCliVersion.STORYBOOK7;
@@ -229,6 +231,7 @@ const STORYBOOK_FLAG_NAME: '--storybook' = '--storybook';
 const STORYBOOK_TEST_FLAG_NAME: '--storybook-test' = '--storybook-test';
 const DOCS_FLAG_NAME: '--docs' = '--docs';
 const NO_OPEN_FLAG_NAME: '--no-open' = '--no-open';
+const PORT_FLAG_NAME: '--port' = '--port';
 
 /** @public */
 export default class StorybookPlugin implements IHeftTaskPlugin<IStorybookPluginOptions> {
@@ -248,6 +251,8 @@ export default class StorybookPlugin implements IHeftTaskPlugin<IStorybookPlugin
     const docsParameter: CommandLineFlagParameter = taskSession.parameters.getFlagParameter(DOCS_FLAG_NAME);
     const noOpenParameter: CommandLineFlagParameter =
       taskSession.parameters.getFlagParameter(NO_OPEN_FLAG_NAME);
+    const portParameter: CommandLineStringParameter =
+      taskSession.parameters.getStringParameter(PORT_FLAG_NAME);
 
     const parseResult: IParsedPackageNameOrError = PackageName.tryParse(options.storykitPackageName);
     if (parseResult.error) {
@@ -312,6 +317,7 @@ export default class StorybookPlugin implements IHeftTaskPlugin<IStorybookPlugin
           isTestMode: storybookTestParameter.value,
           isDocsMode: docsParameter.value,
           isNoOpenMode: noOpenParameter.value,
+          port: portParameter.value,
           ...options
         });
         await this._runStorybookAsync(runStorybookOptions, options);
@@ -470,7 +476,7 @@ export default class StorybookPlugin implements IHeftTaskPlugin<IStorybookPlugin
     runStorybookOptions: IRunStorybookOptions,
     options: IStorybookPluginOptions
   ): Promise<void> {
-    const { logger, resolvedModulePath, verbose, isServeMode, isTestMode, isDocsMode, isNoOpenMode } =
+    const { logger, resolvedModulePath, verbose, isServeMode, isTestMode, isDocsMode, isNoOpenMode, port } =
       runStorybookOptions;
     let { workingDirectory, outputFolder } = runStorybookOptions;
     logger.terminal.writeLine('Running Storybook compilation');
@@ -520,6 +526,10 @@ export default class StorybookPlugin implements IHeftTaskPlugin<IStorybookPlugin
 
     if (isServeMode && isNoOpenMode) {
       storybookArgs.push('--no-open');
+    }
+
+    if (isServeMode && port) {
+      storybookArgs.push('--port', port);
     }
 
     const storybookEnv: NodeJS.ProcessEnv = {


### PR DESCRIPTION
## Summary

When Heft launches Storybook in serve mode (`--storybook` with `heft start`/watch), there was previously no way to control which port the Storybook dev server binds to from the Heft command line — you were limited to Storybook's default port. This PR adds a `--port` parameter to the `storybook` parameter scope that is passed straight through to the Storybook CLI's own `--port` option, so the dev server can be bound to a specific port.

This is helpful in environments that pre-allocate a port before launching the dev server (for example, a build/orchestration daemon that needs to know the port up front so it can poll for readiness).

## Details

The change mirrors the existing `--no-open` flag:

- `heft-plugin.json` declares a new `--port` string parameter (`argumentName: "PORT"`).
- `StorybookPlugin.ts` reads it via `taskSession.parameters.getStringParameter('--port')`, threads it through the prepare/run options, and — only when in serve mode and a value is provided — pushes `--port <value>` onto the Storybook CLI args.

Notes:
- The flag only takes effect in serve mode, consistent with `--no-open` and with where a dev-server port is meaningful; it has no effect on static builds.
- Fully backwards compatible: the parameter is optional, and when omitted the Storybook invocation is unchanged.
- No performance impact.

## How it was tested

- `rushx build` in `heft-storybook-plugin` passes (TypeScript compile + ESLint).
- The equivalent change has been running as a local pnpm patch against the published `@rushstack/heft-storybook-plugin` in a downstream monorepo, where Heft invokes Storybook in serve mode with `--port` and the dev server binds to the requested port.

## Impacted documentation

None. Only the `heft-plugin.json` parameter declaration changed; the options JSON schema (`storybook.schema.json`) and the website docs are unaffected.
