### PR TITLE
[ts-command-line] Fix env var name shown in EnvironmentVariableParser error messages

### DIFF
--- a/common/changes/@rushstack/ts-command-line/fix-env-var-name-in-error-message_2026-06-11.json
+++ b/common/changes/@rushstack/ts-command-line/fix-env-var-name-in-error-message_2026-06-11.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix EnvironmentVariableParser error messages to report the environment variable name instead of its value",
+      "type": "patch",
+      "packageName": "@rushstack/ts-command-line"
+    }
+  ],
+  "packageName": "@rushstack/ts-command-line",
+  "email": "sshaurya914@gmail.com"
+}

--- a/common/changes/@rushstack/ts-command-line/fix-env-var-name-in-error-message_2026-06-11.json
+++ b/common/changes/@rushstack/ts-command-line/fix-env-var-name-in-error-message_2026-06-11.json
@@ -1,7 +1,7 @@
 {
   "changes": [
     {
-      "comment": "Fix EnvironmentVariableParser error messages to report the environment variable name instead of its value",
+      "comment": "Fix an issue where the error thrown for an unparseable environment variable mentions the value instead of the name.",
       "type": "patch",
       "packageName": "@rushstack/ts-command-line"
     }

--- a/libraries/ts-command-line/src/parameters/EnvironmentVariableParser.ts
+++ b/libraries/ts-command-line/src/parameters/EnvironmentVariableParser.ts
@@ -30,14 +30,14 @@ export class EnvironmentVariableParser {
             !parsedJson.every((x) => typeof x === 'string' || typeof x === 'boolean' || typeof x === 'number')
           ) {
             throw new Error(
-              `The ${environmentValue} environment variable value must be a JSON ` +
+              `The ${envVarName} environment variable value must be a JSON ` +
                 ` array containing only strings, numbers, and booleans.`
             );
           }
           return parsedJson.map((x) => x.toString());
         } catch (ex) {
           throw new Error(
-            `The ${environmentValue} environment variable value looks like a JSON array` +
+            `The ${envVarName} environment variable value looks like a JSON array` +
               ` but failed to parse: ` +
               (ex as Error).message
           );

--- a/libraries/ts-command-line/src/test/CommandLineParameter.test.ts
+++ b/libraries/ts-command-line/src/test/CommandLineParameter.test.ts
@@ -439,7 +439,7 @@ describe(CommandLineParameterBase.name, () => {
       }
 
       expect(error).toMatch(
-        /^The \[u environment variable value looks like a JSON array but failed to parse: Unexpected token /
+        /^The ENV_COLOR environment variable value looks like a JSON array but failed to parse: Unexpected token /
       );
     });
 

--- a/libraries/ts-command-line/src/test/__snapshots__/CommandLineParameter.test.ts.snap
+++ b/libraries/ts-command-line/src/test/__snapshots__/CommandLineParameter.test.ts.snap
@@ -30,7 +30,7 @@ Array [
 ]
 `;
 
-exports[`CommandLineParameterBase choice list raises an error if env var value is json containing non-scalars 1`] = `"The [{}] environment variable value looks like a JSON array but failed to parse: The [{}] environment variable value must be a JSON  array containing only strings, numbers, and booleans."`;
+exports[`CommandLineParameterBase choice list raises an error if env var value is json containing non-scalars 1`] = `"The ENV_COLOR environment variable value looks like a JSON array but failed to parse: The ENV_COLOR environment variable value must be a JSON  array containing only strings, numbers, and booleans."`;
 
 exports[`CommandLineParameterBase choice list raises an error if env var value is not a valid choice 1`] = `"Invalid value \\"oblong\\" for the environment variable ENV_COLOR.  Valid choices are: \\"purple\\", \\"yellow\\", \\"pizza\\""`;
 


### PR DESCRIPTION
When parseAsList encounters a malformed JSON array in an environment variable, it throws
two possible error messages. Both messages were accidentally interpolating the variable's
value (environmentValue) instead of the variable's name (envVarName). This means a user
who set MY_VAR='[u' would see:

  The [u environment variable value looks like a JSON array but failed to parse: ...

instead of the expected:

  The MY_VAR environment variable value looks like a JSON array but failed to parse: ...

The fix is a two-character change in each template string, swapping environmentValue for
envVarName. The existing test assertion and snapshot were written against the wrong output,
so those are corrected to match the intended behavior.

I noticed this while reading EnvironmentVariableParser.ts. No open issue existed for it
so I'm filing the fix directly. Happy to open a tracking issue first if that's preferred.