### PR TITLE
[operation-graph] Add Rush-compatible operation statuses

### DIFF
--- a/common/changes/@rushstack/operation-graph/bmiddha-ws0-t5-operation-status.json
+++ b/common/changes/@rushstack/operation-graph/bmiddha-ws0-t5-operation-status.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/operation-graph",
+      "comment": "Add Rush-compatible operation statuses in preparation for graph convergence.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/operation-graph",
+  "email": "5100938+bmiddha@users.noreply.github.com"
+}

--- a/common/reviews/api/operation-graph.api.md
+++ b/common/reviews/api/operation-graph.api.md
@@ -222,9 +222,13 @@ export enum OperationStatus {
     Blocked = "BLOCKED",
     Executing = "EXECUTING",
     Failure = "FAILURE",
+    FromCache = "FROM CACHE",
     NoOp = "NO OP",
+    Queued = "QUEUED",
     Ready = "READY",
+    Skipped = "SKIPPED",
     Success = "SUCCESS",
+    SuccessWithWarning = "SUCCESS WITH WARNINGS",
     Waiting = "WAITING"
 }
 

--- a/libraries/operation-graph/src/Operation.ts
+++ b/libraries/operation-graph/src/Operation.ts
@@ -290,6 +290,7 @@ export class Operation<TMetadata extends {} = {}, TGroupMetadata extends {} = {}
             switch (this.state?.status) {
               case OperationStatus.Waiting:
               case OperationStatus.Ready:
+              case OperationStatus.Queued:
               case OperationStatus.Executing:
                 // If current status has not yet resolved to a fixed value,
                 // re-executing this operation does not require a full rerun
@@ -306,6 +307,9 @@ export class Operation<TMetadata extends {} = {}, TGroupMetadata extends {} = {}
               case OperationStatus.Failure:
               case OperationStatus.NoOp:
               case OperationStatus.Success:
+              case OperationStatus.SuccessWithWarning:
+              case OperationStatus.Skipped:
+              case OperationStatus.FromCache:
                 // The requestRun callback is assumed to remain constant
                 // throughout the lifetime of the process, so it is safe
                 // to capture here.

--- a/libraries/operation-graph/src/OperationStatus.ts
+++ b/libraries/operation-graph/src/OperationStatus.ts
@@ -37,5 +37,21 @@ export enum OperationStatus {
   /**
    * The operation performed no meaningful work.
    */
-  NoOp = 'NO OP'
+  NoOp = 'NO OP',
+  /**
+   * The Operation is queued.
+   */
+  Queued = 'QUEUED',
+  /**
+   * The Operation completed successfully, but wrote to standard output.
+   */
+  SuccessWithWarning = 'SUCCESS WITH WARNINGS',
+  /**
+   * The Operation was skipped via legacy incremental build logic.
+   */
+  Skipped = 'SKIPPED',
+  /**
+   * The Operation had its outputs restored from the build cache.
+   */
+  FromCache = 'FROM CACHE'
 }

--- a/libraries/operation-graph/src/OperationStatus.ts
+++ b/libraries/operation-graph/src/OperationStatus.ts
@@ -47,7 +47,7 @@ export enum OperationStatus {
    */
   SuccessWithWarning = 'SUCCESS WITH WARNINGS',
   /**
-   * The Operation was skipped via legacy incremental build logic.
+   * The Operation was skipped via incremental build logic.
    */
   Skipped = 'SKIPPED',
   /**


### PR DESCRIPTION
## Summary

Prepare `@rushstack/operation-graph` for eventual convergence with rush-lib's stateful operation graph by adding the four operation statuses currently defined only by Rush.

This is intentionally a small, non-blocking first increment. It does not change rush-lib or replace its `OperationGraph`.

## Details

- Add `Queued`, `SuccessWithWarning`, `Skipped`, and `FromCache` to `OperationStatus`, using the exact string values already used by rush-lib.
- Extend the package's exhaustive `requestRun` status handling so the new values remain type-safe.
- Keep existing execution behavior unchanged: no current `@rushstack/operation-graph` path starts emitting any new status.
- Record the additive `@beta` API change as a minor change and update the API report.

The two graph implementations remain structurally different: Rush requires persistent iteration state, selective invalidation, weighted concurrency, and a larger hook/runner contract. Those pieces should converge through later additive APIs and compatibility adapters rather than a big-bang replacement.

## How it was tested

- `node common/scripts/install-run-rush.js test --to @rushstack/operation-graph`
- `cd libraries/operation-graph && node_modules/.bin/heft test --clean` (27 passed, 0 failed)
- `cd apps/heft && node_modules/.bin/heft build --clean`
- `node common/scripts/install-run-rush.js test --to @microsoft/rush-lib --to @rushstack/operation-graph`
- `node common/scripts/install-run-rush.js change --verify`

No snapshots changed.
