### PR TITLE
fix(rush): default rush-pnpm query commands to recursive

### DIFF
--- a/common/changes/@microsoft/rush/fix-rush-pnpm-recursive-queries_2026-06-07-06-00.json
+++ b/common/changes/@microsoft/rush/fix-rush-pnpm-recursive-queries_2026-06-07-06-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Default `rush-pnpm outdated` and `rush-pnpm why` to recursive workspace queries.",
+      "type": "patch",
+      "packageName": "@microsoft/rush"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "262980978+kiranmagic7@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush/fix-rush-pnpm-recursive-queries_2026-06-07-06-00.json
+++ b/common/changes/@microsoft/rush/fix-rush-pnpm-recursive-queries_2026-06-07-06-00.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "comment": "Default `rush-pnpm outdated` and `rush-pnpm why` to recursive workspace queries.",
-      "type": "patch",
+      "type": "minor",
       "packageName": "@microsoft/rush"
     }
   ],

--- a/libraries/rush-lib/src/cli/RushPnpmCommandLineParser.ts
+++ b/libraries/rush-lib/src/cli/RushPnpmCommandLineParser.ts
@@ -36,6 +36,25 @@ import { EnvironmentVariableNames } from '../api/EnvironmentConfiguration';
 import { initializeDotEnv } from '../logic/dotenv';
 
 const RUSH_SKIP_CHECKS_PARAMETER: string = '--rush-skip-checks';
+const RUSH_PNPM_RECURSIVE_DEFAULT_COMMANDS: Set<string> = new Set(['outdated', 'why']);
+
+function _hasRecursiveFlag(pnpmArgs: string[]): boolean {
+  return pnpmArgs.some((arg) => arg === '-r' || arg === '--recursive' || arg.startsWith('--recursive='));
+}
+
+function _hasGlobalFlag(pnpmArgs: string[]): boolean {
+  return pnpmArgs.some((arg) => arg === '-g' || arg === '--global' || arg.startsWith('--global='));
+}
+
+function _addDefaultRecursiveFlagIfNeeded(commandName: string, pnpmArgs: string[]): void {
+  if (
+    RUSH_PNPM_RECURSIVE_DEFAULT_COMMANDS.has(commandName) &&
+    !_hasRecursiveFlag(pnpmArgs) &&
+    !_hasGlobalFlag(pnpmArgs)
+  ) {
+    pnpmArgs.splice(1, 0, '--recursive');
+  }
+}
 
 /**
  * Options for RushPnpmCommandLineParser
@@ -253,6 +272,7 @@ export class RushPnpmCommandLineParser {
       }
 
       this._commandName = commandName;
+      _addDefaultRecursiveFlagIfNeeded(commandName, pnpmArgs);
 
       // Warn about commands known not to work
       /* eslint-disable no-fallthrough */

--- a/libraries/rush-lib/src/cli/test/RushPnpmCommandLineParser.test.ts
+++ b/libraries/rush-lib/src/cli/test/RushPnpmCommandLineParser.test.ts
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { RushPnpmCommandLineParser } from '../RushPnpmCommandLineParser';
+
+interface IRushPnpmCommandLineParserInternals {
+  _validatePnpmUsageAsync(pnpmArgs: string[]): Promise<void>;
+}
+
+async function validatePnpmArgsAsync(pnpmArgs: string[]): Promise<string[]> {
+  const parser: IRushPnpmCommandLineParserInternals = Object.create(RushPnpmCommandLineParser.prototype);
+  await parser._validatePnpmUsageAsync(pnpmArgs);
+  return pnpmArgs;
+}
+
+describe(RushPnpmCommandLineParser.name, () => {
+  it('adds recursive mode to workspace query commands by default', async () => {
+    await expect(validatePnpmArgsAsync(['outdated'])).resolves.toEqual(['outdated', '--recursive']);
+    await expect(validatePnpmArgsAsync(['why', '@rushstack/node-core-library'])).resolves.toEqual([
+      'why',
+      '--recursive',
+      '@rushstack/node-core-library'
+    ]);
+  });
+
+  it('does not duplicate explicit recursive flags', async () => {
+    await expect(validatePnpmArgsAsync(['outdated', '-r'])).resolves.toEqual(['outdated', '-r']);
+    await expect(
+      validatePnpmArgsAsync(['why', '--recursive', '@rushstack/node-core-library'])
+    ).resolves.toEqual(['why', '--recursive', '@rushstack/node-core-library']);
+  });
+
+  it('does not force recursive mode for global outdated checks', async () => {
+    await expect(validatePnpmArgsAsync(['outdated', '--global'])).resolves.toEqual(['outdated', '--global']);
+  });
+});


### PR DESCRIPTION
Fixes #5035.

## What changed

- Defaults `rush-pnpm outdated` and `rush-pnpm why` to pass `--recursive` when the caller has not already provided `-r`/`--recursive` or `--global`.
- Adds unit coverage for default insertion, explicit recursive flags, and global outdated checks.
- Adds a Rush change file for `@microsoft/rush`.

## Why

`outdated` and `why` are workspace query commands in Rush repos. Without recursive mode, they can query the wrong importer or no importer; defaulting these two commands to recursive mode matches the workaround discussed in #5035 while preserving explicit caller flags.

## Compatibility / risk

This only changes the default flags for `rush-pnpm outdated` and `rush-pnpm why`. Explicit recursive flags are preserved, and global outdated checks are left unchanged.

## Tests

- `RUSH_ALLOW_UNSUPPORTED_NODEJS=1 node common/scripts/install-run-rush.js build --to @microsoft/rush-lib --verbose` - passed
- `git diff HEAD^..HEAD --check` - passed
- `RUSH_ALLOW_UNSUPPORTED_NODEJS=1 node common/scripts/install-run-rush.js test --to @microsoft/rush-lib --verbose` - the new `RushPnpmCommandLineParser.test` passed; the full suite failed locally under unsupported Node 25.6.1 due unrelated `RushXCommandLine` snapshots expecting mocked Node `12.12.12 (LTS)` but receiving `(unstable)`.
