### PR TITLE
[heft-jest-plugin] Fix --test-path-pattern being ignored on Jest 30

### DIFF
--- a/common/changes/@rushstack/heft-jest-plugin/fix-heft-jest-test-path-pattern_2026-06-09-03-35.json
+++ b/common/changes/@rushstack/heft-jest-plugin/fix-heft-jest-test-path-pattern_2026-06-09-03-35.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-jest-plugin",
+      "comment": "Fix an issue where the `--test-path-pattern` parameter was ignored, causing all tests to run. In Jest 30 the `Config.Argv` field was renamed from `testPathPattern` to `testPathPatterns`.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/heft-jest-plugin",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/heft-plugins/heft-jest-plugin/src/JestPlugin.ts
+++ b/heft-plugins/heft-jest-plugin/src/JestPlugin.ts
@@ -627,7 +627,7 @@ export default class JestPlugin implements IHeftTaskPlugin<IJestPluginOptions> {
 
       testNamePattern: options.testNamePattern,
       testPathIgnorePatterns: options.testPathIgnorePatterns ? [options.testPathIgnorePatterns] : undefined,
-      testPathPattern: options.testPathPattern ? [options.testPathPattern] : undefined,
+      testPathPatterns: options.testPathPattern ? [options.testPathPattern] : undefined,
       testTimeout: options.testTimeout,
       maxWorkers: options.maxWorkers,
 


### PR DESCRIPTION
## Summary

`heft test --test-path-pattern <regex>` was silently running every test in a project. The Heft Jest plugin was passing the regex to Jest under the field name `testPathPattern` (singular) on `Config.Argv`.

## Root cause

In Jest 30, the `Config.Argv` property was renamed from `testPathPattern` (singular) to `testPathPatterns` (plural). `jest-config` now treats the old name as deprecated and ignores it, which causes Jest to run with no path filter at all.

See `jest-config` v30:

```
testPathPattern: () => formatDeprecation(
  'Option *testPathPattern* was replaced by *--testPathPatterns*. '
  + '*--testPathPatterns* is only available as a command-line option.'
)
```

## Fix

Write the argv as `testPathPatterns` (plural). The user-facing CLI parameter and the `IJestPluginOptions.testPathPattern` option are unchanged.

## Repro

In `libraries/rush-lib`:

```
heft test --test-path-pattern ChangeFile.test
```

Before the fix this ran the entire suite. After the fix it correctly runs only `ChangeFile.test.js`.
