### PR TITLE
[rush] Fix minimumReleaseAge and minimumReleaseAgeExclude for PNPM by moving to pnpm-workspace.yaml

### DIFF
--- a/common/changes/@microsoft/rush/aaron_fix_pnpm_minimum_release_age_2026-07-02-19-35-11.json
+++ b/common/changes/@microsoft/rush/aaron_fix_pnpm_minimum_release_age_2026-07-02-19-35-11.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Fix minimumReleaseAge and minimumReleaseAgeExclude in pnpm-config.json being silently ignored because they were written to package.json instead of pnpm-workspace.yaml",
+      "type": "none",
+      "packageName": "@microsoft/rush"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "aaronmaxlevy@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush/aaron_fix_pnpm_minimum_release_age_2026-07-02-19-35-11.json
+++ b/common/changes/@microsoft/rush/aaron_fix_pnpm_minimum_release_age_2026-07-02-19-35-11.json
@@ -1,7 +1,7 @@
 {
   "changes": [
     {
-      "comment": "Fix minimumReleaseAge and minimumReleaseAgeExclude in pnpm-config.json being silently ignored because they were written to package.json instead of pnpm-workspace.yaml",
+      "comment": "Fix `minimumReleaseAge` and `minimumReleaseAgeExclude` in `pnpm-config.json` being silently ignored because they were written to package.json instead of `pnpm-workspace.yaml`",
       "type": "none",
       "packageName": "@microsoft/rush"
     }

--- a/libraries/rush-lib/src/logic/installManager/InstallHelpers.ts
+++ b/libraries/rush-lib/src/logic/installManager/InstallHelpers.ts
@@ -35,8 +35,6 @@ interface ICommonPackageJson extends IPackageJson {
     ignoredOptionalDependencies?: typeof PnpmOptionsConfiguration.prototype.globalIgnoredOptionalDependencies;
     allowedDeprecatedVersions?: typeof PnpmOptionsConfiguration.prototype.globalAllowedDeprecatedVersions;
     patchedDependencies?: typeof PnpmOptionsConfiguration.prototype.globalPatchedDependencies;
-    minimumReleaseAge?: typeof PnpmOptionsConfiguration.prototype.minimumReleaseAgeMinutes;
-    minimumReleaseAgeExclude?: typeof PnpmOptionsConfiguration.prototype.minimumReleaseAgeExclude;
     trustPolicy?: typeof PnpmOptionsConfiguration.prototype.trustPolicy;
     trustPolicyExclude?: typeof PnpmOptionsConfiguration.prototype.trustPolicyExclude;
     trustPolicyIgnoreAfter?: typeof PnpmOptionsConfiguration.prototype.trustPolicyIgnoreAfterMinutes;
@@ -140,28 +138,6 @@ export class InstallHelpers {
 
       if (pnpmOptions.globalPatchedDependencies) {
         commonPackageJson.pnpm.patchedDependencies = pnpmOptions.globalPatchedDependencies;
-      }
-
-      if (pnpmOptions.minimumReleaseAgeMinutes !== undefined || pnpmOptions.minimumReleaseAgeExclude) {
-        if (semver.lt(pnpmVersion, '10.16.0')) {
-          terminal.writeWarningLine(
-            Colorize.yellow(
-              `Your version of PNPM (${pnpmVersion}) ` +
-                `doesn't support the "minimumReleaseAgeMinutes" or "minimumReleaseAgeExclude" fields in ` +
-                `${rushConfiguration.commonRushConfigFolder}/${RushConstants.pnpmConfigFilename}. ` +
-                'Remove these fields or upgrade to PNPM 10.16.0 or newer.'
-            )
-          );
-        }
-
-        if (pnpmOptions.minimumReleaseAgeMinutes !== undefined) {
-          // NOTE: the pnpm setting is `minimumReleaseAge`, but the Rush setting is `minimumReleaseAgeMinutes`
-          commonPackageJson.pnpm.minimumReleaseAge = pnpmOptions.minimumReleaseAgeMinutes;
-        }
-
-        if (pnpmOptions.minimumReleaseAgeExclude) {
-          commonPackageJson.pnpm.minimumReleaseAgeExclude = pnpmOptions.minimumReleaseAgeExclude;
-        }
       }
 
       if (pnpmOptions.trustPolicy !== undefined) {

--- a/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
+++ b/libraries/rush-lib/src/logic/installManager/WorkspaceInstallManager.ts
@@ -476,10 +476,7 @@ export class WorkspaceInstallManager extends BaseInstallManager {
     ) {
       if (pnpmOptions.globalAllowBuilds) {
         workspaceFile.setAllowBuilds(pnpmOptions.globalAllowBuilds);
-      } else if (
-        pnpmOptions.globalOnlyBuiltDependencies ||
-        pnpmOptions.globalNeverBuiltDependencies
-      ) {
+      } else if (pnpmOptions.globalOnlyBuiltDependencies || pnpmOptions.globalNeverBuiltDependencies) {
         // Backward compatibility: convert globalOnlyBuiltDependencies/globalNeverBuiltDependencies
         // to allowBuilds format for pnpm 11+
         const allowBuilds: Record<string, boolean> = {};
@@ -507,6 +504,33 @@ export class WorkspaceInstallManager extends BaseInstallManager {
             'Remove this field or upgrade to pnpm 11.0.0 or newer.'
         )
       );
+    }
+
+    // Set minimumReleaseAge/minimumReleaseAgeExclude in the workspace file.
+    // pnpm does not read these fields from package.json, only from pnpm-workspace.yaml or .npmrc.
+    if (pnpmOptions.minimumReleaseAgeMinutes !== undefined || pnpmOptions.minimumReleaseAgeExclude) {
+      if (
+        this.rushConfiguration.rushConfigurationJson.pnpmVersion !== undefined &&
+        semver.lt(this.rushConfiguration.rushConfigurationJson.pnpmVersion, '10.16.0')
+      ) {
+        this._terminal.writeWarningLine(
+          Colorize.yellow(
+            `Your version of pnpm (${this.rushConfiguration.rushConfigurationJson.pnpmVersion}) ` +
+              `doesn't support the "minimumReleaseAgeMinutes" or "minimumReleaseAgeExclude" fields in ` +
+              `${this.rushConfiguration.commonRushConfigFolder}/${RushConstants.pnpmConfigFilename}. ` +
+              'Remove these fields or upgrade to pnpm 10.16.0 or newer.'
+          )
+        );
+      }
+
+      if (pnpmOptions.minimumReleaseAgeMinutes !== undefined) {
+        // NOTE: the pnpm setting is `minimumReleaseAge`, but the Rush setting is `minimumReleaseAgeMinutes`
+        workspaceFile.setMinimumReleaseAge(pnpmOptions.minimumReleaseAgeMinutes);
+      }
+
+      if (pnpmOptions.minimumReleaseAgeExclude) {
+        workspaceFile.setMinimumReleaseAgeExclude(pnpmOptions.minimumReleaseAgeExclude);
+      }
     }
 
     // Save the generated workspace file. Don't update the file timestamp unless the content has changed,

--- a/libraries/rush-lib/src/logic/pnpm/PnpmWorkspaceFile.ts
+++ b/libraries/rush-lib/src/logic/pnpm/PnpmWorkspaceFile.ts
@@ -42,6 +42,16 @@ interface IPnpmWorkspaceYaml {
    * (SUPPORTED ONLY IN PNPM 11.0.0 AND NEWER)
    */
   allowBuilds?: Record<string, boolean>;
+  /**
+   * The minimum number of minutes that must pass after a version is published before pnpm will install it.
+   * (SUPPORTED ONLY IN PNPM 10.16.0 AND NEWER)
+   */
+  minimumReleaseAge?: number;
+  /**
+   * List of package names or patterns that are excluded from the minimumReleaseAge check.
+   * (SUPPORTED ONLY IN PNPM 10.16.0 AND NEWER)
+   */
+  minimumReleaseAgeExclude?: string[];
 }
 
 export class PnpmWorkspaceFile extends BaseWorkspaceFile {
@@ -53,6 +63,8 @@ export class PnpmWorkspaceFile extends BaseWorkspaceFile {
   private _workspacePackages: Set<string>;
   private _catalogs: Record<string, Record<string, string>> | undefined;
   private _allowBuilds: Record<string, boolean> | undefined;
+  private _minimumReleaseAge: number | undefined;
+  private _minimumReleaseAgeExclude: string[] | undefined;
 
   /**
    * The PNPM workspace file is used to specify the location of workspaces relative to the root
@@ -67,6 +79,8 @@ export class PnpmWorkspaceFile extends BaseWorkspaceFile {
     this._workspacePackages = new Set<string>();
     this._catalogs = undefined;
     this._allowBuilds = undefined;
+    this._minimumReleaseAge = undefined;
+    this._minimumReleaseAgeExclude = undefined;
   }
 
   /**
@@ -84,6 +98,24 @@ export class PnpmWorkspaceFile extends BaseWorkspaceFile {
    */
   public setAllowBuilds(allowBuilds: Record<string, boolean> | undefined): void {
     this._allowBuilds = allowBuilds;
+  }
+
+  /**
+   * Sets the minimumReleaseAge setting for the workspace.
+   * The minimum number of minutes that must pass after a version is published before pnpm will install it.
+   * (SUPPORTED ONLY IN PNPM 10.16.0 AND NEWER)
+   */
+  public setMinimumReleaseAge(minimumReleaseAge: number | undefined): void {
+    this._minimumReleaseAge = minimumReleaseAge;
+  }
+
+  /**
+   * Sets the minimumReleaseAgeExclude setting for the workspace.
+   * List of package names or patterns that are excluded from the minimumReleaseAge check.
+   * (SUPPORTED ONLY IN PNPM 10.16.0 AND NEWER)
+   */
+  public setMinimumReleaseAgeExclude(minimumReleaseAgeExclude: string[] | undefined): void {
+    this._minimumReleaseAgeExclude = minimumReleaseAgeExclude;
   }
 
   /** @override */
@@ -113,6 +145,14 @@ export class PnpmWorkspaceFile extends BaseWorkspaceFile {
 
     if (this._allowBuilds && Object.keys(this._allowBuilds).length > 0) {
       workspaceYaml.allowBuilds = this._allowBuilds;
+    }
+
+    if (this._minimumReleaseAge !== undefined) {
+      workspaceYaml.minimumReleaseAge = this._minimumReleaseAge;
+    }
+
+    if (this._minimumReleaseAgeExclude && this._minimumReleaseAgeExclude.length > 0) {
+      workspaceYaml.minimumReleaseAgeExclude = this._minimumReleaseAgeExclude;
     }
 
     return yamlModule.dump(workspaceYaml, PNPM_SHRINKWRAP_YAML_FORMAT);

--- a/libraries/rush-lib/src/logic/pnpm/PnpmWorkspaceFile.ts
+++ b/libraries/rush-lib/src/logic/pnpm/PnpmWorkspaceFile.ts
@@ -147,13 +147,9 @@ export class PnpmWorkspaceFile extends BaseWorkspaceFile {
       workspaceYaml.allowBuilds = this._allowBuilds;
     }
 
-    if (this._minimumReleaseAge !== undefined) {
-      workspaceYaml.minimumReleaseAge = this._minimumReleaseAge;
-    }
-
-    if (this._minimumReleaseAgeExclude && this._minimumReleaseAgeExclude.length > 0) {
-      workspaceYaml.minimumReleaseAgeExclude = this._minimumReleaseAgeExclude;
-    }
+    // js-yaml omits mapping entries whose value is `undefined`, so no guard is needed here.
+    workspaceYaml.minimumReleaseAge = this._minimumReleaseAge;
+    workspaceYaml.minimumReleaseAgeExclude = this._minimumReleaseAgeExclude;
 
     return yamlModule.dump(workspaceYaml, PNPM_SHRINKWRAP_YAML_FORMAT);
   }

--- a/libraries/rush-lib/src/logic/pnpm/test/PnpmWorkspaceFile.test.ts
+++ b/libraries/rush-lib/src/logic/pnpm/test/PnpmWorkspaceFile.test.ts
@@ -306,11 +306,23 @@ describe(PnpmWorkspaceFile.name, () => {
       expect(content).not.toContain('minimumReleaseAge');
     });
 
-    it('handles empty minimumReleaseAgeExclude', () => {
+    it('passes through an explicitly-set empty minimumReleaseAgeExclude', () => {
       const workspaceFile: PnpmWorkspaceFile = new PnpmWorkspaceFile(workspaceFilePath);
       workspaceFile.addPackage(path.join(projectsDir, 'app1'));
 
       workspaceFile.setMinimumReleaseAgeExclude([]);
+
+      workspaceFile.save(workspaceFilePath, { onlyIfChanged: true });
+
+      const content: string = FileSystem.readFile(workspaceFilePath);
+      expect(content).toContain('minimumReleaseAgeExclude: []');
+    });
+
+    it('omits an undefined minimumReleaseAgeExclude', () => {
+      const workspaceFile: PnpmWorkspaceFile = new PnpmWorkspaceFile(workspaceFilePath);
+      workspaceFile.addPackage(path.join(projectsDir, 'app1'));
+
+      workspaceFile.setMinimumReleaseAgeExclude(undefined);
 
       workspaceFile.save(workspaceFilePath, { onlyIfChanged: true });
 

--- a/libraries/rush-lib/src/logic/pnpm/test/PnpmWorkspaceFile.test.ts
+++ b/libraries/rush-lib/src/logic/pnpm/test/PnpmWorkspaceFile.test.ts
@@ -242,4 +242,80 @@ describe(PnpmWorkspaceFile.name, () => {
       expect(content).not.toContain('allowBuilds');
     });
   });
+
+  describe('minimumReleaseAge functionality', () => {
+    it('generates workspace file with minimumReleaseAge', () => {
+      const workspaceFile: PnpmWorkspaceFile = new PnpmWorkspaceFile(workspaceFilePath);
+      workspaceFile.addPackage(path.join(projectsDir, 'app1'));
+
+      workspaceFile.setMinimumReleaseAge(20160);
+
+      workspaceFile.save(workspaceFilePath, { onlyIfChanged: true });
+
+      const content: string = FileSystem.readFile(workspaceFilePath);
+      expect(content).toMatchSnapshot();
+    });
+
+    it('generates workspace file with minimumReleaseAge and minimumReleaseAgeExclude', () => {
+      const workspaceFile: PnpmWorkspaceFile = new PnpmWorkspaceFile(workspaceFilePath);
+      workspaceFile.addPackage(path.join(projectsDir, 'app1'));
+
+      workspaceFile.setMinimumReleaseAge(1440);
+      workspaceFile.setMinimumReleaseAgeExclude(['webpack', '@myorg/*']);
+
+      workspaceFile.save(workspaceFilePath, { onlyIfChanged: true });
+
+      const content: string = FileSystem.readFile(workspaceFilePath);
+      expect(content).toMatchSnapshot();
+    });
+
+    it('generates workspace file with minimumReleaseAgeExclude only', () => {
+      const workspaceFile: PnpmWorkspaceFile = new PnpmWorkspaceFile(workspaceFilePath);
+      workspaceFile.addPackage(path.join(projectsDir, 'app1'));
+
+      workspaceFile.setMinimumReleaseAgeExclude(['webpack']);
+
+      workspaceFile.save(workspaceFilePath, { onlyIfChanged: true });
+
+      const content: string = FileSystem.readFile(workspaceFilePath);
+      expect(content).toMatchSnapshot();
+    });
+
+    it('handles zero value for minimumReleaseAge', () => {
+      const workspaceFile: PnpmWorkspaceFile = new PnpmWorkspaceFile(workspaceFilePath);
+      workspaceFile.addPackage(path.join(projectsDir, 'app1'));
+
+      workspaceFile.setMinimumReleaseAge(0);
+
+      workspaceFile.save(workspaceFilePath, { onlyIfChanged: true });
+
+      const content: string = FileSystem.readFile(workspaceFilePath);
+      expect(content).toContain('minimumReleaseAge: 0');
+    });
+
+    it('handles undefined minimumReleaseAge', () => {
+      const workspaceFile: PnpmWorkspaceFile = new PnpmWorkspaceFile(workspaceFilePath);
+      workspaceFile.addPackage(path.join(projectsDir, 'app1'));
+
+      workspaceFile.setMinimumReleaseAge(undefined);
+      workspaceFile.setMinimumReleaseAgeExclude(undefined);
+
+      workspaceFile.save(workspaceFilePath, { onlyIfChanged: true });
+
+      const content: string = FileSystem.readFile(workspaceFilePath);
+      expect(content).not.toContain('minimumReleaseAge');
+    });
+
+    it('handles empty minimumReleaseAgeExclude', () => {
+      const workspaceFile: PnpmWorkspaceFile = new PnpmWorkspaceFile(workspaceFilePath);
+      workspaceFile.addPackage(path.join(projectsDir, 'app1'));
+
+      workspaceFile.setMinimumReleaseAgeExclude([]);
+
+      workspaceFile.save(workspaceFilePath, { onlyIfChanged: true });
+
+      const content: string = FileSystem.readFile(workspaceFilePath);
+      expect(content).not.toContain('minimumReleaseAgeExclude');
+    });
+  });
 });

--- a/libraries/rush-lib/src/logic/pnpm/test/__snapshots__/PnpmWorkspaceFile.test.ts.snap
+++ b/libraries/rush-lib/src/logic/pnpm/test/__snapshots__/PnpmWorkspaceFile.test.ts.snap
@@ -86,3 +86,28 @@ exports[`PnpmWorkspaceFile catalog functionality handles undefined catalog 1`] =
   - projects/app1
 "
 `;
+
+exports[`PnpmWorkspaceFile minimumReleaseAge functionality generates workspace file with minimumReleaseAge 1`] = `
+"minimumReleaseAge: 20160
+packages:
+  - projects/app1
+"
+`;
+
+exports[`PnpmWorkspaceFile minimumReleaseAge functionality generates workspace file with minimumReleaseAge and minimumReleaseAgeExclude 1`] = `
+"minimumReleaseAge: 1440
+minimumReleaseAgeExclude:
+  - webpack
+  - '@myorg/*'
+packages:
+  - projects/app1
+"
+`;
+
+exports[`PnpmWorkspaceFile minimumReleaseAge functionality generates workspace file with minimumReleaseAgeExclude only 1`] = `
+"minimumReleaseAgeExclude:
+  - webpack
+packages:
+  - projects/app1
+"
+`;


### PR DESCRIPTION
… to pnpm-workspace.yaml

<!--------------------------------------------------------------------------
👉 STEP 1: Before getting started, please read the contributor guidelines:
     https://rushstack.io/pages/contributing/get_started/
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 2: We thoughtfully review both implementation AND feature design.
     If you are making a nontrivial change, it's recommended to first create
     a GitHub issue and get feedback on your proposed design.
--------------------------------------------------------------------------->

<!--------------------------------------------------------------------------
👉 STEP 3: Write a concise but specific PR title in the box above.
     Prefix your PR with a relevant Rush Stack package name in brackets.
     For example, if your PR fixes the "@rushstack/ts-command-line" project,
     then your GitHub title might look like:

     "[ts-command-line] Add support for numeric command line parameters"
--------------------------------------------------------------------------->

## Summary

<!--------------------------------------------------------------------------
👉 STEP 4:  In a few sentences, write a summary explaining:

     From the perspective of an end user, what problem are you solving?
     What did you change?

     You can add the magic phrase "Fixes #1234" to automatically close
     issue #1234 when your PR is merged.
--------------------------------------------------------------------------->

Fixes #5752 

## Details

<!--------------------------------------------------------------------------
👉 STEP 5: Provide additional details about your fix:

     How did you solve the problem?
     Mention any alternate approaches you considered.
     Did you completely solve the problem, or are some cases not handled yet?
     Does this change break backwards compatibility?
     Could any aspects of your change impact performance?
--------------------------------------------------------------------------->

This fixes support for PNPM `minimumReleaseAge` and `minimumReleaseAgeExclude` by writing them to pnpm-workspace.yaml instead. There is an existing PR open for this #5798 , however that PR moves it to .npmrc instead, whereas according to @iclanton in https://github.com/microsoft/rushstack/pull/5798#issuecomment-4711051057 it is preferable to put it in pnpm-workspace.yaml instead (which I agree with). It has been two weeks since that comment was left on #5798 and it hasn't been addressed there, so I figured I'd file my own PR, given that there are real security implications to this setting not working currently. Apologies if this is undesired.

## How it was tested

<!--------------------------------------------------------------------------
👉 STEP 6: What test cases did you use to validate your work?
     Given the complexities of how build tools interact with the OS, we only
     require unit tests for algorithmic code (e.g. parsing a string, sorting a list).
     Manual testing is fine; you might write something like:

     "Invoked 'rush install' with useWorkspaces=true and useWorkspaces=false
     and confirmed that peer dependencies were handled correctly."

     NOTE: Manual testing should be performed on the *final* commit.
     Pushing additional commits with "small" fixes often invalidates testing.
--------------------------------------------------------------------------->

Ran the Rush test suite and validated outputs.

## Impacted documentation

<!--------------------------------------------------------------------------
👉 STEP 7: Does your PR affect anything that is discussed in the website docs?
     If so, please paste the URL of each affected web page, so we will
     remember to update the documentation after your PR is merged.
     (Updating the website is appreciated but not required.)
     If no docs are impacted, delete the "Impacted documentation" section.

     If you modified a JSON schema, remember to update init templates such as:
     rush-lib/assets/rush-init/*.json
     api-extractor/src/schemas/api-extractor-template.json
--------------------------------------------------------------------------->
N/A
<!--------------------------------------------------------------------------
👉 STEP 8: Don't forget to run "rush change":

     https://rushjs.io/pages/best_practices/change_logs/
--------------------------------------------------------------------------->


<!-- Have a question?  Ask for help in the chat room: https://rushstack.zulipchat.com/ -->
