### PR TITLE
[rush] Fix an issue that occurs when you run rush-lib tests twice without cleaning.

### DIFF
--- a/common/changes/@microsoft/rush/fix-repeated-test-issue_2026-07-15-22-43-06.json
+++ b/common/changes/@microsoft/rush/fix-repeated-test-issue_2026-07-15-22-43-06.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/src/api/test/RushConfiguration.test.ts
+++ b/libraries/rush-lib/src/api/test/RushConfiguration.test.ts
@@ -312,7 +312,7 @@ describe(RushConfiguration.name, () => {
       const rushConfiguration: RushConfiguration = RushConfiguration.loadFromConfigurationFile(
         `${__dirname}/repo/rush-pnpm.json`
       );
-      jest.spyOn(JsonFile, 'save').mockImplementation(() => {
+      jest.spyOn(JsonFile, 'saveAsync').mockImplementation(async () => {
         /* no-op*/
         return true;
       });


### PR DESCRIPTION
## Summary

Fixes an issue where the wrong function is mocked in a test.

## How it was tested

Ran tests.

## Impacted documentation

None.