### PR TITLE
[heft-sass-plugin] Fix resolution of plain .css files imported via @use / @import

### DIFF
--- a/common/changes/@rushstack/heft-sass-plugin/bartvandenende-wm-5823_2026-06-08-07-10.json
+++ b/common/changes/@rushstack/heft-sass-plugin/bartvandenende-wm-5823_2026-06-08-07-10.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-sass-plugin",
+      "comment": "Fix a regression where plain `.css` files referenced from another stylesheet via `@use`/`@import` could not be resolved by the importer.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft-sass-plugin"
+}

--- a/heft-plugins/heft-sass-plugin/src/SassProcessor.ts
+++ b/heft-plugins/heft-sass-plugin/src/SassProcessor.ts
@@ -586,13 +586,21 @@ export class SassProcessor {
    * @returns The canonical URL of the target file, or null if it does not resolve
    */
   private async _canonicalizeHeftInnerAsync(url: string, context: CanonicalizeContext): AsyncResolution {
-    if (url.endsWith('.sass') || url.endsWith('.scss')) {
+    if (url.endsWith('.sass') || url.endsWith('.scss') || url.endsWith('.css')) {
       // Extension is already present, so only try the exact URL or the corresponding partial
       return await this._canonicalizeFileAsync(url, context);
     }
 
-    // Spec says prefer .sass, but we don't use that extension
-    for (const candidate of [`${url}.scss`, `${url}.sass`, `${url}/index.scss`, `${url}/index.sass`]) {
+    // Spec says prefer .sass, but we don't use that extension.
+    // Plain `.css` is tried last, matching dart-sass's resolution order.
+    for (const candidate of [
+      `${url}.scss`,
+      `${url}.sass`,
+      `${url}.css`,
+      `${url}/index.scss`,
+      `${url}/index.sass`,
+      `${url}/index.css`
+    ]) {
       const result: SyncResolution = await this._canonicalizeFileAsync(candidate, context);
       if (result) {
         return result;

--- a/heft-plugins/heft-sass-plugin/src/test/SassProcessor.test.ts
+++ b/heft-plugins/heft-sass-plugin/src/test/SassProcessor.test.ts
@@ -504,6 +504,31 @@ describe(SassProcessor.name, () => {
     });
   });
 
+  describe('use-plain-css.module.scss (@use of a plain .css file)', () => {
+    it('resolves a plain .css file referenced via @use with an explicit extension', async () => {
+      const { processor, logger } = createProcessor(terminalProvider);
+      await compileFixtureAsync(processor, 'use-plain-css.module.scss');
+      // The @use must resolve without "Can't find stylesheet to import."
+      expect(logger.errors).toHaveLength(0);
+      const css: string = getCssOutput('use-plain-css.module.scss');
+      // Rules from the plain .css file should be inlined into the output
+      expect(css).toContain('.token-base');
+      expect(css).toContain('#0078d4');
+      expect(css).toContain('.container');
+    });
+
+    it('resolves a plain .css file referenced via @use without an explicit extension', async () => {
+      const { processor, logger } = createProcessor(terminalProvider);
+      await compileFixtureAsync(processor, 'use-plain-css-extensionless.module.scss');
+      // Extensionless loads must fall back to the `.css` candidate, matching dart-sass
+      expect(logger.errors).toHaveLength(0);
+      const css: string = getCssOutput('use-plain-css-extensionless.module.scss');
+      expect(css).toContain('.token-base');
+      expect(css).toContain('#0078d4');
+      expect(css).toContain('.container');
+    });
+  });
+
   describe('global-styles.global.sass (.global.sass non-module file)', () => {
     it('compiles indented Sass syntax to plain CSS for a .global.sass file', async () => {
       const { processor } = createProcessor(terminalProvider);

--- a/heft-plugins/heft-sass-plugin/src/test/__snapshots__/SassProcessor.test.ts.snap
+++ b/heft-plugins/heft-sass-plugin/src/test/__snapshots__/SassProcessor.test.ts.snap
@@ -1391,6 +1391,60 @@ export default styles;",
 }
 `;
 
+exports[`SassProcessor use-plain-css.module.scss (@use of a plain .css file) resolves a plain .css file referenced via @use with an explicit extension: terminal-output 1`] = `
+Array [
+  "[verbose] Checking for changes to 1 files...[n]",
+  "[    log] Compiling 1 files...[n]",
+]
+`;
+
+exports[`SassProcessor use-plain-css.module.scss (@use of a plain .css file) resolves a plain .css file referenced via @use with an explicit extension: written-files 1`] = `
+Map {
+  "/fake/output/dts/use-plain-css.module.scss.d.ts" => "declare interface IStyles {
+  \\"token-base\\": string;
+  container: string;
+}
+declare const styles: IStyles;
+export default styles;",
+  "/fake/output/css/use-plain-css.module.css" => "/* A plain CSS file (no Sass syntax) imported via @use from another stylesheet. */
+.token-base {
+  color: #0078d4;
+  display: block;
+}
+
+.container {
+  font-weight: bold;
+}",
+}
+`;
+
+exports[`SassProcessor use-plain-css.module.scss (@use of a plain .css file) resolves a plain .css file referenced via @use without an explicit extension: terminal-output 1`] = `
+Array [
+  "[verbose] Checking for changes to 1 files...[n]",
+  "[    log] Compiling 1 files...[n]",
+]
+`;
+
+exports[`SassProcessor use-plain-css.module.scss (@use of a plain .css file) resolves a plain .css file referenced via @use without an explicit extension: written-files 1`] = `
+Map {
+  "/fake/output/dts/use-plain-css-extensionless.module.scss.d.ts" => "declare interface IStyles {
+  \\"token-base\\": string;
+  container: string;
+}
+declare const styles: IStyles;
+export default styles;",
+  "/fake/output/css/use-plain-css-extensionless.module.css" => "/* A plain CSS file (no Sass syntax) imported via @use from another stylesheet. */
+.token-base {
+  color: #0078d4;
+  display: block;
+}
+
+.container {
+  font-weight: bold;
+}",
+}
+`;
+
 exports[`SassProcessor use-with-partial.module.scss (@use with local partial) generates .d.ts with class names from a file using @use: terminal-output 1`] = `
 Array [
   "[verbose] Checking for changes to 1 files...[n]",

--- a/heft-plugins/heft-sass-plugin/src/test/fixtures/plain-tokens.css
+++ b/heft-plugins/heft-sass-plugin/src/test/fixtures/plain-tokens.css
@@ -1,0 +1,5 @@
+/* A plain CSS file (no Sass syntax) imported via @use from another stylesheet. */
+.token-base {
+  color: #0078d4;
+  display: block;
+}

--- a/heft-plugins/heft-sass-plugin/src/test/fixtures/use-plain-css-extensionless.module.scss
+++ b/heft-plugins/heft-sass-plugin/src/test/fixtures/use-plain-css-extensionless.module.scss
@@ -1,0 +1,8 @@
+// Uses the modern @use syntax to import a plain `.css` file without an explicit extension.
+// dart-sass resolves extensionless loads against `.scss`, `.sass`, then `.css`, so SassProcessor
+// must fall back to the `.css` candidate when no Sass file exists.
+@use './plain-tokens';
+
+.container {
+  font-weight: bold;
+}

--- a/heft-plugins/heft-sass-plugin/src/test/fixtures/use-plain-css.module.scss
+++ b/heft-plugins/heft-sass-plugin/src/test/fixtures/use-plain-css.module.scss
@@ -1,0 +1,8 @@
+// Uses the modern @use syntax to import a plain `.css` file with an explicit extension.
+// dart-sass supports loading plain CSS this way, so SassProcessor must resolve the literal
+// `.css` file rather than probing for `.css.scss` / `.css.sass` candidates.
+@use './plain-tokens.css';
+
+.container {
+  font-weight: bold;
+}


### PR DESCRIPTION
## Summary

Fixes #5823

Since `@rushstack/heft-sass-plugin` v0.17.0, a plain `.css` file referenced from another stylesheet via `@use` (or `@import`) could no longer be resolved, even though the file existed and dart-sass supports loading plain CSS. Builds failed with `Can't find stylesheet to import.` This restores the behavior from v0.16.0 and earlier.

## Details

The importer rewrite in #5140 took over all resolution, but its candidate logic only considered `.sass`/`.scss`. A `.css` URL therefore fell through and probed nonexistent paths like `tokens.css.scss`.

This change makes the importer resolve `.css` the same way dart-sass does:
- An explicit `.css` extension now resolves to the literal file.
- Extensionless imports also fall back to `.css` (and `/index.css`), in Sass's
  preference order (`.scss` → `.sass` → `.css`).

## How it was tested

Added unit tests covering `@use` of a plain `.css` file both with an explicit extension and extensionless, asserting the import resolves and the CSS rules are inlined into the output. All existing tests continue to pass.