### PR TITLE
[api-extractor] Optimize the analysis type-check pass

### DIFF
--- a/apps/api-extractor/src/analyzer/AstSymbolTable.ts
+++ b/apps/api-extractor/src/analyzer/AstSymbolTable.ts
@@ -130,6 +130,25 @@ export class AstSymbolTable {
   }
 
   /**
+   * Returns the set of source files that contain a declaration that was analyzed, i.e. that is
+   * reachable from the entry point.
+   *
+   * @remarks
+   * API Extractor analyzes the compiler's `.d.ts` outputs, and by default does not use
+   * `skipLibCheck`, so type-checking the entire program would bind-and-check every transitively
+   * reachable declaration file -- including deep dependencies that are not part of the API surface.
+   * This set allows compiler diagnostics to be scoped to just the files that contribute
+   * declarations to the analyzed API.
+   */
+  public collectAnalyzedSourceFiles(): Set<ts.SourceFile> {
+    const sourceFiles: Set<ts.SourceFile> = new Set<ts.SourceFile>();
+    for (const declaration of this._astDeclarationsByDeclaration.keys()) {
+      sourceFiles.add(declaration.getSourceFile());
+    }
+    return sourceFiles;
+  }
+
+  /**
    * Attempts to retrieve an export by name from the specified `AstModule`.
    * Returns undefined if no match was found.
    */

--- a/apps/api-extractor/src/analyzer/TypeScriptInternals.ts
+++ b/apps/api-extractor/src/analyzer/TypeScriptInternals.ts
@@ -139,7 +139,24 @@ export class TypeScriptInternals {
     if (!typeChecker.getEmitResolver) {
       throw new InternalError('Missing TypeChecker.getEmitResolver');
     }
-    const resolver: any = typeChecker.getEmitResolver();
+
+    // We only use `EmitResolver.hasGlobalName`, which simply queries the type checker's `globals`
+    // symbol table.  That table (including ambient declarations, `jsGlobalAugmentations`, and
+    // `declare global` augmentations) is populated synchronously when the checker is created, so it
+    // does not require type checking to have run.
+    //
+    // By default, `getEmitResolver()` forces a full-program diagnostic type-check before returning
+    // the resolver.  Since API Extractor otherwise only type-checks the source files that are
+    // reachable from the entry point (see `Collector.analyze`), that full check would dominate the
+    // analysis cost.  Passing `skipDiagnostics: true` avoids it while still returning a resolver
+    // whose `hasGlobalName` behaves identically.  The parameter is a compiler internal; older
+    // TypeScript versions that lack it simply ignore the extra argument (falling back to the
+    // previous, slower behavior).
+    const resolver: any = typeChecker.getEmitResolver(
+      /*sourceFile*/ undefined,
+      /*cancellationToken*/ undefined,
+      /*skipDiagnostics*/ true
+    );
     if (!resolver.hasGlobalName) {
       throw new InternalError('Missing EmitResolver.hasGlobalName');
     }

--- a/apps/api-extractor/src/collector/Collector.ts
+++ b/apps/api-extractor/src/collector/Collector.ts
@@ -200,13 +200,6 @@ export class Collector {
       throw new Error('DtsRollupGenerator.analyze() was already called');
     }
 
-    // This runs a full type analysis, and then augments the Abstract Syntax Tree (i.e. declarations)
-    // with semantic information (i.e. symbols).  The "diagnostics" are a subset of the everyday
-    // compile errors that would result from a full compilation.
-    for (const diagnostic of this._program.getSemanticDiagnostics()) {
-      this.messageRouter.addCompilerDiagnostic(diagnostic);
-    }
-
     const sourceFiles: readonly ts.SourceFile[] = this.program.getSourceFiles();
 
     if (this.messageRouter.showDiagnostics) {
@@ -291,6 +284,25 @@ export class Collector {
     for (const { sourceFile, isExternal } of visitedAstModules) {
       if (!nonExternalSourceFiles.has(sourceFile) && !isExternal) {
         nonExternalSourceFiles.add(sourceFile);
+      }
+    }
+
+    // Report compiler diagnostics, but only for the source files that are reachable from the entry
+    // point: the files that contribute an analyzed declaration, plus the intermediate re-export
+    // files that were visited while resolving exports.  API Extractor analyzes the compiler's `.d.ts`
+    // outputs and (by default) does not enable `skipLibCheck`, so running `getSemanticDiagnostics()`
+    // across the entire program would bind-and-check every transitively reachable declaration file,
+    // including deep dependencies that are not part of the API surface.  Scoping the diagnostics to
+    // the analyzed files avoids that cost while still surfacing every error that pertains to the
+    // exported API.  (Binding, which the analysis relies on, happens eagerly for all files when the
+    // type checker is created, so this does not affect the analysis itself.)
+    const diagnosticSourceFiles: Set<ts.SourceFile> = this.astSymbolTable.collectAnalyzedSourceFiles();
+    for (const sourceFile of nonExternalSourceFiles) {
+      diagnosticSourceFiles.add(sourceFile);
+    }
+    for (const sourceFile of diagnosticSourceFiles) {
+      for (const diagnostic of this._program.getSemanticDiagnostics(sourceFile)) {
+        this.messageRouter.addCompilerDiagnostic(diagnostic);
       }
     }
 

--- a/common/changes/@microsoft/api-extractor/optimize-typecheck_2026-07-21-22-06-48.json
+++ b/common/changes/@microsoft/api-extractor/optimize-typecheck_2026-07-21-22-06-48.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Improve analysis performance by scoping compiler diagnostics to the source files that are reachable from the entry point, rather than type-checking the entire program. As a result, compiler errors are now only reported for declarations that contribute to the analyzed API surface.",
+      "type": "minor",
+      "packageName": "@microsoft/api-extractor"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "dmichon-msft@users.noreply.github.com"
+}


### PR DESCRIPTION
## Summary

API Extractor analyzes the compiler's `.d.ts` outputs and, by default, does **not** enable `skipLibCheck`. Two code paths therefore forced a full-program semantic type-check over the entire transitively-reachable declaration closure — including deep dependencies that are not part of the analyzed API surface:

1. `Collector.analyze` called `program.getSemanticDiagnostics()` with no argument (whole program).
2. `TypeScriptInternals.getGlobalVariableAnalyzer` called `typeChecker.getEmitResolver()`, which forces a full-program diagnostic check before returning — even though only `hasGlobalName` is needed.

## Changes

- **`getEmitResolver(…, skipDiagnostics: true)`** — the `globals` table (ambient decls, `jsGlobalAugmentations`, `declare global`) is populated eagerly at checker creation, so `hasGlobalName` works without running diagnostics.
- **Scoped `getSemanticDiagnostics(sourceFile)`** — diagnostics are now reported only for source files reachable from the entry point: analyzed declaration files (new `AstSymbolTable.collectAnalyzedSourceFiles()`) plus the intermediate re-export files already collected as `nonExternalSourceFiles`.

Binding, which the analysis relies on, still happens eagerly for all files when the checker is created, so the analysis itself is unaffected. The net behavior change is that compiler errors are now only reported for declarations that contribute to the analyzed API surface (errors in unreachable dependency files are no longer surfaced).

## Performance

Verified through real `heft build --clean` runs on `@rushstack/mcp-server` (3 runs each):

| | Baseline | Optimized |
|---|---|---|
| api-extractor step (subtree) | ~4789ms | ~942ms |
| `getEmitResolver` | ~4035ms | ~0ms |
| full build wall clock | ~14.4s | ~9.8s |

In baseline, the expensive whole-program check actually fires inside `getEmitResolver()` during collector construction, which is why both changes are required. A sweep across all ~70 in-repo api-extractor packages showed a consistent ~1s saving on most packages, up to ~4.3s on the heaviest (`mcp-server`); packages with a cheap external type closure (e.g. `rush-lib`) are unaffected. An external production repo reported `getDiagnosticsWorker` dropping 14.1s → 11.3s.

## Validation

- All api-extractor acceptance-test projects rebuilt clean (`api-extractor-scenarios` self-validates snapshots; `test-01..05`, `lib1..5-test`, `api-documenter-*`, `d-cts`/`d-mts`). **Byte-identical** API reports / rollups / doc models.
- Additionally cross-checked several library consumers (`node-core-library`, `ts-command-line`, `terminal`, `rush-lib`, `mcp-server`) — no `.api.md`/`.api.json` changes.
- `heft test`: 89/89 pass.

A `minor` change file is included (the diagnostics-reporting behavior change).