### PR TITLE
Fix Playwright tunnel restart race

### DIFF
--- a/common/changes/playwright-local-browser-server/fix-tunnel-stop-start-race_2026-06-29-18-00.json
+++ b/common/changes/playwright-local-browser-server/fix-tunnel-stop-start-race_2026-06-29-18-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "playwright-local-browser-server",
+      "comment": "Fix a race where restarting the Playwright tunnel could create a replacement before the previous tunnel finished stopping.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "playwright-local-browser-server",
+  "email": "9123665+justinTM@users.noreply.github.com"
+}

--- a/common/config/subspaces/default/pnpm-lock.yaml
+++ b/common/config/subspaces/default/pnpm-lock.yaml
@@ -5263,6 +5263,9 @@ importers:
       '@types/webpack-env':
         specifier: 1.18.8
         version: 1.18.8
+      '@vscode/test-electron':
+        specifier: ^1.6.2
+        version: 1.6.2
 
   ../../../vscode-extensions/rush-vscode-command-webview:
     dependencies:

--- a/vscode-extensions/playwright-local-browser-server-vscode-extension/package.json
+++ b/vscode-extensions/playwright-local-browser-server-vscode-extension/package.json
@@ -34,6 +34,7 @@
     "build": "heft build --clean",
     "build:watch": "heft build-watch",
     "start": "heft start",
+    "test:vscode": "node ./lib/vscodeTest/runTest.js",
     "_phase:build": "heft run --only build -- --clean",
     "_phase:test": ""
   },
@@ -108,7 +109,8 @@
     "@rushstack/heft": "workspace:*",
     "@types/node": "20.17.19",
     "@types/vscode": "1.103.0",
-    "@types/webpack-env": "1.18.8"
+    "@types/webpack-env": "1.18.8",
+    "@vscode/test-electron": "^1.6.2"
   },
   "sideEffects": false
 }

--- a/vscode-extensions/playwright-local-browser-server-vscode-extension/src/extension.ts
+++ b/vscode-extensions/playwright-local-browser-server-vscode-extension/src/extension.ts
@@ -157,6 +157,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
   // Tunnel instance
   let tunnel: PlaywrightTunnel | undefined;
+  let stopTunnelPromise: Promise<void> | undefined;
 
   function getTmpPath(): string {
     return path.join(os.tmpdir(), 'playwright-browser-tunnel');
@@ -290,6 +291,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   }
 
   async function handleStartTunnelAsync(isAutoStart: boolean = false): Promise<void> {
+    const pendingStopPromise: Promise<void> | undefined = stopTunnelPromise;
+    if (pendingStopPromise) {
+      outputChannel.appendLine('Waiting for Playwright tunnel to stop before starting again...');
+      await pendingStopPromise;
+    }
+
     // Store current tunnel reference to avoid race conditions
     const existingTunnel: PlaywrightTunnel | undefined = tunnel;
     if (existingTunnel && currentStatus !== 'stopped' && currentStatus !== 'error') {
@@ -439,6 +446,13 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   }
 
   async function handleStopTunnelAsync(): Promise<void> {
+    const pendingStopPromise: Promise<void> | undefined = stopTunnelPromise;
+    if (pendingStopPromise) {
+      outputChannel.appendLine('Tunnel stop already in progress.');
+      await pendingStopPromise;
+      return;
+    }
+
     const currentTunnel: PlaywrightTunnel | undefined = tunnel;
     if (!currentTunnel) {
       outputChannel.appendLine('No tunnel instance to stop.');
@@ -446,20 +460,25 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       return;
     }
 
-    // Clear the reference before awaiting to avoid race condition
-    tunnel = undefined;
-
-    try {
+    const currentStopPromise: Promise<void> = (async () => {
       outputChannel.appendLine('Stopping Playwright tunnel...');
-      await currentTunnel.stopAsync();
-      updateStatusBar('stopped');
-      outputChannel.appendLine('Tunnel stopped.');
-      void vscode.window.showInformationMessage('Playwright tunnel stopped.');
-    } catch (error) {
-      const errorMessage: string = getNormalizedErrorString(error);
-      outputChannel.appendLine(`Failed to stop tunnel: ${errorMessage}`);
-      void vscode.window.showErrorMessage(`Failed to stop Playwright tunnel: ${errorMessage}`);
-    }
+      try {
+        await currentTunnel.stopAsync();
+        tunnel = undefined;
+        updateStatusBar('stopped');
+        outputChannel.appendLine('Tunnel stopped.');
+        void vscode.window.showInformationMessage('Playwright tunnel stopped.');
+      } catch (error) {
+        const errorMessage: string = getNormalizedErrorString(error);
+        outputChannel.appendLine(`Failed to stop tunnel: ${errorMessage}`);
+        void vscode.window.showErrorMessage(`Failed to stop Playwright tunnel: ${errorMessage}`);
+      } finally {
+        stopTunnelPromise = undefined;
+      }
+    })();
+
+    stopTunnelPromise = currentStopPromise;
+    await currentStopPromise;
   }
 
   async function handleShowMenu(): Promise<void> {

--- a/vscode-extensions/playwright-local-browser-server-vscode-extension/src/vscodeTest/runTest.ts
+++ b/vscode-extensions/playwright-local-browser-server-vscode-extension/src/vscodeTest/runTest.ts
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { runTests } from '@vscode/test-electron';
+
+async function main(): Promise<void> {
+  try {
+    const extensionDevelopmentPath: string = path.resolve(__dirname, '../../dist/vsix/unpacked');
+    const extensionTestsPath: string = path.resolve(__dirname, './suite/index');
+    const testDataPath: string = path.join(os.tmpdir(), 'playwright-local-browser-server-vscode-test');
+
+    await runTests({
+      vscodeExecutablePath: process.env.VSCODE_EXECUTABLE_PATH,
+      extensionDevelopmentPath,
+      extensionTestsPath,
+      launchArgs: [
+        path.join(testDataPath, 'workspace'),
+        '--user-data-dir',
+        path.join(testDataPath, 'user-data'),
+        '--extensions-dir',
+        path.join(testDataPath, 'extensions'),
+        '--disable-workspace-trust',
+        '--skip-welcome',
+        '--skip-release-notes'
+      ]
+    });
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Failed to run VS Code extension tests', error);
+    process.exit(1);
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-floating-promises
+main();

--- a/vscode-extensions/playwright-local-browser-server-vscode-extension/src/vscodeTest/suite/index.ts
+++ b/vscode-extensions/playwright-local-browser-server-vscode-extension/src/vscodeTest/suite/index.ts
@@ -1,0 +1,66 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import * as assert from 'node:assert';
+
+import * as vscode from 'vscode';
+
+const EXTENSION_ID: string = 'ms-RushStack.playwright-local-browser-server';
+const COMMAND_START_TUNNEL: string = 'playwright-local-browser-server.start';
+const COMMAND_STOP_TUNNEL: string = 'playwright-local-browser-server.stop';
+
+function sleepAsync(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+async function promiseSettledWithinAsync(promise: Thenable<unknown>, milliseconds: number): Promise<boolean> {
+  let settled: boolean = false;
+  promise.then(
+    () => {
+      settled = true;
+    },
+    () => {
+      settled = true;
+    }
+  );
+  await sleepAsync(milliseconds);
+  return settled;
+}
+
+export async function run(): Promise<void> {
+  const extension: vscode.Extension<unknown> | undefined = vscode.extensions.getExtension(EXTENSION_ID);
+  assert.ok(extension, `Expected ${EXTENSION_ID} to be installed in the VS Code test host.`);
+
+  await extension.activate();
+
+  const commands: string[] = await vscode.commands.getCommands(true);
+  assert.ok(commands.includes(COMMAND_START_TUNNEL), `Missing command: ${COMMAND_START_TUNNEL}`);
+  assert.ok(commands.includes(COMMAND_STOP_TUNNEL), `Missing command: ${COMMAND_STOP_TUNNEL}`);
+
+  await vscode.workspace
+    .getConfiguration('playwright-local-browser-server')
+    .update('autoStart', true, vscode.ConfigurationTarget.Global);
+
+  await vscode.commands.executeCommand(COMMAND_START_TUNNEL, true);
+  await sleepAsync(250);
+
+  const stopPromise: Thenable<unknown> = vscode.commands.executeCommand(COMMAND_STOP_TUNNEL);
+  await sleepAsync(250);
+
+  const restartPromise: Thenable<unknown> = vscode.commands.executeCommand(COMMAND_START_TUNNEL, true);
+
+  assert.strictEqual(
+    await promiseSettledWithinAsync(restartPromise, 1000),
+    false,
+    'Start resolved while the previous Stop command was still pending.'
+  );
+
+  assert.strictEqual(
+    await promiseSettledWithinAsync(stopPromise, 1),
+    false,
+    'Stop unexpectedly settled before the restart guard could be observed.'
+  );
+
+  // eslint-disable-next-line no-console
+  console.log('Playwright tunnel restart remained pending behind the in-progress stop.');
+}


### PR DESCRIPTION
## Summary

Fixes #5852.

Fixes a lifecycle race in the Playwright Local Browser Server VS Code extension where a rapid stop/start could create a replacement tunnel before the previous tunnel finished stopping.

The extension now tracks an in-progress stop promise, waits for it before starting a replacement tunnel, and only clears the active tunnel reference after `stopAsync()` settles.

## Commit structure

This PR is intentionally split into a red/green sequence:

1. `39a590c935` - adds the real VS Code host regression test only.
2. `d16c95ebb1` - adds the lifecycle fix and change file.

## Red/green proof

Both runs used the same command sequence from `vscode-extensions/playwright-local-browser-server-vscode-extension`:

- `PATH=/Users/justin/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH /Users/justin/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node ../../common/scripts/install-run-rushx.js build`
- `env -u GITHUB_ACCESS_TOKEN -u GH_TOKEN -u GITHUB_TOKEN -u GITLAB_ACCESS_TOKEN -u RUNNER_REGISTRATION_TOKEN -u TAILSCALE_AUTH_KEY PATH=/Users/justin/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH VSCODE_EXECUTABLE_PATH='/Applications/Visual Studio Code.app/Contents/MacOS/Electron' /Users/justin/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node ../../common/scripts/install-run-rushx.js test:vscode`

Red, at test-only commit `39a590c935`:

```text
AssertionError [ERR_ASSERTION]: Start resolved while the previous Stop command was still pending.
true !== false
Exit code:   1
RED_EXIT=1
```

Green, after fix commit `d16c95ebb1`:

```text
Playwright tunnel restart remained pending behind the in-progress stop.
Exit code:   0
GREEN_EXIT=0
```

I also ran `git diff --check origin/main...HEAD` on the final branch.

## Notes

The `test:vscode` script launches a real VS Code extension host against the built `dist/vsix/unpacked` extension using `@vscode/test-electron`. It runs a focused rapid Start/Stop/Start assertion that verifies restart remains pending while the prior Stop command is still in progress.
