### PR TITLE
Add restart command for Playwright browser tunnel

### DIFF
--- a/vscode-extensions/playwright-local-browser-server-vscode-extension/README.md
+++ b/vscode-extensions/playwright-local-browser-server-vscode-extension/README.md
@@ -160,6 +160,7 @@ This extension contributes the following commands:
 
 - **Playwright: Start Playwright Browser Tunnel** (`playwright-local-browser-server.start`)
 - **Playwright: Stop Playwright Browser Tunnel** (`playwright-local-browser-server.stop`)
+- **Playwright: Restart Playwright Browser Tunnel** (`playwright-local-browser-server.restart`)
 - **Playwright Local Browser Server: Manage Launch Options Allowlist** (`playwright-local-browser-server.manageAllowlist`)
 - **Playwright Local Browser Server: Show Log** (`playwright-local-browser-server.showLog`)
 - **Playwright Local Browser Server: Show Settings** (`playwright-local-browser-server.showSettings`)

--- a/vscode-extensions/playwright-local-browser-server-vscode-extension/package.json
+++ b/vscode-extensions/playwright-local-browser-server-vscode-extension/package.json
@@ -50,6 +50,11 @@
         "category": "Playwright"
       },
       {
+        "command": "playwright-local-browser-server.restart",
+        "title": "Restart Playwright Browser Tunnel",
+        "category": "Playwright"
+      },
+      {
         "command": "playwright-local-browser-server.manageAllowlist",
         "title": "Manage Launch Options Allowlist",
         "category": "Playwright Local Browser Server"

--- a/vscode-extensions/playwright-local-browser-server-vscode-extension/package.json
+++ b/vscode-extensions/playwright-local-browser-server-vscode-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-local-browser-server",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/rushstack.git",

--- a/vscode-extensions/playwright-local-browser-server-vscode-extension/src/extension.ts
+++ b/vscode-extensions/playwright-local-browser-server-vscode-extension/src/extension.ts
@@ -31,6 +31,7 @@ const COMMAND_SHOW_LOG: string = 'playwright-local-browser-server.showLog';
 const COMMAND_SHOW_SETTINGS: string = 'playwright-local-browser-server.showSettings';
 const COMMAND_START_TUNNEL: string = 'playwright-local-browser-server.start';
 const COMMAND_STOP_TUNNEL: string = 'playwright-local-browser-server.stop';
+const COMMAND_RESTART_TUNNEL: string = 'playwright-local-browser-server.restart';
 const COMMAND_SHOW_MENU: string = 'playwright-local-browser-server.showMenu';
 const COMMAND_MANAGE_ALLOWLIST: string = 'playwright-local-browser-server.manageAllowlist';
 const VSCODE_COMMAND_WORKSPACE_OPEN_SETTINGS: string = 'workbench.action.openSettings';
@@ -462,9 +463,15 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     }
   }
 
+  async function handleRestartTunnelAsync(): Promise<void> {
+    outputChannel.appendLine('Restarting Playwright tunnel...');
+    await handleStopTunnelAsync();
+    await handleStartTunnelAsync();
+  }
+
   async function handleShowMenu(): Promise<void> {
     interface IQuickPickItem extends vscode.QuickPickItem {
-      action: 'start' | 'stop' | 'showLog' | 'manageAllowlist';
+      action: 'start' | 'stop' | 'restart' | 'showLog' | 'manageAllowlist';
     }
 
     const items: IQuickPickItem[] = [
@@ -477,6 +484,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         label: '$(debug-stop) Stop Tunnel',
         description: 'Stop the Playwright browser tunnel',
         action: 'stop'
+      },
+      {
+        label: '$(debug-restart) Restart Tunnel',
+        description: 'Stop and start the Playwright browser tunnel',
+        action: 'restart'
       },
       {
         label: '$(shield) Manage Allowlist',
@@ -502,6 +514,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         case 'stop':
           await handleStopTunnelAsync();
           break;
+        case 'restart':
+          await handleRestartTunnelAsync();
+          break;
         case 'manageAllowlist':
           await handleManageAllowlist();
           break;
@@ -519,6 +534,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     vscode.commands.registerCommand(COMMAND_SHOW_SETTINGS, handleShowSettings),
     vscode.commands.registerCommand(COMMAND_START_TUNNEL, handleStartTunnelAsync),
     vscode.commands.registerCommand(COMMAND_STOP_TUNNEL, handleStopTunnelAsync),
+    vscode.commands.registerCommand(COMMAND_RESTART_TUNNEL, handleRestartTunnelAsync),
     vscode.commands.registerCommand(COMMAND_SHOW_MENU, handleShowMenu),
     vscode.commands.registerCommand(COMMAND_MANAGE_ALLOWLIST, handleManageAllowlist),
     // Cleanup tunnel on deactivate


### PR DESCRIPTION
Adds a small restart command for the Playwright Local Browser Server VS Code extension.

Changes:
- Contributes `playwright-local-browser-server.restart`.
- Registers a restart handler that stops and then starts the tunnel.
- Adds Restart Tunnel to the status bar quick-pick menu.
- Documents the command in the extension README.

Validation:
- Parsed `vscode-extensions/playwright-local-browser-server-vscode-extension/package.json`.
- Checked that start/stop/restart command contributions are present.
- Ran `git diff --check`.

Note:
- Full Rush build was not run on the remote host because the checkout was sparse and Rush required unrelated monorepo project manifests. Initial Rush install also hit /home disk capacity before temp/cache were redirected to /tmp.