### PR TITLE
Reporter overhaul (3/6): shadow structured emission

### DIFF
--- a/common/changes/@rushstack/rush-reporter/docs-rush-reporter-overhaul-spec_2026-07-15-00-18-26.json
+++ b/common/changes/@rushstack/rush-reporter/docs-rush-reporter-overhaul-spec_2026-07-15-00-18-26.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/reporter",
+      "comment": "Add scoped session reporting (createScopedReporter, RushSessionReporting, IScopedLogger, execution context) and plugin API version compatibility with a migration diagnostic",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/reporter",
+  "email": "TheLarkInn@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/rush-reporter/docs-rush-reporter-overhaul-spec_2026-07-15-00-18-26.json
+++ b/common/changes/@rushstack/rush-reporter/docs-rush-reporter-overhaul-spec_2026-07-15-00-18-26.json
@@ -1,11 +1,11 @@
 {
   "changes": [
     {
-      "packageName": "@rushstack/reporter",
+      "packageName": "@rushstack/rush-reporter",
       "comment": "Add scoped session reporting (createScopedReporter, RushSessionReporting, IScopedLogger, execution context) and plugin API version compatibility with a migration diagnostic",
       "type": "minor"
     }
   ],
-  "packageName": "@rushstack/reporter",
+  "packageName": "@rushstack/rush-reporter",
   "email": "TheLarkInn@users.noreply.github.com"
 }

--- a/common/changes/@rushstack/rush-reporter/docs-rush-reporter-overhaul-spec_2026-07-15-00-24-15.json
+++ b/common/changes/@rushstack/rush-reporter/docs-rush-reporter-overhaul-spec_2026-07-15-00-24-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/reporter",
+      "comment": "Add shadow-phase lifecycle emission: typed lifecycle payloads, a LifecycleEmitter for session/command/operation and diagnostic events, and exit-code and result parity helpers",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/reporter",
+  "email": "TheLarkInn@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/rush-reporter/docs-rush-reporter-overhaul-spec_2026-07-15-00-24-15.json
+++ b/common/changes/@rushstack/rush-reporter/docs-rush-reporter-overhaul-spec_2026-07-15-00-24-15.json
@@ -1,11 +1,11 @@
 {
   "changes": [
     {
-      "packageName": "@rushstack/reporter",
+      "packageName": "@rushstack/rush-reporter",
       "comment": "Add shadow-phase lifecycle emission: typed lifecycle payloads, a LifecycleEmitter for session/command/operation and diagnostic events, and exit-code and result parity helpers",
       "type": "minor"
     }
   ],
-  "packageName": "@rushstack/reporter",
+  "packageName": "@rushstack/rush-reporter",
   "email": "TheLarkInn@users.noreply.github.com"
 }

--- a/common/changes/@rushstack/rush-reporter/docs-rush-reporter-overhaul-spec_2026-07-15-00-30-21.json
+++ b/common/changes/@rushstack/rush-reporter/docs-rush-reporter-overhaul-spec_2026-07-15-00-30-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/reporter",
+      "comment": "Add the telemetry projection subscriber that produces an allowlisted aggregate from canonical events, a reporter adapter to observe events before filtering, and a beforeLog adapter",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/reporter",
+  "email": "TheLarkInn@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/rush-reporter/docs-rush-reporter-overhaul-spec_2026-07-15-00-30-21.json
+++ b/common/changes/@rushstack/rush-reporter/docs-rush-reporter-overhaul-spec_2026-07-15-00-30-21.json
@@ -1,11 +1,11 @@
 {
   "changes": [
     {
-      "packageName": "@rushstack/reporter",
+      "packageName": "@rushstack/rush-reporter",
       "comment": "Add the telemetry projection subscriber that produces an allowlisted aggregate from canonical events, a reporter adapter to observe events before filtering, and a beforeLog adapter",
       "type": "minor"
     }
   ],
-  "packageName": "@rushstack/reporter",
+  "packageName": "@rushstack/rush-reporter",
   "email": "TheLarkInn@users.noreply.github.com"
 }

--- a/common/changes/@rushstack/rush-reporter/docs-rush-reporter-overhaul-spec_2026-07-15-00-35-03.json
+++ b/common/changes/@rushstack/rush-reporter/docs-rush-reporter-overhaul-spec_2026-07-15-00-35-03.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/reporter",
+      "comment": "Add reporter-independent exit-code semantics (resolveExitStatus, resolveExitStatusFromEvents, getSignalExitCode) and separateJsonControls to keep command-specific --json distinct from the json reporter",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/reporter",
+  "email": "TheLarkInn@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/rush-reporter/docs-rush-reporter-overhaul-spec_2026-07-15-00-35-03.json
+++ b/common/changes/@rushstack/rush-reporter/docs-rush-reporter-overhaul-spec_2026-07-15-00-35-03.json
@@ -1,11 +1,11 @@
 {
   "changes": [
     {
-      "packageName": "@rushstack/reporter",
+      "packageName": "@rushstack/rush-reporter",
       "comment": "Add reporter-independent exit-code semantics (resolveExitStatus, resolveExitStatusFromEvents, getSignalExitCode) and separateJsonControls to keep command-specific --json distinct from the json reporter",
       "type": "minor"
     }
   ],
-  "packageName": "@rushstack/reporter",
+  "packageName": "@rushstack/rush-reporter",
   "email": "TheLarkInn@users.noreply.github.com"
 }

--- a/common/reviews/api/rush-reporter.api.md
+++ b/common/reviews/api/rush-reporter.api.md
@@ -39,10 +39,25 @@ export type BootstrapPrivacyClassification = 'public' | 'local-sensitive' | 'sec
 export function computeEnvelopePrivacyFloor(classifications: Iterable<ReporterPrivacyClassification>): ReporterPrivacyClassification;
 
 // @beta
+export function createBeforeLogAdapter(hooks: readonly LegacyBeforeLogHook[]): (aggregate: ITelemetryAggregate) => void;
+
+// @beta
 export function createEngineSink(providedSink?: IReporterEventSink): IEngineSinkResolution;
 
 // @beta
+export function createPluginApiIncompatibleDiagnostic(manifest: IRushPluginManifest): IRushDiagnostic;
+
+// @beta
 export function createRushDiagnostic(code: RushDiagnosticCodes, options?: ICreateRushDiagnosticOptions): IRushDiagnostic;
+
+// @beta
+export function createScopedLogger(reporter: IScopedReporter): IScopedLogger;
+
+// @beta
+export function createScopedReporter(options: ICreateScopedReporterOptions): IScopedReporter;
+
+// @beta
+export function createTelemetryReporter(subscriber: TelemetrySubscriber): IReporter;
 
 // @beta
 export const DEFAULT_FLUSH_TIMEOUT_MS: number;
@@ -57,10 +72,22 @@ export const DEFAULT_SIGNAL_FLUSH_TIMEOUT_MS: number;
 export function deleteBootstrapHandoffFileAsync(filePath: string): Promise<void>;
 
 // @beta
+export function deriveExitCodeFromEvents(events: readonly IReporterEventEnvelope<unknown>[]): number;
+
+// @beta
 export function encodeNdjsonRecord(value: unknown, options?: INdjsonOptions): string;
 
 // @beta
+export const EXIT_CODE_FAILURE: 1;
+
+// @beta
+export const EXIT_CODE_SUCCESS: 0;
+
+// @beta
 export function getPrivacyClassificationRank(classification: ReporterPrivacyClassification): number;
+
+// @beta
+export function getSignalExitCode(signal: NodeJS.Signals): number;
 
 // @beta
 export interface IBootstrapEventBufferOptions {
@@ -123,6 +150,29 @@ export interface IClassifiedDiagnosticValue {
 }
 
 // @beta
+export interface ICommandCompletedPayload {
+    readonly commandName: string;
+    readonly durationMs?: number;
+    readonly exitCode: number;
+}
+
+// @beta
+export interface ICommandResultPayload {
+    readonly commandName: string;
+    readonly exitCode: number;
+    readonly operationCounts?: {
+        readonly [status: string]: number;
+    };
+    readonly succeeded: boolean;
+}
+
+// @beta
+export interface ICommandStartedPayload {
+    readonly argv?: readonly string[];
+    readonly commandName: string;
+}
+
+// @beta
 export interface ICreateRushDiagnosticOptions {
     readonly causeDiagnosticIds?: readonly string[];
     readonly diagnosticId?: string;
@@ -137,6 +187,15 @@ export interface ICreateRushDiagnosticOptions {
 }
 
 // @beta
+export interface ICreateScopedReporterOptions {
+    readonly protocolVersion?: IReporterProtocolVersion;
+    readonly scope?: IReporterEventScope;
+    readonly sessionId: string;
+    readonly sink: IReporterEventSink;
+    readonly source: IReporterEventSource;
+}
+
+// @beta
 export interface IEarlyReporterControls {
     readonly logLevel?: string;
     readonly reporter?: string;
@@ -146,6 +205,21 @@ export interface IEarlyReporterControls {
 export interface IEngineSinkResolution {
     readonly mode: 'structured' | 'legacy-fallback';
     readonly sink: IReporterEventSink;
+}
+
+// @beta
+export interface IJsonControls {
+    readonly commandJson: boolean;
+    readonly reporterJson: boolean;
+}
+
+// @beta
+export interface ILifecycleEmitterOptions {
+    readonly protocolVersion?: IReporterProtocolVersion;
+    readonly scope?: IReporterEventScope;
+    readonly sessionId: string;
+    readonly sink: IReporterEventSink;
+    readonly source: IReporterEventSource;
 }
 
 // @beta
@@ -167,6 +241,19 @@ export interface IOldEngineOutputAdapterOptions {
     readonly sessionId: string;
     readonly sink: IReporterEventSink;
     readonly source: IReporterEventSource;
+}
+
+// @beta
+export interface IOperationRegisteredPayload {
+    readonly operationId: string;
+    readonly phaseName?: string;
+    readonly projectName?: string;
+}
+
+// @beta
+export interface IOperationStatusChangedPayload {
+    readonly operationId: string;
+    readonly status: OperationStatus;
 }
 
 // @beta
@@ -238,6 +325,12 @@ export interface IReporterEventSource {
     readonly component?: string;
     readonly packageName: string;
     readonly packageVersion: string;
+}
+
+// @beta
+export interface IReporterExecutionContext {
+    readonly reporter: IScopedReporter;
+    readonly sink: IReporterEventSink;
 }
 
 // @beta
@@ -313,6 +406,19 @@ export interface IReporterRegistrationOptions {
 }
 
 // @beta
+export interface IResolveExitStatusFromEventsOptions {
+    readonly cancelled?: boolean;
+    readonly signal?: NodeJS.Signals;
+}
+
+// @beta
+export interface IResolveExitStatusOptions {
+    readonly cancelled?: boolean;
+    readonly hasFailures?: boolean;
+    readonly signal?: NodeJS.Signals;
+}
+
+// @beta
 export interface IRushDiagnostic {
     readonly category: RushDiagnosticCategory;
     readonly causeDiagnosticIds?: readonly string[];
@@ -343,12 +449,25 @@ export interface IRushDiagnosticCodeDefinition {
 export type IRushDiagnosticSource = IRushFileDiagnosticSource | IRushToolDiagnosticSource;
 
 // @beta
+export interface IRushExitStatus {
+    readonly exitCode: number;
+    readonly outcome: RushCommandOutcome;
+    readonly signal?: NodeJS.Signals;
+}
+
+// @beta
 export interface IRushFileDiagnosticSource {
     readonly column?: number;
     readonly file: string;
     readonly kind: 'file';
     readonly line?: number;
     readonly toolName?: string;
+}
+
+// @beta
+export interface IRushPluginManifest {
+    readonly pluginApiVersion: string;
+    readonly pluginName: string;
 }
 
 // @beta
@@ -360,6 +479,14 @@ export interface IRushRemediationAction {
 }
 
 // @beta
+export interface IRushSessionReportingOptions {
+    readonly protocolVersion?: IReporterProtocolVersion;
+    readonly sessionId: string;
+    readonly sink: IReporterEventSink;
+    readonly source: IReporterEventSource;
+}
+
+// @beta
 export interface IRushToolDiagnosticSource {
     readonly kind: 'tool';
     readonly toolName: string;
@@ -367,6 +494,14 @@ export interface IRushToolDiagnosticSource {
 
 // @beta
 export function isBootstrapHandoffFileName(fileName: string): boolean;
+
+// @beta
+export interface IScopedLogger {
+    writeDebugLine(text: string): string;
+    writeErrorLine(text: string): string;
+    writeLine(text: string): string;
+    writeWarningLine(text: string): string;
+}
 
 // @beta
 export interface IScopedMessageOptions {
@@ -383,6 +518,31 @@ export interface IScopedReporter {
 }
 
 // @beta
+export interface ISessionCompletedPayload {
+    readonly durationMs?: number;
+    readonly exitCode: number;
+}
+
+// @beta
+export interface ISessionStartedPayload {
+    readonly cwd?: string;
+    readonly rushVersion: string;
+}
+
+// @beta
+export interface IShadowResultSummary {
+    readonly commandName?: string;
+    readonly exitCode: number;
+    readonly operationCounts: {
+        readonly [status: string]: number;
+    };
+    readonly succeeded: boolean;
+}
+
+// @beta
+export function isPluginApiVersionSupported(declaredApiVersion: string, supportedApiVersion?: string): boolean;
+
+// @beta
 export function isReporterEventRequired(type: ReporterEventType): boolean;
 
 // @beta
@@ -395,6 +555,30 @@ export function isReporterProtocolCompatible(consumer: IReporterProtocolVersion,
 export function isValidRushDiagnosticCode(code: string): boolean;
 
 // @beta
+export interface ITelemetryAggregate {
+    readonly commandName?: string;
+    readonly diagnosticCategoryCounts: {
+        readonly [category: string]: number;
+    };
+    readonly diagnosticCodes: readonly string[];
+    readonly durationMs?: number;
+    readonly exitCode?: number;
+    readonly operationStatusCounts: {
+        readonly [status: string]: number;
+    };
+    readonly producerVersions: readonly string[];
+    readonly protocolVersion?: IReporterProtocolVersion;
+    readonly reporterMode?: string;
+    readonly result?: TelemetryResult;
+}
+
+// @beta
+export interface IWatchCycleCompletedPayload {
+    readonly changedProjects?: readonly string[];
+    readonly succeeded: boolean;
+}
+
+// @beta
 export interface IWriteBootstrapHandoffOptions {
     readonly directory?: string;
     readonly pid?: number;
@@ -404,9 +588,34 @@ export interface IWriteBootstrapHandoffOptions {
 export type KnownRushDiagnosticCategory = 'configuration' | 'input' | 'dependency-tool' | 'environment' | 'network-auth' | 'operation' | 'internal';
 
 // @beta
+export type LegacyBeforeLogHook = (telemetry: Record<string, unknown>) => void;
+
+// @beta
 export class LegacyFallbackSink implements IReporterEventSink {
     // (undocumented)
     emit(): string;
+}
+
+// @beta
+export class LifecycleEmitter {
+    constructor(options: ILifecycleEmitterOptions);
+    // (undocumented)
+    emitCommandCompleted(payload: ICommandCompletedPayload): string;
+    // (undocumented)
+    emitCommandResult(payload: ICommandResultPayload): string;
+    // (undocumented)
+    emitCommandStarted(payload: ICommandStartedPayload): string;
+    emitDiagnostic(diagnostic: IRushDiagnostic): string;
+    // (undocumented)
+    emitOperationRegistered(payload: IOperationRegisteredPayload): string;
+    // (undocumented)
+    emitOperationStatusChanged(payload: IOperationStatusChangedPayload): string;
+    // (undocumented)
+    emitSessionCompleted(payload: ISessionCompletedPayload): string;
+    // (undocumented)
+    emitSessionStarted(payload: ISessionStartedPayload): string;
+    // (undocumented)
+    emitWatchCycleCompleted(payload: IWatchCycleCompletedPayload): string;
 }
 
 // @beta
@@ -433,6 +642,9 @@ export class OldEngineOutputAdapter {
 
 // @beta
 export type OneOrMoreRushDiagnosticCodeSegments<S extends string = RushDiagnosticCodeSegment> = S extends string ? S | `${S}${RushDiagnosticCodeSegment}` : never;
+
+// @beta
+export type OperationStatus = 'ready' | 'executing' | 'success' | 'successWithWarnings' | 'failure' | 'blocked' | 'skipped' | 'fromCache' | 'noOp';
 
 // @beta
 export function parseEarlyReporterControls(argv: readonly string[], env: Record<string, string | undefined>): IEarlyReporterControls;
@@ -520,6 +732,12 @@ export class ReporterMultiplexer implements IReporter {
 export type ReporterPrivacyClassification = 'public' | 'local-sensitive' | 'secret';
 
 // @beta
+export function resolveExitStatus(options: IResolveExitStatusOptions): IRushExitStatus;
+
+// @beta
+export function resolveExitStatusFromEvents(events: readonly IReporterEventEnvelope<unknown>[], options?: IResolveExitStatusFromEventsOptions): IRushExitStatus;
+
+// @beta
 export function resolveReporterCompatibility(frontend: IReporterFrontendDescriptor, engine: IReporterEngineDescriptor): IReporterCompatibilityDecision;
 
 // @beta
@@ -571,6 +789,12 @@ export const RUSH_DIAGNOSTIC_CODE_DEFINITIONS: readonly [{
     readonly defaultSeverity: "error";
     readonly summaryKey: "diagnostic.RUSH_INTERNAL_UNEXPECTED.summary";
     readonly detailKey: "diagnostic.RUSH_INTERNAL_UNEXPECTED.detail";
+}, {
+    readonly code: "RUSH_PLUGIN_API_INCOMPATIBLE";
+    readonly category: "configuration";
+    readonly defaultSeverity: "error";
+    readonly summaryKey: "diagnostic.RUSH_PLUGIN_API_INCOMPATIBLE.summary";
+    readonly detailKey: undefined;
 }];
 
 // @beta
@@ -583,10 +807,16 @@ export const RUSH_DIAGNOSTIC_TEMPLATES: Readonly<Record<RushDiagnosticTemplateKe
 export const RUSH_INTERNAL_ERROR_CODE: 'RUSH_INTERNAL_UNEXPECTED';
 
 // @beta
+export const RUSH_PLUGIN_API_VERSION: '1.0.0';
+
+// @beta
 export const RUSH_REPORTER_BOOTSTRAP_HANDOFF_ENV_VAR: '_RUSH_REPORTER_BOOTSTRAP_HANDOFF';
 
 // @beta
 export const RUSH_REPORTER_BOOTSTRAP_NONCE_ENV_VAR: '_RUSH_REPORTER_BOOTSTRAP_NONCE';
+
+// @beta
+export type RushCommandOutcome = 'succeeded' | 'failed' | 'cancelled' | 'signal';
 
 // @beta
 export type RushDiagnosticCategory = KnownRushDiagnosticCategory | (string & {});
@@ -621,6 +851,35 @@ export class RushError extends Error {
 
 // @beta
 export type RushRemediationSafety = 'safe' | 'requires-confirmation' | 'unsafe';
+
+// @beta
+export class RushSessionReporting {
+    constructor(options: IRushSessionReportingOptions);
+    createExecutionContext(scope?: IReporterEventScope): IReporterExecutionContext;
+    createScopedLogger(scope?: IReporterEventScope): IScopedLogger;
+    createScopedReporter(scope?: IReporterEventScope): IScopedReporter;
+    getSink(): IReporterEventSink;
+}
+
+// @beta
+export function separateJsonControls(argv: readonly string[]): IJsonControls;
+
+// @beta
+export function summarizeShadowResult(events: readonly IReporterEventEnvelope<unknown>[]): IShadowResultSummary;
+
+// @beta
+export const TELEMETRY_AGGREGATE_KEYS: readonly string[];
+
+// @beta
+export type TelemetryResult = 'succeeded' | 'failed';
+
+// @beta
+export class TelemetrySubscriber {
+    constructor();
+    buildAggregate(): ITelemetryAggregate;
+    ingest(event: IReporterEventEnvelope<unknown>): void;
+    setReporterMode(reporterMode: string): void;
+}
 
 // @beta
 export function writeBootstrapHandoffFileAsync(buffer: BootstrapEventBuffer, options?: IWriteBootstrapHandoffOptions): Promise<IBootstrapHandoffWriteResult>;

--- a/common/reviews/api/rush-reporter.api.md
+++ b/common/reviews/api/rush-reporter.api.md
@@ -39,10 +39,25 @@ export type BootstrapPrivacyClassification = 'public' | 'local-sensitive' | 'sec
 export function computeEnvelopePrivacyFloor(classifications: Iterable<ReporterPrivacyClassification>): ReporterPrivacyClassification;
 
 // @beta
+export function createBeforeLogAdapter(hooks: readonly LegacyBeforeLogHook[]): (aggregate: ITelemetryAggregate) => void;
+
+// @beta
 export function createEngineSink(providedSink?: IReporterEventSink): IEngineSinkResolution;
 
 // @beta
+export function createPluginApiIncompatibleDiagnostic(manifest: IRushPluginManifest): IRushDiagnostic;
+
+// @beta
 export function createRushDiagnostic(code: RushDiagnosticCodes, options?: ICreateRushDiagnosticOptions): IRushDiagnostic;
+
+// @beta
+export function createScopedLogger(reporter: IScopedReporter): IScopedLogger;
+
+// @beta
+export function createScopedReporter(options: ICreateScopedReporterOptions): IScopedReporter;
+
+// @beta
+export function createTelemetryReporter(subscriber: TelemetrySubscriber): IReporter;
 
 // @beta
 export const DEFAULT_FLUSH_TIMEOUT_MS: number;
@@ -57,10 +72,22 @@ export const DEFAULT_SIGNAL_FLUSH_TIMEOUT_MS: number;
 export function deleteBootstrapHandoffFileAsync(filePath: string): Promise<void>;
 
 // @beta
+export function deriveExitCodeFromEvents(events: readonly IReporterEventEnvelope<unknown>[]): number;
+
+// @beta
 export function encodeNdjsonRecord(value: unknown, options?: INdjsonOptions): string;
 
 // @beta
+export const EXIT_CODE_FAILURE: 1;
+
+// @beta
+export const EXIT_CODE_SUCCESS: 0;
+
+// @beta
 export function getPrivacyClassificationRank(classification: ReporterPrivacyClassification): number;
+
+// @beta
+export function getSignalExitCode(signal: NodeJS.Signals): number;
 
 // @beta
 export interface IBootstrapEventBufferOptions {
@@ -123,6 +150,29 @@ export interface IClassifiedDiagnosticValue {
 }
 
 // @beta
+export interface ICommandCompletedPayload {
+    readonly commandName: string;
+    readonly durationMs?: number;
+    readonly exitCode: number;
+}
+
+// @beta
+export interface ICommandResultPayload {
+    readonly commandName: string;
+    readonly exitCode: number;
+    readonly operationCounts?: {
+        readonly [status: string]: number;
+    };
+    readonly succeeded: boolean;
+}
+
+// @beta
+export interface ICommandStartedPayload {
+    readonly argv?: readonly string[];
+    readonly commandName: string;
+}
+
+// @beta
 export interface ICreateRushDiagnosticOptions {
     readonly causeDiagnosticIds?: readonly string[];
     readonly diagnosticId?: string;
@@ -137,6 +187,15 @@ export interface ICreateRushDiagnosticOptions {
 }
 
 // @beta
+export interface ICreateScopedReporterOptions {
+    readonly protocolVersion?: IReporterProtocolVersion;
+    readonly scope?: IReporterEventScope;
+    readonly sessionId: string;
+    readonly sink: IReporterEventSink;
+    readonly source: IReporterEventSource;
+}
+
+// @beta
 export interface IEarlyReporterControls {
     readonly logLevel?: string;
     readonly reporter?: string;
@@ -146,6 +205,21 @@ export interface IEarlyReporterControls {
 export interface IEngineSinkResolution {
     readonly mode: 'structured' | 'legacy-fallback';
     readonly sink: IReporterEventSink;
+}
+
+// @beta
+export interface IJsonControls {
+    readonly commandJson: boolean;
+    readonly reporterJson: boolean;
+}
+
+// @beta
+export interface ILifecycleEmitterOptions {
+    readonly protocolVersion?: IReporterProtocolVersion;
+    readonly scope?: IReporterEventScope;
+    readonly sessionId: string;
+    readonly sink: IReporterEventSink;
+    readonly source: IReporterEventSource;
 }
 
 // @beta
@@ -172,6 +246,19 @@ export interface IOldEngineOutputAdapterOptions {
     readonly sessionId: string;
     readonly sink: IReporterEventSink;
     readonly source: IReporterEventSource;
+}
+
+// @beta
+export interface IOperationRegisteredPayload {
+    readonly operationId: string;
+    readonly phaseName?: string;
+    readonly projectName?: string;
+}
+
+// @beta
+export interface IOperationStatusChangedPayload {
+    readonly operationId: string;
+    readonly status: OperationStatus;
 }
 
 // @beta
@@ -243,6 +330,12 @@ export interface IReporterEventSource {
     readonly component?: string;
     readonly packageName: string;
     readonly packageVersion: string;
+}
+
+// @beta
+export interface IReporterExecutionContext {
+    readonly reporter: IScopedReporter;
+    readonly sink: IReporterEventSink;
 }
 
 // @beta
@@ -318,6 +411,19 @@ export interface IReporterRegistrationOptions {
 }
 
 // @beta
+export interface IResolveExitStatusFromEventsOptions {
+    readonly cancelled?: boolean;
+    readonly signal?: NodeJS.Signals;
+}
+
+// @beta
+export interface IResolveExitStatusOptions {
+    readonly cancelled?: boolean;
+    readonly hasFailures?: boolean;
+    readonly signal?: NodeJS.Signals;
+}
+
+// @beta
 export interface IRushDiagnostic {
     readonly category: RushDiagnosticCategory;
     readonly causeDiagnosticIds?: readonly string[];
@@ -348,12 +454,25 @@ export interface IRushDiagnosticCodeDefinition {
 export type IRushDiagnosticSource = IRushFileDiagnosticSource | IRushToolDiagnosticSource;
 
 // @beta
+export interface IRushExitStatus {
+    readonly exitCode: number;
+    readonly outcome: RushCommandOutcome;
+    readonly signal?: NodeJS.Signals;
+}
+
+// @beta
 export interface IRushFileDiagnosticSource {
     readonly column?: number;
     readonly file: string;
     readonly kind: 'file';
     readonly line?: number;
     readonly toolName?: string;
+}
+
+// @beta
+export interface IRushPluginManifest {
+    readonly pluginApiVersion: string;
+    readonly pluginName: string;
 }
 
 // @beta
@@ -365,6 +484,14 @@ export interface IRushRemediationAction {
 }
 
 // @beta
+export interface IRushSessionReportingOptions {
+    readonly protocolVersion?: IReporterProtocolVersion;
+    readonly sessionId: string;
+    readonly sink: IReporterEventSink;
+    readonly source: IReporterEventSource;
+}
+
+// @beta
 export interface IRushToolDiagnosticSource {
     readonly kind: 'tool';
     readonly toolName: string;
@@ -372,6 +499,14 @@ export interface IRushToolDiagnosticSource {
 
 // @beta
 export function isBootstrapHandoffFileName(fileName: string): boolean;
+
+// @beta
+export interface IScopedLogger {
+    writeDebugLine(text: string): string;
+    writeErrorLine(text: string): string;
+    writeLine(text: string): string;
+    writeWarningLine(text: string): string;
+}
 
 // @beta
 export interface IScopedMessageOptions {
@@ -388,6 +523,31 @@ export interface IScopedReporter {
 }
 
 // @beta
+export interface ISessionCompletedPayload {
+    readonly durationMs?: number;
+    readonly exitCode: number;
+}
+
+// @beta
+export interface ISessionStartedPayload {
+    readonly cwd?: string;
+    readonly rushVersion: string;
+}
+
+// @beta
+export interface IShadowResultSummary {
+    readonly commandName?: string;
+    readonly exitCode: number;
+    readonly operationCounts: {
+        readonly [status: string]: number;
+    };
+    readonly succeeded: boolean;
+}
+
+// @beta
+export function isPluginApiVersionSupported(declaredApiVersion: string, supportedApiVersion?: string): boolean;
+
+// @beta
 export function isReporterEventRequired(type: ReporterEventType): boolean;
 
 // @beta
@@ -400,6 +560,30 @@ export function isReporterProtocolCompatible(consumer: IReporterProtocolVersion,
 export function isValidRushDiagnosticCode(code: string): boolean;
 
 // @beta
+export interface ITelemetryAggregate {
+    readonly commandName?: string;
+    readonly diagnosticCategoryCounts: {
+        readonly [category: string]: number;
+    };
+    readonly diagnosticCodes: readonly string[];
+    readonly durationMs?: number;
+    readonly exitCode?: number;
+    readonly operationStatusCounts: {
+        readonly [status: string]: number;
+    };
+    readonly producerVersions: readonly string[];
+    readonly protocolVersion?: IReporterProtocolVersion;
+    readonly reporterMode?: string;
+    readonly result?: TelemetryResult;
+}
+
+// @beta
+export interface IWatchCycleCompletedPayload {
+    readonly changedProjects?: readonly string[];
+    readonly succeeded: boolean;
+}
+
+// @beta
 export interface IWriteBootstrapHandoffOptions {
     readonly directory?: string;
     readonly pid?: number;
@@ -409,9 +593,34 @@ export interface IWriteBootstrapHandoffOptions {
 export type KnownRushDiagnosticCategory = 'configuration' | 'input' | 'dependency-tool' | 'environment' | 'network-auth' | 'operation' | 'internal';
 
 // @beta
+export type LegacyBeforeLogHook = (telemetry: Record<string, unknown>) => void;
+
+// @beta
 export class LegacyFallbackSink implements IReporterEventSink {
     // (undocumented)
     emit(): string;
+}
+
+// @beta
+export class LifecycleEmitter {
+    constructor(options: ILifecycleEmitterOptions);
+    // (undocumented)
+    emitCommandCompleted(payload: ICommandCompletedPayload): string;
+    // (undocumented)
+    emitCommandResult(payload: ICommandResultPayload): string;
+    // (undocumented)
+    emitCommandStarted(payload: ICommandStartedPayload): string;
+    emitDiagnostic(diagnostic: IRushDiagnostic): string;
+    // (undocumented)
+    emitOperationRegistered(payload: IOperationRegisteredPayload): string;
+    // (undocumented)
+    emitOperationStatusChanged(payload: IOperationStatusChangedPayload): string;
+    // (undocumented)
+    emitSessionCompleted(payload: ISessionCompletedPayload): string;
+    // (undocumented)
+    emitSessionStarted(payload: ISessionStartedPayload): string;
+    // (undocumented)
+    emitWatchCycleCompleted(payload: IWatchCycleCompletedPayload): string;
 }
 
 // @beta
@@ -446,6 +655,9 @@ export class OldEngineOutputAdapter {
 
 // @beta
 export type OneOrMoreRushDiagnosticCodeSegments<TSegments extends string = string> = string extends TSegments ? `_${Uppercase<string>}` : TSegments extends `_${infer Segments}` ? Segments extends '' ? never : TSegments extends Uppercase<TSegments> ? TSegments : never : never;
+
+// @beta
+export type OperationStatus = 'ready' | 'executing' | 'success' | 'successWithWarnings' | 'failure' | 'blocked' | 'skipped' | 'fromCache' | 'noOp';
 
 // @beta
 export function parseEarlyReporterControls(argv: readonly string[], env: Record<string, string | undefined>): IEarlyReporterControls;
@@ -542,6 +754,12 @@ export class ReporterMultiplexer implements IReporter {
 export type ReporterPrivacyClassification = 'public' | 'local-sensitive' | 'secret';
 
 // @beta
+export function resolveExitStatus(options: IResolveExitStatusOptions): IRushExitStatus;
+
+// @beta
+export function resolveExitStatusFromEvents(events: readonly IReporterEventEnvelope<unknown>[], options?: IResolveExitStatusFromEventsOptions): IRushExitStatus;
+
+// @beta
 export function resolveReporterCompatibility(frontend: IReporterFrontendDescriptor, engine: IReporterEngineDescriptor): IReporterCompatibilityDecision;
 
 // @beta
@@ -593,6 +811,12 @@ export const RUSH_DIAGNOSTIC_CODE_DEFINITIONS: readonly [{
     readonly defaultSeverity: "error";
     readonly summaryKey: "diagnostic.RUSH_INTERNAL_UNEXPECTED.summary";
     readonly detailKey: "diagnostic.RUSH_INTERNAL_UNEXPECTED.detail";
+}, {
+    readonly code: "RUSH_PLUGIN_API_INCOMPATIBLE";
+    readonly category: "configuration";
+    readonly defaultSeverity: "error";
+    readonly summaryKey: "diagnostic.RUSH_PLUGIN_API_INCOMPATIBLE.summary";
+    readonly detailKey: undefined;
 }];
 
 // @beta
@@ -605,10 +829,16 @@ export const RUSH_DIAGNOSTIC_TEMPLATES: Readonly<Record<RushDiagnosticTemplateKe
 export const RUSH_INTERNAL_ERROR_CODE: 'RUSH_INTERNAL_UNEXPECTED';
 
 // @beta
+export const RUSH_PLUGIN_API_VERSION: '1.0.0';
+
+// @beta
 export const RUSH_REPORTER_BOOTSTRAP_HANDOFF_ENV_VAR: '_RUSH_REPORTER_BOOTSTRAP_HANDOFF';
 
 // @beta
 export const RUSH_REPORTER_BOOTSTRAP_NONCE_ENV_VAR: '_RUSH_REPORTER_BOOTSTRAP_NONCE';
+
+// @beta
+export type RushCommandOutcome = 'succeeded' | 'failed' | 'cancelled' | 'signal';
 
 // @beta
 export type RushDiagnosticCategory = KnownRushDiagnosticCategory | (string & {});
@@ -643,6 +873,35 @@ export class RushError extends Error {
 
 // @beta
 export type RushRemediationSafety = 'safe' | 'requires-confirmation' | 'unsafe';
+
+// @beta
+export class RushSessionReporting {
+    constructor(options: IRushSessionReportingOptions);
+    createExecutionContext(scope?: IReporterEventScope): IReporterExecutionContext;
+    createScopedLogger(scope?: IReporterEventScope): IScopedLogger;
+    createScopedReporter(scope?: IReporterEventScope): IScopedReporter;
+    getSink(): IReporterEventSink;
+}
+
+// @beta
+export function separateJsonControls(argv: readonly string[]): IJsonControls;
+
+// @beta
+export function summarizeShadowResult(events: readonly IReporterEventEnvelope<unknown>[]): IShadowResultSummary;
+
+// @beta
+export const TELEMETRY_AGGREGATE_KEYS: readonly string[];
+
+// @beta
+export type TelemetryResult = 'succeeded' | 'failed';
+
+// @beta
+export class TelemetrySubscriber {
+    constructor();
+    buildAggregate(): ITelemetryAggregate;
+    ingest(event: IReporterEventEnvelope<unknown>): void;
+    setReporterMode(reporterMode: string): void;
+}
 
 // @beta
 export function writeBootstrapHandoffFileAsync(buffer: BootstrapEventBuffer, options?: IWriteBootstrapHandoffOptions): Promise<IBootstrapHandoffWriteResult>;

--- a/libraries/reporter/src/diagnostics/RushDiagnosticCodeRegistry.ts
+++ b/libraries/reporter/src/diagnostics/RushDiagnosticCodeRegistry.ts
@@ -130,6 +130,13 @@ export const RUSH_DIAGNOSTIC_CODE_DEFINITIONS = [
     defaultSeverity: 'error',
     summaryKey: 'diagnostic.RUSH_INTERNAL_UNEXPECTED.summary',
     detailKey: 'diagnostic.RUSH_INTERNAL_UNEXPECTED.detail'
+  },
+  {
+    code: 'RUSH_PLUGIN_API_INCOMPATIBLE',
+    category: 'configuration',
+    defaultSeverity: 'error',
+    summaryKey: 'diagnostic.RUSH_PLUGIN_API_INCOMPATIBLE.summary',
+    detailKey: undefined
   }
 ] as const satisfies readonly IRushDiagnosticCodeDefinition[];
 

--- a/libraries/reporter/src/diagnostics/RushDiagnosticCodeRegistry.ts
+++ b/libraries/reporter/src/diagnostics/RushDiagnosticCodeRegistry.ts
@@ -212,6 +212,13 @@ export const RUSH_DIAGNOSTIC_CODE_DEFINITIONS = defineRushDiagnosticCodeDefiniti
     defaultSeverity: 'error',
     summaryKey: 'diagnostic.RUSH_INTERNAL_UNEXPECTED.summary',
     detailKey: 'diagnostic.RUSH_INTERNAL_UNEXPECTED.detail'
+  },
+  {
+    code: 'RUSH_PLUGIN_API_INCOMPATIBLE',
+    category: 'configuration',
+    defaultSeverity: 'error',
+    summaryKey: 'diagnostic.RUSH_PLUGIN_API_INCOMPATIBLE.summary',
+    detailKey: undefined
   }
 ]);
 

--- a/libraries/reporter/src/diagnostics/templates/configuration.ts
+++ b/libraries/reporter/src/diagnostics/templates/configuration.ts
@@ -10,5 +10,7 @@
  */
 // eslint-disable-next-line @typescript-eslint/typedef -- literal keys are required for the Record<RushDiagnosticTemplateKey, string> aggregate check
 export const CONFIGURATION_DIAGNOSTIC_TEMPLATES = {
-  'diagnostic.RUSH_CONFIG_INVALID_JSON.summary': 'The configuration file {file} contains invalid JSON.'
+  'diagnostic.RUSH_CONFIG_INVALID_JSON.summary': 'The configuration file {file} contains invalid JSON.',
+  'diagnostic.RUSH_PLUGIN_API_INCOMPATIBLE.summary':
+    'The plugin {pluginName} declares plugin API version {declaredApiVersion}, which is incompatible with this Rush (supported: {supportedApiVersion}).'
 } as const;

--- a/libraries/reporter/src/exit/CommandJson.ts
+++ b/libraries/reporter/src/exit/CommandJson.ts
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+/**
+ * The independently-resolved JSON controls on a command line.
+ *
+ * @beta
+ */
+export interface IJsonControls {
+  /**
+   * Whether the command-specific `--json` flag was requested. This selects the
+   * command's own JSON schema and is unchanged by the reporter system.
+   */
+  readonly commandJson: boolean;
+
+  /**
+   * Whether the `json` reporter was requested through `--reporter`.
+   */
+  readonly reporterJson: boolean;
+}
+
+/**
+ * Separates the command-specific `--json` flag from the `json` reporter selection.
+ *
+ * @remarks
+ * The command-specific `--json` behavior is preserved and is never an alias for
+ * `--reporter=json`. Both may be requested independently, and each keeps its own
+ * output schema.
+ *
+ * @param argv - the command-line arguments, excluding the node executable and script
+ *
+ * @beta
+ */
+export function separateJsonControls(argv: readonly string[]): IJsonControls {
+  let commandJson: boolean = false;
+  let reporterJson: boolean = false;
+
+  for (let index: number = 0; index < argv.length; index++) {
+    const arg: string = argv[index];
+    if (arg === '--json') {
+      commandJson = true;
+    } else if (arg === '--reporter=json') {
+      reporterJson = true;
+    } else if (arg === '--reporter' && argv[index + 1] === 'json') {
+      reporterJson = true;
+    }
+  }
+
+  return { commandJson, reporterJson };
+}

--- a/libraries/reporter/src/exit/ExitStatus.ts
+++ b/libraries/reporter/src/exit/ExitStatus.ts
@@ -1,0 +1,164 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import * as os from 'node:os';
+
+import type { IReporterEventEnvelope } from '../events/IReporterEventEnvelope';
+
+/**
+ * The exit code returned for success, including warning-only success.
+ *
+ * @beta
+ */
+export const EXIT_CODE_SUCCESS: 0 = 0;
+
+/**
+ * The exit code returned for a Rush or operation failure and for logical cancellation.
+ *
+ * @beta
+ */
+export const EXIT_CODE_FAILURE: 1 = 1;
+
+/**
+ * The logical outcome of a command, independent of presentation.
+ *
+ * @beta
+ */
+export type RushCommandOutcome = 'succeeded' | 'failed' | 'cancelled' | 'signal';
+
+/**
+ * The resolved exit status of a command.
+ *
+ * @beta
+ */
+export interface IRushExitStatus {
+  /**
+   * The process exit code.
+   */
+  readonly exitCode: number;
+
+  /**
+   * The logical outcome.
+   */
+  readonly outcome: RushCommandOutcome;
+
+  /**
+   * The terminating OS signal, when the outcome is `signal`.
+   */
+  readonly signal?: NodeJS.Signals;
+}
+
+/**
+ * Returns the conventional exit code for an OS signal, `128 + signalNumber`.
+ *
+ * @param signal - the terminating signal
+ *
+ * @beta
+ */
+export function getSignalExitCode(signal: NodeJS.Signals): number {
+  const signalNumber: number | undefined = (os.constants.signals as Record<string, number>)[signal];
+  return 128 + (signalNumber ?? 0);
+}
+
+/**
+ * Options for {@link resolveExitStatus}.
+ *
+ * @beta
+ */
+export interface IResolveExitStatusOptions {
+  /**
+   * Whether the command had a Rush or operation failure. Warnings alone are not failures.
+   */
+  readonly hasFailures?: boolean;
+
+  /**
+   * Whether the command was logically cancelled or aborted.
+   */
+  readonly cancelled?: boolean;
+
+  /**
+   * The terminating OS signal, if any.
+   */
+  readonly signal?: NodeJS.Signals;
+}
+
+/**
+ * Resolves a command's exit status from its outcome.
+ *
+ * @remarks
+ * A signal termination yields the conventional signal-derived status.
+ * Cancellation and failure yield `1`. Everything else, including warning-only
+ * success, yields `0`. The reporter mode and diagnostic categories are never
+ * inputs, so they can never select the exit code.
+ *
+ * @param options - the command outcome
+ *
+ * @beta
+ */
+export function resolveExitStatus(options: IResolveExitStatusOptions): IRushExitStatus {
+  if (options.signal) {
+    return { exitCode: getSignalExitCode(options.signal), outcome: 'signal', signal: options.signal };
+  }
+  if (options.cancelled) {
+    return { exitCode: EXIT_CODE_FAILURE, outcome: 'cancelled' };
+  }
+  if (options.hasFailures) {
+    return { exitCode: EXIT_CODE_FAILURE, outcome: 'failed' };
+  }
+  return { exitCode: EXIT_CODE_SUCCESS, outcome: 'succeeded' };
+}
+
+/**
+ * Options for {@link resolveExitStatusFromEvents}.
+ *
+ * @beta
+ */
+export interface IResolveExitStatusFromEventsOptions {
+  /**
+   * Whether the command was logically cancelled or aborted.
+   */
+  readonly cancelled?: boolean;
+
+  /**
+   * The terminating OS signal, if any.
+   */
+  readonly signal?: NodeJS.Signals;
+}
+
+/**
+ * Resolves a command's exit status from its structured event stream.
+ *
+ * @remarks
+ * A failure is any failed command result, any error-severity diagnostic, or any
+ * failed operation. Diagnostic categories and the selected reporter are never
+ * consulted, so they cannot influence the exit code. Warning-severity
+ * diagnostics never cause failure.
+ *
+ * @param events - the structured events emitted during the command
+ * @param options - cancellation and signal state
+ *
+ * @beta
+ */
+export function resolveExitStatusFromEvents(
+  events: readonly IReporterEventEnvelope<unknown>[],
+  options: IResolveExitStatusFromEventsOptions = {}
+): IRushExitStatus {
+  let hasFailures: boolean = false;
+  for (const event of events) {
+    if (event.type === 'commandResult') {
+      if ((event.payload as { succeeded: boolean }).succeeded === false) {
+        hasFailures = true;
+      }
+    } else if (event.type === 'diagnosticEmitted') {
+      if ((event.payload as { severity?: string }).severity === 'error') {
+        hasFailures = true;
+      }
+    } else if (event.type === 'operationStatusChanged') {
+      if ((event.payload as { status?: string }).status === 'failure') {
+        hasFailures = true;
+      }
+    }
+  }
+
+  return resolveExitStatus({ hasFailures, cancelled: options.cancelled, signal: options.signal });
+}

--- a/libraries/reporter/src/index.ts
+++ b/libraries/reporter/src/index.ts
@@ -156,6 +156,22 @@ export {
   createPluginApiIncompatibleDiagnostic
 } from './session/PluginApi';
 
+export type {
+  OperationStatus,
+  ISessionStartedPayload,
+  ISessionCompletedPayload,
+  ICommandStartedPayload,
+  ICommandCompletedPayload,
+  IOperationRegisteredPayload,
+  IOperationStatusChangedPayload,
+  ICommandResultPayload,
+  IWatchCycleCompletedPayload
+} from './lifecycle/LifecycleEvents';
+export type { ILifecycleEmitterOptions } from './lifecycle/LifecycleEmitter';
+export { LifecycleEmitter } from './lifecycle/LifecycleEmitter';
+export type { IShadowResultSummary } from './lifecycle/ShadowParity';
+export { deriveExitCodeFromEvents, summarizeShadowResult } from './lifecycle/ShadowParity';
+
 export type { IReporterEmitEventInput, IReporterEventSink } from './producers/IReporterEventSink';
 export type {
   ReporterMessageSeverity,

--- a/libraries/reporter/src/index.ts
+++ b/libraries/reporter/src/index.ts
@@ -172,6 +172,12 @@ export { LifecycleEmitter } from './lifecycle/LifecycleEmitter';
 export type { IShadowResultSummary } from './lifecycle/ShadowParity';
 export { deriveExitCodeFromEvents, summarizeShadowResult } from './lifecycle/ShadowParity';
 
+export type { TelemetryResult, ITelemetryAggregate } from './telemetry/TelemetryAggregate';
+export { TELEMETRY_AGGREGATE_KEYS } from './telemetry/TelemetryAggregate';
+export { TelemetrySubscriber, createTelemetryReporter } from './telemetry/TelemetrySubscriber';
+export type { LegacyBeforeLogHook } from './telemetry/BeforeLogAdapter';
+export { createBeforeLogAdapter } from './telemetry/BeforeLogAdapter';
+
 export type { IReporterEmitEventInput, IReporterEventSink } from './producers/IReporterEventSink';
 export type {
   ReporterMessageSeverity,

--- a/libraries/reporter/src/index.ts
+++ b/libraries/reporter/src/index.ts
@@ -153,6 +153,19 @@ export { LegacyFallbackSink, createEngineSink } from './compat/LegacyFallbackSin
 export type { IOldEngineOutputAdapterOptions } from './compat/OldEngineOutputAdapter';
 export { OldEngineOutputAdapter } from './compat/OldEngineOutputAdapter';
 
+export type { ICreateScopedReporterOptions } from './session/ScopedReporterFactory';
+export { createScopedReporter } from './session/ScopedReporterFactory';
+export type { IScopedLogger } from './session/ScopedLogger';
+export { createScopedLogger } from './session/ScopedLogger';
+export type { IRushSessionReportingOptions, IReporterExecutionContext } from './session/RushSessionReporting';
+export { RushSessionReporting } from './session/RushSessionReporting';
+export type { IRushPluginManifest } from './session/PluginApi';
+export {
+  RUSH_PLUGIN_API_VERSION,
+  isPluginApiVersionSupported,
+  createPluginApiIncompatibleDiagnostic
+} from './session/PluginApi';
+
 export type { IReporterEmitEventInput, IReporterEventSink } from './producers/IReporterEventSink';
 export type {
   ReporterMessageSeverity,

--- a/libraries/reporter/src/index.ts
+++ b/libraries/reporter/src/index.ts
@@ -166,6 +166,22 @@ export {
   createPluginApiIncompatibleDiagnostic
 } from './session/PluginApi';
 
+export type {
+  OperationStatus,
+  ISessionStartedPayload,
+  ISessionCompletedPayload,
+  ICommandStartedPayload,
+  ICommandCompletedPayload,
+  IOperationRegisteredPayload,
+  IOperationStatusChangedPayload,
+  ICommandResultPayload,
+  IWatchCycleCompletedPayload
+} from './lifecycle/LifecycleEvents';
+export type { ILifecycleEmitterOptions } from './lifecycle/LifecycleEmitter';
+export { LifecycleEmitter } from './lifecycle/LifecycleEmitter';
+export type { IShadowResultSummary } from './lifecycle/ShadowParity';
+export { deriveExitCodeFromEvents, summarizeShadowResult } from './lifecycle/ShadowParity';
+
 export type { IReporterEmitEventInput, IReporterEventSink } from './producers/IReporterEventSink';
 export type {
   ReporterMessageSeverity,

--- a/libraries/reporter/src/index.ts
+++ b/libraries/reporter/src/index.ts
@@ -182,6 +182,12 @@ export { LifecycleEmitter } from './lifecycle/LifecycleEmitter';
 export type { IShadowResultSummary } from './lifecycle/ShadowParity';
 export { deriveExitCodeFromEvents, summarizeShadowResult } from './lifecycle/ShadowParity';
 
+export type { TelemetryResult, ITelemetryAggregate } from './telemetry/TelemetryAggregate';
+export { TELEMETRY_AGGREGATE_KEYS } from './telemetry/TelemetryAggregate';
+export { TelemetrySubscriber, createTelemetryReporter } from './telemetry/TelemetrySubscriber';
+export type { LegacyBeforeLogHook } from './telemetry/BeforeLogAdapter';
+export { createBeforeLogAdapter } from './telemetry/BeforeLogAdapter';
+
 export type { IReporterEmitEventInput, IReporterEventSink } from './producers/IReporterEventSink';
 export type {
   ReporterMessageSeverity,

--- a/libraries/reporter/src/index.ts
+++ b/libraries/reporter/src/index.ts
@@ -178,6 +178,22 @@ export { TelemetrySubscriber, createTelemetryReporter } from './telemetry/Teleme
 export type { LegacyBeforeLogHook } from './telemetry/BeforeLogAdapter';
 export { createBeforeLogAdapter } from './telemetry/BeforeLogAdapter';
 
+export type {
+  RushCommandOutcome,
+  IRushExitStatus,
+  IResolveExitStatusOptions,
+  IResolveExitStatusFromEventsOptions
+} from './exit/ExitStatus';
+export {
+  EXIT_CODE_SUCCESS,
+  EXIT_CODE_FAILURE,
+  getSignalExitCode,
+  resolveExitStatus,
+  resolveExitStatusFromEvents
+} from './exit/ExitStatus';
+export type { IJsonControls } from './exit/CommandJson';
+export { separateJsonControls } from './exit/CommandJson';
+
 export type { IReporterEmitEventInput, IReporterEventSink } from './producers/IReporterEventSink';
 export type {
   ReporterMessageSeverity,

--- a/libraries/reporter/src/index.ts
+++ b/libraries/reporter/src/index.ts
@@ -143,6 +143,19 @@ export { LegacyFallbackSink, createEngineSink } from './compat/LegacyFallbackSin
 export type { IOldEngineOutputAdapterOptions } from './compat/OldEngineOutputAdapter';
 export { OldEngineOutputAdapter } from './compat/OldEngineOutputAdapter';
 
+export type { ICreateScopedReporterOptions } from './session/ScopedReporterFactory';
+export { createScopedReporter } from './session/ScopedReporterFactory';
+export type { IScopedLogger } from './session/ScopedLogger';
+export { createScopedLogger } from './session/ScopedLogger';
+export type { IRushSessionReportingOptions, IReporterExecutionContext } from './session/RushSessionReporting';
+export { RushSessionReporting } from './session/RushSessionReporting';
+export type { IRushPluginManifest } from './session/PluginApi';
+export {
+  RUSH_PLUGIN_API_VERSION,
+  isPluginApiVersionSupported,
+  createPluginApiIncompatibleDiagnostic
+} from './session/PluginApi';
+
 export type { IReporterEmitEventInput, IReporterEventSink } from './producers/IReporterEventSink';
 export type {
   ReporterMessageSeverity,

--- a/libraries/reporter/src/index.ts
+++ b/libraries/reporter/src/index.ts
@@ -188,6 +188,22 @@ export { TelemetrySubscriber, createTelemetryReporter } from './telemetry/Teleme
 export type { LegacyBeforeLogHook } from './telemetry/BeforeLogAdapter';
 export { createBeforeLogAdapter } from './telemetry/BeforeLogAdapter';
 
+export type {
+  RushCommandOutcome,
+  IRushExitStatus,
+  IResolveExitStatusOptions,
+  IResolveExitStatusFromEventsOptions
+} from './exit/ExitStatus';
+export {
+  EXIT_CODE_SUCCESS,
+  EXIT_CODE_FAILURE,
+  getSignalExitCode,
+  resolveExitStatus,
+  resolveExitStatusFromEvents
+} from './exit/ExitStatus';
+export type { IJsonControls } from './exit/CommandJson';
+export { separateJsonControls } from './exit/CommandJson';
+
 export type { IReporterEmitEventInput, IReporterEventSink } from './producers/IReporterEventSink';
 export type {
   ReporterMessageSeverity,

--- a/libraries/reporter/src/lifecycle/LifecycleEmitter.ts
+++ b/libraries/reporter/src/lifecycle/LifecycleEmitter.ts
@@ -1,0 +1,157 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import type { IReporterProtocolVersion } from '../events/ReporterProtocolVersion';
+import type { IReporterEventScope, IReporterEventSource } from '../events/IReporterEventEnvelope';
+import type { IReporterEventSink } from '../producers/IReporterEventSink';
+import type { IRushDiagnostic } from '../diagnostics/IRushDiagnostic';
+import { computeEnvelopePrivacyFloor } from '../diagnostics/DiagnosticPrivacy';
+import { REPORTER_PROTOCOL_VERSION } from '../protocol/ReporterProtocol';
+import type {
+  ISessionStartedPayload,
+  ISessionCompletedPayload,
+  ICommandStartedPayload,
+  ICommandCompletedPayload,
+  IOperationRegisteredPayload,
+  IOperationStatusChangedPayload,
+  ICommandResultPayload,
+  IWatchCycleCompletedPayload
+} from './LifecycleEvents';
+
+/**
+ * Options for constructing a {@link LifecycleEmitter}.
+ *
+ * @beta
+ */
+export interface ILifecycleEmitterOptions {
+  /**
+   * The sink events are emitted into.
+   */
+  readonly sink: IReporterEventSink;
+
+  /**
+   * The session id stamped onto emitted events.
+   */
+  readonly sessionId: string;
+
+  /**
+   * The producer identity stamped onto emitted events.
+   */
+  readonly source: IReporterEventSource;
+
+  /**
+   * The base scope merged into every emitted event.
+   */
+  readonly scope?: IReporterEventScope;
+
+  /**
+   * The protocol version stamped onto emitted events. Defaults to
+   * {@link REPORTER_PROTOCOL_VERSION}.
+   */
+  readonly protocolVersion?: IReporterProtocolVersion;
+}
+
+/**
+ * Emits the canonical first-party lifecycle and diagnostic events.
+ *
+ * @remarks
+ * Actions, the operation scheduler, and plugins use this to publish structured
+ * events. During the shadow phase these events flow to subscribers while legacy
+ * rendering remains the sole visible output; the emitter itself writes nothing
+ * to stdout or stderr. Every lifecycle, result, and diagnostic event is marked
+ * required so the manager never drops it.
+ *
+ * @beta
+ */
+export class LifecycleEmitter {
+  private readonly _sink: IReporterEventSink;
+  private readonly _sessionId: string;
+  private readonly _source: IReporterEventSource;
+  private readonly _scope: IReporterEventScope | undefined;
+  private readonly _protocolVersion: IReporterProtocolVersion;
+
+  public constructor(options: ILifecycleEmitterOptions) {
+    this._sink = options.sink;
+    this._sessionId = options.sessionId;
+    this._source = options.source;
+    this._scope = options.scope;
+    this._protocolVersion = options.protocolVersion ?? REPORTER_PROTOCOL_VERSION;
+  }
+
+  public emitSessionStarted(payload: ISessionStartedPayload): string {
+    return this._emit('sessionStarted', payload, 'public');
+  }
+
+  public emitSessionCompleted(payload: ISessionCompletedPayload): string {
+    return this._emit('sessionCompleted', payload, 'public');
+  }
+
+  public emitCommandStarted(payload: ICommandStartedPayload): string {
+    return this._emit('commandStarted', payload, 'public', { commandName: payload.commandName });
+  }
+
+  public emitCommandCompleted(payload: ICommandCompletedPayload): string {
+    return this._emit('commandCompleted', payload, 'public', { commandName: payload.commandName });
+  }
+
+  public emitOperationRegistered(payload: IOperationRegisteredPayload): string {
+    return this._emit('operationRegistered', payload, 'public', {
+      operationId: payload.operationId,
+      projectName: payload.projectName,
+      phaseName: payload.phaseName
+    });
+  }
+
+  public emitOperationStatusChanged(payload: IOperationStatusChangedPayload): string {
+    return this._emit('operationStatusChanged', payload, 'public', {
+      operationId: payload.operationId
+    });
+  }
+
+  public emitCommandResult(payload: ICommandResultPayload): string {
+    return this._emit('commandResult', payload, 'public', { commandName: payload.commandName });
+  }
+
+  public emitWatchCycleCompleted(payload: IWatchCycleCompletedPayload): string {
+    return this._emit('watchCycleCompleted', payload, 'public');
+  }
+
+  /**
+   * Emits a structured diagnostic alongside the existing legacy rendering.
+   */
+  public emitDiagnostic(diagnostic: IRushDiagnostic): string {
+    const classifications: ReadonlyArray<'public' | 'local-sensitive' | 'secret'> = diagnostic.parameters
+      ? Object.values(diagnostic.parameters).map((value) => value.privacy)
+      : [];
+    return this._emit('diagnosticEmitted', diagnostic, computeEnvelopePrivacyFloor(classifications));
+  }
+
+  private _emit(
+    type:
+      | 'sessionStarted'
+      | 'sessionCompleted'
+      | 'commandStarted'
+      | 'commandCompleted'
+      | 'operationRegistered'
+      | 'operationStatusChanged'
+      | 'commandResult'
+      | 'watchCycleCompleted'
+      | 'diagnosticEmitted',
+    payload: unknown,
+    privacy: 'public' | 'local-sensitive' | 'secret',
+    scopeOverride?: IReporterEventScope
+  ): string {
+    const scope: IReporterEventScope | undefined =
+      this._scope || scopeOverride ? { ...this._scope, ...scopeOverride } : undefined;
+    return this._sink.emit({
+      protocolVersion: this._protocolVersion,
+      sessionId: this._sessionId,
+      source: this._source,
+      scope,
+      privacy,
+      required: true,
+      type,
+      payload
+    });
+  }
+}

--- a/libraries/reporter/src/lifecycle/LifecycleEmitter.ts
+++ b/libraries/reporter/src/lifecycle/LifecycleEmitter.ts
@@ -149,7 +149,6 @@ export class LifecycleEmitter {
       source: this._source,
       scope,
       privacy,
-      required: true,
       type,
       payload
     });

--- a/libraries/reporter/src/lifecycle/LifecycleEvents.ts
+++ b/libraries/reporter/src/lifecycle/LifecycleEvents.ts
@@ -1,0 +1,174 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+/**
+ * The terminal or transient status of a scheduled operation.
+ *
+ * @beta
+ */
+export type OperationStatus =
+  | 'ready'
+  | 'executing'
+  | 'success'
+  | 'successWithWarnings'
+  | 'failure'
+  | 'blocked'
+  | 'skipped'
+  | 'fromCache'
+  | 'noOp';
+
+/**
+ * The payload of a `sessionStarted` event.
+ *
+ * @beta
+ */
+export interface ISessionStartedPayload {
+  /**
+   * The Rush version that started the session.
+   */
+  readonly rushVersion: string;
+
+  /**
+   * The working directory, when recorded.
+   */
+  readonly cwd?: string;
+}
+
+/**
+ * The payload of a `sessionCompleted` event.
+ *
+ * @beta
+ */
+export interface ISessionCompletedPayload {
+  /**
+   * The process exit code.
+   */
+  readonly exitCode: number;
+
+  /**
+   * The total session duration in milliseconds.
+   */
+  readonly durationMs?: number;
+}
+
+/**
+ * The payload of a `commandStarted` event.
+ *
+ * @beta
+ */
+export interface ICommandStartedPayload {
+  /**
+   * The command name.
+   */
+  readonly commandName: string;
+
+  /**
+   * The command arguments.
+   */
+  readonly argv?: readonly string[];
+}
+
+/**
+ * The payload of a `commandCompleted` event.
+ *
+ * @beta
+ */
+export interface ICommandCompletedPayload {
+  /**
+   * The command name.
+   */
+  readonly commandName: string;
+
+  /**
+   * The process exit code.
+   */
+  readonly exitCode: number;
+
+  /**
+   * The command duration in milliseconds.
+   */
+  readonly durationMs?: number;
+}
+
+/**
+ * The payload of an `operationRegistered` event.
+ *
+ * @beta
+ */
+export interface IOperationRegisteredPayload {
+  /**
+   * The operation id.
+   */
+  readonly operationId: string;
+
+  /**
+   * The project the operation belongs to.
+   */
+  readonly projectName?: string;
+
+  /**
+   * The phase the operation belongs to.
+   */
+  readonly phaseName?: string;
+}
+
+/**
+ * The payload of an `operationStatusChanged` event.
+ *
+ * @beta
+ */
+export interface IOperationStatusChangedPayload {
+  /**
+   * The operation id.
+   */
+  readonly operationId: string;
+
+  /**
+   * The new status.
+   */
+  readonly status: OperationStatus;
+}
+
+/**
+ * The payload of a `commandResult` event.
+ *
+ * @beta
+ */
+export interface ICommandResultPayload {
+  /**
+   * The command name.
+   */
+  readonly commandName: string;
+
+  /**
+   * Whether the command succeeded, including warning-only success.
+   */
+  readonly succeeded: boolean;
+
+  /**
+   * The process exit code.
+   */
+  readonly exitCode: number;
+
+  /**
+   * Operation counts keyed by status.
+   */
+  readonly operationCounts?: { readonly [status: string]: number };
+}
+
+/**
+ * The payload of a `watchCycleCompleted` event.
+ *
+ * @beta
+ */
+export interface IWatchCycleCompletedPayload {
+  /**
+   * Whether the watch cycle succeeded.
+   */
+  readonly succeeded: boolean;
+
+  /**
+   * The projects that changed to trigger the cycle.
+   */
+  readonly changedProjects?: readonly string[];
+}

--- a/libraries/reporter/src/lifecycle/ShadowParity.ts
+++ b/libraries/reporter/src/lifecycle/ShadowParity.ts
@@ -1,0 +1,103 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import type { IReporterEventEnvelope } from '../events/IReporterEventEnvelope';
+import type { ICommandResultPayload, IOperationStatusChangedPayload } from './LifecycleEvents';
+
+/**
+ * A shadow-phase summary derived from the structured event stream, used to
+ * validate parity with legacy behavior.
+ *
+ * @beta
+ */
+export interface IShadowResultSummary {
+  /**
+   * The command name, when a command result was present.
+   */
+  readonly commandName?: string;
+
+  /**
+   * Whether the command succeeded.
+   */
+  readonly succeeded: boolean;
+
+  /**
+   * The derived process exit code.
+   */
+  readonly exitCode: number;
+
+  /**
+   * The number of operations that reached each status.
+   */
+  readonly operationCounts: { readonly [status: string]: number };
+}
+
+/**
+ * Derives the process exit code from a structured event stream.
+ *
+ * @remarks
+ * This shadow-phase helper validates exit-code parity: a `commandResult` maps a
+ * successful command, including warning-only success, to `0` and a failure to
+ * its non-zero code. A `sessionCompleted` code is used as a fallback. The
+ * authoritative exit-code semantics are defined separately.
+ *
+ * @param events - the structured events emitted during the command
+ *
+ * @beta
+ */
+export function deriveExitCodeFromEvents(events: readonly IReporterEventEnvelope<unknown>[]): number {
+  for (const event of events) {
+    if (event.type === 'commandResult') {
+      const payload: ICommandResultPayload = event.payload as ICommandResultPayload;
+      if (payload.succeeded) {
+        return 0;
+      }
+      return payload.exitCode !== 0 ? payload.exitCode : 1;
+    }
+  }
+
+  for (const event of events) {
+    if (event.type === 'sessionCompleted') {
+      return (event.payload as { exitCode: number }).exitCode;
+    }
+  }
+
+  return 0;
+}
+
+/**
+ * Summarizes a command's structured event stream for parity validation.
+ *
+ * @remarks
+ * The returned counts and result are shadow-phase parity data, not the
+ * allowlisted telemetry projection.
+ *
+ * @param events - the structured events emitted during the command
+ *
+ * @beta
+ */
+export function summarizeShadowResult(
+  events: readonly IReporterEventEnvelope<unknown>[]
+): IShadowResultSummary {
+  const operationCounts: { [status: string]: number } = {};
+  let commandName: string | undefined;
+  let succeeded: boolean = true;
+
+  for (const event of events) {
+    if (event.type === 'operationStatusChanged') {
+      const payload: IOperationStatusChangedPayload = event.payload as IOperationStatusChangedPayload;
+      operationCounts[payload.status] = (operationCounts[payload.status] ?? 0) + 1;
+    } else if (event.type === 'commandResult') {
+      const payload: ICommandResultPayload = event.payload as ICommandResultPayload;
+      commandName = payload.commandName;
+      succeeded = payload.succeeded;
+    }
+  }
+
+  return {
+    commandName,
+    succeeded,
+    exitCode: deriveExitCodeFromEvents(events),
+    operationCounts
+  };
+}

--- a/libraries/reporter/src/session/PluginApi.ts
+++ b/libraries/reporter/src/session/PluginApi.ts
@@ -1,0 +1,79 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import type { IRushDiagnostic } from '../diagnostics/IRushDiagnostic';
+import { createRushDiagnostic } from '../diagnostics/createRushDiagnostic';
+
+/**
+ * The Rush plugin API version this package implements.
+ *
+ * @remarks
+ * A plugin manifest declares the plugin API version it targets. Compatibility is
+ * gated on the major version.
+ *
+ * @beta
+ */
+export const RUSH_PLUGIN_API_VERSION: '1.0.0' = '1.0.0';
+
+/**
+ * The reporting-relevant fields of a Rush plugin manifest.
+ *
+ * @beta
+ */
+export interface IRushPluginManifest {
+  /**
+   * The plugin's name.
+   */
+  readonly pluginName: string;
+
+  /**
+   * The Rush plugin API version the plugin targets, for example `1.0.0`.
+   */
+  readonly pluginApiVersion: string;
+}
+
+function majorOf(version: string): number {
+  return Number.parseInt(version.split('.')[0], 10);
+}
+
+/**
+ * Returns `true` if a plugin's declared API version is supported.
+ *
+ * @remarks
+ * Compatibility requires an equal major version.
+ *
+ * @param declaredApiVersion - the version declared by the plugin manifest
+ * @param supportedApiVersion - the version supported by Rush; defaults to
+ * {@link RUSH_PLUGIN_API_VERSION}
+ *
+ * @beta
+ */
+export function isPluginApiVersionSupported(
+  declaredApiVersion: string,
+  supportedApiVersion: string = RUSH_PLUGIN_API_VERSION
+): boolean {
+  const declaredMajor: number = majorOf(declaredApiVersion);
+  const supportedMajor: number = majorOf(supportedApiVersion);
+  return Number.isFinite(declaredMajor) && declaredMajor === supportedMajor;
+}
+
+/**
+ * Creates the structured migration diagnostic for an incompatible plugin.
+ *
+ * @remarks
+ * An incompatible plugin fails before its `apply()` runs. This diagnostic is
+ * emitted at that boundary.
+ *
+ * @param manifest - the incompatible plugin's manifest
+ *
+ * @beta
+ */
+export function createPluginApiIncompatibleDiagnostic(manifest: IRushPluginManifest): IRushDiagnostic {
+  return createRushDiagnostic('RUSH_PLUGIN_API_INCOMPATIBLE', {
+    parameters: {
+      pluginName: { value: manifest.pluginName, privacy: 'public' },
+      declaredApiVersion: { value: manifest.pluginApiVersion, privacy: 'public' },
+      supportedApiVersion: { value: RUSH_PLUGIN_API_VERSION, privacy: 'public' }
+    }
+  });
+}

--- a/libraries/reporter/src/session/RushSessionReporting.ts
+++ b/libraries/reporter/src/session/RushSessionReporting.ts
@@ -1,0 +1,120 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import type { IReporterProtocolVersion } from '../events/ReporterProtocolVersion';
+import type { IReporterEventScope, IReporterEventSource } from '../events/IReporterEventEnvelope';
+import type { IReporterEventSink } from '../producers/IReporterEventSink';
+import type { IScopedReporter } from '../producers/IScopedReporter';
+import { createScopedReporter } from './ScopedReporterFactory';
+import { createScopedLogger, type IScopedLogger } from './ScopedLogger';
+
+/**
+ * Options for constructing a {@link RushSessionReporting}.
+ *
+ * @beta
+ */
+export interface IRushSessionReportingOptions {
+  /**
+   * The sink events are emitted into.
+   */
+  readonly sink: IReporterEventSink;
+
+  /**
+   * The session id stamped onto emitted events.
+   */
+  readonly sessionId: string;
+
+  /**
+   * The producer identity stamped onto emitted events.
+   */
+  readonly source: IReporterEventSource;
+
+  /**
+   * The protocol version stamped onto emitted events.
+   */
+  readonly protocolVersion?: IReporterProtocolVersion;
+}
+
+/**
+ * The reporting context handed to an action.
+ *
+ * @remarks
+ * Actions receive both the raw sink and a scoped reporter through their
+ * execution context. Neither exposes reporter instances, destinations, modes, or
+ * thresholds.
+ *
+ * @beta
+ */
+export interface IReporterExecutionContext {
+  /**
+   * The sink the action may emit into directly.
+   */
+  readonly sink: IReporterEventSink;
+
+  /**
+   * A scoped reporter bound to the action's scope.
+   */
+  readonly reporter: IScopedReporter;
+}
+
+/**
+ * The reporting surface exposed by `RushSession` to actions and plugins.
+ *
+ * @remarks
+ * `RushSession` composes this to create scoped reporters and loggers. Plugins
+ * receive scoped reporters and loggers only, so they cannot inspect active
+ * modes, destinations, or thresholds. Actions additionally receive the sink
+ * through an execution context.
+ *
+ * @beta
+ */
+export class RushSessionReporting {
+  private readonly _sink: IReporterEventSink;
+  private readonly _sessionId: string;
+  private readonly _source: IReporterEventSource;
+  private readonly _protocolVersion: IReporterProtocolVersion | undefined;
+
+  public constructor(options: IRushSessionReportingOptions) {
+    this._sink = options.sink;
+    this._sessionId = options.sessionId;
+    this._source = options.source;
+    this._protocolVersion = options.protocolVersion;
+  }
+
+  /**
+   * Creates a scoped reporter bound to the given scope.
+   */
+  public createScopedReporter(scope?: IReporterEventScope): IScopedReporter {
+    return createScopedReporter({
+      sink: this._sink,
+      sessionId: this._sessionId,
+      source: this._source,
+      scope,
+      protocolVersion: this._protocolVersion
+    });
+  }
+
+  /**
+   * Creates a scoped logger bound to the given scope.
+   */
+  public createScopedLogger(scope?: IReporterEventScope): IScopedLogger {
+    return createScopedLogger(this.createScopedReporter(scope));
+  }
+
+  /**
+   * Returns the raw sink handed to actions through the execution context.
+   */
+  public getSink(): IReporterEventSink {
+    return this._sink;
+  }
+
+  /**
+   * Creates the execution context an action receives.
+   */
+  public createExecutionContext(scope?: IReporterEventScope): IReporterExecutionContext {
+    return {
+      sink: this._sink,
+      reporter: this.createScopedReporter(scope)
+    };
+  }
+}

--- a/libraries/reporter/src/session/ScopedLogger.ts
+++ b/libraries/reporter/src/session/ScopedLogger.ts
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import type { IScopedReporter } from '../producers/IScopedReporter';
+
+/**
+ * A minimal, presentation-free logger backed by a scoped reporter.
+ *
+ * @remarks
+ * This replaces the terminal-coupled `ILogger`. It exposes no `terminal` or
+ * terminal-provider handle; every method emits a structured message through the
+ * scoped reporter and returns the assigned event id.
+ *
+ * @beta
+ */
+export interface IScopedLogger {
+  /**
+   * Emits an informational message.
+   */
+  writeLine(text: string): string;
+
+  /**
+   * Emits a debug message.
+   */
+  writeDebugLine(text: string): string;
+
+  /**
+   * Emits a warning message.
+   */
+  writeWarningLine(text: string): string;
+
+  /**
+   * Emits an error message.
+   */
+  writeErrorLine(text: string): string;
+}
+
+/**
+ * Creates a scoped logger that forwards to a scoped reporter.
+ *
+ * @param reporter - the scoped reporter that receives the messages
+ *
+ * @beta
+ */
+export function createScopedLogger(reporter: IScopedReporter): IScopedLogger {
+  return {
+    writeLine(text: string): string {
+      return reporter.emitMessage({ severity: 'info', text });
+    },
+    writeDebugLine(text: string): string {
+      return reporter.emitMessage({ severity: 'debug', text });
+    },
+    writeWarningLine(text: string): string {
+      return reporter.emitMessage({ severity: 'warning', text });
+    },
+    writeErrorLine(text: string): string {
+      return reporter.emitMessage({ severity: 'error', text });
+    }
+  };
+}

--- a/libraries/reporter/src/session/ScopedReporterFactory.ts
+++ b/libraries/reporter/src/session/ScopedReporterFactory.ts
@@ -1,0 +1,114 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import type { IReporterProtocolVersion } from '../events/ReporterProtocolVersion';
+import type { IReporterEventScope, IReporterEventSource } from '../events/IReporterEventEnvelope';
+import type { IReporterEventSink } from '../producers/IReporterEventSink';
+import type { IScopedReporter, IScopedMessageOptions } from '../producers/IScopedReporter';
+import { isReporterExtensionEventName } from '../producers/ReporterExtensionEventName';
+import type { IRushDiagnostic } from '../diagnostics/IRushDiagnostic';
+import { computeEnvelopePrivacyFloor } from '../diagnostics/DiagnosticPrivacy';
+import { REPORTER_PROTOCOL_VERSION } from '../protocol/ReporterProtocol';
+
+/**
+ * Options for {@link createScopedReporter}.
+ *
+ * @beta
+ */
+export interface ICreateScopedReporterOptions {
+  /**
+   * The sink events are emitted into.
+   */
+  readonly sink: IReporterEventSink;
+
+  /**
+   * The session id stamped onto emitted events.
+   */
+  readonly sessionId: string;
+
+  /**
+   * The producer identity stamped onto emitted events.
+   */
+  readonly source: IReporterEventSource;
+
+  /**
+   * The scope bound to every emitted event.
+   */
+  readonly scope?: IReporterEventScope;
+
+  /**
+   * The protocol version stamped onto emitted events. Defaults to
+   * {@link REPORTER_PROTOCOL_VERSION}.
+   */
+  readonly protocolVersion?: IReporterProtocolVersion;
+}
+
+/**
+ * Creates a scoped reporter bound to a scope and backed by a sink.
+ *
+ * @remarks
+ * The returned reporter exposes only emit methods. It never exposes reporter
+ * instances, destinations, active modes, or thresholds, so producers and plugins
+ * cannot inspect them. Human messages are carried on the `activityChanged`
+ * channel; warning and error messages are marked required so they are never
+ * coalesced.
+ *
+ * @param options - the sink, identity, and scope to bind
+ *
+ * @beta
+ */
+export function createScopedReporter(options: ICreateScopedReporterOptions): IScopedReporter {
+  const protocolVersion: IReporterProtocolVersion = options.protocolVersion ?? REPORTER_PROTOCOL_VERSION;
+  const sink: IReporterEventSink = options.sink;
+  const sessionId: string = options.sessionId;
+  const source: IReporterEventSource = options.source;
+  const scope: IReporterEventScope | undefined = options.scope;
+
+  return {
+    emitMessage(messageOptions: IScopedMessageOptions): string {
+      const required: boolean = messageOptions.severity === 'warning' || messageOptions.severity === 'error';
+      return sink.emit({
+        protocolVersion,
+        sessionId,
+        source,
+        scope,
+        privacy: messageOptions.privacy ?? 'public',
+        required,
+        type: 'activityChanged',
+        payload: { kind: 'message', severity: messageOptions.severity, text: messageOptions.text }
+      });
+    },
+
+    emitDiagnostic(diagnostic: IRushDiagnostic): string {
+      const classifications: ReadonlyArray<'public' | 'local-sensitive' | 'secret'> = diagnostic.parameters
+        ? Object.values(diagnostic.parameters).map((value) => value.privacy)
+        : [];
+      return sink.emit({
+        protocolVersion,
+        sessionId,
+        source,
+        scope,
+        privacy: computeEnvelopePrivacyFloor(classifications),
+        required: diagnostic.severity === 'error',
+        type: 'diagnosticEmitted',
+        payload: diagnostic
+      });
+    },
+
+    emitExtension<TPayload>(name: string, payload: TPayload): string {
+      if (!isReporterExtensionEventName(name)) {
+        throw new Error(`Invalid extension event name: ${JSON.stringify(name)}`);
+      }
+      return sink.emit({
+        protocolVersion,
+        sessionId,
+        source,
+        scope,
+        privacy: 'public',
+        required: false,
+        type: 'extension',
+        payload: { name, payload }
+      });
+    }
+  };
+}

--- a/libraries/reporter/src/session/ScopedReporterFactory.ts
+++ b/libraries/reporter/src/session/ScopedReporterFactory.ts
@@ -66,16 +66,15 @@ export function createScopedReporter(options: ICreateScopedReporterOptions): ISc
 
   return {
     emitMessage(messageOptions: IScopedMessageOptions): string {
-      const required: boolean = messageOptions.severity === 'warning' || messageOptions.severity === 'error';
       return sink.emit({
         protocolVersion,
         sessionId,
         source,
         scope,
-        privacy: messageOptions.privacy ?? 'public',
-        required,
-        type: 'activityChanged',
-        payload: { kind: 'message', severity: messageOptions.severity, text: messageOptions.text }
+        // Message text fails safe at local-sensitive by default.
+        privacy: messageOptions.privacy ?? 'local-sensitive',
+        type: 'messageEmitted',
+        payload: { severity: messageOptions.severity, text: messageOptions.text }
       });
     },
 
@@ -89,7 +88,6 @@ export function createScopedReporter(options: ICreateScopedReporterOptions): ISc
         source,
         scope,
         privacy: computeEnvelopePrivacyFloor(classifications),
-        required: diagnostic.severity === 'error',
         type: 'diagnosticEmitted',
         payload: diagnostic
       });
@@ -105,7 +103,6 @@ export function createScopedReporter(options: ICreateScopedReporterOptions): ISc
         source,
         scope,
         privacy: 'public',
-        required: false,
         type: 'extension',
         payload: { name, payload }
       });

--- a/libraries/reporter/src/telemetry/BeforeLogAdapter.ts
+++ b/libraries/reporter/src/telemetry/BeforeLogAdapter.ts
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import type { ITelemetryAggregate } from './TelemetryAggregate';
+
+/**
+ * The legacy `beforeLog` telemetry hook signature.
+ *
+ * @remarks
+ * Existing telemetry consumers register a `beforeLog` hook that runs with the
+ * telemetry record before it is written. The hook receives a plain object.
+ *
+ * @beta
+ */
+export type LegacyBeforeLogHook = (telemetry: Record<string, unknown>) => void;
+
+/**
+ * Adapts the allowlisted telemetry aggregate to the legacy `beforeLog` hook.
+ *
+ * @remarks
+ * During migration the existing `beforeLog` hook is preserved: the adapter runs
+ * each legacy hook with a plain-object copy of the new aggregate, so no hook
+ * observes non-allowlisted data.
+ *
+ * @param hooks - the legacy hooks to preserve
+ *
+ * @beta
+ */
+export function createBeforeLogAdapter(
+  hooks: readonly LegacyBeforeLogHook[]
+): (aggregate: ITelemetryAggregate) => void {
+  return (aggregate: ITelemetryAggregate): void => {
+    const record: Record<string, unknown> = { ...aggregate };
+    for (const hook of hooks) {
+      hook(record);
+    }
+  };
+}

--- a/libraries/reporter/src/telemetry/TelemetryAggregate.ts
+++ b/libraries/reporter/src/telemetry/TelemetryAggregate.ts
@@ -1,0 +1,94 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import type { IReporterProtocolVersion } from '../events/ReporterProtocolVersion';
+
+/**
+ * The command result recorded by telemetry.
+ *
+ * @beta
+ */
+export type TelemetryResult = 'succeeded' | 'failed';
+
+/**
+ * The allowlisted telemetry aggregate produced at command completion.
+ *
+ * @remarks
+ * Only these fields ever leave the machine. Messages, templates, paths, raw
+ * stdout/stderr, command arguments, remediation parameters, stack traces, and
+ * any local-sensitive or secret values are excluded by construction.
+ *
+ * @beta
+ */
+export interface ITelemetryAggregate {
+  /**
+   * The command name.
+   */
+  readonly commandName?: string;
+
+  /**
+   * Whether the command succeeded or failed.
+   */
+  readonly result?: TelemetryResult;
+
+  /**
+   * The process exit code.
+   */
+  readonly exitCode?: number;
+
+  /**
+   * The command or session duration in milliseconds.
+   */
+  readonly durationMs?: number;
+
+  /**
+   * The number of operations that reached each status.
+   */
+  readonly operationStatusCounts: { readonly [status: string]: number };
+
+  /**
+   * The distinct diagnostic codes emitted, sorted.
+   */
+  readonly diagnosticCodes: readonly string[];
+
+  /**
+   * The number of diagnostics emitted in each category.
+   */
+  readonly diagnosticCategoryCounts: { readonly [category: string]: number };
+
+  /**
+   * The selected reporter mode.
+   */
+  readonly reporterMode?: string;
+
+  /**
+   * The reporter protocol version.
+   */
+  readonly protocolVersion?: IReporterProtocolVersion;
+
+  /**
+   * The distinct `packageName@packageVersion` producers observed, sorted.
+   */
+  readonly producerVersions: readonly string[];
+}
+
+/**
+ * The complete set of allowlisted telemetry aggregate keys.
+ *
+ * @remarks
+ * Used to assert that no non-allowlisted field ever appears in the aggregate.
+ *
+ * @beta
+ */
+export const TELEMETRY_AGGREGATE_KEYS: readonly string[] = [
+  'commandName',
+  'result',
+  'exitCode',
+  'durationMs',
+  'operationStatusCounts',
+  'diagnosticCodes',
+  'diagnosticCategoryCounts',
+  'reporterMode',
+  'protocolVersion',
+  'producerVersions'
+];

--- a/libraries/reporter/src/telemetry/TelemetrySubscriber.ts
+++ b/libraries/reporter/src/telemetry/TelemetrySubscriber.ts
@@ -1,0 +1,190 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import type { IReporterProtocolVersion } from '../events/ReporterProtocolVersion';
+import type { IReporterEventEnvelope } from '../events/IReporterEventEnvelope';
+import type { IReporter } from '../manager/IReporter';
+import type { ITelemetryAggregate, TelemetryResult } from './TelemetryAggregate';
+
+/**
+ * Consumes canonical events and produces the allowlisted telemetry aggregate.
+ *
+ * @remarks
+ * The subscriber runs before reporter filtering, so it observes every event. It
+ * extracts only allowlisted values: from a diagnostic it keeps the code and
+ * category but never the parameters, remediation, or templates; it ignores
+ * messages, raw external output, and command arguments entirely.
+ *
+ * @beta
+ */
+export class TelemetrySubscriber {
+  private _commandName: string | undefined;
+  private _result: TelemetryResult | undefined;
+  private _exitCode: number | undefined;
+  private _durationMs: number | undefined;
+  private _reporterMode: string | undefined;
+  private _protocolVersion: IReporterProtocolVersion | undefined;
+  private readonly _operationStatusCounts: { [status: string]: number };
+  private readonly _diagnosticCategoryCounts: { [category: string]: number };
+  private readonly _diagnosticCodes: Set<string>;
+  private readonly _producerVersions: Set<string>;
+
+  public constructor() {
+    this._operationStatusCounts = {};
+    this._diagnosticCategoryCounts = {};
+    this._diagnosticCodes = new Set();
+    this._producerVersions = new Set();
+  }
+
+  /**
+   * Records the selected reporter mode.
+   */
+  public setReporterMode(reporterMode: string): void {
+    this._reporterMode = reporterMode;
+  }
+
+  /**
+   * Ingests one event, extracting only allowlisted values.
+   */
+  public ingest(event: IReporterEventEnvelope<unknown>): void {
+    this._protocolVersion = event.protocolVersion;
+    this._producerVersions.add(`${event.source.packageName}@${event.source.packageVersion}`);
+
+    switch (event.type) {
+      case 'commandStarted': {
+        // Deliberately ignores argv.
+        this._commandName = (event.payload as { commandName: string }).commandName;
+        break;
+      }
+      case 'commandResult': {
+        const payload: { commandName: string; succeeded: boolean; exitCode: number } = event.payload as {
+          commandName: string;
+          succeeded: boolean;
+          exitCode: number;
+        };
+        this._commandName = payload.commandName;
+        this._result = payload.succeeded ? 'succeeded' : 'failed';
+        this._exitCode = payload.exitCode;
+        break;
+      }
+      case 'commandCompleted': {
+        const payload: { durationMs?: number } = event.payload as { durationMs?: number };
+        if (payload.durationMs !== undefined) {
+          this._durationMs = payload.durationMs;
+        }
+        break;
+      }
+      case 'sessionCompleted': {
+        const payload: { exitCode: number; durationMs?: number } = event.payload as {
+          exitCode: number;
+          durationMs?: number;
+        };
+        if (this._exitCode === undefined) {
+          this._exitCode = payload.exitCode;
+        }
+        if (payload.durationMs !== undefined) {
+          this._durationMs = payload.durationMs;
+        }
+        break;
+      }
+      case 'operationStatusChanged': {
+        const status: string = (event.payload as { status: string }).status;
+        this._operationStatusCounts[status] = (this._operationStatusCounts[status] ?? 0) + 1;
+        break;
+      }
+      case 'diagnosticEmitted': {
+        // Keeps only the code and category, never parameters, remediation, or templates.
+        const payload: { code?: string; category?: string } = event.payload as {
+          code?: string;
+          category?: string;
+        };
+        if (payload.code !== undefined) {
+          this._diagnosticCodes.add(payload.code);
+        }
+        if (payload.category !== undefined) {
+          this._diagnosticCategoryCounts[payload.category] =
+            (this._diagnosticCategoryCounts[payload.category] ?? 0) + 1;
+        }
+        break;
+      }
+      default: {
+        // Messages, raw external output, artifacts, and extension events are not
+        // telemetry.
+        break;
+      }
+    }
+  }
+
+  /**
+   * Builds the allowlisted aggregate.
+   */
+  public buildAggregate(): ITelemetryAggregate {
+    const aggregate: {
+      commandName?: string;
+      result?: TelemetryResult;
+      exitCode?: number;
+      durationMs?: number;
+      operationStatusCounts: { [status: string]: number };
+      diagnosticCodes: string[];
+      diagnosticCategoryCounts: { [category: string]: number };
+      reporterMode?: string;
+      protocolVersion?: IReporterProtocolVersion;
+      producerVersions: string[];
+    } = {
+      operationStatusCounts: { ...this._operationStatusCounts },
+      diagnosticCodes: [...this._diagnosticCodes].sort(),
+      diagnosticCategoryCounts: { ...this._diagnosticCategoryCounts },
+      producerVersions: [...this._producerVersions].sort()
+    };
+
+    if (this._commandName !== undefined) {
+      aggregate.commandName = this._commandName;
+    }
+    if (this._result !== undefined) {
+      aggregate.result = this._result;
+    }
+    if (this._exitCode !== undefined) {
+      aggregate.exitCode = this._exitCode;
+    }
+    if (this._durationMs !== undefined) {
+      aggregate.durationMs = this._durationMs;
+    }
+    if (this._reporterMode !== undefined) {
+      aggregate.reporterMode = this._reporterMode;
+    }
+    if (this._protocolVersion !== undefined) {
+      aggregate.protocolVersion = this._protocolVersion;
+    }
+
+    return aggregate;
+  }
+}
+
+/**
+ * Wraps a telemetry subscriber as a reporter so it can be registered with the
+ * manager and observe every event before reporter filtering.
+ *
+ * @remarks
+ * The returned reporter owns no destination and renders nothing.
+ *
+ * @param subscriber - the telemetry subscriber to feed
+ *
+ * @beta
+ */
+export function createTelemetryReporter(subscriber: TelemetrySubscriber): IReporter {
+  return {
+    name: 'telemetry',
+    async initializeAsync(): Promise<void> {
+      /* no-op */
+    },
+    report(event: IReporterEventEnvelope<unknown>): void {
+      subscriber.ingest(event);
+    },
+    async flushAsync(): Promise<void> {
+      /* no-op */
+    },
+    async closeAsync(): Promise<void> {
+      /* no-op */
+    }
+  };
+}

--- a/libraries/reporter/src/test/ExitStatus.test.ts
+++ b/libraries/reporter/src/test/ExitStatus.test.ts
@@ -1,0 +1,130 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import {
+  resolveExitStatus,
+  resolveExitStatusFromEvents,
+  getSignalExitCode,
+  separateJsonControls,
+  EXIT_CODE_SUCCESS,
+  EXIT_CODE_FAILURE,
+  type IJsonControls,
+  type IReporterEventEnvelope,
+  type IRushExitStatus
+} from '../index';
+
+function ev(type: string, payload: unknown): IReporterEventEnvelope<unknown> {
+  return { type, payload } as unknown as IReporterEventEnvelope<unknown>;
+}
+
+describe('resolveExitStatus', () => {
+  it('returns success for a clean run', () => {
+    expect(resolveExitStatus({})).toEqual({ exitCode: EXIT_CODE_SUCCESS, outcome: 'succeeded' });
+  });
+
+  it('treats warning-only success as success', () => {
+    // Warnings are not failures, so hasFailures stays false.
+    expect(resolveExitStatus({ hasFailures: false }).exitCode).toBe(0);
+  });
+
+  it('returns failure for failures and for logical cancellation', () => {
+    expect(resolveExitStatus({ hasFailures: true })).toEqual({
+      exitCode: EXIT_CODE_FAILURE,
+      outcome: 'failed'
+    });
+    expect(resolveExitStatus({ cancelled: true })).toEqual({
+      exitCode: EXIT_CODE_FAILURE,
+      outcome: 'cancelled'
+    });
+  });
+
+  it('returns the signal-derived status, which takes precedence over failures', () => {
+    const status: IRushExitStatus = resolveExitStatus({ hasFailures: true, signal: 'SIGINT' });
+    expect(status.outcome).toBe('signal');
+    expect(status.signal).toBe('SIGINT');
+    expect(status.exitCode).toBe(130);
+  });
+});
+
+describe('getSignalExitCode', () => {
+  it('uses the conventional 128 + signal number', () => {
+    expect(getSignalExitCode('SIGINT')).toBe(130);
+    expect(getSignalExitCode('SIGTERM')).toBe(143);
+  });
+});
+
+describe('resolveExitStatusFromEvents', () => {
+  it('maps warning-only diagnostics with a successful result to success', () => {
+    const status: IRushExitStatus = resolveExitStatusFromEvents([
+      ev('diagnosticEmitted', { code: 'RUSH_X', category: 'operation', severity: 'warning' }),
+      ev('commandResult', { commandName: 'build', succeeded: true, exitCode: 0 })
+    ]);
+    expect(status.exitCode).toBe(0);
+    expect(status.outcome).toBe('succeeded');
+  });
+
+  it('fails on an error diagnostic, a failed operation, or a failed result', () => {
+    expect(
+      resolveExitStatusFromEvents([
+        ev('diagnosticEmitted', { code: 'E', category: 'internal', severity: 'error' })
+      ]).exitCode
+    ).toBe(1);
+    expect(
+      resolveExitStatusFromEvents([ev('operationStatusChanged', { operationId: 'a', status: 'failure' })])
+        .exitCode
+    ).toBe(1);
+    expect(
+      resolveExitStatusFromEvents([ev('commandResult', { commandName: 'b', succeeded: false, exitCode: 1 })])
+        .exitCode
+    ).toBe(1);
+  });
+
+  it('never lets the diagnostic category select the exit code', () => {
+    const errorInternal: number = resolveExitStatusFromEvents([
+      ev('diagnosticEmitted', { code: 'A', category: 'internal', severity: 'error' })
+    ]).exitCode;
+    const errorConfig: number = resolveExitStatusFromEvents([
+      ev('diagnosticEmitted', { code: 'B', category: 'configuration', severity: 'error' })
+    ]).exitCode;
+    expect(errorInternal).toBe(errorConfig);
+
+    const warnInternal: number = resolveExitStatusFromEvents([
+      ev('diagnosticEmitted', { code: 'C', category: 'internal', severity: 'warning' })
+    ]).exitCode;
+    const warnConfig: number = resolveExitStatusFromEvents([
+      ev('diagnosticEmitted', { code: 'D', category: 'network-auth', severity: 'warning' })
+    ]).exitCode;
+    expect(warnInternal).toBe(0);
+    expect(warnConfig).toBe(0);
+  });
+
+  it('honors cancellation and signal state', () => {
+    expect(resolveExitStatusFromEvents([], { cancelled: true }).outcome).toBe('cancelled');
+    expect(resolveExitStatusFromEvents([], { signal: 'SIGTERM' }).exitCode).toBe(143);
+  });
+});
+
+describe('separateJsonControls', () => {
+  it('keeps command-specific --json separate from the json reporter', () => {
+    expect(separateJsonControls(['list', '--json'])).toEqual<IJsonControls>({
+      commandJson: true,
+      reporterJson: false
+    });
+    expect(separateJsonControls(['build', '--reporter=json'])).toEqual<IJsonControls>({
+      commandJson: false,
+      reporterJson: true
+    });
+    expect(separateJsonControls(['build', '--reporter', 'json'])).toEqual<IJsonControls>({
+      commandJson: false,
+      reporterJson: true
+    });
+    expect(separateJsonControls(['list', '--json', '--reporter=json'])).toEqual<IJsonControls>({
+      commandJson: true,
+      reporterJson: true
+    });
+    expect(separateJsonControls(['build'])).toEqual<IJsonControls>({
+      commandJson: false,
+      reporterJson: false
+    });
+  });
+});

--- a/libraries/reporter/src/test/Lifecycle.test.ts
+++ b/libraries/reporter/src/test/Lifecycle.test.ts
@@ -1,0 +1,178 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import {
+  LifecycleEmitter,
+  deriveExitCodeFromEvents,
+  summarizeShadowResult,
+  createRushDiagnostic,
+  ReporterManager,
+  type IReporter,
+  type IReporterEventEnvelope,
+  type IReporterEventSink,
+  type IReporterEventSource,
+  type IShadowResultSummary
+} from '../index';
+
+class CapturingSink implements IReporterEventSink {
+  public readonly inputs: Record<string, unknown>[] = [];
+
+  public emit(event: Record<string, unknown>): string {
+    this.inputs.push(event);
+    return `evt_${this.inputs.length}`;
+  }
+}
+
+class RecordingReporter implements IReporter {
+  public readonly name: string = 'recording';
+  public readonly reported: IReporterEventEnvelope<unknown>[] = [];
+
+  public async initializeAsync(): Promise<void> {
+    /* no-op */
+  }
+
+  public report(event: IReporterEventEnvelope<unknown>): void {
+    this.reported.push(event);
+  }
+
+  public async flushAsync(): Promise<void> {
+    /* no-op */
+  }
+
+  public async closeAsync(): Promise<void> {
+    /* no-op */
+  }
+}
+
+const SOURCE: IReporterEventSource = { packageName: '@microsoft/rush-lib', packageVersion: '5.177.2' };
+
+function ev(type: string, payload: unknown): IReporterEventEnvelope<unknown> {
+  return { type, payload } as unknown as IReporterEventEnvelope<unknown>;
+}
+
+describe('LifecycleEmitter', () => {
+  it('emits required lifecycle events with merged scope', () => {
+    const sink: CapturingSink = new CapturingSink();
+    const emitter: LifecycleEmitter = new LifecycleEmitter({
+      sink,
+      sessionId: 'sess',
+      source: SOURCE,
+      scope: { commandName: 'build' }
+    });
+
+    emitter.emitOperationRegistered({ operationId: 'op1', projectName: 'p', phaseName: '_phase:build' });
+
+    expect(sink.inputs[0].type).toBe('operationRegistered');
+    expect(sink.inputs[0].required).toBe(true);
+    expect(sink.inputs[0].scope).toEqual({
+      commandName: 'build',
+      operationId: 'op1',
+      projectName: 'p',
+      phaseName: '_phase:build'
+    });
+  });
+
+  it('emits diagnostics on the diagnosticEmitted channel with the privacy floor', () => {
+    const sink: CapturingSink = new CapturingSink();
+    const emitter: LifecycleEmitter = new LifecycleEmitter({ sink, sessionId: 'sess', source: SOURCE });
+    emitter.emitDiagnostic(
+      createRushDiagnostic('RUSH_OPERATION_FAILED', {
+        parameters: { logPath: { value: '/tmp/x.log', privacy: 'local-sensitive' } }
+      })
+    );
+    expect(sink.inputs[0].type).toBe('diagnosticEmitted');
+    expect(sink.inputs[0].privacy).toBe('local-sensitive');
+    expect(sink.inputs[0].required).toBe(true);
+  });
+
+  it('writes nothing to stdout or stderr while events flow (shadow mode)', () => {
+    const stdoutSpy: jest.SpyInstance = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    const stderrSpy: jest.SpyInstance = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      const sink: CapturingSink = new CapturingSink();
+      const emitter: LifecycleEmitter = new LifecycleEmitter({ sink, sessionId: 'sess', source: SOURCE });
+      emitter.emitSessionStarted({ rushVersion: '5.177.2' });
+      emitter.emitCommandStarted({ commandName: 'build' });
+      emitter.emitDiagnostic(createRushDiagnostic('RUSH_OPERATION_FAILED'));
+      emitter.emitCommandResult({ commandName: 'build', succeeded: true, exitCode: 0 });
+      emitter.emitSessionCompleted({ exitCode: 0 });
+
+      expect(sink.inputs).toHaveLength(5);
+      expect(stdoutSpy).not.toHaveBeenCalled();
+      expect(stderrSpy).not.toHaveBeenCalled();
+    } finally {
+      stdoutSpy.mockRestore();
+      stderrSpy.mockRestore();
+    }
+  });
+});
+
+describe('deriveExitCodeFromEvents', () => {
+  it('maps a successful command, including warning-only success, to zero', () => {
+    expect(
+      deriveExitCodeFromEvents([
+        ev('operationStatusChanged', { operationId: 'op1', status: 'successWithWarnings' }),
+        ev('commandResult', { commandName: 'build', succeeded: true, exitCode: 0 })
+      ])
+    ).toBe(0);
+  });
+
+  it('maps a failed command to its non-zero exit code', () => {
+    expect(
+      deriveExitCodeFromEvents([ev('commandResult', { commandName: 'build', succeeded: false, exitCode: 1 })])
+    ).toBe(1);
+  });
+
+  it('falls back to the sessionCompleted exit code', () => {
+    expect(deriveExitCodeFromEvents([ev('sessionCompleted', { exitCode: 1 })])).toBe(1);
+  });
+
+  it('defaults to zero when no result is present', () => {
+    expect(deriveExitCodeFromEvents([ev('commandStarted', { commandName: 'build' })])).toBe(0);
+  });
+});
+
+describe('summarizeShadowResult', () => {
+  it('aggregates operation statuses and the command result', () => {
+    const summary: IShadowResultSummary = summarizeShadowResult([
+      ev('operationStatusChanged', { operationId: 'a', status: 'success' }),
+      ev('operationStatusChanged', { operationId: 'b', status: 'success' }),
+      ev('operationStatusChanged', { operationId: 'c', status: 'fromCache' }),
+      ev('operationStatusChanged', { operationId: 'd', status: 'failure' }),
+      ev('commandResult', { commandName: 'build', succeeded: false, exitCode: 1 })
+    ]);
+
+    expect(summary.commandName).toBe('build');
+    expect(summary.succeeded).toBe(false);
+    expect(summary.exitCode).toBe(1);
+    expect(summary.operationCounts).toEqual({ success: 2, fromCache: 1, failure: 1 });
+  });
+});
+
+describe('shadow emission parity through the manager', () => {
+  it('reproduces the exit code and result summary from delivered events', async () => {
+    const manager: ReporterManager = new ReporterManager();
+    const reporter: RecordingReporter = new RecordingReporter();
+    manager.addReporter(reporter);
+    await manager.initializeAsync();
+
+    const emitter: LifecycleEmitter = new LifecycleEmitter({
+      sink: manager,
+      sessionId: 'sess',
+      source: SOURCE,
+      scope: { commandName: 'build' }
+    });
+
+    emitter.emitSessionStarted({ rushVersion: '5.177.2' });
+    emitter.emitCommandStarted({ commandName: 'build' });
+    emitter.emitOperationStatusChanged({ operationId: 'op1', status: 'success' });
+    emitter.emitCommandResult({ commandName: 'build', succeeded: true, exitCode: 0 });
+    emitter.emitSessionCompleted({ exitCode: 0 });
+    await manager.flushAsync();
+
+    expect(deriveExitCodeFromEvents(reporter.reported)).toBe(0);
+    const summary: IShadowResultSummary = summarizeShadowResult(reporter.reported);
+    expect(summary.succeeded).toBe(true);
+    expect(summary.operationCounts).toEqual({ success: 1 });
+  });
+});

--- a/libraries/reporter/src/test/Lifecycle.test.ts
+++ b/libraries/reporter/src/test/Lifecycle.test.ts
@@ -7,6 +7,7 @@ import {
   summarizeShadowResult,
   createRushDiagnostic,
   ReporterManager,
+  isReporterEventRequired,
   type IReporter,
   type IReporterEventEnvelope,
   type IReporterEventSink,
@@ -63,7 +64,8 @@ describe('LifecycleEmitter', () => {
     emitter.emitOperationRegistered({ operationId: 'op1', projectName: 'p', phaseName: '_phase:build' });
 
     expect(sink.inputs[0].type).toBe('operationRegistered');
-    expect(sink.inputs[0].required).toBe(true);
+    // Lifecycle events are protected; the manager derives `required` from the type.
+    expect(isReporterEventRequired('operationRegistered')).toBe(true);
     expect(sink.inputs[0].scope).toEqual({
       commandName: 'build',
       operationId: 'op1',
@@ -82,7 +84,7 @@ describe('LifecycleEmitter', () => {
     );
     expect(sink.inputs[0].type).toBe('diagnosticEmitted');
     expect(sink.inputs[0].privacy).toBe('local-sensitive');
-    expect(sink.inputs[0].required).toBe(true);
+    expect(isReporterEventRequired('diagnosticEmitted')).toBe(true);
   });
 
   it('writes nothing to stdout or stderr while events flow (shadow mode)', () => {

--- a/libraries/reporter/src/test/Session.test.ts
+++ b/libraries/reporter/src/test/Session.test.ts
@@ -1,0 +1,182 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import {
+  createScopedReporter,
+  createScopedLogger,
+  createRushDiagnostic,
+  RushSessionReporting,
+  ReporterManager,
+  RUSH_PLUGIN_API_VERSION,
+  isPluginApiVersionSupported,
+  createPluginApiIncompatibleDiagnostic,
+  type IReporter,
+  type IReporterEventEnvelope,
+  type IReporterEventScope,
+  type IReporterEventSink,
+  type IReporterEventSource,
+  type IReporterExecutionContext,
+  type IRushDiagnostic,
+  type IScopedLogger,
+  type IScopedReporter
+} from '../index';
+
+class CapturingSink implements IReporterEventSink {
+  public readonly inputs: Record<string, unknown>[] = [];
+
+  public emit(event: Record<string, unknown>): string {
+    this.inputs.push(event);
+    return `evt_${this.inputs.length}`;
+  }
+}
+
+class RecordingReporter implements IReporter {
+  public readonly name: string = 'recording';
+  public readonly reported: IReporterEventEnvelope<unknown>[] = [];
+
+  public async initializeAsync(): Promise<void> {
+    /* no-op */
+  }
+
+  public report(event: IReporterEventEnvelope<unknown>): void {
+    this.reported.push(event);
+  }
+
+  public async flushAsync(): Promise<void> {
+    /* no-op */
+  }
+
+  public async closeAsync(): Promise<void> {
+    /* no-op */
+  }
+}
+
+const SOURCE: IReporterEventSource = { packageName: '@microsoft/rush-lib', packageVersion: '5.177.2' };
+
+describe('createScopedReporter', () => {
+  it('emits scoped messages on the activityChanged channel', () => {
+    const sink: CapturingSink = new CapturingSink();
+    const scope: IReporterEventScope = { commandName: 'build', projectName: '@my/project' };
+    const reporter: IScopedReporter = createScopedReporter({
+      sink,
+      sessionId: 'sess',
+      source: SOURCE,
+      scope
+    });
+
+    reporter.emitMessage({ severity: 'info', text: 'hello' });
+    expect(sink.inputs[0].type).toBe('activityChanged');
+    expect(sink.inputs[0].scope).toEqual(scope);
+    expect(sink.inputs[0].required).toBe(false);
+    expect(sink.inputs[0].payload).toEqual({ kind: 'message', severity: 'info', text: 'hello' });
+  });
+
+  it('marks warning and error messages as required', () => {
+    const sink: CapturingSink = new CapturingSink();
+    const reporter: IScopedReporter = createScopedReporter({ sink, sessionId: 'sess', source: SOURCE });
+    reporter.emitMessage({ severity: 'warning', text: 'careful' });
+    reporter.emitMessage({ severity: 'error', text: 'boom' });
+    expect(sink.inputs[0].required).toBe(true);
+    expect(sink.inputs[1].required).toBe(true);
+  });
+
+  it('emits diagnostics with the envelope privacy floor', () => {
+    const sink: CapturingSink = new CapturingSink();
+    const reporter: IScopedReporter = createScopedReporter({ sink, sessionId: 'sess', source: SOURCE });
+    const diagnostic: IRushDiagnostic = createRushDiagnostic('RUSH_OPERATION_FAILED', {
+      parameters: {
+        projectName: { value: 'p', privacy: 'public' },
+        logPath: { value: '/tmp/x.log', privacy: 'secret' }
+      }
+    });
+    reporter.emitDiagnostic(diagnostic);
+    expect(sink.inputs[0].type).toBe('diagnosticEmitted');
+    // Least sensitive field is the floor.
+    expect(sink.inputs[0].privacy).toBe('public');
+    expect(sink.inputs[0].required).toBe(true);
+    expect(sink.inputs[0].payload).toBe(diagnostic);
+  });
+
+  it('validates and wraps extension events, rejecting non-namespaced names', () => {
+    const sink: CapturingSink = new CapturingSink();
+    const reporter: IScopedReporter = createScopedReporter({ sink, sessionId: 'sess', source: SOURCE });
+    reporter.emitExtension('acme.cache-warmed', { hits: 3 });
+    expect(sink.inputs[0].type).toBe('extension');
+    expect(sink.inputs[0].payload).toEqual({ name: 'acme.cache-warmed', payload: { hits: 3 } });
+    expect(() => reporter.emitExtension('notnamespaced', {})).toThrow(/Invalid extension event name/);
+  });
+
+  it('exposes only emit methods, hiding modes, destinations, and thresholds', () => {
+    const sink: CapturingSink = new CapturingSink();
+    const reporter: IScopedReporter = createScopedReporter({ sink, sessionId: 'sess', source: SOURCE });
+    expect(Object.keys(reporter).sort()).toEqual(['emitDiagnostic', 'emitExtension', 'emitMessage']);
+  });
+});
+
+describe('createScopedLogger', () => {
+  it('maps log methods to message severities and has no terminal handle', () => {
+    const sink: CapturingSink = new CapturingSink();
+    const reporter: IScopedReporter = createScopedReporter({ sink, sessionId: 'sess', source: SOURCE });
+    const logger: IScopedLogger = createScopedLogger(reporter);
+
+    logger.writeLine('a');
+    logger.writeDebugLine('b');
+    logger.writeWarningLine('c');
+    logger.writeErrorLine('d');
+
+    const severities: unknown[] = sink.inputs.map(
+      (input: Record<string, unknown>) => (input.payload as { severity: string }).severity
+    );
+    expect(severities).toEqual(['info', 'debug', 'warning', 'error']);
+    expect(Object.keys(logger)).not.toContain('terminal');
+  });
+});
+
+describe('RushSessionReporting', () => {
+  it('creates scoped reporters, loggers, and an execution context that reach reporters', async () => {
+    const manager: ReporterManager = new ReporterManager();
+    const recording: RecordingReporter = new RecordingReporter();
+    manager.addReporter(recording);
+    await manager.initializeAsync();
+
+    const reporting: RushSessionReporting = new RushSessionReporting({
+      sink: manager,
+      sessionId: 'sess',
+      source: SOURCE
+    });
+
+    expect(reporting.getSink()).toBe(manager);
+
+    const context: IReporterExecutionContext = reporting.createExecutionContext({ commandName: 'build' });
+    context.reporter.emitMessage({ severity: 'warning', text: 'from action' });
+
+    const logger: IScopedLogger = reporting.createScopedLogger({ projectName: '@my/project' });
+    logger.writeErrorLine('from plugin');
+
+    await manager.flushAsync();
+
+    expect(recording.reported).toHaveLength(2);
+    expect(recording.reported[0].scope).toEqual({ commandName: 'build' });
+    expect(recording.reported[1].scope).toEqual({ projectName: '@my/project' });
+  });
+});
+
+describe('plugin API compatibility', () => {
+  it('accepts a matching major and rejects a mismatched or invalid major', () => {
+    expect(isPluginApiVersionSupported(RUSH_PLUGIN_API_VERSION)).toBe(true);
+    expect(isPluginApiVersionSupported('1.4.2')).toBe(true);
+    expect(isPluginApiVersionSupported('2.0.0')).toBe(false);
+    expect(isPluginApiVersionSupported('not-a-version')).toBe(false);
+  });
+
+  it('builds a migration diagnostic for an incompatible plugin', () => {
+    const diagnostic: IRushDiagnostic = createPluginApiIncompatibleDiagnostic({
+      pluginName: '@acme/rush-plugin',
+      pluginApiVersion: '2.0.0'
+    });
+    expect(diagnostic.code).toBe('RUSH_PLUGIN_API_INCOMPATIBLE');
+    expect(diagnostic.category).toBe('configuration');
+    expect(diagnostic.parameters?.pluginName.value).toBe('@acme/rush-plugin');
+    expect(diagnostic.parameters?.declaredApiVersion.value).toBe('2.0.0');
+  });
+});

--- a/libraries/reporter/src/test/Session.test.ts
+++ b/libraries/reporter/src/test/Session.test.ts
@@ -10,6 +10,7 @@ import {
   RUSH_PLUGIN_API_VERSION,
   isPluginApiVersionSupported,
   createPluginApiIncompatibleDiagnostic,
+  isReporterEventRequired,
   type IReporter,
   type IReporterEventEnvelope,
   type IReporterEventScope,
@@ -65,19 +66,24 @@ describe('createScopedReporter', () => {
     });
 
     reporter.emitMessage({ severity: 'info', text: 'hello' });
-    expect(sink.inputs[0].type).toBe('activityChanged');
+    expect(sink.inputs[0].type).toBe('messageEmitted');
     expect(sink.inputs[0].scope).toEqual(scope);
-    expect(sink.inputs[0].required).toBe(false);
-    expect(sink.inputs[0].payload).toEqual({ kind: 'message', severity: 'info', text: 'hello' });
+    // The manager derives `required`; messages are never coalescible.
+    expect(isReporterEventRequired('messageEmitted')).toBe(true);
+    // Message text fails safe at local-sensitive by default.
+    expect(sink.inputs[0].privacy).toBe('local-sensitive');
+    expect(sink.inputs[0].payload).toEqual({ severity: 'info', text: 'hello' });
   });
 
-  it('marks warning and error messages as required', () => {
+  it('emits messages on the messageEmitted channel for every severity', () => {
     const sink: CapturingSink = new CapturingSink();
     const reporter: IScopedReporter = createScopedReporter({ sink, sessionId: 'sess', source: SOURCE });
     reporter.emitMessage({ severity: 'warning', text: 'careful' });
     reporter.emitMessage({ severity: 'error', text: 'boom' });
-    expect(sink.inputs[0].required).toBe(true);
-    expect(sink.inputs[1].required).toBe(true);
+    expect(sink.inputs[0].type).toBe('messageEmitted');
+    expect(sink.inputs[0].payload).toEqual({ severity: 'warning', text: 'careful' });
+    expect(sink.inputs[1].type).toBe('messageEmitted');
+    expect(sink.inputs[1].payload).toEqual({ severity: 'error', text: 'boom' });
   });
 
   it('emits diagnostics with the envelope privacy floor', () => {
@@ -93,7 +99,7 @@ describe('createScopedReporter', () => {
     expect(sink.inputs[0].type).toBe('diagnosticEmitted');
     // Least sensitive field is the floor.
     expect(sink.inputs[0].privacy).toBe('public');
-    expect(sink.inputs[0].required).toBe(true);
+    expect(isReporterEventRequired('diagnosticEmitted')).toBe(true);
     expect(sink.inputs[0].payload).toBe(diagnostic);
   });
 
@@ -103,7 +109,9 @@ describe('createScopedReporter', () => {
     reporter.emitExtension('acme.cache-warmed', { hits: 3 });
     expect(sink.inputs[0].type).toBe('extension');
     expect(sink.inputs[0].payload).toEqual({ name: 'acme.cache-warmed', payload: { hits: 3 } });
-    expect(() => reporter.emitExtension('notnamespaced', {})).toThrow(/Invalid extension event name/);
+    expect(() => reporter.emitExtension('notnamespaced' as Parameters<IScopedReporter['emitExtension']>[0], {})).toThrow(
+      /Invalid extension event name/
+    );
   });
 
   it('exposes only emit methods, hiding modes, destinations, and thresholds', () => {

--- a/libraries/reporter/src/test/Session.test.ts
+++ b/libraries/reporter/src/test/Session.test.ts
@@ -11,6 +11,7 @@ import {
   isPluginApiVersionSupported,
   createPluginApiIncompatibleDiagnostic,
   isReporterEventRequired,
+  parseReporterExtensionEventName,
   type IReporter,
   type IReporterEventEnvelope,
   type IReporterEventScope,
@@ -106,12 +107,12 @@ describe('createScopedReporter', () => {
   it('validates and wraps extension events, rejecting non-namespaced names', () => {
     const sink: CapturingSink = new CapturingSink();
     const reporter: IScopedReporter = createScopedReporter({ sink, sessionId: 'sess', source: SOURCE });
-    reporter.emitExtension('acme.cache-warmed', { hits: 3 });
+    reporter.emitExtension(parseReporterExtensionEventName('acme.cache-warmed'), { hits: 3 });
     expect(sink.inputs[0].type).toBe('extension');
     expect(sink.inputs[0].payload).toEqual({ name: 'acme.cache-warmed', payload: { hits: 3 } });
-    expect(() => reporter.emitExtension('notnamespaced' as Parameters<IScopedReporter['emitExtension']>[0], {})).toThrow(
-      /Invalid extension event name/
-    );
+    expect(() =>
+      reporter.emitExtension('notnamespaced' as Parameters<IScopedReporter['emitExtension']>[0], {})
+    ).toThrow(/Invalid extension event name/);
   });
 
   it('exposes only emit methods, hiding modes, destinations, and thresholds', () => {

--- a/libraries/reporter/src/test/Telemetry.test.ts
+++ b/libraries/reporter/src/test/Telemetry.test.ts
@@ -1,0 +1,187 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import {
+  TelemetrySubscriber,
+  createTelemetryReporter,
+  createBeforeLogAdapter,
+  TELEMETRY_AGGREGATE_KEYS,
+  LifecycleEmitter,
+  ReporterManager,
+  createRushDiagnostic,
+  type IReporter,
+  type IReporterEmitEventInput,
+  type IReporterEventEnvelope,
+  type IReporterEventSource,
+  type ITelemetryAggregate,
+  type LegacyBeforeLogHook
+} from '../index';
+
+class RecordingReporter implements IReporter {
+  public readonly name: string = 'recording';
+  public readonly reported: IReporterEventEnvelope<unknown>[] = [];
+
+  public async initializeAsync(): Promise<void> {
+    /* no-op */
+  }
+
+  public report(event: IReporterEventEnvelope<unknown>): void {
+    this.reported.push(event);
+  }
+
+  public async flushAsync(): Promise<void> {
+    /* no-op */
+  }
+
+  public async closeAsync(): Promise<void> {
+    /* no-op */
+  }
+}
+
+const SOURCE: IReporterEventSource = { packageName: '@microsoft/rush-lib', packageVersion: '5.177.2' };
+
+function rawInput(type: string, payload: unknown): IReporterEmitEventInput<unknown> {
+  return {
+    protocolVersion: { major: 1, minor: 0 },
+    sessionId: 'sess',
+    source: SOURCE,
+    privacy: 'public',
+    required: false,
+    type: type as IReporterEmitEventInput<unknown>['type'],
+    payload
+  };
+}
+
+describe('TelemetrySubscriber', () => {
+  it('produces an allowlisted aggregate from the event stream before reporter filtering', async () => {
+    const telemetry: TelemetrySubscriber = new TelemetrySubscriber();
+    telemetry.setReporterMode('default');
+    const manager: ReporterManager = new ReporterManager();
+    const recording: RecordingReporter = new RecordingReporter();
+    manager.addReporter(createTelemetryReporter(telemetry));
+    manager.addReporter(recording);
+    await manager.initializeAsync();
+
+    const emitter: LifecycleEmitter = new LifecycleEmitter({
+      sink: manager,
+      sessionId: 'sess',
+      source: SOURCE,
+      scope: { commandName: 'build' }
+    });
+    emitter.emitCommandStarted({ commandName: 'build', argv: ['--to', 'x'] });
+    emitter.emitOperationStatusChanged({ operationId: 'op1', status: 'success' });
+    emitter.emitOperationStatusChanged({ operationId: 'op2', status: 'fromCache' });
+    emitter.emitDiagnostic(createRushDiagnostic('RUSH_OPERATION_FAILED'));
+    emitter.emitCommandCompleted({ commandName: 'build', exitCode: 0, durationMs: 1234 });
+    emitter.emitCommandResult({ commandName: 'build', succeeded: true, exitCode: 0 });
+    emitter.emitSessionCompleted({ exitCode: 0, durationMs: 1500 });
+    await manager.flushAsync();
+
+    const aggregate: ITelemetryAggregate = telemetry.buildAggregate();
+    expect(aggregate.commandName).toBe('build');
+    expect(aggregate.result).toBe('succeeded');
+    expect(aggregate.exitCode).toBe(0);
+    expect(aggregate.durationMs).toBe(1500);
+    expect(aggregate.operationStatusCounts).toEqual({ success: 1, fromCache: 1 });
+    expect(aggregate.diagnosticCodes).toEqual(['RUSH_OPERATION_FAILED']);
+    expect(aggregate.diagnosticCategoryCounts).toEqual({ operation: 1 });
+    expect(aggregate.reporterMode).toBe('default');
+    expect(aggregate.protocolVersion).toEqual({ major: 1, minor: 0 });
+    expect(aggregate.producerVersions).toEqual(['@microsoft/rush-lib@5.177.2']);
+
+    // The subscriber runs alongside a rendering reporter and does not consume events from it.
+    expect(recording.reported.length).toBeGreaterThan(0);
+  });
+
+  it('only ever contains allowlisted keys', async () => {
+    const telemetry: TelemetrySubscriber = new TelemetrySubscriber();
+    const manager: ReporterManager = new ReporterManager();
+    manager.addReporter(createTelemetryReporter(telemetry));
+    await manager.initializeAsync();
+    const emitter: LifecycleEmitter = new LifecycleEmitter({
+      sink: manager,
+      sessionId: 'sess',
+      source: SOURCE
+    });
+    emitter.emitCommandResult({ commandName: 'build', succeeded: true, exitCode: 0 });
+    await manager.flushAsync();
+
+    for (const key of Object.keys(telemetry.buildAggregate())) {
+      expect(TELEMETRY_AGGREGATE_KEYS).toContain(key);
+    }
+  });
+
+  it('never leaks messages, paths, arguments, remediation, raw output, or secret values', async () => {
+    const SECRET: string = 'sk-super-secret-value';
+    const LOG_PATH: string = '/home/user/secret/install.log';
+    const ARG: string = '--auth-token=abc123';
+    const MESSAGE: string = 'verbose diagnostic message text';
+    const REMEDIATION_COMMAND: string = 'rush update --purge-and-leak';
+
+    const telemetry: TelemetrySubscriber = new TelemetrySubscriber();
+    const manager: ReporterManager = new ReporterManager();
+    manager.addReporter(createTelemetryReporter(telemetry));
+    await manager.initializeAsync();
+
+    const emitter: LifecycleEmitter = new LifecycleEmitter({
+      sink: manager,
+      sessionId: 'sess',
+      source: SOURCE
+    });
+    emitter.emitCommandStarted({ commandName: 'build', argv: [ARG] });
+    emitter.emitDiagnostic(
+      createRushDiagnostic('RUSH_DEPENDENCY_TOOL_FAILED', {
+        parameters: {
+          token: { value: SECRET, privacy: 'secret' },
+          logPath: { value: LOG_PATH, privacy: 'local-sensitive' }
+        },
+        remediation: [
+          { descriptionKey: 'r', command: REMEDIATION_COMMAND, automatedExecutionSafety: 'unsafe' }
+        ]
+      })
+    );
+    manager.emit(rawInput('externalOutput', { stream: 'stdout', text: `${SECRET} raw output` }));
+    manager.emit(rawInput('activityChanged', { kind: 'message', severity: 'info', text: MESSAGE }));
+    emitter.emitCommandResult({ commandName: 'build', succeeded: false, exitCode: 1 });
+    await manager.flushAsync();
+
+    const aggregate: ITelemetryAggregate = telemetry.buildAggregate();
+    const serialized: string = JSON.stringify(aggregate);
+    for (const forbidden of [SECRET, LOG_PATH, ARG, MESSAGE, REMEDIATION_COMMAND]) {
+      expect(serialized).not.toContain(forbidden);
+    }
+    // But the allowlisted diagnostic code and category are retained.
+    expect(aggregate.diagnosticCodes).toEqual(['RUSH_DEPENDENCY_TOOL_FAILED']);
+    expect(aggregate.diagnosticCategoryCounts).toEqual({ 'dependency-tool': 1 });
+    expect(aggregate.result).toBe('failed');
+    for (const key of Object.keys(aggregate)) {
+      expect(TELEMETRY_AGGREGATE_KEYS).toContain(key);
+    }
+  });
+});
+
+describe('createBeforeLogAdapter', () => {
+  it('runs legacy hooks with a plain copy of the aggregate', () => {
+    const observed: Record<string, unknown>[] = [];
+    const hook: LegacyBeforeLogHook = (telemetry: Record<string, unknown>) => {
+      observed.push(telemetry);
+    };
+    const adapter: (aggregate: ITelemetryAggregate) => void = createBeforeLogAdapter([hook]);
+
+    const aggregate: ITelemetryAggregate = {
+      commandName: 'build',
+      result: 'succeeded',
+      exitCode: 0,
+      operationStatusCounts: { success: 2 },
+      diagnosticCodes: [],
+      diagnosticCategoryCounts: {},
+      producerVersions: ['@microsoft/rush-lib@5.177.2']
+    };
+    adapter(aggregate);
+
+    expect(observed).toHaveLength(1);
+    expect(observed[0]).toEqual({ ...aggregate });
+    // The hook receives a copy, not the aggregate itself.
+    expect(observed[0]).not.toBe(aggregate);
+  });
+});

--- a/libraries/reporter/src/test/Telemetry.test.ts
+++ b/libraries/reporter/src/test/Telemetry.test.ts
@@ -46,7 +46,6 @@ function rawInput(type: string, payload: unknown): IReporterEmitEventInput<unkno
     sessionId: 'sess',
     source: SOURCE,
     privacy: 'public',
-    required: false,
     type: type as IReporterEmitEventInput<unknown>['type'],
     payload
   };

--- a/research/feature-list.json
+++ b/research/feature-list.json
@@ -166,7 +166,7 @@
       "Ensure reporters and diagnostic categories never select exit codes",
       "Preserve command-specific JSON schemas"
     ],
-    "passes": false
+    "passes": true
   },
   {
     "category": "functional",

--- a/research/feature-list.json
+++ b/research/feature-list.json
@@ -131,7 +131,7 @@
       "Prevent plugins from inspecting modes, destinations, or thresholds",
       "Declare the supported Rush plugin API version in plugin manifests"
     ],
-    "passes": false
+    "passes": true
   },
   {
     "category": "functional",

--- a/research/feature-list.json
+++ b/research/feature-list.json
@@ -142,7 +142,7 @@
       "Keep legacy output unchanged while events flow",
       "Validate telemetry and exit-code parity against the frozen baselines"
     ],
-    "passes": false
+    "passes": true
   },
   {
     "category": "functional",

--- a/research/feature-list.json
+++ b/research/feature-list.json
@@ -154,7 +154,7 @@
       "Preserve the existing beforeLog hook through an adapter",
       "Add allowlist schema and leakage tests"
     ],
-    "passes": false
+    "passes": true
   },
   {
     "category": "functional",

--- a/research/progress.txt
+++ b/research/progress.txt
@@ -198,3 +198,19 @@
     - rush test --only @rushstack/reporter: clean SUCCESS (build + jest)
     - lifecycle emit + scope merge, diagnostic privacy floor, shadow output-neutrality, exit-code parity (4 cases), result summary, manager integration tests pass; all exports @beta
   Next: Feature 13/28 - Telemetry projection subscriber (allowlist + beforeLog adapter)
+
+[2026-07-14] Feature 13/28 COMPLETE: Telemetry projection subscriber (allowlist + beforeLog adapter)
+  Files (new):
+    - telemetry/TelemetryAggregate.ts (ITelemetryAggregate allowlist: commandName/result/exitCode/durationMs/operationStatusCounts/diagnosticCodes/diagnosticCategoryCounts/reporterMode/protocolVersion/producerVersions; TELEMETRY_AGGREGATE_KEYS)
+    - telemetry/TelemetrySubscriber.ts (ingest extracts only allowlisted values - diagnostics keep code+category only, ignores argv/messages/external/artifacts; buildAggregate; setReporterMode; createTelemetryReporter adapter = IReporter with no destination, feeds before reporter filtering)
+    - telemetry/BeforeLogAdapter.ts (LegacyBeforeLogHook + createBeforeLogAdapter runs hooks with plain copy of aggregate)
+    - test/Telemetry.test.ts
+  Files (modified): index.ts, api.md
+  Notes:
+    - "Before reporter filtering": manager fans full events to all reporters (each filters internally), so telemetry-as-reporter sees unfiltered events.
+    - Leakage test emits secret param/path/argv/message/remediation-command/raw-output; asserts JSON.stringify(aggregate) contains none; keys subset of allowlist.
+    - Same source-of-truth scoping (Rush telemetry lives in rush-lib; not wired live).
+  Verify:
+    - rush test --only @rushstack/reporter: clean SUCCESS (build + jest)
+    - aggregate build, allowlist schema, leakage (5 forbidden strings absent), beforeLog adapter (plain copy) tests pass; all exports @beta
+  Next: Feature 14/28 - Preserve command success + exit-code semantics independent of reporters

--- a/research/progress.txt
+++ b/research/progress.txt
@@ -165,3 +165,20 @@
     - rush test --only @rushstack/reporter: clean SUCCESS (build + jest)
     - resolver (5 combos incl newer-major), engine sink (structured + fallback), adapter bridge + chunk-split tests pass; all exports @beta
   Next: Feature 11/28 - Expose RushSession event sink and scoped producers to actions and plugins
+
+[2026-07-14] Feature 11/28 COMPLETE: RushSession event sink + scoped producers for actions/plugins
+  Files (new):
+    - session/ScopedReporterFactory.ts (createScopedReporter -> IScopedReporter; emitMessage->activityChanged {kind:'message',severity,text}, required for warning/error; emitDiagnostic->diagnosticEmitted with computeEnvelopePrivacyFloor; emitExtension validates namespaced name, wraps {name,payload})
+    - session/ScopedLogger.ts (IScopedLogger writeLine/writeDebugLine/writeWarningLine/writeErrorLine; NO .terminal handle)
+    - session/RushSessionReporting.ts (facade: createScopedReporter/createScopedLogger; getSink(); createExecutionContext()->IReporterExecutionContext {sink, reporter})
+    - session/PluginApi.ts (RUSH_PLUGIN_API_VERSION '1.0.0', IRushPluginManifest.pluginApiVersion, isPluginApiVersionSupported major-equality, createPluginApiIncompatibleDiagnostic migration diagnostic)
+    - test/Session.test.ts
+  Files (modified): diagnostics/RushDiagnosticCodeRegistry.ts (APPENDED RUSH_PLUGIN_API_INCOMPATIBLE code+templates), index.ts, api.md
+  Notes:
+    - Human messages map to activityChanged (closed union has no 'message' type; golden freezes the 15). required-by-severity so warnings/errors aren't coalesced.
+    - Step 3 (no modes/destinations/thresholds) satisfied structurally: scoped reporter/logger + sink are emit-only. Test asserts Object.keys == 3 emit methods.
+    - Same source-of-truth scoping (RushSession itself lives in rush-lib; not wired live).
+  Verify:
+    - rush test --only @rushstack/reporter: clean SUCCESS (build + jest)
+    - scoped message/diagnostic/extension, privacy floor, emit-only surface, logger severities, session facade end-to-end via ReporterManager, plugin API compat + migration diagnostic tests pass; all exports @beta
+  Next: Feature 12/28 - Emit shadow structured lifecycle + diagnostic events without changing output

--- a/research/progress.txt
+++ b/research/progress.txt
@@ -182,3 +182,19 @@
     - rush test --only @rushstack/reporter: clean SUCCESS (build + jest)
     - scoped message/diagnostic/extension, privacy floor, emit-only surface, logger severities, session facade end-to-end via ReporterManager, plugin API compat + migration diagnostic tests pass; all exports @beta
   Next: Feature 12/28 - Emit shadow structured lifecycle + diagnostic events without changing output
+
+[2026-07-14] Feature 12/28 COMPLETE: Shadow structured lifecycle + diagnostic emission
+  Files (new):
+    - lifecycle/LifecycleEvents.ts (OperationStatus + payload interfaces: session/command started+completed, operation registered+statusChanged, commandResult, watchCycleCompleted)
+    - lifecycle/LifecycleEmitter.ts (emit* methods, all required=true; merges base scope + per-event scope override; emitDiagnostic uses privacy floor; writes nothing to stdout/stderr)
+    - lifecycle/ShadowParity.ts (deriveExitCodeFromEvents: commandResult succeeded->0 else exitCode/1, sessionCompleted fallback; summarizeShadowResult: operationCounts + result)
+    - test/Lifecycle.test.ts
+  Files (modified): index.ts, api.md
+  Notes:
+    - Step 3 "keep legacy output unchanged": emitter is output-neutral (only sink.emit). Test spies process.stdout/stderr.write and asserts not called.
+    - Step 4 parity: exit-code parity helper + result summary. Full telemetry allowlist deferred to Feature 13; authoritative exit-code semantics to Feature 14 (this is shadow parity derivation).
+    - Same source-of-truth scoping (actions/scheduler/plugins live in rush-lib; not wired live).
+  Verify:
+    - rush test --only @rushstack/reporter: clean SUCCESS (build + jest)
+    - lifecycle emit + scope merge, diagnostic privacy floor, shadow output-neutrality, exit-code parity (4 cases), result summary, manager integration tests pass; all exports @beta
+  Next: Feature 13/28 - Telemetry projection subscriber (allowlist + beforeLog adapter)

--- a/research/progress.txt
+++ b/research/progress.txt
@@ -214,3 +214,19 @@
     - rush test --only @rushstack/reporter: clean SUCCESS (build + jest)
     - aggregate build, allowlist schema, leakage (5 forbidden strings absent), beforeLog adapter (plain copy) tests pass; all exports @beta
   Next: Feature 14/28 - Preserve command success + exit-code semantics independent of reporters
+
+[2026-07-14] Feature 14/28 COMPLETE: Authoritative command success + exit-code semantics
+  Files (new):
+    - exit/ExitStatus.ts (EXIT_CODE_SUCCESS=0/FAILURE=1; RushCommandOutcome succeeded|failed|cancelled|signal; getSignalExitCode=128+os.constants.signals[sig]; resolveExitStatus(hasFailures/cancelled/signal); resolveExitStatusFromEvents - failure = failed commandResult OR error diagnostic OR failed operation; category & reporter never inputs; precedence signal>cancelled>failure)
+    - exit/CommandJson.ts (separateJsonControls -> {commandJson (--json), reporterJson (--reporter=json/--reporter json)} independent)
+    - test/ExitStatus.test.ts
+  Files (modified): index.ts, api.md
+  Notes:
+    - Warning-only success -> 0 (warnings not failures). Signal-derived status conventional (SIGINT->130, SIGTERM->143).
+    - Category-independence proven: error diagnostics of any category ->1; warnings of any category ->0.
+    - Command-specific --json preserved and NOT an alias for --reporter=json.
+    - Distinct from Feature 12 shadow deriveExitCodeFromEvents (this is authoritative full outcome incl cancel/signal).
+  Verify:
+    - rush test --only @rushstack/reporter: clean SUCCESS (build + jest)
+    - resolveExitStatus (success/warning-only/failure/cancel/signal precedence), signal codes, from-events (warning/error/op-failure/failed-result/category-independence/cancel/signal), separateJsonControls (5 cases) tests pass; all exports @beta
+  Next: Feature 15/28 - Reporter selection + configuration controls with precedence


### PR DESCRIPTION
### 📚 Reporter Overhaul PR stack (merge bottom-up)
| # | PR | Phase | Base |
|---|-----|-------|------|
| 1 | #5865 | Contracts & baselines (package) | `main` |
| 2 | #5866 | Bootstrap & compatibility | #5865 |
| 3 | #5867 | Shadow structured emission | #5866 |
| 4 | #5868 | Opt-in reporters | #5867 |
| 5 | #5869 | Heft protocol track | #5868 |
| 6 | #5870 | Perf budgets & default flip | #5869 |

Each PR's diff is scoped to its phase; review independently, merge from #5865 upward.

👉 **This is PR 3 of 6.**

## Phase 3 — Shadow structured emission (RFC §8.1)

First-party lifecycle and diagnostic events are emitted **without changing visible output**, and telemetry/exit-code parity is validated.

### What's included
- **`RushSession` event sink + scoped producers** exposed to actions and plugins (plugins cannot inspect modes/destinations/thresholds).
- **Shadow lifecycle emission** — structured lifecycle + diagnostic events run alongside the legacy renderer with no output change.
- **Telemetry projection subscriber** — allowlist + `beforeLog` adapter.
- **Reporter-independent exit codes** — command success/exit semantics preserved regardless of the active reporter.

### Validation
- `rush build --to @rushstack/reporter` ✅   `rush test --only @rushstack/reporter` ✅ (adds Session, Lifecycle, Telemetry, ExitStatus suites)
- All exports `@beta`.

### Scope note
Standalone package; not yet wired into the live CLI. Independently releasable/revertible per RFC §8.1.
