### PR TITLE
Bump Playwright to 1.61.1

### DIFF
--- a/apps/playwright-browser-tunnel/package.json
+++ b/apps/playwright-browser-tunnel/package.json
@@ -49,7 +49,7 @@
     "@rushstack/ts-command-line": "workspace:*",
     "string-argv": "~0.3.1",
     "ws": "~8.21.0",
-    "playwright": "1.56.1"
+    "playwright": "1.61.1"
   },
   "devDependencies": {
     "@rushstack/heft": "workspace:*",
@@ -57,12 +57,12 @@
     "local-node-rig": "workspace:*",
     "@types/semver": "7.7.1",
     "@types/ws": "8.18.1",
-    "playwright-core": "~1.56.1",
-    "@playwright/test": "~1.56.1",
+    "playwright-core": "~1.61.1",
+    "@playwright/test": "~1.61.1",
     "@types/node": "20.17.19"
   },
   "peerDependencies": {
-    "playwright-core": "~1.56.1"
+    "playwright-core": "~1.61.1"
   },
   "sideEffects": false
 }

--- a/common/changes/@rushstack/playwright-browser-tunnel/bump-playwright-1.61.1_2026-07-01-21-48.json
+++ b/common/changes/@rushstack/playwright-browser-tunnel/bump-playwright-1.61.1_2026-07-01-21-48.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Bump the Playwright dependencies to 1.61.1",
+      "type": "patch",
+      "packageName": "@rushstack/playwright-browser-tunnel"
+    }
+  ],
+  "packageName": "@rushstack/playwright-browser-tunnel",
+  "email": "223556219+Copilot@users.noreply.github.com"
+}

--- a/common/config/subspaces/default/pnpm-lock.yaml
+++ b/common/config/subspaces/default/pnpm-lock.yaml
@@ -320,8 +320,8 @@ importers:
         specifier: workspace:*
         version: link:../../libraries/ts-command-line
       playwright:
-        specifier: 1.56.1
-        version: 1.56.1
+        specifier: 1.61.1
+        version: 1.61.1
       string-argv:
         specifier: ~0.3.1
         version: 0.3.2
@@ -330,8 +330,8 @@ importers:
         version: 8.21.0
     devDependencies:
       '@playwright/test':
-        specifier: ~1.56.1
-        version: 1.56.1
+        specifier: ~1.61.1
+        version: 1.61.1
       '@rushstack/heft':
         specifier: workspace:*
         version: link:../heft
@@ -351,8 +351,8 @@ importers:
         specifier: workspace:*
         version: link:../../rigs/local-node-rig
       playwright-core:
-        specifier: ~1.56.1
-        version: 1.56.1
+        specifier: ~1.61.1
+        version: 1.61.1
 
   ../../../apps/rundown:
     dependencies:
@@ -5239,8 +5239,8 @@ importers:
         specifier: workspace:*
         version: link:../vscode-shared
       playwright-core:
-        specifier: ~1.56.1
-        version: 1.56.1
+        specifier: ~1.61.1
+        version: 1.61.1
       tslib:
         specifier: ~2.8.1
         version: 2.8.1
@@ -8571,8 +8571,8 @@ packages:
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
-  '@playwright/test@1.56.1':
-    resolution: {integrity: sha512-vSMYtL/zOcFpvJCW71Q/OEGQb7KYBPAdKh35WNSkaZA75JlAO8ED8UN6GUNTm3drWomcbcqRPFqQbLae8yBTdg==}
+  '@playwright/test@1.61.1':
+    resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -16198,13 +16198,13 @@ packages:
     resolution: {integrity: sha512-emEcLuomt2j03vxD54giVB4SxTjnsqkU692xZOZXHDVoYyypEm+b3jpiTcc+Cf+myooc+/Ly0z01jqeNHVgJGw==}
     engines: {node: '>=16.0.0'}
 
-  playwright-core@1.56.1:
-    resolution: {integrity: sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==}
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.56.1:
-    resolution: {integrity: sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==}
+  playwright@1.61.1:
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -23711,9 +23711,9 @@ snapshots:
 
   '@pkgr/core@0.2.9': {}
 
-  '@playwright/test@1.56.1':
+  '@playwright/test@1.61.1':
     dependencies:
-      playwright: 1.56.1
+      playwright: 1.61.1
 
   '@pmmmwh/react-refresh-webpack-plugin@0.5.17(@types/webpack@4.41.32)(react-refresh@0.11.0)(type-fest@0.21.3)(webpack-dev-server@5.2.3(@types/webpack@4.41.32)(webpack@4.47.0))(webpack-hot-middleware@2.26.1)(webpack@4.47.0)':
     dependencies:
@@ -34925,11 +34925,11 @@ snapshots:
       pvutils: 1.1.5
       tslib: 2.8.1
 
-  playwright-core@1.56.1: {}
+  playwright-core@1.61.1: {}
 
-  playwright@1.56.1:
+  playwright@1.61.1:
     dependencies:
-      playwright-core: 1.56.1
+      playwright-core: 1.61.1
     optionalDependencies:
       fsevents: 2.3.2
 

--- a/common/config/subspaces/default/repo-state.json
+++ b/common/config/subspaces/default/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "265008d6cb4e700aad22dea81810ed1f363cbf31",
+  "pnpmShrinkwrapHash": "c68b888d4f7decce47e2eba36d8c3b6415426973",
   "preferredVersionsHash": "029c99bd6e65c5e1f25e2848340509811ff9753c"
 }

--- a/vscode-extensions/playwright-local-browser-server-vscode-extension/package.json
+++ b/vscode-extensions/playwright-local-browser-server-vscode-extension/package.json
@@ -99,7 +99,7 @@
     "@rushstack/node-core-library": "workspace:*",
     "@rushstack/terminal": "workspace:*",
     "@rushstack/vscode-shared": "workspace:*",
-    "playwright-core": "~1.56.1",
+    "playwright-core": "~1.61.1",
     "tslib": "~2.8.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Bumps the Playwright dependencies from 1.56.1 to 1.61.1.

## Changes
- `apps/playwright-browser-tunnel`: `playwright`, `playwright-core`, `@playwright/test`, and the `playwright-core` peer dependency bumped to 1.61.1
- `vscode-extensions/playwright-local-browser-server-vscode-extension`: `playwright-core` bumped to `~1.61.1`
- Regenerated the pnpm lockfile via `rush update`
- Added a change file for `@rushstack/playwright-browser-tunnel`