### PR TITLE
[rush] Add per-iteration runner persistence control

### DIFF
--- a/common/changes/@microsoft/rush/bmiddha-runner-persist-policy.json
+++ b/common/changes/@microsoft/rush/bmiddha-runner-persist-policy.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add a per-iteration, host-driven runner persist policy so IPC runners can be kept hot or torn down per operation per iteration, instead of fixing persistence at plugin construction.",
+      "type": "minor"
+    }
+  ]
+}

--- a/common/changes/@microsoft/rush/bmiddha-runner-persist-policy.json
+++ b/common/changes/@microsoft/rush/bmiddha-runner-persist-policy.json
@@ -3,7 +3,7 @@
     {
       "packageName": "@microsoft/rush",
       "comment": "Add a per-iteration, host-driven runner persist policy so IPC runners can be kept hot or torn down per operation per iteration, instead of fixing persistence at plugin construction.",
-      "type": "minor"
+      "type": "patch"
     }
   ]
 }

--- a/common/changes/@microsoft/rush/bmiddha-runner-persist-policy.json
+++ b/common/changes/@microsoft/rush/bmiddha-runner-persist-policy.json
@@ -3,7 +3,7 @@
     {
       "packageName": "@microsoft/rush",
       "comment": "Add a per-iteration, host-driven runner persist policy so IPC runners can be kept hot or torn down per operation per iteration, instead of fixing persistence at plugin construction.",
-      "type": "patch"
+      "type": "minor"
     }
   ]
 }

--- a/common/changes/@rushstack/heft-node-rig/bmiddha-heft-node-rig-es2022_2026-08-17-22-54-46.json
+++ b/common/changes/@rushstack/heft-node-rig/bmiddha-heft-node-rig-es2022_2026-08-17-22-54-46.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-node-rig",
+      "comment": "Update the default TypeScript library definitions to ES2022.",
+      "type": "patch"
+    }
+  ]
+}

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -740,6 +740,7 @@ export interface IOperationRunnerContext {
         createLogFile: boolean;
         logFileSuffix?: string;
     }): Promise<T>;
+    readonly shouldRunnerPersist: boolean;
     status: OperationStatus;
     stopwatch: IStopwatchResult;
 }

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -668,6 +668,7 @@ export interface _IOperationGraphEventSink {
 
 // @alpha
 export interface IOperationGraphIterationOptions {
+    getRunnerPersistence?: (operation: Operation) => boolean;
     // (undocumented)
     inputsSnapshot?: IInputsSnapshot;
     startTime?: number;

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -668,9 +668,9 @@ export interface _IOperationGraphEventSink {
 
 // @alpha
 export interface IOperationGraphIterationOptions {
-    getRunnerPersistence?: (operation: Operation) => boolean;
     // (undocumented)
     inputsSnapshot?: IInputsSnapshot;
+    shouldRunnerPersist?: (operation: Operation) => boolean;
     startTime?: number;
 }
 
@@ -739,6 +739,7 @@ export interface IOperationRunnerContext {
         createLogFile: boolean;
         logFileSuffix?: string;
     }): Promise<T>;
+    shouldRunnerPersist?: boolean;
     status: OperationStatus;
     stopwatch: IStopwatchResult;
 }

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -408,6 +408,7 @@ export interface ICobuildLockProvider {
 // @alpha
 export interface IConfigurableOperation extends IBaseOperationExecutionResult {
     enabled: boolean;
+    shouldRunnerPersist: boolean;
 }
 
 // @public
@@ -620,6 +621,7 @@ export interface IOperationExecutionResult extends IBaseOperationExecutionResult
     readonly logFilePaths: ILogFilePaths | undefined;
     readonly nonCachedDurationMs: number | undefined;
     readonly problemCollector: IProblemCollector;
+    readonly shouldRunnerPersist: boolean;
     readonly silent: boolean;
     readonly status: OperationStatus;
     readonly stdioSummarizer: StdioSummarizer;
@@ -670,7 +672,6 @@ export interface _IOperationGraphEventSink {
 export interface IOperationGraphIterationOptions {
     // (undocumented)
     inputsSnapshot?: IInputsSnapshot;
-    shouldRunnerPersist?: (operation: Operation) => boolean;
     startTime?: number;
 }
 
@@ -739,7 +740,6 @@ export interface IOperationRunnerContext {
         createLogFile: boolean;
         logFileSuffix?: string;
     }): Promise<T>;
-    shouldRunnerPersist?: boolean;
     status: OperationStatus;
     stopwatch: IStopwatchResult;
 }

--- a/libraries/rush-lib/src/logic/operations/IOperationExecutionResult.ts
+++ b/libraries/rush-lib/src/logic/operations/IOperationExecutionResult.ts
@@ -67,6 +67,12 @@ export interface IConfigurableOperation extends IBaseOperationExecutionResult {
    * True if the operation should execute in this iteration, false otherwise.
    */
   enabled: boolean;
+
+  /**
+   * True if the operation's runner should remain active after this iteration, false otherwise.
+   * Defaults to true.
+   */
+  shouldRunnerPersist: boolean;
 }
 
 /**
@@ -94,6 +100,10 @@ export interface IOperationExecutionResult extends IBaseOperationExecutionResult
    * True if the operation should execute in this iteration, false otherwise.
    */
   readonly enabled: boolean;
+  /**
+   * True if the operation's runner should remain active after this iteration, false otherwise.
+   */
+  readonly shouldRunnerPersist: boolean;
   /**
    * Object tracking execution timing.
    */

--- a/libraries/rush-lib/src/logic/operations/IOperationGraph.ts
+++ b/libraries/rush-lib/src/logic/operations/IOperationGraph.ts
@@ -26,10 +26,11 @@ export interface IOperationGraphIterationOptions {
    * Returns whether the operation's runner should remain active after this iteration.
    *
    * @remarks
-   * When omitted, all runners remain active. Returning `false` causes the operation's runner to be closed
-   * after the iteration, including when the operation was disabled for that iteration.
+   * When omitted, all runners remain active. Returning `false` causes a runner that supports immediate
+   * teardown to close when its operation completes. Any cold runner that remains active because its operation
+   * did not execute is closed after the iteration.
    */
-  getRunnerPersistence?: (operation: Operation) => boolean;
+  shouldRunnerPersist?: (operation: Operation) => boolean;
 }
 
 /**

--- a/libraries/rush-lib/src/logic/operations/IOperationGraph.ts
+++ b/libraries/rush-lib/src/logic/operations/IOperationGraph.ts
@@ -21,6 +21,15 @@ export interface IOperationGraphIterationOptions {
    * The time when the iteration was scheduled, if available, as returned by `performance.now()`.
    */
   startTime?: number;
+
+  /**
+   * Returns whether the operation's runner should remain active after this iteration.
+   *
+   * @remarks
+   * When omitted, all runners remain active. Returning `false` causes the operation's runner to be closed
+   * after the iteration, including when the operation was disabled for that iteration.
+   */
+  getRunnerPersistence?: (operation: Operation) => boolean;
 }
 
 /**

--- a/libraries/rush-lib/src/logic/operations/IOperationGraph.ts
+++ b/libraries/rush-lib/src/logic/operations/IOperationGraph.ts
@@ -21,16 +21,6 @@ export interface IOperationGraphIterationOptions {
    * The time when the iteration was scheduled, if available, as returned by `performance.now()`.
    */
   startTime?: number;
-
-  /**
-   * Returns whether the operation's runner should remain active after this iteration.
-   *
-   * @remarks
-   * When omitted, all runners remain active. Returning `false` causes a runner that supports immediate
-   * teardown to close when its operation completes. Any cold runner that remains active because its operation
-   * did not execute is closed after the iteration.
-   */
-  shouldRunnerPersist?: (operation: Operation) => boolean;
 }
 
 /**

--- a/libraries/rush-lib/src/logic/operations/IOperationRunner.ts
+++ b/libraries/rush-lib/src/logic/operations/IOperationRunner.ts
@@ -70,6 +70,15 @@ export interface IOperationRunnerContext {
   error?: Error;
 
   /**
+   * Whether the host wants this operation's runner to remain resident (kept warm) after the
+   * operation completes for the current iteration. Defaults to `true` when the host provides no
+   * persistence policy. Runners that own a long-lived child process (such as `IPCOperationRunner`)
+   * must release that process as soon as the operation completes when this is `false`, so that the
+   * subprocess does not consume memory while downstream operations execute.
+   */
+  shouldRunnerPersist?: boolean;
+
+  /**
    * Returns a callback that invalidates this operation so that it will be re-executed in the next iteration.
    * The returned callback captures only the minimal state needed, avoiding retention of the full context.
    * Callers should store the result rather than calling this method repeatedly.
@@ -134,6 +143,8 @@ export interface IOperationRunner {
    * If true, this runner currently owns some kind of active resource (e.g. a service or a watch process).
    * This can be used to determine if the operation is "in progress" even if it is not currently executing.
    * If the runner supports this property, it should update it as appropriate during execution.
+   * A runner that closes its resource during `executeAsync()` when `context.shouldRunnerPersist` is false
+   * must report `false` afterward so that the graph's fallback cleanup does not close it again.
    * The property is optional to avoid breaking existing implementations of IOperationRunner.
    */
   readonly isActive?: boolean;

--- a/libraries/rush-lib/src/logic/operations/IOperationRunner.ts
+++ b/libraries/rush-lib/src/logic/operations/IOperationRunner.ts
@@ -58,6 +58,11 @@ export interface IOperationRunnerContext {
   status: OperationStatus;
 
   /**
+   * True if the runner should remain active after this execution, false otherwise.
+   */
+  readonly shouldRunnerPersist: boolean;
+
+  /**
    * The environment in which the operation is being executed.
    * A return value of `undefined` indicates that it should inherit the environment from the parent process.
    */

--- a/libraries/rush-lib/src/logic/operations/IOperationRunner.ts
+++ b/libraries/rush-lib/src/logic/operations/IOperationRunner.ts
@@ -70,15 +70,6 @@ export interface IOperationRunnerContext {
   error?: Error;
 
   /**
-   * Whether the host wants this operation's runner to remain resident (kept warm) after the
-   * operation completes for the current iteration. Defaults to `true` when the host provides no
-   * persistence policy. Runners that own a long-lived child process (such as `IPCOperationRunner`)
-   * must release that process as soon as the operation completes when this is `false`, so that the
-   * subprocess does not consume memory while downstream operations execute.
-   */
-  shouldRunnerPersist?: boolean;
-
-  /**
    * Returns a callback that invalidates this operation so that it will be re-executed in the next iteration.
    * The returned callback captures only the minimal state needed, avoiding retention of the full context.
    * Callers should store the result rather than calling this method repeatedly.
@@ -143,8 +134,6 @@ export interface IOperationRunner {
    * If true, this runner currently owns some kind of active resource (e.g. a service or a watch process).
    * This can be used to determine if the operation is "in progress" even if it is not currently executing.
    * If the runner supports this property, it should update it as appropriate during execution.
-   * A runner that closes its resource during `executeAsync()` when `context.shouldRunnerPersist` is false
-   * must report `false` afterward so that the graph's fallback cleanup does not close it again.
    * The property is optional to avoid breaking existing implementations of IOperationRunner.
    */
   readonly isActive?: boolean;

--- a/libraries/rush-lib/src/logic/operations/IPCOperationRunner.ts
+++ b/libraries/rush-lib/src/logic/operations/IPCOperationRunner.ts
@@ -28,7 +28,6 @@ export interface IIPCOperationRunnerOptions {
   initialCommand: string;
   incrementalCommand: string | undefined;
   commandForHash: string;
-  persist: boolean;
   ignoredParameterValues: ReadonlyArray<string>;
 }
 
@@ -58,7 +57,6 @@ export class IPCOperationRunner implements IOperationRunner {
   private readonly _initialCommand: string;
   private readonly _incrementalCommand: string | undefined;
   private readonly _commandForHash: string;
-  private readonly _persist: boolean;
   private readonly _ignoredParameterValues: ReadonlyArray<string>;
 
   private _ipcProcess: ChildProcess | undefined;
@@ -72,7 +70,6 @@ export class IPCOperationRunner implements IOperationRunner {
       initialCommand,
       incrementalCommand,
       commandForHash,
-      persist,
       ignoredParameterValues
     } = options;
     this.name = name;
@@ -83,7 +80,6 @@ export class IPCOperationRunner implements IOperationRunner {
     this._incrementalCommand = incrementalCommand;
     this._commandForHash = commandForHash;
 
-    this._persist = persist;
     this._ignoredParameterValues = ignoredParameterValues;
   }
 
@@ -100,7 +96,6 @@ export class IPCOperationRunner implements IOperationRunner {
     const invalidate: (reason: string) => void = context.getInvalidateCallback();
     return await context.runWithTerminalAsync(
       async (terminal: ITerminal, terminalProvider: ITerminalProvider): Promise<OperationStatus> => {
-        let isConnected: boolean = false;
         if (!this._ipcProcess || typeof this._ipcProcess.exitCode === 'number') {
           // Log any ignored parameters
           if (this._ignoredParameterValues.length > 0) {
@@ -204,7 +199,6 @@ export class IPCOperationRunner implements IOperationRunner {
           subProcess.on('exit', onExit);
 
           this._processReadyPromise!.then(() => {
-            isConnected = true;
             terminal.writeLine('Child supports IPC protocol. Sending "run" command...');
             const runCommand: IRunCommandMessage = {
               command: 'run'
@@ -212,10 +206,6 @@ export class IPCOperationRunner implements IOperationRunner {
             subProcess.send(runCommand);
           }, reject);
         });
-
-        if (isConnected && !this._persist) {
-          await this.closeAsync();
-        }
 
         // @rushstack/operation-graph does not currently have a concept of "Success with Warning"
         // To match existing ShellOperationRunner behavior we treat any stderr as a warning.

--- a/libraries/rush-lib/src/logic/operations/IPCOperationRunner.ts
+++ b/libraries/rush-lib/src/logic/operations/IPCOperationRunner.ts
@@ -96,6 +96,7 @@ export class IPCOperationRunner implements IOperationRunner {
     const invalidate: (reason: string) => void = context.getInvalidateCallback();
     return await context.runWithTerminalAsync(
       async (terminal: ITerminal, terminalProvider: ITerminalProvider): Promise<OperationStatus> => {
+        let isConnected: boolean = false;
         if (!this._ipcProcess || typeof this._ipcProcess.exitCode === 'number') {
           // Log any ignored parameters
           if (this._ignoredParameterValues.length > 0) {
@@ -199,6 +200,7 @@ export class IPCOperationRunner implements IOperationRunner {
           subProcess.on('exit', onExit);
 
           this._processReadyPromise!.then(() => {
+            isConnected = true;
             terminal.writeLine('Child supports IPC protocol. Sending "run" command...');
             const runCommand: IRunCommandMessage = {
               command: 'run'
@@ -206,6 +208,14 @@ export class IPCOperationRunner implements IOperationRunner {
             subProcess.send(runCommand);
           }, reject);
         });
+
+        // If the host does not want this runner kept warm for the next iteration, release the
+        // long-lived subprocess immediately now that the operation has completed. Deferring this to
+        // the end of the iteration would keep the subprocess resident (consuming memory) while
+        // downstream operations execute, risking RAM exhaustion.
+        if (isConnected && context.shouldRunnerPersist === false) {
+          await this.closeAsync();
+        }
 
         // @rushstack/operation-graph does not currently have a concept of "Success with Warning"
         // To match existing ShellOperationRunner behavior we treat any stderr as a warning.

--- a/libraries/rush-lib/src/logic/operations/IPCOperationRunner.ts
+++ b/libraries/rush-lib/src/logic/operations/IPCOperationRunner.ts
@@ -96,7 +96,6 @@ export class IPCOperationRunner implements IOperationRunner {
     const invalidate: (reason: string) => void = context.getInvalidateCallback();
     return await context.runWithTerminalAsync(
       async (terminal: ITerminal, terminalProvider: ITerminalProvider): Promise<OperationStatus> => {
-        let isConnected: boolean = false;
         if (!this._ipcProcess || typeof this._ipcProcess.exitCode === 'number') {
           // Log any ignored parameters
           if (this._ignoredParameterValues.length > 0) {
@@ -198,9 +197,7 @@ export class IPCOperationRunner implements IOperationRunner {
           subProcess.on('message', finishHandler);
           subProcess.on('error', reject);
           subProcess.on('exit', onExit);
-
           this._processReadyPromise!.then(() => {
-            isConnected = true;
             terminal.writeLine('Child supports IPC protocol. Sending "run" command...');
             const runCommand: IRunCommandMessage = {
               command: 'run'
@@ -208,14 +205,6 @@ export class IPCOperationRunner implements IOperationRunner {
             subProcess.send(runCommand);
           }, reject);
         });
-
-        // If the host does not want this runner kept warm for the next iteration, release the
-        // long-lived subprocess immediately now that the operation has completed. Deferring this to
-        // the end of the iteration would keep the subprocess resident (consuming memory) while
-        // downstream operations execute, risking RAM exhaustion.
-        if (isConnected && context.shouldRunnerPersist === false) {
-          await this.closeAsync();
-        }
 
         // @rushstack/operation-graph does not currently have a concept of "Success with Warning"
         // To match existing ShellOperationRunner behavior we treat any stderr as a warning.

--- a/libraries/rush-lib/src/logic/operations/IPCOperationRunner.ts
+++ b/libraries/rush-lib/src/logic/operations/IPCOperationRunner.ts
@@ -96,6 +96,7 @@ export class IPCOperationRunner implements IOperationRunner {
     const invalidate: (reason: string) => void = context.getInvalidateCallback();
     return await context.runWithTerminalAsync(
       async (terminal: ITerminal, terminalProvider: ITerminalProvider): Promise<OperationStatus> => {
+        let isConnected: boolean = false;
         if (!this._ipcProcess || typeof this._ipcProcess.exitCode === 'number') {
           // Log any ignored parameters
           if (this._ignoredParameterValues.length > 0) {
@@ -198,6 +199,7 @@ export class IPCOperationRunner implements IOperationRunner {
           subProcess.on('error', reject);
           subProcess.on('exit', onExit);
           this._processReadyPromise!.then(() => {
+            isConnected = true;
             terminal.writeLine('Child supports IPC protocol. Sending "run" command...');
             const runCommand: IRunCommandMessage = {
               command: 'run'
@@ -205,6 +207,10 @@ export class IPCOperationRunner implements IOperationRunner {
             subProcess.send(runCommand);
           }, reject);
         });
+
+        if (isConnected && !context.shouldRunnerPersist) {
+          await this.closeAsync();
+        }
 
         // @rushstack/operation-graph does not currently have a concept of "Success with Warning"
         // To match existing ShellOperationRunner behavior we treat any stderr as a warning.

--- a/libraries/rush-lib/src/logic/operations/IPCOperationRunnerPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/IPCOperationRunnerPlugin.ts
@@ -81,7 +81,6 @@ export class IPCOperationRunnerPlugin implements IPhasedCommandPlugin {
             initialCommand,
             incrementalCommand,
             commandForHash,
-            persist: true,
             ignoredParameterValues
           });
 

--- a/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
@@ -170,7 +170,6 @@ export class OperationExecutionRecord implements IOperationRunnerContext, IOpera
   private readonly _context: IOperationExecutionRecordContext;
 
   private _collatedWriter: CollatedWriter | undefined = undefined;
-  private _isFinalized: boolean = false;
   private _status: OperationStatus;
   private _stateHash: string | undefined;
   private _stateHashComponents: IOperationStateHashComponents | undefined;
@@ -485,22 +484,14 @@ export class OperationExecutionRecord implements IOperationRunnerContext, IOpera
       // Delegate global state reporting
       await executeContext.onResultAsync(this);
     } finally {
-      this.finalize();
-    }
-  }
-
-  /**
-   * Closes per-record output resources after the record reaches a terminal state.
-   */
-  public finalize(): void {
-    if (this.isTerminal && !this._isFinalized) {
-      this._isFinalized = true;
-      this._collatedWriter?.close();
-      if (this._collatedWriter) {
-        this._context.eventSink?.onOperationStreamClosed?.(this.name);
+      if (this.isTerminal) {
+        this._collatedWriter?.close();
+        if (this._collatedWriter) {
+          this._context.eventSink?.onOperationStreamClosed?.(this.name);
+        }
+        this.stdioSummarizer.close();
+        this.problemCollector.close();
       }
-      this.stdioSummarizer.close();
-      this.problemCollector.close();
     }
   }
 }

--- a/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
@@ -48,6 +48,7 @@ export interface IOperationExecutionRecordContext {
   onOperationStateChanged?: (record: OperationExecutionRecord) => void;
   createEnvironment?: (record: OperationExecutionRecord) => IEnvironment;
   invalidate?: (operations: Iterable<Operation>, reason: string) => void;
+  shouldRunnerPersist?: (operation: Operation) => boolean;
   inputsSnapshot: IInputsSnapshot | undefined;
   maxParallelism: number;
 
@@ -228,6 +229,14 @@ export class OperationExecutionRecord implements IOperationRunnerContext, IOpera
 
   public get environment(): IEnvironment | undefined {
     return this._context.createEnvironment?.(this);
+  }
+
+  /**
+   * Whether this operation's runner should remain resident after the operation completes for the
+   * current iteration. Defaults to `true` (kept warm) when the host supplies no persistence policy.
+   */
+  public get shouldRunnerPersist(): boolean {
+    return this._context.shouldRunnerPersist?.(this.operation) ?? true;
   }
 
   public getInvalidateCallback(): (reason: string) => void {

--- a/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
@@ -170,6 +170,7 @@ export class OperationExecutionRecord implements IOperationRunnerContext, IOpera
   private readonly _context: IOperationExecutionRecordContext;
 
   private _collatedWriter: CollatedWriter | undefined = undefined;
+  private _isFinalized: boolean = false;
   private _status: OperationStatus;
   private _stateHash: string | undefined;
   private _stateHashComponents: IOperationStateHashComponents | undefined;
@@ -484,14 +485,22 @@ export class OperationExecutionRecord implements IOperationRunnerContext, IOpera
       // Delegate global state reporting
       await executeContext.onResultAsync(this);
     } finally {
-      if (this.isTerminal) {
-        this._collatedWriter?.close();
-        if (this._collatedWriter) {
-          this._context.eventSink?.onOperationStreamClosed?.(this.name);
-        }
-        this.stdioSummarizer.close();
-        this.problemCollector.close();
+      this.finalize();
+    }
+  }
+
+  /**
+   * Closes per-record output resources after the record reaches a terminal state.
+   */
+  public finalize(): void {
+    if (this.isTerminal && !this._isFinalized) {
+      this._isFinalized = true;
+      this._collatedWriter?.close();
+      if (this._collatedWriter) {
+        this._context.eventSink?.onOperationStreamClosed?.(this.name);
       }
+      this.stdioSummarizer.close();
+      this.problemCollector.close();
     }
   }
 }

--- a/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
@@ -48,7 +48,6 @@ export interface IOperationExecutionRecordContext {
   onOperationStateChanged?: (record: OperationExecutionRecord) => void;
   createEnvironment?: (record: OperationExecutionRecord) => IEnvironment;
   invalidate?: (operations: Iterable<Operation>, reason: string) => void;
-  shouldRunnerPersist?: (operation: Operation) => boolean;
   inputsSnapshot: IInputsSnapshot | undefined;
   maxParallelism: number;
 
@@ -92,6 +91,11 @@ export class OperationExecutionRecord implements IOperationRunnerContext, IOpera
    * If true, this operation should be executed. If false, it should be skipped.
    */
   public enabled: boolean;
+
+  /**
+   * If true, this operation's runner should remain active after this iteration.
+   */
+  public shouldRunnerPersist: boolean = true;
 
   /**
    * This number represents how far away this Operation is from the furthest "root" operation (i.e.
@@ -229,14 +233,6 @@ export class OperationExecutionRecord implements IOperationRunnerContext, IOpera
 
   public get environment(): IEnvironment | undefined {
     return this._context.createEnvironment?.(this);
-  }
-
-  /**
-   * Whether this operation's runner should remain resident after the operation completes for the
-   * current iteration. Defaults to `true` (kept warm) when the host supplies no persistence policy.
-   */
-  public get shouldRunnerPersist(): boolean {
-    return this._context.shouldRunnerPersist?.(this.operation) ?? true;
   }
 
   public getInvalidateCallback(): (reason: string) => void {

--- a/libraries/rush-lib/src/logic/operations/OperationGraph.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationGraph.ts
@@ -926,6 +926,9 @@ export class OperationGraph implements IOperationGraph {
       },
       { concurrency: this.parallelism }
     );
+    for (const record of executionRecords.values()) {
+      record.finalize();
+    }
 
     const status: OperationStatus = (() => {
       if (state.hasAnyFailures) return OperationStatus.Failure;

--- a/libraries/rush-lib/src/logic/operations/OperationGraph.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationGraph.ts
@@ -86,7 +86,7 @@ interface IExecutionIterationContext extends IOperationExecutionRecordContext {
   promise: Promise<OperationStatus> | undefined;
 
   startTime?: number;
-  getRunnerPersistence: IOperationGraphIterationOptions['getRunnerPersistence'];
+  shouldRunnerPersist: IOperationGraphIterationOptions['shouldRunnerPersist'];
 
   completedOperations: number;
   totalOperations: number;
@@ -589,12 +589,12 @@ export class OperationGraph implements IOperationGraph {
     const {
       startTime = performance.now(),
       inputsSnapshot = await getInputsSnapshotAsync?.(),
-      getRunnerPersistence
+      shouldRunnerPersist
     } = iterationOptions;
     const iterationOptionsForCallbacks: IOperationGraphIterationOptions = {
       startTime,
       inputsSnapshot,
-      getRunnerPersistence
+      shouldRunnerPersist
     };
 
     const { hooks } = this;
@@ -628,7 +628,7 @@ export class OperationGraph implements IOperationGraph {
     const iterationContext: IExecutionIterationContext = {
       abortController,
       startTime,
-      getRunnerPersistence,
+      shouldRunnerPersist,
       streamCollator,
       terminal,
       inputsSnapshot,
@@ -788,7 +788,7 @@ export class OperationGraph implements IOperationGraph {
     const iterationOptions: IOperationGraphIterationOptions = {
       inputsSnapshot: iterationContext.inputsSnapshot,
       startTime: iterationContext.startTime,
-      getRunnerPersistence: iterationContext.getRunnerPersistence
+      shouldRunnerPersist: iterationContext.shouldRunnerPersist
     };
 
     const executionQueue: AsyncOperationQueue = new AsyncOperationQueue(
@@ -1049,11 +1049,14 @@ export class OperationGraph implements IOperationGraph {
       telemetry.log(logEntry);
     }
 
-    const { getRunnerPersistence } = iterationContext;
-    if (getRunnerPersistence) {
+    // IPC operations that executed this iteration release their runner immediately upon completion.
+    // This fallback closes cold runners that remain active because their operation did not execute,
+    // for example due to a cache hit, abort, blocked dependency, or disabled operation.
+    const { shouldRunnerPersist } = iterationContext;
+    if (shouldRunnerPersist) {
       const operationsToClose: Operation[] = [];
       for (const operation of this.operations) {
-        if (!getRunnerPersistence(operation)) {
+        if (!shouldRunnerPersist(operation) && operation.runner?.isActive !== false) {
           operationsToClose.push(operation);
         }
       }

--- a/libraries/rush-lib/src/logic/operations/OperationGraph.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationGraph.ts
@@ -86,6 +86,7 @@ interface IExecutionIterationContext extends IOperationExecutionRecordContext {
   promise: Promise<OperationStatus> | undefined;
 
   startTime?: number;
+  getRunnerPersistence: IOperationGraphIterationOptions['getRunnerPersistence'];
 
   completedOperations: number;
   totalOperations: number;
@@ -585,9 +586,16 @@ export class OperationGraph implements IOperationGraph {
   ): Promise<IExecutionIterationContext | undefined> {
     const { _getInputsSnapshotAsync: getInputsSnapshotAsync } = this;
 
-    const { startTime = performance.now(), inputsSnapshot = await getInputsSnapshotAsync?.() } =
-      iterationOptions;
-    const iterationOptionsForCallbacks: IOperationGraphIterationOptions = { startTime, inputsSnapshot };
+    const {
+      startTime = performance.now(),
+      inputsSnapshot = await getInputsSnapshotAsync?.(),
+      getRunnerPersistence
+    } = iterationOptions;
+    const iterationOptionsForCallbacks: IOperationGraphIterationOptions = {
+      startTime,
+      inputsSnapshot,
+      getRunnerPersistence
+    };
 
     const { hooks } = this;
 
@@ -620,6 +628,7 @@ export class OperationGraph implements IOperationGraph {
     const iterationContext: IExecutionIterationContext = {
       abortController,
       startTime,
+      getRunnerPersistence,
       streamCollator,
       terminal,
       inputsSnapshot,
@@ -778,7 +787,8 @@ export class OperationGraph implements IOperationGraph {
 
     const iterationOptions: IOperationGraphIterationOptions = {
       inputsSnapshot: iterationContext.inputsSnapshot,
-      startTime: iterationContext.startTime
+      startTime: iterationContext.startTime,
+      getRunnerPersistence: iterationContext.getRunnerPersistence
     };
 
     const executionQueue: AsyncOperationQueue = new AsyncOperationQueue(
@@ -1037,6 +1047,17 @@ export class OperationGraph implements IOperationGraph {
 
       measureFn(`${PERF_PREFIX}:beforeLog`, () => this.hooks.beforeLog.call(logEntry));
       telemetry.log(logEntry);
+    }
+
+    const { getRunnerPersistence } = iterationContext;
+    if (getRunnerPersistence) {
+      const operationsToClose: Operation[] = [];
+      for (const operation of this.operations) {
+        if (!getRunnerPersistence(operation)) {
+          operationsToClose.push(operation);
+        }
+      }
+      await this.closeRunnersAsync(operationsToClose);
     }
 
     return status;

--- a/libraries/rush-lib/src/logic/operations/OperationGraph.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationGraph.ts
@@ -91,6 +91,33 @@ interface IExecutionIterationContext extends IOperationExecutionRecordContext {
   totalOperations: number;
 }
 
+interface IOperationRunnerCloseEntry {
+  operation: Operation;
+  closeAsync: () => Promise<void>;
+}
+
+class OperationRunnerCloseError extends Error {
+  public readonly operation: Operation;
+  public readonly innerError: Error;
+
+  public constructor(operation: Operation, innerError: Error) {
+    super(innerError.message);
+    this.name = OperationRunnerCloseError.name;
+    this.operation = operation;
+    this.innerError = innerError;
+  }
+}
+
+class OperationRunnersCloseError extends Error {
+  public readonly errors: ReadonlyArray<OperationRunnerCloseError>;
+
+  public constructor(errors: OperationRunnerCloseError[]) {
+    super(`Failed to close ${errors.length} operation runner(s).`);
+    this.name = OperationRunnersCloseError.name;
+    this.errors = errors;
+  }
+}
+
 /**
  * Telemetry data for a phased execution
  */
@@ -404,29 +431,39 @@ export class OperationGraph implements IOperationGraph {
   }
 
   public async closeRunnersAsync(operations?: Iterable<Operation>): Promise<void> {
-    const promises: Promise<void>[] = [];
+    const runnersToClose: IOperationRunnerCloseEntry[] = [];
     const recordMap: ReadonlyMap<Operation, OperationExecutionRecord> =
       this._currentIteration?.records ?? this.resultByOperation;
     const closedRecords: Set<OperationExecutionRecord> = new Set();
     for (const operation of operations ?? this.operations) {
-      if (operation.runner?.closeAsync) {
-        const record: OperationExecutionRecord | undefined = recordMap.get(operation);
-        promises.push(
-          operation.runner.closeAsync().then(() => {
-            if (record) {
-              // Collect for batched notification
-              closedRecords.add(record);
-            }
-          })
-        );
+      const closeAsync: (() => Promise<void>) | undefined = operation.runner?.closeAsync;
+      if (closeAsync) {
+        runnersToClose.push({ operation, closeAsync: closeAsync.bind(operation.runner) });
       }
     }
-    await Promise.all(promises);
-    if (this.abortController.signal.aborted) {
-      return;
+    const results: PromiseSettledResult<void>[] = await Promise.allSettled(
+      runnersToClose.map((entry) => entry.closeAsync())
+    );
+    const errors: OperationRunnerCloseError[] = [];
+    for (let index: number = 0; index < results.length; index++) {
+      const operation: Operation = runnersToClose[index].operation;
+      const result: PromiseSettledResult<void> = results[index];
+      if (result.status === 'fulfilled') {
+        const record: OperationExecutionRecord | undefined = recordMap.get(operation);
+        if (record) {
+          closedRecords.add(record);
+        }
+      } else {
+        const innerError: Error =
+          result.reason instanceof Error ? result.reason : new Error(String(result.reason));
+        errors.push(new OperationRunnerCloseError(operation, innerError));
+      }
     }
-    if (closedRecords.size) {
+    if (!this.abortController.signal.aborted && closedRecords.size) {
       this.hooks.onExecutionStatesUpdated.call(closedRecords);
+    }
+    if (errors.length > 0) {
+      throw new OperationRunnersCloseError(errors);
     }
   }
 
@@ -917,8 +954,19 @@ export class OperationGraph implements IOperationGraph {
       try {
         await this.closeRunnersAsync(recordsToClose.map((record) => record.operation));
       } catch (e) {
-        for (const record of recordsToClose) {
-          reportRunnerCleanupFailure(record, e);
+        if (e instanceof OperationRunnersCloseError) {
+          for (const error of e.errors) {
+            if (error instanceof OperationRunnerCloseError) {
+              const record: OperationExecutionRecord | undefined = executionRecords.get(error.operation);
+              if (record) {
+                reportRunnerCleanupFailure(record, error.innerError);
+              }
+            }
+          }
+        } else {
+          for (const record of recordsToClose) {
+            reportRunnerCleanupFailure(record, e);
+          }
         }
       }
     }

--- a/libraries/rush-lib/src/logic/operations/OperationGraph.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationGraph.ts
@@ -820,6 +820,8 @@ export class OperationGraph implements IOperationGraph {
       onStartAsync: onOperationStartAsync,
       onResultAsync: onOperationCompleteAsync
     };
+    // Track runners closed by normal operation completion so the end-of-iteration fallback does not
+    // issue a concurrent or duplicate closeAsync() call for the same runner.
     const recordsWithRunnerCleanup: Set<OperationExecutionRecord> = new Set();
     const graph: OperationGraph = this;
 
@@ -1085,6 +1087,8 @@ export class OperationGraph implements IOperationGraph {
           record.status = OperationStatus.Failure;
         }
         if (!record.shouldRunnerPersist) {
+          // The runner's executeAsync() and the post-operation hook have both settled before cleanup,
+          // so persistence cleanup cannot race this operation's execution.
           recordsWithRunnerCleanup.add(record);
           try {
             await graph.closeRunnersAsync([record.operation]);

--- a/libraries/rush-lib/src/logic/operations/OperationGraph.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationGraph.ts
@@ -903,19 +903,33 @@ export class OperationGraph implements IOperationGraph {
       });
     }
 
-    const operationsToClose: Operation[] = [];
-    for (const [operation, record] of executionRecords) {
+    const recordsToClose: OperationExecutionRecord[] = [];
+    for (const record of executionRecords.values()) {
       if (!recordsWithRunnerCleanup.has(record) && !record.shouldRunnerPersist) {
-        operationsToClose.push(operation);
+        recordsToClose.push(record);
       }
     }
-    if (operationsToClose.length > 0) {
-      await this.closeRunnersAsync(operationsToClose);
+    function reportRunnerCleanupFailure(record: OperationExecutionRecord, error: Error): void {
+      record.error = error;
+      record.status = OperationStatus.Failure;
+      _reportOperationErrorIfAny(record);
+      state.hasAnyFailures = true;
     }
+    await Async.forEachAsync(
+      recordsToClose,
+      async (record: OperationExecutionRecord) => {
+        try {
+          await this.closeRunnersAsync([record.operation]);
+        } catch (e) {
+          reportRunnerCleanupFailure(record, e);
+        }
+      },
+      { concurrency: this.parallelism }
+    );
 
     const status: OperationStatus = (() => {
-      if (bailStatus) return bailStatus;
       if (state.hasAnyFailures) return OperationStatus.Failure;
+      if (bailStatus) return bailStatus;
       if (state.hasAnyAborted) return OperationStatus.Aborted;
       if (state.hasAnyNonAllowedWarnings) return OperationStatus.SuccessWithWarning;
       if (iterationContext.totalOperations === 0) return OperationStatus.NoOp;

--- a/libraries/rush-lib/src/logic/operations/OperationGraph.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationGraph.ts
@@ -98,23 +98,13 @@ interface IOperationRunnerCloseEntry {
 
 class OperationRunnerCloseError extends Error {
   public readonly operation: Operation;
-  public readonly innerError: Error;
+  public override readonly cause: Error;
 
-  public constructor(operation: Operation, innerError: Error) {
-    super(innerError.message);
+  public constructor(operation: Operation, cause: Error) {
+    super(cause.message, { cause });
     this.name = OperationRunnerCloseError.name;
     this.operation = operation;
-    this.innerError = innerError;
-  }
-}
-
-class OperationRunnersCloseError extends Error {
-  public readonly errors: ReadonlyArray<OperationRunnerCloseError>;
-
-  public constructor(errors: OperationRunnerCloseError[]) {
-    super(`Failed to close ${errors.length} operation runner(s).`);
-    this.name = OperationRunnersCloseError.name;
-    this.errors = errors;
+    this.cause = cause;
   }
 }
 
@@ -463,7 +453,7 @@ export class OperationGraph implements IOperationGraph {
       this.hooks.onExecutionStatesUpdated.call(closedRecords);
     }
     if (errors.length > 0) {
-      throw new OperationRunnersCloseError(errors);
+      throw new AggregateError(errors, `Failed to close ${errors.length} operation runner(s).`);
     }
   }
 
@@ -954,12 +944,12 @@ export class OperationGraph implements IOperationGraph {
       try {
         await this.closeRunnersAsync(recordsToClose.map((record) => record.operation));
       } catch (e) {
-        if (e instanceof OperationRunnersCloseError) {
+        if (e instanceof AggregateError) {
           for (const error of e.errors) {
             if (error instanceof OperationRunnerCloseError) {
               const record: OperationExecutionRecord | undefined = executionRecords.get(error.operation);
               if (record) {
-                reportRunnerCleanupFailure(record, error.innerError);
+                reportRunnerCleanupFailure(record, error.cause);
               }
             }
           }

--- a/libraries/rush-lib/src/logic/operations/OperationGraph.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationGraph.ts
@@ -403,7 +403,7 @@ export class OperationGraph implements IOperationGraph {
     }
   }
 
-  public async closeRunnersAsync(operations?: Operation[]): Promise<void> {
+  public async closeRunnersAsync(operations?: Iterable<Operation>): Promise<void> {
     const promises: Promise<void>[] = [];
     const recordMap: ReadonlyMap<Operation, OperationExecutionRecord> =
       this._currentIteration?.records ?? this.resultByOperation;
@@ -820,10 +820,6 @@ export class OperationGraph implements IOperationGraph {
       onStartAsync: onOperationStartAsync,
       onResultAsync: onOperationCompleteAsync
     };
-    // Track runners closed by normal operation completion so the end-of-iteration fallback does not
-    // issue a concurrent or duplicate closeAsync() call for the same runner.
-    const recordsWithRunnerCleanup: Set<OperationExecutionRecord> = new Set();
-    const graph: OperationGraph = this;
 
     const { eventSink } = this;
     if (!this.quietMode) {
@@ -907,7 +903,7 @@ export class OperationGraph implements IOperationGraph {
 
     const recordsToClose: OperationExecutionRecord[] = [];
     for (const record of executionRecords.values()) {
-      if (!recordsWithRunnerCleanup.has(record) && !record.shouldRunnerPersist) {
+      if (!record.shouldRunnerPersist) {
         recordsToClose.push(record);
       }
     }
@@ -917,19 +913,18 @@ export class OperationGraph implements IOperationGraph {
       _reportOperationErrorIfAny(record);
       state.hasAnyFailures = true;
     }
-    await Async.forEachAsync(
-      recordsToClose,
-      async (record: OperationExecutionRecord) => {
-        try {
-          await this.closeRunnersAsync([record.operation]);
-        } catch (e) {
+    if (recordsToClose.length > 0) {
+      try {
+        await this.closeRunnersAsync(recordsToClose.map((record) => record.operation));
+      } catch (e) {
+        for (const record of recordsToClose) {
           reportRunnerCleanupFailure(record, e);
         }
-      },
-      { concurrency: this.parallelism }
-    );
+      }
+    }
     for (const record of executionRecords.values()) {
-      record.finalize();
+      record.stdioSummarizer.close();
+      record.problemCollector.close();
     }
 
     const status: OperationStatus = (() => {
@@ -1085,18 +1080,6 @@ export class OperationGraph implements IOperationGraph {
           _reportOperationErrorIfAny(record);
           record.error = e;
           record.status = OperationStatus.Failure;
-        }
-        if (!record.shouldRunnerPersist) {
-          // The runner's executeAsync() and the post-operation hook have both settled before cleanup,
-          // so persistence cleanup cannot race this operation's execution.
-          recordsWithRunnerCleanup.add(record);
-          try {
-            await graph.closeRunnersAsync([record.operation]);
-          } catch (e) {
-            _reportOperationErrorIfAny(record);
-            record.error = e;
-            record.status = OperationStatus.Failure;
-          }
         }
         _onOperationComplete(record, state);
       }

--- a/libraries/rush-lib/src/logic/operations/OperationGraph.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationGraph.ts
@@ -86,7 +86,6 @@ interface IExecutionIterationContext extends IOperationExecutionRecordContext {
   promise: Promise<OperationStatus> | undefined;
 
   startTime?: number;
-  shouldRunnerPersist: IOperationGraphIterationOptions['shouldRunnerPersist'];
 
   completedOperations: number;
   totalOperations: number;
@@ -586,16 +585,9 @@ export class OperationGraph implements IOperationGraph {
   ): Promise<IExecutionIterationContext | undefined> {
     const { _getInputsSnapshotAsync: getInputsSnapshotAsync } = this;
 
-    const {
-      startTime = performance.now(),
-      inputsSnapshot = await getInputsSnapshotAsync?.(),
-      shouldRunnerPersist
-    } = iterationOptions;
-    const iterationOptionsForCallbacks: IOperationGraphIterationOptions = {
-      startTime,
-      inputsSnapshot,
-      shouldRunnerPersist
-    };
+    const { startTime = performance.now(), inputsSnapshot = await getInputsSnapshotAsync?.() } =
+      iterationOptions;
+    const iterationOptionsForCallbacks: IOperationGraphIterationOptions = { startTime, inputsSnapshot };
 
     const { hooks } = this;
 
@@ -628,7 +620,6 @@ export class OperationGraph implements IOperationGraph {
     const iterationContext: IExecutionIterationContext = {
       abortController,
       startTime,
-      shouldRunnerPersist,
       streamCollator,
       terminal,
       inputsSnapshot,
@@ -787,8 +778,7 @@ export class OperationGraph implements IOperationGraph {
 
     const iterationOptions: IOperationGraphIterationOptions = {
       inputsSnapshot: iterationContext.inputsSnapshot,
-      startTime: iterationContext.startTime,
-      shouldRunnerPersist: iterationContext.shouldRunnerPersist
+      startTime: iterationContext.startTime
     };
 
     const executionQueue: AsyncOperationQueue = new AsyncOperationQueue(
@@ -830,6 +820,8 @@ export class OperationGraph implements IOperationGraph {
       onStartAsync: onOperationStartAsync,
       onResultAsync: onOperationCompleteAsync
     };
+    const recordsWithRunnerCleanup: Set<OperationExecutionRecord> = new Set();
+    const graph: OperationGraph = this;
 
     const { eventSink } = this;
     if (!this.quietMode) {
@@ -909,6 +901,16 @@ export class OperationGraph implements IOperationGraph {
           }
         );
       });
+    }
+
+    const operationsToClose: Operation[] = [];
+    for (const [operation, record] of executionRecords) {
+      if (!recordsWithRunnerCleanup.has(record) && !record.shouldRunnerPersist) {
+        operationsToClose.push(operation);
+      }
+    }
+    if (operationsToClose.length > 0) {
+      await this.closeRunnersAsync(operationsToClose);
     }
 
     const status: OperationStatus = (() => {
@@ -1049,20 +1051,6 @@ export class OperationGraph implements IOperationGraph {
       telemetry.log(logEntry);
     }
 
-    // IPC operations that executed this iteration release their runner immediately upon completion.
-    // This fallback closes cold runners that remain active because their operation did not execute,
-    // for example due to a cache hit, abort, blocked dependency, or disabled operation.
-    const { shouldRunnerPersist } = iterationContext;
-    if (shouldRunnerPersist) {
-      const operationsToClose: Operation[] = [];
-      for (const operation of this.operations) {
-        if (!shouldRunnerPersist(operation) && operation.runner?.isActive !== false) {
-          operationsToClose.push(operation);
-        }
-      }
-      await this.closeRunnersAsync(operationsToClose);
-    }
-
     return status;
 
     // This function is a callback because it may write to the collatedWriter before
@@ -1078,6 +1066,16 @@ export class OperationGraph implements IOperationGraph {
           _reportOperationErrorIfAny(record);
           record.error = e;
           record.status = OperationStatus.Failure;
+        }
+        if (!record.shouldRunnerPersist) {
+          recordsWithRunnerCleanup.add(record);
+          try {
+            await graph.closeRunnersAsync([record.operation]);
+          } catch (e) {
+            _reportOperationErrorIfAny(record);
+            record.error = e;
+            record.status = OperationStatus.Failure;
+          }
         }
         _onOperationComplete(record, state);
       }

--- a/libraries/rush-lib/src/logic/operations/test/OperationGraph.test.ts
+++ b/libraries/rush-lib/src/logic/operations/test/OperationGraph.test.ts
@@ -107,6 +107,12 @@ function createGraph(
   return new OperationGraph(new Set([operation]), graphOptions);
 }
 
+class ClosableRunner extends MockOperationRunner {
+  public readonly closeAsync: jest.Mock<Promise<void>, []> = jest.fn(async () => {
+    /* no-op */
+  });
+}
+
 describe('OperationGraph', () => {
   let graphOptions: IOperationGraphOptions;
   let graphIterationOptions: IOperationGraphIterationOptions;
@@ -1134,13 +1140,76 @@ describe('deferred invalidation during active iteration', () => {
   });
 });
 
-describe('closeRunnersAsync', () => {
-  class ClosableRunner extends MockOperationRunner {
-    public readonly closeAsync: jest.Mock<Promise<void>, []> = jest.fn(async () => {
-      /* no-op */
-    });
-  }
+describe('runner persistence policy', () => {
+  const graphOptions: IOperationGraphOptions = {
+    quietMode: false,
+    debugMode: false,
+    parallelism: 3,
+    allowOversubscription: true,
+    destinations: [mockWritable],
+    abortController: new AbortController()
+  };
 
+  it('keeps runners active across successive iterations when no policy is provided', async () => {
+    const runAsync: jest.Mock<Promise<OperationStatus>, []> = jest.fn(async () => OperationStatus.Success);
+    const runner: ClosableRunner = new ClosableRunner('default-persistent', runAsync);
+    const graph: OperationGraph = createGraph(graphOptions, runner);
+
+    await graph.executeAsync({});
+    expect(runAsync).toHaveBeenCalledTimes(1);
+    expect(runner.closeAsync).not.toHaveBeenCalled();
+
+    await graph.executeAsync({});
+    expect(runAsync).toHaveBeenCalledTimes(2);
+    expect(runner.closeAsync).not.toHaveBeenCalled();
+  });
+
+  it('applies per-operation policies independently on each iteration', async () => {
+    const persistentRunner: ClosableRunner = new ClosableRunner('persistent');
+    const oneShotRunner: ClosableRunner = new ClosableRunner('one-shot');
+    const changingRunner: ClosableRunner = new ClosableRunner('changing');
+
+    const persistentOperation: Operation = new Operation({
+      runner: persistentRunner,
+      logFilenameIdentifier: 'persistent',
+      phase: mockPhase,
+      project: getOrCreateProject('persistent')
+    });
+    const oneShotOperation: Operation = new Operation({
+      runner: oneShotRunner,
+      logFilenameIdentifier: 'one-shot',
+      phase: mockPhase,
+      project: getOrCreateProject('one-shot')
+    });
+    const changingOperation: Operation = new Operation({
+      runner: changingRunner,
+      logFilenameIdentifier: 'changing',
+      phase: mockPhase,
+      project: getOrCreateProject('changing')
+    });
+
+    const graph: OperationGraph = new OperationGraph(
+      new Set([persistentOperation, oneShotOperation, changingOperation]),
+      graphOptions
+    );
+
+    await graph.executeAsync({
+      getRunnerPersistence: (operation) => operation !== oneShotOperation
+    });
+    expect(persistentRunner.closeAsync).not.toHaveBeenCalled();
+    expect(oneShotRunner.closeAsync).toHaveBeenCalledTimes(1);
+    expect(changingRunner.closeAsync).not.toHaveBeenCalled();
+
+    await graph.executeAsync({
+      getRunnerPersistence: (operation) => operation === persistentOperation
+    });
+    expect(persistentRunner.closeAsync).not.toHaveBeenCalled();
+    expect(oneShotRunner.closeAsync).toHaveBeenCalledTimes(2);
+    expect(changingRunner.closeAsync).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('closeRunnersAsync', () => {
   it('invokes closeAsync on runners and triggers onExecutionStatesUpdated hook', async () => {
     const localOptions: IOperationGraphOptions = {
       quietMode: false,

--- a/libraries/rush-lib/src/logic/operations/test/OperationGraph.test.ts
+++ b/libraries/rush-lib/src/logic/operations/test/OperationGraph.test.ts
@@ -108,9 +108,23 @@ function createGraph(
 }
 
 class ClosableRunner extends MockOperationRunner {
+  public isActive: boolean = false;
+
   public readonly closeAsync: jest.Mock<Promise<void>, []> = jest.fn(async () => {
-    /* no-op */
+    this.isActive = false;
   });
+
+  public override async executeAsync(context: IOperationRunnerContext): Promise<OperationStatus> {
+    this.isActive = true;
+    const status: OperationStatus = await super.executeAsync(context);
+    // Mirror IPCOperationRunner: a runner that owns a long-lived resource must release it
+    // immediately upon completion when the host has opted this operation out of persistence for
+    // the current iteration, rather than waiting until the end of the iteration.
+    if (context.shouldRunnerPersist === false) {
+      await this.closeAsync();
+    }
+    return status;
+  }
 }
 
 describe('OperationGraph', () => {
@@ -1194,18 +1208,106 @@ describe('runner persistence policy', () => {
     );
 
     await graph.executeAsync({
-      getRunnerPersistence: (operation) => operation !== oneShotOperation
+      shouldRunnerPersist: (operation) => operation !== oneShotOperation
     });
     expect(persistentRunner.closeAsync).not.toHaveBeenCalled();
     expect(oneShotRunner.closeAsync).toHaveBeenCalledTimes(1);
     expect(changingRunner.closeAsync).not.toHaveBeenCalled();
 
     await graph.executeAsync({
-      getRunnerPersistence: (operation) => operation === persistentOperation
+      shouldRunnerPersist: (operation) => operation === persistentOperation
     });
     expect(persistentRunner.closeAsync).not.toHaveBeenCalled();
     expect(oneShotRunner.closeAsync).toHaveBeenCalledTimes(2);
     expect(changingRunner.closeAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it('releases a non-persistent runner before its dependents execute', async () => {
+    const executionOrder: string[] = [];
+
+    const upstreamRunner: ClosableRunner = new ClosableRunner('upstream', async () => {
+      executionOrder.push('upstream:run');
+      return OperationStatus.Success;
+    });
+    upstreamRunner.closeAsync.mockImplementation(async () => {
+      executionOrder.push('upstream:close');
+      upstreamRunner.isActive = false;
+    });
+
+    const downstreamRunner: ClosableRunner = new ClosableRunner('downstream', async () => {
+      executionOrder.push('downstream:run');
+      return OperationStatus.Success;
+    });
+
+    const upstreamOperation: Operation = new Operation({
+      runner: upstreamRunner,
+      logFilenameIdentifier: 'upstream',
+      phase: mockPhase,
+      project: getOrCreateProject('upstream')
+    });
+    const downstreamOperation: Operation = new Operation({
+      runner: downstreamRunner,
+      logFilenameIdentifier: 'downstream',
+      phase: mockPhase,
+      project: getOrCreateProject('downstream')
+    });
+    downstreamOperation.addDependency(upstreamOperation);
+
+    const graph: OperationGraph = new OperationGraph(
+      new Set([upstreamOperation, downstreamOperation]),
+      graphOptions
+    );
+
+    await graph.executeAsync({
+      shouldRunnerPersist: (operation) => operation !== upstreamOperation
+    });
+
+    expect(upstreamRunner.closeAsync).toHaveBeenCalledTimes(1);
+    expect(downstreamRunner.closeAsync).not.toHaveBeenCalled();
+    // The non-persistent upstream runner must be released immediately upon its own completion,
+    // before the downstream operation begins executing — not deferred to the end of the iteration.
+    expect(executionOrder).toEqual(['upstream:run', 'upstream:close', 'downstream:run']);
+  });
+
+  it('closes an active cold runner when an iteration bypasses runner execution', async () => {
+    const persistentRunner: ClosableRunner = new ClosableRunner('persistent');
+    const coldRunner: ClosableRunner = new ClosableRunner('cold');
+
+    const persistentOperation: Operation = new Operation({
+      runner: persistentRunner,
+      logFilenameIdentifier: 'persistent',
+      phase: mockPhase,
+      project: getOrCreateProject('persistent')
+    });
+    const coldOperation: Operation = new Operation({
+      runner: coldRunner,
+      logFilenameIdentifier: 'cold',
+      phase: mockPhase,
+      project: getOrCreateProject('cold')
+    });
+
+    const graph: OperationGraph = new OperationGraph(
+      new Set([persistentOperation, coldOperation]),
+      graphOptions
+    );
+
+    await graph.executeAsync({});
+    expect(persistentRunner.isActive).toBe(true);
+    expect(coldRunner.isActive).toBe(true);
+
+    graph.hooks.beforeExecuteIterationAsync.tapPromise(
+      'test',
+      async (): Promise<OperationStatus> => OperationStatus.FromCache
+    );
+
+    await graph.executeAsync({
+      shouldRunnerPersist: (operation) => operation === persistentOperation
+    });
+
+    expect(coldRunner.closeAsync).toHaveBeenCalledTimes(1);
+    expect(coldRunner.isActive).toBe(false);
+    expect(persistentRunner.closeAsync).not.toHaveBeenCalled();
+    expect(persistentRunner.isActive).toBe(true);
   });
 });
 

--- a/libraries/rush-lib/src/logic/operations/test/OperationGraph.test.ts
+++ b/libraries/rush-lib/src/logic/operations/test/OperationGraph.test.ts
@@ -1317,6 +1317,61 @@ describe('runner persistence policy', () => {
     expect(persistentRunner.closeAsync).not.toHaveBeenCalled();
     expect(persistentRunner.isActive).toBe(true);
   });
+
+  it('reports a bypassed runner cleanup failure before finalizing the iteration', async () => {
+    const persistentRunner: ClosableRunner = new ClosableRunner('persistent');
+    const coldRunner: ClosableRunner = new ClosableRunner('cold');
+    const closeError: Error = new Error('close failed');
+    const lifecycleEvents: string[] = [];
+
+    const persistentOperation: Operation = new Operation({
+      runner: persistentRunner,
+      logFilenameIdentifier: 'persistent',
+      phase: mockPhase,
+      project: getOrCreateProject('persistent')
+    });
+    const coldOperation: Operation = new Operation({
+      runner: coldRunner,
+      logFilenameIdentifier: 'cold',
+      phase: mockPhase,
+      project: getOrCreateProject('cold')
+    });
+
+    const graph: OperationGraph = new OperationGraph(
+      new Set([persistentOperation, coldOperation]),
+      graphOptions
+    );
+
+    await graph.executeAsync({});
+
+    configureRunnerPersistence(graph, (operation) => operation === persistentOperation);
+    coldRunner.closeAsync.mockImplementationOnce(async () => {
+      lifecycleEvents.push('close');
+      throw closeError;
+    });
+    graph.hooks.beforeExecuteIterationAsync.tapPromise(
+      'test',
+      async (): Promise<OperationStatus> => OperationStatus.FromCache
+    );
+    let afterIterationStatus: OperationStatus | undefined;
+    graph.hooks.afterExecuteIterationAsync.tapPromise('test', async (status) => {
+      lifecycleEvents.push('after-iteration');
+      afterIterationStatus = status;
+      return status;
+    });
+
+    const result: IExecutionResult = await graph.executeAsync({});
+    const coldResult: IOperationExecutionResult | undefined =
+      result.operationResults.get(coldOperation);
+
+    expect(lifecycleEvents).toEqual(['close', 'after-iteration']);
+    expect(afterIterationStatus).toBe(OperationStatus.Failure);
+    expect(result.status).toBe(OperationStatus.Failure);
+    expect(graph.status).toBe(OperationStatus.Failure);
+    expect(coldResult?.status).toBe(OperationStatus.Failure);
+    expect(coldResult?.error).toBe(closeError);
+    expect(persistentRunner.closeAsync).not.toHaveBeenCalled();
+  });
 });
 
 describe('closeRunnersAsync', () => {

--- a/libraries/rush-lib/src/logic/operations/test/OperationGraph.test.ts
+++ b/libraries/rush-lib/src/logic/operations/test/OperationGraph.test.ts
@@ -116,15 +116,19 @@ class ClosableRunner extends MockOperationRunner {
 
   public override async executeAsync(context: IOperationRunnerContext): Promise<OperationStatus> {
     this.isActive = true;
-    const status: OperationStatus = await super.executeAsync(context);
-    // Mirror IPCOperationRunner: a runner that owns a long-lived resource must release it
-    // immediately upon completion when the host has opted this operation out of persistence for
-    // the current iteration, rather than waiting until the end of the iteration.
-    if (context.shouldRunnerPersist === false) {
-      await this.closeAsync();
-    }
-    return status;
+    return await super.executeAsync(context);
   }
+}
+
+function configureRunnerPersistence(
+  graph: OperationGraph,
+  shouldRunnerPersist: (operation: Operation) => boolean
+): void {
+  graph.hooks.configureIteration.tap('test-runner-persistence', (records) => {
+    for (const [operation, record] of records) {
+      record.shouldRunnerPersist = shouldRunnerPersist(operation);
+    }
+  });
 }
 
 describe('OperationGraph', () => {
@@ -1164,7 +1168,7 @@ describe('runner persistence policy', () => {
     abortController: new AbortController()
   };
 
-  it('keeps runners active across successive iterations when no policy is provided', async () => {
+  it('keeps runners active across successive iterations by default', async () => {
     const runAsync: jest.Mock<Promise<OperationStatus>, []> = jest.fn(async () => OperationStatus.Success);
     const runner: ClosableRunner = new ClosableRunner('default-persistent', runAsync);
     const graph: OperationGraph = createGraph(graphOptions, runner);
@@ -1178,7 +1182,7 @@ describe('runner persistence policy', () => {
     expect(runner.closeAsync).not.toHaveBeenCalled();
   });
 
-  it('applies per-operation policies independently on each iteration', async () => {
+  it('applies configured record policies independently on each iteration', async () => {
     const persistentRunner: ClosableRunner = new ClosableRunner('persistent');
     const oneShotRunner: ClosableRunner = new ClosableRunner('one-shot');
     const changingRunner: ClosableRunner = new ClosableRunner('changing');
@@ -1207,16 +1211,16 @@ describe('runner persistence policy', () => {
       graphOptions
     );
 
-    await graph.executeAsync({
-      shouldRunnerPersist: (operation) => operation !== oneShotOperation
-    });
+    let persistentOperations: ReadonlySet<Operation> = new Set([persistentOperation, changingOperation]);
+    configureRunnerPersistence(graph, (operation) => persistentOperations.has(operation));
+
+    await graph.executeAsync({});
     expect(persistentRunner.closeAsync).not.toHaveBeenCalled();
     expect(oneShotRunner.closeAsync).toHaveBeenCalledTimes(1);
     expect(changingRunner.closeAsync).not.toHaveBeenCalled();
 
-    await graph.executeAsync({
-      shouldRunnerPersist: (operation) => operation === persistentOperation
-    });
+    persistentOperations = new Set([persistentOperation]);
+    await graph.executeAsync({});
     expect(persistentRunner.closeAsync).not.toHaveBeenCalled();
     expect(oneShotRunner.closeAsync).toHaveBeenCalledTimes(2);
     expect(changingRunner.closeAsync).toHaveBeenCalledTimes(1);
@@ -1258,9 +1262,8 @@ describe('runner persistence policy', () => {
       graphOptions
     );
 
-    await graph.executeAsync({
-      shouldRunnerPersist: (operation) => operation !== upstreamOperation
-    });
+    configureRunnerPersistence(graph, (operation) => operation !== upstreamOperation);
+    await graph.executeAsync({});
 
     expect(upstreamRunner.closeAsync).toHaveBeenCalledTimes(1);
     expect(downstreamRunner.closeAsync).not.toHaveBeenCalled();
@@ -1272,6 +1275,7 @@ describe('runner persistence policy', () => {
   it('closes an active cold runner when an iteration bypasses runner execution', async () => {
     const persistentRunner: ClosableRunner = new ClosableRunner('persistent');
     const coldRunner: ClosableRunner = new ClosableRunner('cold');
+    let coldRunnerWasClosedBeforeAfterIteration: boolean = false;
 
     const persistentOperation: Operation = new Operation({
       runner: persistentRunner,
@@ -1295,17 +1299,21 @@ describe('runner persistence policy', () => {
     expect(persistentRunner.isActive).toBe(true);
     expect(coldRunner.isActive).toBe(true);
 
+    configureRunnerPersistence(graph, (operation) => operation === persistentOperation);
     graph.hooks.beforeExecuteIterationAsync.tapPromise(
       'test',
       async (): Promise<OperationStatus> => OperationStatus.FromCache
     );
-
-    await graph.executeAsync({
-      shouldRunnerPersist: (operation) => operation === persistentOperation
+    graph.hooks.afterExecuteIterationAsync.tapPromise('test', async (status) => {
+      coldRunnerWasClosedBeforeAfterIteration = coldRunner.isActive === false;
+      return status;
     });
+
+    await graph.executeAsync({});
 
     expect(coldRunner.closeAsync).toHaveBeenCalledTimes(1);
     expect(coldRunner.isActive).toBe(false);
+    expect(coldRunnerWasClosedBeforeAfterIteration).toBe(true);
     expect(persistentRunner.closeAsync).not.toHaveBeenCalled();
     expect(persistentRunner.isActive).toBe(true);
   });

--- a/libraries/rush-lib/src/logic/operations/test/OperationGraph.test.ts
+++ b/libraries/rush-lib/src/logic/operations/test/OperationGraph.test.ts
@@ -116,7 +116,11 @@ class ClosableRunner extends MockOperationRunner {
 
   public override async executeAsync(context: IOperationRunnerContext): Promise<OperationStatus> {
     this.isActive = true;
-    return await super.executeAsync(context);
+    const status: OperationStatus = await super.executeAsync(context);
+    if (!context.shouldRunnerPersist) {
+      await this.closeAsync();
+    }
+    return status;
   }
 }
 
@@ -1216,14 +1220,14 @@ describe('runner persistence policy', () => {
 
     await graph.executeAsync({});
     expect(persistentRunner.closeAsync).not.toHaveBeenCalled();
-    expect(oneShotRunner.closeAsync).toHaveBeenCalledTimes(1);
+    expect(oneShotRunner.closeAsync).toHaveBeenCalledTimes(2);
     expect(changingRunner.closeAsync).not.toHaveBeenCalled();
 
     persistentOperations = new Set([persistentOperation]);
     await graph.executeAsync({});
     expect(persistentRunner.closeAsync).not.toHaveBeenCalled();
-    expect(oneShotRunner.closeAsync).toHaveBeenCalledTimes(2);
-    expect(changingRunner.closeAsync).toHaveBeenCalledTimes(1);
+    expect(oneShotRunner.closeAsync).toHaveBeenCalledTimes(4);
+    expect(changingRunner.closeAsync).toHaveBeenCalledTimes(2);
   });
 
   it('releases a non-persistent runner before its dependents execute', async () => {
@@ -1234,7 +1238,9 @@ describe('runner persistence policy', () => {
       return OperationStatus.Success;
     });
     upstreamRunner.closeAsync.mockImplementation(async () => {
-      executionOrder.push('upstream:close');
+      if (upstreamRunner.isActive) {
+        executionOrder.push('upstream:close');
+      }
       upstreamRunner.isActive = false;
     });
 
@@ -1265,7 +1271,7 @@ describe('runner persistence policy', () => {
     configureRunnerPersistence(graph, (operation) => operation !== upstreamOperation);
     await graph.executeAsync({});
 
-    expect(upstreamRunner.closeAsync).toHaveBeenCalledTimes(1);
+    expect(upstreamRunner.closeAsync).toHaveBeenCalledTimes(2);
     expect(downstreamRunner.closeAsync).not.toHaveBeenCalled();
     // The non-persistent upstream runner must be released immediately upon its own completion,
     // before the downstream operation begins executing — not deferred to the end of the iteration.
@@ -1365,8 +1371,7 @@ describe('runner persistence policy', () => {
     });
 
     const result: IExecutionResult = await graph.executeAsync({});
-    const coldResult: IOperationExecutionResult | undefined =
-      result.operationResults.get(coldOperation);
+    const coldResult: IOperationExecutionResult | undefined = result.operationResults.get(coldOperation);
 
     expect(lifecycleEvents).toEqual(['close', 'after-iteration']);
     expect(afterIterationStatus).toBe(OperationStatus.Failure);

--- a/libraries/rush-lib/src/logic/operations/test/OperationGraph.test.ts
+++ b/libraries/rush-lib/src/logic/operations/test/OperationGraph.test.ts
@@ -1327,6 +1327,7 @@ describe('runner persistence policy', () => {
   it('reports a bypassed runner cleanup failure before finalizing the iteration', async () => {
     const persistentRunner: ClosableRunner = new ClosableRunner('persistent');
     const coldRunner: ClosableRunner = new ClosableRunner('cold');
+    const successfulColdRunner: ClosableRunner = new ClosableRunner('successful-cold');
     const closeError: Error = new Error('close failed');
     const lifecycleEvents: string[] = [];
 
@@ -1342,9 +1343,15 @@ describe('runner persistence policy', () => {
       phase: mockPhase,
       project: getOrCreateProject('cold')
     });
+    const successfulColdOperation: Operation = new Operation({
+      runner: successfulColdRunner,
+      logFilenameIdentifier: 'successful-cold',
+      phase: mockPhase,
+      project: getOrCreateProject('successful-cold')
+    });
 
     const graph: OperationGraph = new OperationGraph(
-      new Set([persistentOperation, coldOperation]),
+      new Set([persistentOperation, coldOperation, successfulColdOperation]),
       graphOptions
     );
 
@@ -1372,6 +1379,8 @@ describe('runner persistence policy', () => {
 
     const result: IExecutionResult = await graph.executeAsync({});
     const coldResult: IOperationExecutionResult | undefined = result.operationResults.get(coldOperation);
+    const successfulColdResult: IOperationExecutionResult | undefined =
+      result.operationResults.get(successfulColdOperation);
 
     expect(lifecycleEvents).toEqual(['close', 'after-iteration']);
     expect(afterIterationStatus).toBe(OperationStatus.Failure);
@@ -1379,6 +1388,9 @@ describe('runner persistence policy', () => {
     expect(graph.status).toBe(OperationStatus.Failure);
     expect(coldResult?.status).toBe(OperationStatus.Failure);
     expect(coldResult?.error).toBe(closeError);
+    expect(successfulColdResult?.status).toBe(OperationStatus.Skipped);
+    expect(successfulColdResult?.error).toBeUndefined();
+    expect(successfulColdRunner.closeAsync).toHaveBeenCalledTimes(1);
     expect(persistentRunner.closeAsync).not.toHaveBeenCalled();
   });
 });

--- a/libraries/rush-lib/src/logic/operations/test/OperationGraph.test.ts
+++ b/libraries/rush-lib/src/logic/operations/test/OperationGraph.test.ts
@@ -1359,6 +1359,10 @@ describe('runner persistence policy', () => {
       afterIterationStatus = status;
       return status;
     });
+    graph.hooks.afterExecuteIterationAsync.tap('test-summary', (status, records) => {
+      _printOperationStatus(mockTerminal, { status, operationResults: records });
+      return status;
+    });
 
     const result: IExecutionResult = await graph.executeAsync({});
     const coldResult: IOperationExecutionResult | undefined =

--- a/libraries/rush-lib/src/pluginFramework/OperationGraphHooks.ts
+++ b/libraries/rush-lib/src/pluginFramework/OperationGraphHooks.ts
@@ -42,7 +42,8 @@ export class OperationGraphHooks {
   /**
    * Hook invoked to decide what work a potential new iteration contains.
    * Use the `lastExecutedRecords` to determine which operations are new or have had their inputs changed.
-   * Set the `enabled` states on the values in `initialRecords` to control which operations will be executed.
+   * Set `enabled` and `shouldRunnerPersist` on the values in `initialRecords` to control which operations
+   * execute and which runners remain active after the iteration.
    *
    * @remarks
    * This hook is synchronous to guarantee that the `lastExecutedRecords` map remains stable for the


### PR DESCRIPTION
## Summary

Adds opt-in, per-iteration runner persistence control to the operation graph. Hosts can keep selected runners warm between iterations and tear down cold runners, while the default behavior remains unchanged.

## Details

`IConfigurableOperation` now exposes a mutable `shouldRunnerPersist: boolean`, defaulting to `true`. Hosts set it during `configureIteration` alongside `enabled`, giving both controls the same per-operation, per-iteration semantics. `IOperationExecutionResult` exposes the configured value as readonly.

After `afterExecuteOperationAsync`, the graph closes a completed operation's runner when the value is `false`, before queue completion can unblock downstream operations. Cold operations that bypass normal completion are closed before `afterExecuteIterationAsync`. If one of those fallback closes fails, the current operation record and iteration become failures, the error is reported, and iteration finalization still runs instead of leaving the graph in the `Executing` state. Terminal output resources are finalized before iteration hooks so summary consumers can safely inspect failures for records that never executed.

This moves persistence ownership out of `IPCOperationRunnerPlugin` and keeps `IPCOperationRunner` policy-agnostic. The plugin no longer hard-codes `persist: true`; runners remain resident by default, so existing watch behavior is preserved. The new control has no production caller yet and is available for a future daemon warm-selection policy.

The record-based control was chosen over an iteration callback because `configureIteration` already owns per-iteration operation decisions and mutable record state avoids threading policy through runner contexts.

The public additions are `@alpha`, so there is no stable API compatibility break. The internal `IIPCOperationRunnerOptions.persist` field was removed; unsupported deep-import callers must remove that argument. Each iteration performs a linear record sweep, and cold-runner cleanup is bounded by the graph's configured parallelism.

## How it was tested

- `cd libraries/rush-lib && node_modules/.bin/heft test --test-path-pattern OperationGraph` - 42/42 tests passed
- `node common/scripts/install-run-rush.js test --to @microsoft/rush-lib` - 718/718 tests passed across 75 suites
- `node common/scripts/install-run-rush.js build -t rush` - passed
- `node common/scripts/install-run-rush.js change --verify`
- Locally built `apps/rush/lib-commonjs/start-dev.js` in an isolated Git-backed Rush repo - default reuse, cold teardown, bypass fallback teardown, and injected cleanup-failure scenarios all passed

The tests cover two successive iterations with default, persistent, one-shot, and changing policies. They also verify teardown before downstream execution, fallback teardown before `afterExecuteIterationAsync`, and cleanup-failure reporting/finalization for bypassed runners. The local CLI harness confirmed that the default policy reused one IPC child PID, the cold policy created a fresh PID per iteration and exited each child before its dependent ran, a bypassed cold runner exited before the iteration post-hook, and an injected fallback close failure reached the normal Rush failure summary without an uncaught exception.
