### PR TITLE
Add local-vscode-extension-rig and migrate VS Code extensions to it

### DIFF
--- a/common/config/rush/nonbrowser-approved-packages.json
+++ b/common/config/rush/nonbrowser-approved-packages.json
@@ -276,7 +276,7 @@
     },
     {
       "name": "@rushstack/heft-vscode-extension-rig",
-      "allowedCategories": [ "vscode-extensions" ]
+      "allowedCategories": [ "libraries" ]
     },
     {
       "name": "@rushstack/heft-web-rig",
@@ -700,7 +700,7 @@
     },
     {
       "name": "fast-glob",
-      "allowedCategories": [ "libraries" ]
+      "allowedCategories": [ "libraries", "vscode-extensions" ]
     },
     {
       "name": "fastify",
@@ -717,10 +717,6 @@
     {
       "name": "git-repo-info",
       "allowedCategories": [ "libraries" ]
-    },
-    {
-      "name": "glob",
-      "allowedCategories": [ "libraries", "vscode-extensions" ]
     },
     {
       "name": "heft-action-plugin",
@@ -861,6 +857,10 @@
     {
       "name": "local-node-rig",
       "allowedCategories": [ "libraries", "tests", "vscode-extensions" ]
+    },
+    {
+      "name": "local-vscode-extension-rig",
+      "allowedCategories": [ "vscode-extensions" ]
     },
     {
       "name": "local-web-rig",

--- a/common/config/subspaces/default/pnpm-lock.yaml
+++ b/common/config/subspaces/default/pnpm-lock.yaml
@@ -4819,6 +4819,33 @@ importers:
         specifier: ~5.8.2
         version: 5.8.2
 
+  ../../../rigs/local-vscode-extension-rig:
+    dependencies:
+      '@rushstack/heft':
+        specifier: workspace:*
+        version: link:../../apps/heft
+      '@rushstack/heft-vscode-extension-plugin':
+        specifier: workspace:*
+        version: link:../../heft-plugins/heft-vscode-extension-plugin
+      '@rushstack/heft-vscode-extension-rig':
+        specifier: workspace:*
+        version: link:../heft-vscode-extension-rig
+      '@rushstack/webpack-preserve-dynamic-require-plugin':
+        specifier: workspace:*
+        version: link:../../webpack/preserve-dynamic-require-plugin
+      eslint:
+        specifier: ~9.37.0
+        version: 9.37.0
+      local-eslint-config:
+        specifier: workspace:*
+        version: link:../../eslint/local-eslint-config
+      local-node-rig:
+        specifier: workspace:*
+        version: link:../local-node-rig
+      typescript:
+        specifier: ~5.8.2
+        version: 5.8.2
+
   ../../../rigs/local-web-rig:
     dependencies:
       '@microsoft/api-extractor':
@@ -5211,9 +5238,6 @@ importers:
       '@rushstack/heft':
         specifier: workspace:*
         version: link:../../apps/heft
-      '@rushstack/heft-vscode-extension-rig':
-        specifier: workspace:*
-        version: link:../../rigs/heft-vscode-extension-rig
       '@types/node':
         specifier: 20.17.19
         version: 20.17.19
@@ -5223,6 +5247,9 @@ importers:
       '@types/webpack-env':
         specifier: 1.18.8
         version: 1.18.8
+      local-vscode-extension-rig:
+        specifier: workspace:*
+        version: link:../../rigs/local-vscode-extension-rig
 
   ../../../vscode-extensions/playwright-local-browser-server-vscode-extension:
     dependencies:
@@ -5251,9 +5278,6 @@ importers:
       '@rushstack/heft-node-rig':
         specifier: workspace:*
         version: link:../../rigs/heft-node-rig
-      '@rushstack/heft-vscode-extension-rig':
-        specifier: workspace:*
-        version: link:../../rigs/heft-vscode-extension-rig
       '@types/node':
         specifier: 20.17.19
         version: 20.17.19
@@ -5263,6 +5287,9 @@ importers:
       '@types/webpack-env':
         specifier: 1.18.8
         version: 1.18.8
+      local-vscode-extension-rig:
+        specifier: workspace:*
+        version: link:../../rigs/local-vscode-extension-rig
 
   ../../../vscode-extensions/rush-vscode-command-webview:
     dependencies:
@@ -5352,12 +5379,6 @@ importers:
       '@rushstack/heft':
         specifier: workspace:*
         version: link:../../apps/heft
-      '@rushstack/heft-vscode-extension-rig':
-        specifier: workspace:*
-        version: link:../../rigs/heft-vscode-extension-rig
-      '@types/glob':
-        specifier: 7.1.1
-        version: 7.1.1
       '@types/mocha':
         specifier: 10.0.6
         version: 10.0.6
@@ -5373,9 +5394,12 @@ importers:
       eslint:
         specifier: ~9.37.0
         version: 9.37.0
-      glob:
-        specifier: ~7.0.5
-        version: 7.0.6
+      fast-glob:
+        specifier: ~3.3.1
+        version: 3.3.3
+      local-vscode-extension-rig:
+        specifier: workspace:*
+        version: link:../../rigs/local-vscode-extension-rig
       mocha:
         specifier: ^10.1.0
         version: 10.8.2

--- a/rigs/local-vscode-extension-rig/README.md
+++ b/rigs/local-vscode-extension-rig/README.md
@@ -1,0 +1,6 @@
+# local-vscode-extension-rig
+
+A rig package for VSCode Extension projects that build using Heft inside the RushStack repository. This
+package extends `local-node-rig` and adds some options that are specific to VScode extensions.
+
+Note that this rig is not published to the NPM registry.

--- a/rigs/local-vscode-extension-rig/package.json
+++ b/rigs/local-vscode-extension-rig/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "local-vscode-extension-rig",
+  "version": "1.0.0",
+  "description": "A rig package for VSCode extension projects that build using Heft inside the RushStack repository.",
+  "license": "MIT",
+  "private": true,
+  "scripts": {
+    "build": "",
+    "_phase:build": ""
+  },
+  "dependencies": {
+    "@rushstack/heft-vscode-extension-plugin": "workspace:*",
+    "@rushstack/heft-vscode-extension-rig": "workspace:*",
+    "@rushstack/heft": "workspace:*",
+    "@rushstack/webpack-preserve-dynamic-require-plugin": "workspace:*",
+    "eslint": "~9.37.0",
+    "local-eslint-config": "workspace:*",
+    "local-node-rig": "workspace:*",
+    "typescript": "~5.8.2"
+  }
+}

--- a/rigs/local-vscode-extension-rig/profiles/default/config/api-extractor-base.json
+++ b/rigs/local-vscode-extension-rig/profiles/default/config/api-extractor-base.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
+
+  "extends": "local-node-rig/profiles/default/config/api-extractor-base.json"
+}

--- a/rigs/local-vscode-extension-rig/profiles/default/config/api-extractor-task.json
+++ b/rigs/local-vscode-extension-rig/profiles/default/config/api-extractor-task.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/heft/v0/api-extractor-task.schema.json",
+
+  "extends": "local-node-rig/profiles/default/config/api-extractor-task.json"
+}

--- a/rigs/local-vscode-extension-rig/profiles/default/config/heft.json
+++ b/rigs/local-vscode-extension-rig/profiles/default/config/heft.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/heft/v0/heft.schema.json",
+
+  "extends": "@rushstack/heft-vscode-extension-rig/profiles/default/config/heft.json",
+
+  "phasesByName": {
+    "build": {
+      "cleanFiles": [{ "includeGlobs": ["lib-esnext"] }],
+
+      "tasksByName": {
+        "lint": {
+          "taskPlugin": {
+            "options": {
+              "sarifLogPath": "temp/build/lint/lint.sarif"
+            }
+          }
+        }
+      }
+    },
+
+    "test": {
+      "cleanFiles": [{ "includeGlobs": ["coverage"] }]
+    }
+  }
+}

--- a/rigs/local-vscode-extension-rig/profiles/default/config/jest.config.json
+++ b/rigs/local-vscode-extension-rig/profiles/default/config/jest.config.json
@@ -1,0 +1,3 @@
+{
+  "extends": "local-node-rig/profiles/default/config/jest.config.json"
+}

--- a/rigs/local-vscode-extension-rig/profiles/default/config/rush-project.json
+++ b/rigs/local-vscode-extension-rig/profiles/default/config/rush-project.json
@@ -1,0 +1,3 @@
+{
+  "extends": "local-node-rig/profiles/default/config/rush-project.json"
+}

--- a/rigs/local-vscode-extension-rig/profiles/default/config/typescript.json
+++ b/rigs/local-vscode-extension-rig/profiles/default/config/typescript.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/heft/v0/typescript.schema.json",
+
+  "extends": "local-node-rig/profiles/default/config/typescript.json"
+}

--- a/rigs/local-vscode-extension-rig/profiles/default/includes/eslint/flat/mixins/friendly-locals.js
+++ b/rigs/local-vscode-extension-rig/profiles/default/includes/eslint/flat/mixins/friendly-locals.js
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+const friendlyLocalsMixin = require('local-eslint-config/flat/mixins/friendly-locals');
+
+module.exports = [...friendlyLocalsMixin];

--- a/rigs/local-vscode-extension-rig/profiles/default/includes/eslint/flat/mixins/packlets.js
+++ b/rigs/local-vscode-extension-rig/profiles/default/includes/eslint/flat/mixins/packlets.js
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+const packletsMixin = require('local-eslint-config/flat/mixins/packlets');
+
+module.exports = [...packletsMixin];

--- a/rigs/local-vscode-extension-rig/profiles/default/includes/eslint/flat/mixins/react.js
+++ b/rigs/local-vscode-extension-rig/profiles/default/includes/eslint/flat/mixins/react.js
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+const reactMixin = require('local-eslint-config/flat/mixins/react');
+
+module.exports = [...reactMixin];

--- a/rigs/local-vscode-extension-rig/profiles/default/includes/eslint/flat/mixins/tsdoc.js
+++ b/rigs/local-vscode-extension-rig/profiles/default/includes/eslint/flat/mixins/tsdoc.js
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+const tsdocMixin = require('local-eslint-config/flat/mixins/tsdoc');
+
+module.exports = [...tsdocMixin];

--- a/rigs/local-vscode-extension-rig/profiles/default/includes/eslint/flat/patch/eslint-bulk-suppressions.js
+++ b/rigs/local-vscode-extension-rig/profiles/default/includes/eslint/flat/patch/eslint-bulk-suppressions.js
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+require('@rushstack/eslint-patch/eslint-bulk-suppressions');

--- a/rigs/local-vscode-extension-rig/profiles/default/includes/eslint/flat/profile/node-trusted-tool.js
+++ b/rigs/local-vscode-extension-rig/profiles/default/includes/eslint/flat/profile/node-trusted-tool.js
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+const nodeTrustedToolProfile = require('local-eslint-config/flat/profile/node-trusted-tool');
+
+module.exports = [...nodeTrustedToolProfile];

--- a/rigs/local-vscode-extension-rig/profiles/default/includes/eslint/flat/profile/node.js
+++ b/rigs/local-vscode-extension-rig/profiles/default/includes/eslint/flat/profile/node.js
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+const nodeProfile = require('local-eslint-config/flat/profile/node');
+
+module.exports = [...nodeProfile];

--- a/rigs/local-vscode-extension-rig/profiles/default/tsconfig-base.json
+++ b/rigs/local-vscode-extension-rig/profiles/default/tsconfig-base.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "http://json.schemastore.org/tsconfig",
+  "extends": "../../node_modules/local-node-rig/profiles/default/tsconfig-base.json"
+}

--- a/rigs/local-vscode-extension-rig/profiles/default/webpack.config.base.js
+++ b/rigs/local-vscode-extension-rig/profiles/default/webpack.config.base.js
@@ -1,0 +1,1 @@
+module.exports = require('@rushstack/heft-vscode-extension-rig/profiles/default/webpack.config.base');

--- a/rush.json
+++ b/rush.json
@@ -1414,6 +1414,12 @@
       "shouldPublish": false
     },
     {
+      "packageName": "local-vscode-extension-rig",
+      "projectFolder": "rigs/local-vscode-extension-rig",
+      "reviewCategory": "libraries",
+      "shouldPublish": false
+    },
+    {
       "packageName": "local-web-rig",
       "projectFolder": "rigs/local-web-rig",
       "reviewCategory": "libraries",

--- a/vscode-extensions/debug-certificate-manager-vscode-extension/config/heft.json
+++ b/vscode-extensions/debug-certificate-manager-vscode-extension/config/heft.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/heft/v0/heft.schema.json",
 
-  "extends": "@rushstack/heft-vscode-extension-rig/profiles/default/config/heft.json",
+  "extends": "local-vscode-extension-rig/profiles/default/config/heft.json",
 
   "phasesByName": {
     "build": {

--- a/vscode-extensions/debug-certificate-manager-vscode-extension/config/rig.json
+++ b/vscode-extensions/debug-certificate-manager-vscode-extension/config/rig.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/rig-package/rig.schema.json",
 
-  "rigPackageName": "@rushstack/heft-vscode-extension-rig"
+  "rigPackageName": "local-vscode-extension-rig"
 }

--- a/vscode-extensions/debug-certificate-manager-vscode-extension/config/rush-project.json
+++ b/vscode-extensions/debug-certificate-manager-vscode-extension/config/rush-project.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/rush/v5/rush-project.schema.json",
-  "extends": "@rushstack/heft-vscode-extension-rig/profiles/default/config/rush-project.json"
+  "extends": "local-vscode-extension-rig/profiles/default/config/rush-project.json"
 }

--- a/vscode-extensions/debug-certificate-manager-vscode-extension/eslint.config.js
+++ b/vscode-extensions/debug-certificate-manager-vscode-extension/eslint.config.js
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-const nodeTrustedToolProfile = require('@rushstack/heft-vscode-extension-rig/profiles/default/includes/eslint/flat/profile/node-trusted-tool');
-const friendlyLocalsMixin = require('@rushstack/heft-vscode-extension-rig/profiles/default/includes/eslint/flat/mixins/friendly-locals');
+const nodeTrustedToolProfile = require('local-vscode-extension-rig/profiles/default/includes/eslint/flat/profile/node-trusted-tool');
+const friendlyLocalsMixin = require('local-vscode-extension-rig/profiles/default/includes/eslint/flat/mixins/friendly-locals');
 
 module.exports = [...nodeTrustedToolProfile, ...friendlyLocalsMixin];

--- a/vscode-extensions/debug-certificate-manager-vscode-extension/package.json
+++ b/vscode-extensions/debug-certificate-manager-vscode-extension/package.json
@@ -122,11 +122,11 @@
     "tslib": "~2.8.1"
   },
   "devDependencies": {
-    "@rushstack/heft-vscode-extension-rig": "workspace:*",
     "@rushstack/heft": "workspace:*",
     "@types/node": "20.17.19",
     "@types/vscode": "1.103.0",
-    "@types/webpack-env": "1.18.8"
+    "@types/webpack-env": "1.18.8",
+    "local-vscode-extension-rig": "workspace:*"
   },
   "sideEffects": false
 }

--- a/vscode-extensions/debug-certificate-manager-vscode-extension/src/certificates.ts
+++ b/vscode-extensions/debug-certificate-manager-vscode-extension/src/certificates.ts
@@ -1,9 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import { getConfig } from './config';
 import { CertificateManager, CertificateStore } from '@rushstack/debug-certificate-manager';
 import type { ITerminal } from '@rushstack/terminal';
+
+import { getConfig } from './config';
 
 export function getCertificateManager(terminal: ITerminal): CertificateManager {
   const { caCertificateFilename, keyFilename, certificateFilename, storePath } = getConfig(terminal);

--- a/vscode-extensions/debug-certificate-manager-vscode-extension/src/config.ts
+++ b/vscode-extensions/debug-certificate-manager-vscode-extension/src/config.ts
@@ -1,10 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import * as vscode from 'vscode';
 import * as path from 'node:path';
+
+import * as vscode from 'vscode';
+
 import type { ITerminal } from '@rushstack/terminal';
 import type { ICertificateStoreOptions } from '@rushstack/debug-certificate-manager';
+
 import {
   CONFIG_AUTOSYNC,
   CONFIG_SECTION,
@@ -29,8 +32,7 @@ export function getConfig(terminal: ITerminal): IExtensionConfig {
     config.get(CONFIG_CERTIFICATE_FILENAME) || 'rushstack-serve.pem';
   const keyFilename: string | undefined = config.get(CONFIG_KEY_FILENAME) || 'rushstack-serve.key';
   const autoSync: boolean = config.get(CONFIG_AUTOSYNC) ?? false;
-  const homeDirectory: string | undefined =
-    config.get<string>(CONFIG_HOME_DIRECTORY) || undefined;
+  const homeDirectory: string | undefined = config.get<string>(CONFIG_HOME_DIRECTORY) || undefined;
   let storePath: string | undefined = undefined;
 
   const platformMap: Record<string, keyof StorePaths> = {

--- a/vscode-extensions/debug-certificate-manager-vscode-extension/src/constants.ts
+++ b/vscode-extensions/debug-certificate-manager-vscode-extension/src/constants.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
+
 import packageJson from '../package.json';
 
 export const EXTENSION_DISPLAY_NAME: string = 'Debug Certificate Manager';

--- a/vscode-extensions/debug-certificate-manager-vscode-extension/src/extension.ts
+++ b/vscode-extensions/debug-certificate-manager-vscode-extension/src/extension.ts
@@ -5,15 +5,15 @@ import * as vscode from 'vscode';
 
 import { Async } from '@rushstack/node-core-library/lib/Async';
 import { Terminal } from '@rushstack/terminal';
-import {
+import type {
   CertificateManager,
   ICertificateStoreOptions,
   ICertificateValidationResult,
-  type ICertificate
+  ICertificate
 } from '@rushstack/debug-certificate-manager';
-
 import { runWorkspaceCommandAsync } from '@rushstack/vscode-shared/lib/runWorkspaceCommandAsync';
 import { VScodeOutputChannelTerminalProvider } from '@rushstack/vscode-shared/lib/VScodeOutputChannelTerminalProvider';
+
 import { getCertificateManager } from './certificates';
 import { getConfig } from './config';
 import {
@@ -229,7 +229,7 @@ export function activate(context: vscode.ExtensionContext): void {
             throw new Error('Failed to parse home directory from command output');
           }
         } else {
-          homeDir = require('os').homedir();
+          homeDir = require('node:os').homedir();
         }
 
         terminal.writeLine(`Resolved home directory: ${homeDir}`);

--- a/vscode-extensions/debug-certificate-manager-vscode-extension/tsconfig.json
+++ b/vscode-extensions/debug-certificate-manager-vscode-extension/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "$schema": "http://json.schemastore.org/tsconfig",
-  "extends": "./node_modules/@rushstack/heft-vscode-extension-rig/profiles/default/tsconfig-base.json"
+  "extends": "./node_modules/local-vscode-extension-rig/profiles/default/tsconfig-base.json"
 }

--- a/vscode-extensions/debug-certificate-manager-vscode-extension/webpack.config.js
+++ b/vscode-extensions/debug-certificate-manager-vscode-extension/webpack.config.js
@@ -3,19 +3,16 @@
 
 'use strict';
 
-const {
-  createExtensionConfig
-} = require('@rushstack/heft-vscode-extension-rig/profiles/default/webpack.config.base');
-const path = require('node:path');
+const { createExtensionConfig } = require('local-vscode-extension-rig/profiles/default/webpack.config.base');
 
 function createConfig({ production, webpack }) {
   const config = createExtensionConfig({
     production: false,
     webpack,
     entry: {
-      extension: './lib/extension.js'
+      extension: './lib-esm/extension.js'
     },
-    outputPath: path.resolve(__dirname, 'dist', 'vsix', 'unpacked')
+    outputPath: `${__dirname}/dist/vsix/unpacked`
   });
   return config;
 }

--- a/vscode-extensions/playwright-local-browser-server-vscode-extension/config/heft.json
+++ b/vscode-extensions/playwright-local-browser-server-vscode-extension/config/heft.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/heft/v0/heft.schema.json",
-  "extends": "@rushstack/heft-vscode-extension-rig/profiles/default/config/heft.json"
+  "extends": "local-vscode-extension-rig/profiles/default/config/heft.json"
 }

--- a/vscode-extensions/playwright-local-browser-server-vscode-extension/config/rig.json
+++ b/vscode-extensions/playwright-local-browser-server-vscode-extension/config/rig.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/rig-package/rig.schema.json",
 
-  "rigPackageName": "@rushstack/heft-vscode-extension-rig"
+  "rigPackageName": "local-vscode-extension-rig"
 }

--- a/vscode-extensions/playwright-local-browser-server-vscode-extension/config/rush-project.json
+++ b/vscode-extensions/playwright-local-browser-server-vscode-extension/config/rush-project.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/rush/v5/rush-project.schema.json",
-  "extends": "@rushstack/heft-vscode-extension-rig/profiles/default/config/rush-project.json"
+  "extends": "local-vscode-extension-rig/profiles/default/config/rush-project.json"
 }

--- a/vscode-extensions/playwright-local-browser-server-vscode-extension/eslint.config.js
+++ b/vscode-extensions/playwright-local-browser-server-vscode-extension/eslint.config.js
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-const nodeTrustedToolProfile = require('@rushstack/heft-vscode-extension-rig/profiles/default/includes/eslint/flat/profile/node-trusted-tool');
-const friendlyLocalsMixin = require('@rushstack/heft-vscode-extension-rig/profiles/default/includes/eslint/flat/mixins/friendly-locals');
+const nodeTrustedToolProfile = require('local-vscode-extension-rig/profiles/default/includes/eslint/flat/profile/node-trusted-tool');
+const friendlyLocalsMixin = require('local-vscode-extension-rig/profiles/default/includes/eslint/flat/mixins/friendly-locals');
 
 module.exports = [...nodeTrustedToolProfile, ...friendlyLocalsMixin];

--- a/vscode-extensions/playwright-local-browser-server-vscode-extension/package.json
+++ b/vscode-extensions/playwright-local-browser-server-vscode-extension/package.json
@@ -103,12 +103,12 @@
     "tslib": "~2.8.1"
   },
   "devDependencies": {
-    "@rushstack/heft-vscode-extension-rig": "workspace:*",
     "@rushstack/heft-node-rig": "workspace:*",
     "@rushstack/heft": "workspace:*",
     "@types/node": "20.17.19",
     "@types/vscode": "1.103.0",
-    "@types/webpack-env": "1.18.8"
+    "@types/webpack-env": "1.18.8",
+    "local-vscode-extension-rig": "workspace:*"
   },
   "sideEffects": false
 }

--- a/vscode-extensions/playwright-local-browser-server-vscode-extension/src/extension.ts
+++ b/vscode-extensions/playwright-local-browser-server-vscode-extension/src/extension.ts
@@ -3,6 +3,7 @@
 
 import * as os from 'node:os';
 import * as path from 'node:path';
+
 import * as vscode from 'vscode';
 
 import type {
@@ -11,19 +12,16 @@ import type {
   ILaunchOptionsAllowlist,
   ILaunchOptionsValidationResult
 } from '@rushstack/playwright-browser-tunnel';
-
 import { PlaywrightTunnel } from '@rushstack/playwright-browser-tunnel/lib/PlaywrightBrowserTunnel';
-
 import {
   EXTENSION_INSTALLED_FILENAME,
   getNormalizedErrorString
 } from '@rushstack/playwright-browser-tunnel/lib/utilities';
 import { LaunchOptionsValidator } from '@rushstack/playwright-browser-tunnel/lib/LaunchOptionsValidator';
-
 import { Terminal, type ITerminal, type ITerminalProvider } from '@rushstack/terminal';
-
 import { runWorkspaceCommandAsync } from '@rushstack/vscode-shared/lib/runWorkspaceCommandAsync';
 import { VScodeOutputChannelTerminalProvider } from '@rushstack/vscode-shared/lib/VScodeOutputChannelTerminalProvider';
+
 import packageJson from '../package.json';
 
 const EXTENSION_DISPLAY_NAME: string = 'Playwright Local Browser Server';
@@ -348,6 +346,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
           outputChannel.appendLine(`Tunnel status changed: ${status}`);
           updateStatusBar(status);
         },
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         onBeforeLaunch: async (handshake: IHandshake) => {
           // Validate launch options against the allowlist
           const validationResult: ILaunchOptionsValidationResult =

--- a/vscode-extensions/playwright-local-browser-server-vscode-extension/src/utils/getNormalizedErrorString.ts
+++ b/vscode-extensions/playwright-local-browser-server-vscode-extension/src/utils/getNormalizedErrorString.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
 export function getNormalizedErrorString(error: unknown): string {
   if (error instanceof Error) {
     if (error.stack) {

--- a/vscode-extensions/playwright-local-browser-server-vscode-extension/tsconfig.json
+++ b/vscode-extensions/playwright-local-browser-server-vscode-extension/tsconfig.json
@@ -1,4 +1,9 @@
 {
   "$schema": "http://json.schemastore.org/tsconfig",
-  "extends": "./node_modules/@rushstack/heft-vscode-extension-rig/profiles/default/tsconfig-base.json"
+  "extends": "./node_modules/local-vscode-extension-rig/profiles/default/tsconfig-base.json",
+  "compilerOptions": {
+    // playwright-core's type definitions reference DOM types (Node, HTMLElement, SVGElement, etc.),
+    // so include the DOM lib to satisfy them, matching apps/playwright-browser-tunnel.
+    "lib": ["DOM"]
+  }
 }

--- a/vscode-extensions/playwright-local-browser-server-vscode-extension/webpack.config.js
+++ b/vscode-extensions/playwright-local-browser-server-vscode-extension/webpack.config.js
@@ -3,17 +3,14 @@
 
 'use strict';
 
-const {
-  createExtensionConfig
-} = require('@rushstack/heft-vscode-extension-rig/profiles/default/webpack.config.base');
-const path = require('node:path');
+const { createExtensionConfig } = require('local-vscode-extension-rig/profiles/default/webpack.config.base');
 
 function createConfig({ production, webpack }) {
   const config = createExtensionConfig({
     production: false,
     webpack,
     entry: {
-      extension: './lib/extension.js'
+      extension: './lib-esm/extension.js'
     },
     outputPath: `${__dirname}/dist/vsix/unpacked`
   });

--- a/vscode-extensions/rush-vscode-command-webview/src/Message/IFromExtensionMessage.ts
+++ b/vscode-extensions/rush-vscode-command-webview/src/Message/IFromExtensionMessage.ts
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import type { IProjectState } from '../store/slices/project';
+
+// This message contract is intentionally kept in its own DOM-free module so it can be re-exported from
+// the package barrel (index.ts) and consumed by the Node-based `rush-vscode-extension` project. The
+// sibling `fromExtension.ts` declares `fromExtensionListener` using the browser's generic
+// `MessageEvent<T>`, which is only available with the DOM lib. If this type lived there, importing it
+// from a Node project (which resolves `MessageEvent` to the non-generic `@types/node` declaration)
+// would fail to type-check with "Type 'MessageEvent' is not generic" (TS2315).
+export type IFromExtensionMessage = IFromExtensionMessageInitialize;
+
+interface IFromExtensionMessageInitialize {
+  command: string;
+  state: IProjectState;
+}

--- a/vscode-extensions/rush-vscode-command-webview/src/Message/fromExtension.ts
+++ b/vscode-extensions/rush-vscode-command-webview/src/Message/fromExtension.ts
@@ -2,14 +2,8 @@
 // See LICENSE in the project root for license information.
 
 import { store } from '../store';
-import { type IProjectState, initializeProjectInfo, onChangeProject } from '../store/slices/project';
-
-export type IFromExtensionMessage = IFromExtensionMessageInitialize;
-
-interface IFromExtensionMessageInitialize {
-  command: string;
-  state: IProjectState;
-}
+import { initializeProjectInfo, onChangeProject } from '../store/slices/project';
+import type { IFromExtensionMessage } from './IFromExtensionMessage';
 
 export const fromExtensionListener: (event: MessageEvent<IFromExtensionMessage>) => void = (
   event: MessageEvent<IFromExtensionMessage>

--- a/vscode-extensions/rush-vscode-command-webview/src/index.ts
+++ b/vscode-extensions/rush-vscode-command-webview/src/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-export type { IFromExtensionMessage } from './Message/fromExtension';
+export type { IFromExtensionMessage } from './Message/IFromExtensionMessage';
 export type { IRootState } from './store';
 export type { IToExtensionMessage } from './Message/toExtension';
 export type { ICommandLineParameter } from './store/slices/parameter';

--- a/vscode-extensions/rush-vscode-command-webview/webpack.config.js
+++ b/vscode-extensions/rush-vscode-command-webview/webpack.config.js
@@ -1,5 +1,4 @@
 /* eslint-env es6 */
-const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 
@@ -16,10 +15,10 @@ function createWebpackConfig({ production }) {
       }
     },
     entry: {
-      bundle: path.join(__dirname, 'lib-esm', 'entry.js')
+      bundle: `${__dirname}/lib-esm/entry.js`
     },
     output: {
-      path: path.join(__dirname, 'dist'),
+      path: `${__dirname}/dist`,
       filename: '[name].js'
     },
     module: {
@@ -58,9 +57,9 @@ function createWebpackConfig({ production }) {
       new BundleAnalyzerPlugin({
         openAnalyzer: false,
         analyzerMode: 'static',
-        reportFilename: path.resolve(__dirname, 'temp', 'stats.html'),
+        reportFilename: `${__dirname}/temp/stats.html`,
         generateStatsFile: true,
-        statsFilename: path.resolve(__dirname, 'temp', 'stats.json'),
+        statsFilename: `${__dirname}/temp/stats.json`,
         logLevel: 'info'
       })
     ].filter(Boolean)

--- a/vscode-extensions/rush-vscode-extension/config/heft.json
+++ b/vscode-extensions/rush-vscode-extension/config/heft.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/heft/v0/heft.schema.json",
 
-  "extends": "@rushstack/heft-vscode-extension-rig/profiles/default/config/heft.json",
+  "extends": "local-vscode-extension-rig/profiles/default/config/heft.json",
 
   "aliasesByName": {
     "start": {

--- a/vscode-extensions/rush-vscode-extension/config/rig.json
+++ b/vscode-extensions/rush-vscode-extension/config/rig.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/rig-package/rig.schema.json",
 
-  "rigPackageName": "@rushstack/heft-vscode-extension-rig"
+  "rigPackageName": "local-vscode-extension-rig"
 }

--- a/vscode-extensions/rush-vscode-extension/config/rush-project.json
+++ b/vscode-extensions/rush-vscode-extension/config/rush-project.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/rush/v5/rush-project.schema.json",
-  "extends": "@rushstack/heft-vscode-extension-rig/profiles/default/config/rush-project.json",
+  "extends": "local-vscode-extension-rig/profiles/default/config/rush-project.json",
   "operationSettings": [
     {
       "operationName": "_phase:build",

--- a/vscode-extensions/rush-vscode-extension/eslint.config.js
+++ b/vscode-extensions/rush-vscode-extension/eslint.config.js
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-const nodeTrustedToolProfile = require('@rushstack/heft-vscode-extension-rig/profiles/default/includes/eslint/flat/profile/node-trusted-tool');
-const friendlyLocalsMixin = require('@rushstack/heft-vscode-extension-rig/profiles/default/includes/eslint/flat/mixins/friendly-locals');
+const nodeTrustedToolProfile = require('local-vscode-extension-rig/profiles/default/includes/eslint/flat/profile/node-trusted-tool');
+const friendlyLocalsMixin = require('local-vscode-extension-rig/profiles/default/includes/eslint/flat/mixins/friendly-locals');
 
 module.exports = [...nodeTrustedToolProfile, ...friendlyLocalsMixin];

--- a/vscode-extensions/rush-vscode-extension/package.json
+++ b/vscode-extensions/rush-vscode-extension/package.json
@@ -302,14 +302,13 @@
   "devDependencies": {
     "@microsoft/rush-lib": "workspace:*",
     "@rushstack/heft": "workspace:*",
-    "@types/glob": "7.1.1",
     "@types/mocha": "10.0.6",
     "@types/vscode": "1.103.0",
     "@types/webpack-env": "1.18.8",
     "@vscode/test-electron": "^1.6.2",
     "eslint": "~9.37.0",
-    "glob": "~7.0.5",
-    "@rushstack/heft-vscode-extension-rig": "workspace:*",
+    "fast-glob": "~3.3.1",
+    "local-vscode-extension-rig": "workspace:*",
     "mocha": "^10.1.0"
   },
   "engines": {

--- a/vscode-extensions/rush-vscode-extension/src/extension.ts
+++ b/vscode-extensions/rush-vscode-extension/src/extension.ts
@@ -4,6 +4,7 @@
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
 import * as vscode from 'vscode';
+
 import { type LogLevel, setLogLevel, terminal } from './logic/logger';
 import { RushWorkspace } from './logic/RushWorkspace';
 import { RushProjectsProvider } from './providers/RushProjectsProvider';

--- a/vscode-extensions/rush-vscode-extension/src/logic/RushCommandWebViewPanel.ts
+++ b/vscode-extensions/rush-vscode-extension/src/logic/RushCommandWebViewPanel.ts
@@ -1,10 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import * as vscode from 'vscode';
-import * as path from 'path';
-import { FileSystem } from '@rushstack/node-core-library';
+import * as path from 'node:path';
 
+import * as vscode from 'vscode';
+
+import { FileSystem } from '@rushstack/node-core-library';
 import type { IFromExtensionMessage, IRootState } from '@rushstack/rush-vscode-command-webview';
 
 export class RushCommandWebViewPanel {

--- a/vscode-extensions/rush-vscode-extension/src/logic/RushCommandWebViewPanel.ts
+++ b/vscode-extensions/rush-vscode-extension/src/logic/RushCommandWebViewPanel.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import * as path from 'node:path';
-
 import * as vscode from 'vscode';
 
 import { FileSystem } from '@rushstack/node-core-library';
@@ -166,10 +164,10 @@ export class RushCommandWebViewPanel {
     // eslint-disable-next-line no-console
     console.log('loading rush command webview html and bundle');
     let html: string = await FileSystem.readFileAsync(
-      path.join(this._extensionPath, 'webview/rush-command-webview/index.html')
+      `${this._extensionPath}/webview/rush-command-webview/index.html`
     );
     const scriptSrc: vscode.Uri = this._panel!.webview.asWebviewUri(
-      vscode.Uri.file(path.join(this._extensionPath, 'webview/rush-command-webview/bundle.js'))
+      vscode.Uri.file(`${this._extensionPath}/webview/rush-command-webview/bundle.js`)
     );
 
     // replace bundled js with the correct path

--- a/vscode-extensions/rush-vscode-extension/src/logic/RushCommandWebViewPanel.ts
+++ b/vscode-extensions/rush-vscode-extension/src/logic/RushCommandWebViewPanel.ts
@@ -12,8 +12,9 @@ export class RushCommandWebViewPanel {
   private static _instance: RushCommandWebViewPanel | undefined;
   private _panel: vscode.WebviewView | undefined;
   private _webViewProvider: vscode.WebviewViewProvider | undefined;
-  private _context: vscode.ExtensionContext;
-  private _extensionPath: string;
+  private readonly _context: vscode.ExtensionContext;
+  private readonly _extensionPath: string;
+
   private constructor(context: vscode.ExtensionContext) {
     this._extensionPath = context.extensionPath;
     this._context = context;
@@ -59,11 +60,11 @@ export class RushCommandWebViewPanel {
       }
     };
 
-    const resolveWebviewView = (
+    const resolveWebviewView = async (
       thisWebview: vscode.WebviewView,
       thisWebviewContext: vscode.WebviewViewResolveContext,
       thisToken: vscode.CancellationToken
-    ): void => {
+    ): Promise<void> => {
       this._panel = thisWebview;
 
       const message: IFromExtensionMessage = {
@@ -73,9 +74,9 @@ export class RushCommandWebViewPanel {
       // eslint-disable-next-line no-console
       console.log('message', message);
       thisWebview.webview.options = { enableScripts: true };
-      thisWebview.webview.html = this._getWebviewContent();
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      thisWebview.webview.postMessage(message);
+      // eslint-disable-next-line require-atomic-updates
+      thisWebview.webview.html = await this._getWebviewContentAsync();
+      await thisWebview.webview.postMessage(message);
     };
 
     const provider: vscode.WebviewViewProvider = {
@@ -153,17 +154,18 @@ export class RushCommandWebViewPanel {
     // }
   }
 
-  private _setWebviewContent(state: IRootState): void {
+  private async _setWebviewContentAsync(state: IRootState): Promise<void> {
     if (!this._panel) {
       return;
     }
-    this._panel.webview.html = this._getWebviewContent(state);
+
+    this._panel.webview.html = await this._getWebviewContentAsync(state);
   }
 
-  private _getWebviewContent(state: unknown = {}): string {
+  private async _getWebviewContentAsync(state: unknown = {}): Promise<string> {
     // eslint-disable-next-line no-console
     console.log('loading rush command webview html and bundle');
-    let html: string = FileSystem.readFile(
+    let html: string = await FileSystem.readFileAsync(
       path.join(this._extensionPath, 'webview/rush-command-webview/index.html')
     );
     const scriptSrc: vscode.Uri = this._panel!.webview.asWebviewUri(

--- a/vscode-extensions/rush-vscode-extension/src/logic/RushWorkspace.ts
+++ b/vscode-extensions/rush-vscode-extension/src/logic/RushWorkspace.ts
@@ -1,14 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import { RushSdkLoader, type ISdkCallbackEvent } from '@rushstack/rush-sdk/loader';
-
 import * as vscode from 'vscode';
-import { terminal } from './logger';
 
+import { RushSdkLoader, type ISdkCallbackEvent } from '@rushstack/rush-sdk/loader';
 import type { CommandLineAction } from '@rushstack/rush-vscode-command-webview';
 import type * as RushLib from '@rushstack/rush-sdk';
 import type * as RushCommandLine from '@rushstack/ts-command-line';
+
+import { terminal } from './logger';
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 declare let ___DEV___: boolean;

--- a/vscode-extensions/rush-vscode-extension/src/providers/RushCommandsProvider.ts
+++ b/vscode-extensions/rush-vscode-extension/src/providers/RushCommandsProvider.ts
@@ -113,7 +113,8 @@ export class RushCommandsProvider implements vscode.TreeDataProvider<RushCommand
     return element;
   }
 
-  public getChildren(element?: vscode.TreeItem): Thenable<RushCommand[]> {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  public async getChildren(element?: vscode.TreeItem): Promise<RushCommand[]> {
     // eslint-disable-next-line no-console
     console.log('children: ', this._commandLineActions);
     // eslint-disable-next-line no-console
@@ -121,10 +122,10 @@ export class RushCommandsProvider implements vscode.TreeDataProvider<RushCommand
     if (!this._commandLineActions) {
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       vscode.window.showInformationMessage('No RushProjects in empty workspace');
-      return Promise.resolve([]);
+      return [];
     }
 
-    return Promise.resolve([
+    return [
       {
         label: 'Test label',
         collapsibleState: vscode.TreeItemCollapsibleState.None
@@ -137,11 +138,11 @@ export class RushCommandsProvider implements vscode.TreeDataProvider<RushCommand
         label: 'Test label3',
         collapsibleState: vscode.TreeItemCollapsibleState.None
       }
-    ]);
+    ];
 
     // top-level
     // if (!element) {
-    //   return Promise.resolve(
+    //   return (
     //     this._commandLineActions.map(
     //       (commandLineAction) =>
     //         new RushCommand({
@@ -153,6 +154,6 @@ export class RushCommandsProvider implements vscode.TreeDataProvider<RushCommand
     //   );
     // }
 
-    // return Promise.resolve([]);
+    // return [];
   }
 }

--- a/vscode-extensions/rush-vscode-extension/src/providers/RushCommandsProvider.ts
+++ b/vscode-extensions/rush-vscode-extension/src/providers/RushCommandsProvider.ts
@@ -2,10 +2,11 @@
 // See LICENSE in the project root for license information.
 
 import * as vscode from 'vscode';
-import { terminal } from '../logic/logger';
-import { RushWorkspace } from '../logic/RushWorkspace';
 
 import type { CommandLineAction } from '@rushstack/rush-vscode-command-webview';
+
+import { terminal } from '../logic/logger';
+import { RushWorkspace } from '../logic/RushWorkspace';
 
 interface IRushCommandParams {
   label: string;

--- a/vscode-extensions/rush-vscode-extension/src/providers/RushProjectsProvider.ts
+++ b/vscode-extensions/rush-vscode-extension/src/providers/RushProjectsProvider.ts
@@ -1,11 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import path from 'node:path';
-
 import * as vscode from 'vscode';
 
-import { JsonFile, type JsonObject } from '@rushstack/node-core-library';
 import type { RushConfiguration, RushConfigurationProject } from '@rushstack/rush-sdk';
 
 import { RushTaskProvider } from './TaskProvider';
@@ -148,13 +145,14 @@ export class RushProjectsProvider implements vscode.TreeDataProvider<RushProject
     return element;
   }
 
-  public getChildren(
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  public async getChildren(
     element?: RushProject | RushProjectScript
-  ): Thenable<RushProject[] | RushProjectScript[]> {
+  ): Promise<RushProject[] | RushProjectScript[]> {
     if (!this._rushConfiguration) {
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       vscode.window.showInformationMessage('No RushProjects in empty workspace');
-      return Promise.resolve([]);
+      return [];
     }
 
     // top-level
@@ -167,31 +165,33 @@ export class RushProjectsProvider implements vscode.TreeDataProvider<RushProject
             collapsibleState: vscode.TreeItemCollapsibleState.Collapsed
           })
       );
-      return Promise.resolve(rushProjectTreeItems);
+      return rushProjectTreeItems;
     }
 
     if (element instanceof RushProject) {
       try {
-        const projectFolder: string = element.rushConfigurationProject.projectFolder;
-        const projectRelativeFolder: string = element.rushConfigurationProject.projectRelativeFolder;
-        const packageJson: JsonObject = JsonFile.load(path.join(projectFolder, 'package.json'));
-        const rushProjectScriptTreeItems: RushProjectScript[] = Object.keys(packageJson.scripts).map(
-          (scriptName) =>
+        const {
+          projectFolder,
+          projectRelativeFolder,
+          packageJson: { scripts = {} }
+        } = element.rushConfigurationProject;
+        const rushProjectScriptTreeItems: RushProjectScript[] = Object.entries(scripts).map(
+          ([scriptName, scriptValue]) =>
             new RushProjectScript({
               label: scriptName,
               collapsibleState: vscode.TreeItemCollapsibleState.None,
               projectFolder,
               projectRelativeFolder,
               scriptName,
-              scriptValue: packageJson.scripts[scriptName]
+              scriptValue
             })
         );
-        return Promise.resolve(rushProjectScriptTreeItems);
+        return rushProjectScriptTreeItems;
       } catch {
-        return Promise.resolve([]);
+        return [];
       }
     }
 
-    return Promise.resolve([]);
+    return [];
   }
 }

--- a/vscode-extensions/rush-vscode-extension/src/providers/RushProjectsProvider.ts
+++ b/vscode-extensions/rush-vscode-extension/src/providers/RushProjectsProvider.ts
@@ -1,14 +1,16 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+import path from 'node:path';
+
 import * as vscode from 'vscode';
-import * as path from 'path';
+
 import { JsonFile, type JsonObject } from '@rushstack/node-core-library';
+import type { RushConfiguration, RushConfigurationProject } from '@rushstack/rush-sdk';
+
 import { RushTaskProvider } from './TaskProvider';
 import { terminal } from '../logic/logger';
 import { RushWorkspace } from '../logic/RushWorkspace';
-
-import type { RushConfiguration, RushConfigurationProject } from '@rushstack/rush-sdk';
 import { RushCommandWebViewPanel } from '../logic/RushCommandWebViewPanel';
 
 interface IRushProjectParams {

--- a/vscode-extensions/rush-vscode-extension/src/providers/TaskProvider.ts
+++ b/vscode-extensions/rush-vscode-extension/src/providers/TaskProvider.ts
@@ -2,6 +2,7 @@
 // See LICENSE in the project root for license information.
 
 import * as vscode from 'vscode';
+
 import { terminal } from '../logic/logger';
 
 let rushTaskProvider: RushTaskProvider | undefined;

--- a/vscode-extensions/rush-vscode-extension/src/test/runTest.ts
+++ b/vscode-extensions/rush-vscode-extension/src/test/runTest.ts
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import * as path from 'path';
+import path from 'node:path';
 
 import { runTests } from '@vscode/test-electron';
 
-async function main(): Promise<void> {
+async function mainAsync(): Promise<void> {
   try {
     // The folder containing the Extension Manifest package.json
     // Passed to `--extensionDevelopmentPath`
@@ -13,7 +13,7 @@ async function main(): Promise<void> {
 
     // The path to test runner
     // Passed to --extensionTestsPath
-    const extensionTestsPath: string = path.resolve(__dirname, './suite/index');
+    const extensionTestsPath: string = `${__dirname}./suite/index`;
 
     // Download VS Code, unzip it and run the integration test
     await runTests({ extensionDevelopmentPath, extensionTestsPath });
@@ -24,5 +24,5 @@ async function main(): Promise<void> {
   }
 }
 
-// eslint-disable-next-line @typescript-eslint/no-floating-promises
-main();
+// eslint-disable-next-line no-console
+void mainAsync().catch(console.error);

--- a/vscode-extensions/rush-vscode-extension/src/test/suite/extension.test.ts
+++ b/vscode-extensions/rush-vscode-extension/src/test/suite/extension.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import * as assert from 'assert';
+import * as assert from 'node:assert';
 
 // You can import and use all API from the 'vscode' module
 // as well as import your extension to test it

--- a/vscode-extensions/rush-vscode-extension/src/test/suite/index.ts
+++ b/vscode-extensions/rush-vscode-extension/src/test/suite/index.ts
@@ -1,11 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import * as path from 'path';
+import path from 'node:path';
+import { promisify } from 'node:util';
 import Mocha from 'mocha';
-import glob from 'glob';
+import glob from 'fast-glob';
 
-export function run(): Promise<void> {
+export async function run(): Promise<void> {
   // Create the mocha test
   const mocha: Mocha = new Mocha({
     ui: 'tdd',
@@ -14,29 +15,8 @@ export function run(): Promise<void> {
 
   const testsRoot: string = path.resolve(__dirname, '..');
 
-  return new Promise((resolve, reject) => {
-    glob('**/**.test.js', { cwd: testsRoot }, (err1, files) => {
-      if (err1) {
-        return reject(err1);
-      }
-
-      // Add files to the test suite
-      files.forEach((f) => mocha.addFile(path.resolve(testsRoot, f)));
-
-      try {
-        // Run the mocha test
-        mocha.run((failures) => {
-          if (failures > 0) {
-            reject(new Error(`${failures} tests failed.`));
-          } else {
-            resolve();
-          }
-        });
-      } catch (err2) {
-        // eslint-disable-next-line no-console
-        console.error(err2);
-        reject(err2);
-      }
-    });
-  });
+  const files: string[] = await glob('**/**.test.js', { cwd: testsRoot });
+  // Add files to the test suite
+  files.forEach((f) => mocha.addFile(path.resolve(testsRoot, f)));
+  await promisify(mocha.run.bind(mocha));
 }

--- a/vscode-extensions/rush-vscode-extension/tsconfig.json
+++ b/vscode-extensions/rush-vscode-extension/tsconfig.json
@@ -1,3 +1,8 @@
 {
-  "extends": "./node_modules/@rushstack/heft-vscode-extension-rig/profiles/default/tsconfig-base.json"
+  "extends": "./node_modules/local-vscode-extension-rig/profiles/default/tsconfig-base.json",
+  "compilerOptions": {
+    // This project provides VS Code integration tests that run under Mocha (via @vscode/test-electron),
+    // so override the rig's default Jest typings to avoid colliding ambient test globals (describe/it/beforeEach).
+    "types": ["mocha", "node"]
+  }
 }

--- a/vscode-extensions/rush-vscode-extension/webpack.config.js
+++ b/vscode-extensions/rush-vscode-extension/webpack.config.js
@@ -3,19 +3,16 @@
 
 'use strict';
 
-const {
-  createExtensionConfig
-} = require('@rushstack/heft-vscode-extension-rig/profiles/default/webpack.config.base');
-const path = require('node:path');
+const { createExtensionConfig } = require('local-vscode-extension-rig/profiles/default/webpack.config.base');
 
 function createConfig({ production, webpack }) {
   const config = createExtensionConfig({
     production,
     webpack,
     entry: {
-      extension: './lib/extension.js'
+      extension: './lib-esm/extension.js'
     },
-    outputPath: path.resolve(__dirname, 'dist', 'vsix', 'unpacked')
+    outputPath: `${__dirname}/dist/vsix/unpacked`
   });
 
   if (!config.externals) {


### PR DESCRIPTION
## Summary

Adds a new local `local-vscode-extension-rig` and migrates the repo's VS Code extension projects from the public `@rushstack/heft-vscode-extension-rig` to it. The new rig delegates to `local-node-rig` and **no longer enables `skipLibCheck`**, which surfaced several pre-existing declaration-file type errors (previously suppressed) plus one genuine source bug. This PR fixes all of them so the affected projects build cleanly.

## Why the build broke

The old public rig set `"skipLibCheck": true`, which silently hid type errors inside `.d.ts` files. The new rig does not, so `tsc` now checks declaration files and reports issues that were always present.

## Changes

**New rig**
- `rigs/local-vscode-extension-rig` — profiles, eslint includes, heft/typescript/jest/rush-project config, webpack base.

**Migrated projects** (`rig.json`, `heft.json`, `rush-project.json`, `eslint.config.js`, `webpack.config.js`, `package.json`, `tsconfig.json`):
- `vscode-extensions/rush-vscode-extension`
- `vscode-extensions/debug-certificate-manager-vscode-extension`
- `vscode-extensions/playwright-local-browser-server-vscode-extension`

**Type fixes**
- **`rush-vscode-extension` (TS2403 ×7):** the rig forces `"types": ["jest", "node"]`, whose ambient test globals (`describe`/`it`/`beforeEach`) collide with this project's `@types/mocha` (it uses Mocha + `@vscode/test-electron` for VS Code integration tests). Overrode `types` to `["mocha", "node"]` in the project's `tsconfig.json`.
- **`rush-vscode-command-webview` (TS2315):** `IFromExtensionMessage` lived in `fromExtension.ts` alongside `fromExtensionListener`, which uses the DOM-generic `MessageEvent<T>`. When the Node-based extension imported the type via the package barrel, `MessageEvent` resolved to the non-generic `@types/node` declaration. Extracted the contract into a new DOM-free module `src/Message/IFromExtensionMessage.ts` and re-pointed the barrel at it.
- **`playwright-local-browser-server` (TS2304):** `playwright-core`'s type definitions reference DOM types (`Node`, `HTMLElement`, `SVGElement`). Added `"lib": ["DOM"]` to the project's `tsconfig.json`, matching the existing convention in `apps/playwright-browser-tunnel`.
- **`rush-vscode-extension/src/test/suite/index.ts` (TS2794):** real source bug — `new Promise(...)` inferred `Promise<unknown>` so `resolve()` required an argument.

Also includes `eslint --fix` import-order and `node:` protocol cleanups picked up by the pre-commit hook.

## Notes

- No `rush change` files were added: all affected projects are non-published (`private` rigs/webview, or `vsix`-tagged apps / `shouldPublish: false`). `rush change --verify` passes.
- This is the minimal "get green" change. A follow-up could modernize the VS Code test tooling (`@vscode/test-electron` 1.x → 3.x, adopt `@vscode/test-cli`) and split unit (Jest) vs. integration (Mocha-in-host) tests, but that is intentionally out of scope here.

## Testing

- `rush build` across all migrated projects + dependents: green (lint warnings only, all pre-existing/unrelated).
- `rush test --only .` on the affected projects: passes.
- `rush change --verify`: passes.
