### PR TITLE
fix: [rush] Parse pnpm-config.json with JsonSyntax.JsonWithComments

### DIFF
--- a/common/changes/@microsoft/rush/fix-pnpm-config-jsonc_2026-06-06-09-15.json
+++ b/common/changes/@microsoft/rush/fix-pnpm-config-jsonc_2026-06-06-09-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix a regression where Rush change-detection treated any `pnpm-config.json` containing comments as unparseable, causing every project to be flagged as impacted.",
+      "type": "patch",
+      "packageName": "@microsoft/rush"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "bartvandenende-wm@users.noreply.github.com"
+}

--- a/libraries/rush-lib/src/logic/ProjectChangeAnalyzer.ts
+++ b/libraries/rush-lib/src/logic/ProjectChangeAnalyzer.ts
@@ -6,7 +6,7 @@ import * as path from 'node:path';
 import ignore, { type Ignore } from 'ignore';
 
 import type { IReadonlyLookupByPath, LookupByPath, IPrefixMatch } from '@rushstack/lookup-by-path';
-import { Path, FileSystem, Async, AlreadyReportedError, Sort } from '@rushstack/node-core-library';
+import { Path, FileSystem, Async, AlreadyReportedError, Sort, JsonFile } from '@rushstack/node-core-library';
 import {
   getRepoChanges,
   getRepoRoot,
@@ -545,16 +545,16 @@ export class ProjectChangeAnalyzer {
         blobSpec: `${mergeCommit}:${pnpmConfigRelativePath}`,
         repositoryRoot: repoRoot
       });
-      const oldPnpmConfig: IPnpmOptionsJson = JSON.parse(oldPnpmConfigText);
+      const oldPnpmConfig: IPnpmOptionsJson = JsonFile.parseString(oldPnpmConfigText);
       oldCatalogs = oldPnpmConfig.globalCatalogs ?? {};
     } catch {
       // Old file didn't exist or was unparseable — treat all packages in all current catalogs as changed
       if (rushConfiguration.subspacesFeatureEnabled) {
-        terminal.writeLine(
+        terminal.writeWarningLine(
           `"${subspace.subspaceName}" subspace pnpm-config.json was created or unparseable. Assuming all projects are affected.`
         );
       } else {
-        terminal.writeLine(
+        terminal.writeWarningLine(
           `pnpm-config.json was created or unparseable. Assuming all projects are affected.`
         );
       }
@@ -608,8 +608,7 @@ export class ProjectChangeAnalyzer {
       // Check each project in the subspace to see if it depends on a changed catalog package
       const subspaceProjects: RushConfigurationProject[] = subspace.getProjects();
       subspaceProjects.forEach((project) => {
-        const { dependencies, devDependencies, optionalDependencies, peerDependencies } =
-          project.packageJson;
+        const { dependencies, devDependencies, optionalDependencies, peerDependencies } = project.packageJson;
         const allDependencies: Set<[string, string]> = new Set(
           [dependencies, devDependencies, optionalDependencies, peerDependencies].flatMap((deps) =>
             Object.entries(deps ?? {})

--- a/libraries/rush-lib/src/logic/test/ProjectChangeAnalyzer.test.ts
+++ b/libraries/rush-lib/src/logic/test/ProjectChangeAnalyzer.test.ts
@@ -842,6 +842,35 @@ describe(ProjectChangeAnalyzer.name, () => {
         // 'c' has no catalog deps
         expect(changedProjects.has(rushConfiguration.getProjectByName('c')!)).toBe(false);
       });
+
+      it('parses pnpm-config.json blobs containing comments (regression #5813)', async () => {
+        const rushConfiguration: RushConfiguration = getCatalogRushConfiguration();
+        mockPnpmConfigChanged();
+        mockGetBlobContentAsync.mockImplementation(() => {
+          return Promise.resolve(
+            `// banner comment from rush init template\n` +
+              `/* block comment */\n` +
+              JSON.stringify({
+                globalCatalogs: {
+                  default: { react: '^18.0.0', semver: '^7.5.4' },
+                  tools: { typescript: '~5.3.0', eslint: '^8.50.0' }
+                }
+              })
+          );
+        });
+
+        const projectChangeAnalyzer: ProjectChangeAnalyzer = new ProjectChangeAnalyzer(rushConfiguration);
+        const terminal: Terminal = new Terminal(new StringBufferTerminalProvider(true));
+
+        const changedProjects = await projectChangeAnalyzer.getChangedProjectsAsync({
+          enableFiltering: false,
+          includeExternalDependencies: false,
+          targetBranchName: 'main',
+          terminal
+        });
+
+        expect(changedProjects.size).toBe(0);
+      });
     });
 
     describe('subspace catalog change detection', () => {


### PR DESCRIPTION
<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

Fixes #5813.

`ProjectChangeAnalyzer` parses the *current* `pnpm-config.json` with a comment-tolerant loader, but parsed the *historical* git blob with strict `JSON.parse`. Any repo who uses the default pnpm config template shipped with rush fell into the "created or unparseable" branch on every diff — flagging every project as impacted and writing a diagnostic to **stdout**, which corrupts `rush list --json --impacted-by`.


## Details

Two small changes in `ProjectChangeAnalyzer._detectCatalogChangesAsync`:
- Parse the old blob with `JsonFile.parseString(...)` from `@rushstack/node-core-library`, consistent with how the live file is loaded via `NonProjectConfigurationFile`.
- Route the diagnostic through `terminal.writeWarningLine` (stderr), matching the surrounding diagnostics in this file.

## How it was tested

Added one targeted regression test in `ProjectChangeAnalyzer.test.ts` that feeds the analyzer an old `pnpm-config.json` blob containing `//` and `/* */` comments with catalogs identical to current, and asserts zero projects are flagged — pre-fix this would have parse-failed and flagged every catalog-using project.

## Impacted documentation
N/A
<!--------------------------------------------------------------------------
👉 STEP 7: Does your PR affect anything that is discussed in the website docs?
     If so, please paste the URL of each affected web page, so we will
     remember to update the documentation after your PR is merged.
     (Updating the website is appreciated but not required.)
     If no docs are impacted, delete the "Impacted documentation" section.

     If you modified a JSON schema, remember to update init templates such as:
     rush-lib/assets/rush-init/*.json
     api-extractor/src/schemas/api-extractor-template.json
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 8: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
