### PR TITLE
[webpack-plugin-utilities] Add evaluateConstantEstreeExpression

### DIFF
--- a/common/changes/@rushstack/hashed-folder-copy-plugin/main_2026-06-26-00-18-27.json
+++ b/common/changes/@rushstack/hashed-folder-copy-plugin/main_2026-06-26-00-18-27.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/hashed-folder-copy-plugin",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/hashed-folder-copy-plugin"
+}

--- a/common/changes/@rushstack/webpack-plugin-utilities/evaluate-constant-estree-expression_2026-06-25-00-00.json
+++ b/common/changes/@rushstack/webpack-plugin-utilities/evaluate-constant-estree-expression_2026-06-25-00-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Add `evaluateConstantEstreeExpression` for statically evaluating constant ESTree expression nodes.",
+      "type": "minor",
+      "packageName": "@rushstack/webpack-plugin-utilities"
+    }
+  ],
+  "packageName": "@rushstack/webpack-plugin-utilities",
+  "email": "iclanton@users.noreply.github.com"
+}

--- a/common/config/subspaces/default/pnpm-lock.yaml
+++ b/common/config/subspaces/default/pnpm-lock.yaml
@@ -5407,6 +5407,9 @@ importers:
       '@rushstack/node-core-library':
         specifier: workspace:*
         version: link:../../libraries/node-core-library
+      '@rushstack/webpack-plugin-utilities':
+        specifier: workspace:*
+        version: link:../webpack-plugin-utilities
       fast-glob:
         specifier: ~3.3.1
         version: 3.3.3
@@ -5560,6 +5563,9 @@ importers:
 
   ../../../webpack/webpack-plugin-utilities:
     dependencies:
+      '@types/estree':
+        specifier: 1.0.8
+        version: 1.0.8
       memfs:
         specifier: 4.12.0
         version: 4.12.0

--- a/common/reviews/api/webpack-plugin-utilities.api.md
+++ b/common/reviews/api/webpack-plugin-utilities.api.md
@@ -5,10 +5,15 @@
 ```ts
 
 import type { Configuration } from 'webpack';
+import type { Expression } from 'estree';
 import { IFs } from 'memfs';
 import type { MultiStats } from 'webpack';
+import type { SpreadElement } from 'estree';
 import type { Stats } from 'webpack';
 import type * as Webpack from 'webpack';
+
+// @beta
+export function evaluateConstantEstreeExpression<TNode>(node: Expression | SpreadElement): TNode;
 
 // @public
 function getTestingWebpackCompilerAsync(entry: string, additionalConfig?: Configuration, memFs?: IFs): Promise<(Stats | MultiStats) | undefined>;

--- a/webpack/hashed-folder-copy-plugin/package.json
+++ b/webpack/hashed-folder-copy-plugin/package.json
@@ -52,6 +52,7 @@
   },
   "dependencies": {
     "@rushstack/node-core-library": "workspace:*",
+    "@rushstack/webpack-plugin-utilities": "workspace:*",
     "fast-glob": "~3.3.1"
   },
   "devDependencies": {

--- a/webpack/hashed-folder-copy-plugin/src/HashedFolderCopyPlugin.ts
+++ b/webpack/hashed-folder-copy-plugin/src/HashedFolderCopyPlugin.ts
@@ -6,6 +6,7 @@ import type webpack from 'webpack';
 import type glob from 'fast-glob';
 
 import { Async } from '@rushstack/node-core-library';
+import { evaluateConstantEstreeExpression } from '@rushstack/webpack-plugin-utilities';
 
 import {
   type IHashedFolderDependency,
@@ -24,16 +25,6 @@ const ParserHelpers: IParserHelpers = require('webpack/lib/javascript/Javascript
 const PLUGIN_NAME: 'hashed-folder-copy-plugin' = 'hashed-folder-copy-plugin';
 
 const EXPRESSION_NAME: 'requireFolder' = 'requireFolder';
-
-interface IAcornNode<TExpression> {
-  computed: boolean | undefined;
-  elements: IAcornNode<unknown>[];
-  key: IAcornNode<unknown> | undefined;
-  name: string | undefined;
-  properties: IAcornNode<unknown>[] | undefined;
-  type: 'Literal' | 'ObjectExpression' | 'Identifier' | 'ArrayExpression' | unknown;
-  value: TExpression;
-}
 
 export function renderError(errorMessage: string): string {
   return `(function () { throw new Error(${JSON.stringify(errorMessage)}); })()`;
@@ -92,10 +83,9 @@ export class HashedFolderCopyPlugin implements webpack.WebpackPluginInstance {
             if (expression.arguments.length !== 1) {
               errorMessage = `Exactly one argument is required to be passed to "${EXPRESSION_NAME}"`;
             } else {
-              const argument: IAcornNode<IRequireFolderOptions> = expression
-                .arguments[0] as IAcornNode<IRequireFolderOptions>;
+              const argument: Expression = expression.arguments[0] as Expression;
               try {
-                requireFolderOptions = this._evaluateAcornNode(argument) as IRequireFolderOptions;
+                requireFolderOptions = evaluateConstantEstreeExpression(argument);
               } catch (e) {
                 errorMessage = (e as Error).message;
               }
@@ -163,38 +153,5 @@ export class HashedFolderCopyPlugin implements webpack.WebpackPluginInstance {
         normalModuleFactory.hooks.parser.for('javascript/dynamic').tap(PLUGIN_NAME, handler);
       }
     );
-  }
-
-  private _evaluateAcornNode(node: IAcornNode<unknown>): unknown {
-    switch (node.type) {
-      case 'Literal': {
-        return node.value;
-      }
-
-      case 'ObjectExpression': {
-        const result: Record<string, unknown> = {};
-
-        for (const property of node.properties!) {
-          const keyNode: IAcornNode<unknown> = property.key!;
-          if (keyNode.type !== 'Identifier' || keyNode.computed) {
-            throw new Error('Property keys must be non-computed identifiers');
-          }
-
-          const key: string = keyNode.name!;
-          const value: unknown = this._evaluateAcornNode(property.value as IAcornNode<unknown>);
-          result[key] = value;
-        }
-
-        return result;
-      }
-
-      case 'ArrayExpression': {
-        return node.elements.map((element) => this._evaluateAcornNode(element));
-      }
-
-      default: {
-        throw new Error(`Unsupported node type: "${node.type}"`);
-      }
-    }
   }
 }

--- a/webpack/webpack-plugin-utilities/package.json
+++ b/webpack/webpack-plugin-utilities/package.json
@@ -35,11 +35,14 @@
   },
   "scripts": {
     "build": "heft build --clean",
-    "_phase:build": "heft run --only build -- --clean"
+    "test": "heft run --only test",
+    "_phase:build": "heft run --only build -- --clean",
+    "_phase:test": "heft run --only test -- --clean"
   },
   "dependencies": {
-    "webpack-merge": "~5.8.0",
-    "memfs": "4.12.0"
+    "@types/estree": "1.0.8",
+    "memfs": "4.12.0",
+    "webpack-merge": "~5.8.0"
   },
   "peerDependencies": {
     "@types/webpack": "^4.39.8",
@@ -55,9 +58,9 @@
   },
   "devDependencies": {
     "@rushstack/heft": "workspace:*",
+    "@types/tapable": "1.0.6",
     "eslint": "~9.37.0",
     "local-node-rig": "workspace:*",
-    "@types/tapable": "1.0.6",
     "webpack": "~5.105.2"
   },
   "sideEffects": false

--- a/webpack/webpack-plugin-utilities/src/evaluateConstantEstreeExpression.ts
+++ b/webpack/webpack-plugin-utilities/src/evaluateConstantEstreeExpression.ts
@@ -1,0 +1,117 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import type { Expression, PrivateIdentifier, SpreadElement } from 'estree';
+
+/**
+ * Statically evaluates an ESTree (acorn) expression node into its corresponding
+ * runtime JavaScript value.
+ *
+ * @remarks
+ * This is intended to be used inside webpack plugins and loaders that hook into
+ * the parser (for example `parser.hooks.call`) and need to read the literal
+ * arguments passed to a function call at build time, without actually executing
+ * the user's code. A common use case is extracting a plain options object that
+ * was passed to a custom `require()`-style expression.
+ *
+ * Only a small subset of expression types is supported, namely those needed to
+ * express JSON-like constant values:
+ *
+ * - `Literal` (strings, numbers, booleans, `null`, etc.)
+ * - `UnaryExpression` (the `-`, `+`, `!`, and `~` operators applied to a constant
+ *   argument, e.g. the `-1` in `{ count: -1 }`)
+ * - `TemplateLiteral` (only when it has no `${...}` substitutions)
+ * - `ObjectExpression` (with non-computed identifier keys)
+ * - `ArrayExpression` (including sparse holes, which evaluate to `null`)
+ *
+ * @example
+ * ```ts
+ * // Given source: requireFolder({ outputFolder: 'assets', sources: [] })
+ * const options: IRequireFolderOptions = evaluateConstantEstreeExpression(callExpression.arguments[0]);
+ * ```
+ *
+ * @remarks Limitations
+ * Because the node is evaluated statically rather than executed, anything that
+ * is not a compile-time constant is unsupported and will cause an `Error` to be
+ * thrown. This includes:
+ *
+ * - Identifiers and variable references (e.g. `someVariable`)
+ * - Computed property keys (e.g. `{ [key]: value }`)
+ * - Spread elements in object expressions (e.g. `{ ...other }`)
+ * - Function calls, template literals, and any other expression type not listed above
+ *
+ * @param node - The ESTree expression node to evaluate.
+ * @returns The evaluated value, cast to the caller-specified type `TNode`. Note
+ * that the cast is unchecked; the caller is responsible for validating that the
+ * returned shape matches `TNode`.
+ * @throws An `Error` if the node (or any nested node) uses an unsupported
+ * expression type or syntax.
+ * @beta
+ */
+export function evaluateConstantEstreeExpression<TNode>(node: Expression | SpreadElement): TNode {
+  switch (node.type) {
+    case 'Literal': {
+      return node.value as TNode;
+    }
+
+    case 'UnaryExpression': {
+      const argumentValue: unknown = evaluateConstantEstreeExpression(node.argument);
+      switch (node.operator) {
+        case '-': {
+          return -(argumentValue as number) as TNode;
+        }
+        case '+': {
+          return +(argumentValue as number) as TNode;
+        }
+        case '!': {
+          return !argumentValue as TNode;
+        }
+        case '~': {
+          return ~(argumentValue as number) as TNode;
+        }
+        default: {
+          throw new Error(`Unsupported unary operator: "${node.operator}"`);
+        }
+      }
+    }
+
+    case 'TemplateLiteral': {
+      if (node.expressions.length > 0) {
+        throw new Error('Template literals with substitutions are not supported');
+      }
+
+      return node.quasis[0].value.cooked as TNode;
+    }
+
+    case 'ObjectExpression': {
+      const result: Record<string, unknown> = {};
+
+      for (const property of node.properties) {
+        if (property.type === 'SpreadElement') {
+          throw new Error('Spread elements are not supported in object expressions');
+        }
+
+        const keyNode: Expression | PrivateIdentifier = property.key;
+        if (keyNode.type !== 'Identifier' || property.computed) {
+          throw new Error('Property keys must be non-computed identifiers');
+        }
+
+        const key: string = keyNode.name;
+        const value: unknown = evaluateConstantEstreeExpression(property.value as Expression);
+        result[key] = value;
+      }
+
+      return result as TNode;
+    }
+
+    case 'ArrayExpression': {
+      return node.elements.map((element) =>
+        element === null ? null : evaluateConstantEstreeExpression(element)
+      ) as TNode;
+    }
+
+    default: {
+      throw new Error(`Unsupported node type: "${node.type}"`);
+    }
+  }
+}

--- a/webpack/webpack-plugin-utilities/src/index.ts
+++ b/webpack/webpack-plugin-utilities/src/index.ts
@@ -10,3 +10,5 @@
 import * as VersionDetection from './DetectWebpackVersion';
 import * as Testing from './Testing';
 export { VersionDetection, Testing };
+
+export { evaluateConstantEstreeExpression } from './evaluateConstantEstreeExpression';

--- a/webpack/webpack-plugin-utilities/src/test/evaluateConstantEstreeExpression.test.ts
+++ b/webpack/webpack-plugin-utilities/src/test/evaluateConstantEstreeExpression.test.ts
@@ -1,0 +1,214 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import type {
+  ArrayExpression,
+  Expression,
+  Identifier,
+  ObjectExpression,
+  Property,
+  SimpleLiteral,
+  SpreadElement,
+  TemplateLiteral,
+  UnaryExpression,
+  UnaryOperator
+} from 'estree';
+
+import { evaluateConstantEstreeExpression } from '../evaluateConstantEstreeExpression';
+
+// Minimal typed builders for the subset of ESTree nodes used by these tests.
+// They intentionally only populate the fields that `evaluateConstantEstreeExpression` reads.
+
+function literal(value: SimpleLiteral['value']): SimpleLiteral {
+  return { type: 'Literal', value };
+}
+
+function identifier(name: string): Identifier {
+  return { type: 'Identifier', name };
+}
+
+function unary(operator: UnaryOperator, argument: Expression): UnaryExpression {
+  return { type: 'UnaryExpression', operator, prefix: true, argument };
+}
+
+function templateLiteral(cooked: string, expressions: Expression[] = []): TemplateLiteral {
+  return {
+    type: 'TemplateLiteral',
+    expressions,
+    quasis: [
+      {
+        type: 'TemplateElement',
+        tail: true,
+        value: { cooked, raw: cooked }
+      }
+    ]
+  };
+}
+
+function array(elements: ArrayExpression['elements']): ArrayExpression {
+  return { type: 'ArrayExpression', elements };
+}
+
+function property(key: Expression, value: Expression, options: { computed?: boolean } = {}): Property {
+  return {
+    type: 'Property',
+    key,
+    value,
+    kind: 'init',
+    method: false,
+    shorthand: false,
+    computed: options.computed ?? false
+  };
+}
+
+function object(properties: Array<Property | SpreadElement>): ObjectExpression {
+  return { type: 'ObjectExpression', properties };
+}
+
+describe(evaluateConstantEstreeExpression.name, () => {
+  describe('Literal', () => {
+    it('evaluates string literals', () => {
+      expect(evaluateConstantEstreeExpression(literal('hello'))).toBe('hello');
+    });
+
+    it('evaluates number literals', () => {
+      expect(evaluateConstantEstreeExpression(literal(42))).toBe(42);
+    });
+
+    it('evaluates boolean literals', () => {
+      expect(evaluateConstantEstreeExpression(literal(true))).toBe(true);
+      expect(evaluateConstantEstreeExpression(literal(false))).toBe(false);
+    });
+
+    it('evaluates null literals', () => {
+      expect(evaluateConstantEstreeExpression(literal(null))).toBeNull();
+    });
+  });
+
+  describe('UnaryExpression', () => {
+    it('evaluates negated numbers', () => {
+      expect(evaluateConstantEstreeExpression(unary('-', literal(1)))).toBe(-1);
+    });
+
+    it('evaluates the unary plus operator', () => {
+      expect(evaluateConstantEstreeExpression(unary('+', literal(5)))).toBe(5);
+    });
+
+    it('evaluates the logical not operator', () => {
+      expect(evaluateConstantEstreeExpression(unary('!', literal(false)))).toBe(true);
+      expect(evaluateConstantEstreeExpression(unary('!', literal(0)))).toBe(true);
+      expect(evaluateConstantEstreeExpression(unary('!', literal('')))).toBe(true);
+    });
+
+    it('evaluates the bitwise not operator', () => {
+      expect(evaluateConstantEstreeExpression(unary('~', literal(0)))).toBe(-1);
+    });
+
+    it('throws for unsupported unary operators', () => {
+      expect(() => evaluateConstantEstreeExpression(unary('typeof', literal('x')))).toThrow(
+        'Unsupported unary operator: "typeof"'
+      );
+    });
+  });
+
+  describe('TemplateLiteral', () => {
+    it('evaluates a template literal with no substitutions', () => {
+      expect(evaluateConstantEstreeExpression(templateLiteral('hello'))).toBe('hello');
+    });
+
+    it('throws for template literals with substitutions', () => {
+      const node: TemplateLiteral = templateLiteral('hello', [literal('world')]);
+      expect(() => evaluateConstantEstreeExpression(node)).toThrow(
+        'Template literals with substitutions are not supported'
+      );
+    });
+  });
+
+  describe('ArrayExpression', () => {
+    it('evaluates an array of literals', () => {
+      const node: ArrayExpression = array([literal(1), literal('two'), literal(true)]);
+      expect(evaluateConstantEstreeExpression(node)).toEqual([1, 'two', true]);
+    });
+
+    it('evaluates an empty array', () => {
+      expect(evaluateConstantEstreeExpression(array([]))).toEqual([]);
+    });
+
+    it('evaluates sparse holes as null', () => {
+      const node: ArrayExpression = array([literal(1), null, literal(3)]);
+      expect(evaluateConstantEstreeExpression(node)).toEqual([1, null, 3]);
+    });
+
+    it('evaluates nested arrays', () => {
+      const node: ArrayExpression = array([array([literal(1)]), array([literal(2)])]);
+      expect(evaluateConstantEstreeExpression(node)).toEqual([[1], [2]]);
+    });
+  });
+
+  describe('ObjectExpression', () => {
+    it('evaluates an object with identifier keys', () => {
+      const node: ObjectExpression = object([
+        property(identifier('outputFolder'), literal('assets')),
+        property(identifier('count'), unary('-', literal(1)))
+      ]);
+      expect(evaluateConstantEstreeExpression(node)).toEqual({ outputFolder: 'assets', count: -1 });
+    });
+
+    it('evaluates an empty object', () => {
+      expect(evaluateConstantEstreeExpression(object([]))).toEqual({});
+    });
+
+    it('evaluates nested objects and arrays', () => {
+      const node: ObjectExpression = object([
+        property(
+          identifier('sources'),
+          array([object([property(identifier('globsBase'), literal('./assets'))])])
+        )
+      ]);
+      expect(evaluateConstantEstreeExpression(node)).toEqual({
+        sources: [{ globsBase: './assets' }]
+      });
+    });
+
+    it('throws for computed keys', () => {
+      const node: ObjectExpression = object([
+        property(identifier('key'), literal('value'), { computed: true })
+      ]);
+      expect(() => evaluateConstantEstreeExpression(node)).toThrow(
+        'Property keys must be non-computed identifiers'
+      );
+    });
+
+    it('throws for non-identifier keys', () => {
+      const node: ObjectExpression = object([property(literal('key'), literal('value'))]);
+      expect(() => evaluateConstantEstreeExpression(node)).toThrow(
+        'Property keys must be non-computed identifiers'
+      );
+    });
+
+    it('throws for spread elements', () => {
+      const node: ObjectExpression = object([{ type: 'SpreadElement', argument: identifier('other') }]);
+      expect(() => evaluateConstantEstreeExpression(node)).toThrow(
+        'Spread elements are not supported in object expressions'
+      );
+    });
+  });
+
+  describe('unsupported nodes', () => {
+    it('throws for identifiers', () => {
+      expect(() => evaluateConstantEstreeExpression(identifier('someVariable'))).toThrow(
+        'Unsupported node type: "Identifier"'
+      );
+    });
+
+    it('throws for call expressions', () => {
+      const node: Expression = {
+        type: 'CallExpression',
+        callee: identifier('fn'),
+        arguments: [],
+        optional: false
+      };
+      expect(() => evaluateConstantEstreeExpression(node)).toThrow('Unsupported node type: "CallExpression"');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Reworks the `evaluateAcornNode` helper in `@rushstack/webpack-plugin-utilities`:

- **Renamed** `evaluateAcornNode` → `evaluateConstantEstreeExpression` (the previous name referenced the parser rather than the node shape it operates on).
- **Removed** the hand-rolled `IAcornNode` interface in favor of the existing `@types/estree` types. This surfaced and fixed a few latent correctness gaps that the old `any`-ish casts hid:
  - object `SpreadElement`s (`{ ...other }`) are now explicitly rejected instead of silently mis-evaluated,
  - computed / non-identifier property keys are handled via proper narrowing,
  - sparse array holes (`[1, , 3]`) now evaluate to `null` instead of being passed into the recursion.
- **Expanded supported node types** for constant values:
  - `UnaryExpression` — notably negative numbers like `-1`, which parse as a unary `-` applied to a literal and previously threw. Also supports `+`, `!`, `~`.
  - `TemplateLiteral` with no `${...}` substitutions.
- **Added a TSDoc comment** describing intended usage (reading literal call arguments inside webpack parser hooks), the supported node types, and limitations.
- **Added unit tests** covering every supported node type, nesting, sparse holes, and all error paths (computed keys, non-identifier keys, object spreads, unsupported operators / node types). This enables the `test` phase for the package, which previously had none.
- Updated the `hashed-folder-copy-plugin` consumer to the new name.

## Details

- The package previously had no Jest setup; `test` / `_phase:test` scripts were added (the rig already provides the test phase + config).
- All 23 tests pass and the build is clean (API report regenerated).

## How it was tested

`rush build` and `rush test` for `@rushstack/webpack-plugin-utilities`, plus a build of the `hashed-folder-copy-plugin` consumer.