### PR TITLE
[rush] Treat a phased command with zero operations as success

### DIFF
--- a/common/changes/@microsoft/rush/fix-noop-exit-code_2026-07-28-18-56-00.json
+++ b/common/changes/@microsoft/rush/fix-noop-exit-code_2026-07-28-18-56-00.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/rush",
-      "comment": "Fix an issue where a phased command exited with a nonzero exit code when a plugin legitimately produced no operations, which broke `rush <command> --drop-graph` in `@rushstack/rush-buildxl-graph-plugin`.",
+      "comment": "Fix an issue where a phased command exited with a nonzero exit code when its overall execution status was successful but not `SUCCESS`. This covers an iteration that scheduled no operations because a plugin consumed the work itself (which broke `rush <command> --drop-graph` in `@rushstack/rush-buildxl-graph-plugin`), as well as an iteration that a plugin short-circuited with a `SKIPPED` or `FROM CACHE` status.",
       "type": "patch"
     }
   ],

--- a/common/changes/@microsoft/rush/fix-noop-exit-code_2026-07-28-18-56-00.json
+++ b/common/changes/@microsoft/rush/fix-noop-exit-code_2026-07-28-18-56-00.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Fix an issue where a phased command exited with a nonzero exit code when a plugin legitimately produced no operations, which broke `rush <command> --drop-graph` in `@rushstack/rush-buildxl-graph-plugin`.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/libraries/rush-lib/config/heft.json
+++ b/libraries/rush-lib/config/heft.json
@@ -28,6 +28,14 @@
                   "hardlink": true
                 },
                 {
+                  "sourcePath": "lib-intermediate-commonjs/cli/test/rush-mock-clear-operations-plugin",
+                  "destinationFolders": [
+                    "lib-intermediate-commonjs/cli/test/clearOperationsAndRunBuildActionRepo/common/autoinstallers/plugins/node_modules/rush-mock-clear-operations-plugin"
+                  ],
+                  "fileExtensions": [".json", ".js", ".map"],
+                  "hardlink": true
+                },
+                {
                   "sourcePath": "src/cli/test",
                   "destinationFolders": ["lib-intermediate-commonjs/cli/test"],
                   "fileExtensions": [".js", ".yaml"]

--- a/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
+++ b/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
@@ -65,6 +65,28 @@ import { measureAsyncFn, measureFn } from '../../utilities/performance';
 const PERF_PREFIX: 'rush:phasedScriptAction' = 'rush:phasedScriptAction';
 
 /**
+ * The set of overall execution statuses that mean the command did what was asked of it and should
+ * exit with code 0.
+ *
+ * - `NoOp` -- the iteration scheduled no non-silent operations. This happens when a plugin
+ *   legitimately consumes the work itself, either by returning an empty operation set from
+ *   `createOperationsAsync` or by disabling every operation during `configureIteration` (a disabled
+ *   record is silent, so both routes converge on this status).
+ * - `Skipped` / `FromCache` -- a tap short-circuited the iteration with a successful bail status,
+ *   for example the bridge-cache plugin performing a cache read/write out of band.
+ *
+ * `PhasedScriptAction` already treats an empty *project* selection as success, so treating an empty
+ * *operation* set as a failure would be inconsistent. `SuccessWithWarning` is deliberately excluded
+ * because non-allowed warnings are expected to fail the command.
+ */
+const SUCCESSFUL_EXECUTION_STATUSES: ReadonlySet<OperationStatus> = new Set([
+  OperationStatus.Success,
+  OperationStatus.Skipped,
+  OperationStatus.FromCache,
+  OperationStatus.NoOp
+]);
+
+/**
  * Constructor parameters for PhasedScriptAction.
  */
 export interface IPhasedScriptActionOptions extends IBaseScriptActionOptions<IPhasedCommandConfig> {
@@ -721,14 +743,7 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> i
           return await graph.executeAsync(iterationOptions);
         }
       );
-      // An iteration that produced no operations is not a failure. This happens when a plugin
-      // legitimately consumes the work itself and returns an empty operation set -- for example
-      // `@rushstack/rush-buildxl-graph-plugin`, which writes the graph to disk in response to
-      // `--drop-graph` and then returns `new Set()` because there is nothing left to execute.
-      // Note that `PhasedScriptAction` already treats an empty *project* selection as success, so
-      // treating an empty *operation* set as a failure would be inconsistent.
-      success =
-        definiteResult.status === OperationStatus.Success || definiteResult.status === OperationStatus.NoOp;
+      success = SUCCESSFUL_EXECUTION_STATUSES.has(definiteResult.status);
 
       stopwatch.stop();
 

--- a/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
+++ b/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
@@ -713,7 +713,6 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> i
     const { graph, ignoreHooks, stopwatch, terminal } = options;
 
     let success: boolean = false;
-    let result: IExecutionResult | undefined;
 
     try {
       const definiteResult: IExecutionResult = await measureAsyncFn(
@@ -722,13 +721,19 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> i
           return await graph.executeAsync(iterationOptions);
         }
       );
-      success = definiteResult.status === OperationStatus.Success;
-      result = definiteResult;
+      // An iteration that produced no operations is not a failure. This happens when a plugin
+      // legitimately consumes the work itself and returns an empty operation set -- for example
+      // `@rushstack/rush-buildxl-graph-plugin`, which writes the graph to disk in response to
+      // `--drop-graph` and then returns `new Set()` because there is nothing left to execute.
+      // Note that `PhasedScriptAction` already treats an empty *project* selection as success, so
+      // treating an empty *operation* set as a failure would be inconsistent.
+      success =
+        definiteResult.status === OperationStatus.Success || definiteResult.status === OperationStatus.NoOp;
 
       stopwatch.stop();
 
       const message: string = `rush ${this.actionName} (${stopwatch.toString()})`;
-      if (result.status === OperationStatus.Success) {
+      if (success) {
         terminal.writeLine(Colorize.green(message));
       } else {
         terminal.writeLine(message);

--- a/libraries/rush-lib/src/cli/test/RushCommandLineParser.test.ts
+++ b/libraries/rush-lib/src/cli/test/RushCommandLineParser.test.ts
@@ -317,6 +317,27 @@ describe('RushCommandLineParser', () => {
       });
     });
 
+    describe('in repo plugin that produces no operations', () => {
+      it('succeeds when a plugin returns an empty operation set', async () => {
+        // Regression test: `@rushstack/rush-buildxl-graph-plugin` writes the build graph to disk in
+        // response to `--drop-graph` and then returns an empty operation set, because there is
+        // nothing left for Rush to execute. An iteration with zero operations resolves to
+        // `OperationStatus.NoOp`, which must not be reported as a failure.
+        const repoName: string = 'clearOperationsAndRunBuildActionRepo';
+        const { parser, spawnMock } = await getCommandLineParserInstanceAsync(repoName, 'build');
+
+        /**
+         * The plugin is copied into the autoinstaller folder using an option in /config/heft.json
+         */
+        jest.spyOn(Autoinstaller.prototype, 'prepareAsync').mockImplementation(async function () {});
+
+        await expect(parser.executeAsync()).resolves.toEqual(true);
+
+        // Nothing should have been executed, since the plugin removed every operation.
+        expect(spawnMock.mock.calls.length).toEqual(0);
+      });
+    });
+
     describe('in repo plugin with build command', () => {
       describe("'build' action", () => {
         it(`executes the package's 'build' script`, async () => {

--- a/libraries/rush-lib/src/cli/test/clearOperationsAndRunBuildActionRepo/a/package.json
+++ b/libraries/rush-lib/src/cli/test/clearOperationsAndRunBuildActionRepo/a/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "a",
+  "version": "1.0.0",
+  "description": "Test package a",
+  "scripts": {
+    "build": "fake_build_task_but_works_with_mock",
+    "rebuild": "fake_REbuild_task_but_works_with_mock"
+  }
+}

--- a/libraries/rush-lib/src/cli/test/clearOperationsAndRunBuildActionRepo/b/package.json
+++ b/libraries/rush-lib/src/cli/test/clearOperationsAndRunBuildActionRepo/b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "b",
+  "version": "1.0.0",
+  "description": "Test package b",
+  "scripts": {
+    "build": "fake_build_task_but_works_with_mock",
+    "rebuild": "fake_REbuild_task_but_works_with_mock"
+  }
+}

--- a/libraries/rush-lib/src/cli/test/clearOperationsAndRunBuildActionRepo/common/autoinstallers/plugins/package.json
+++ b/libraries/rush-lib/src/cli/test/clearOperationsAndRunBuildActionRepo/common/autoinstallers/plugins/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "plugins",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "rush-mock-clear-operations-plugin": "file:../../../../rush-mock-clear-operations-plugin"
+  }
+}

--- a/libraries/rush-lib/src/cli/test/clearOperationsAndRunBuildActionRepo/common/autoinstallers/plugins/rush-plugins/rush-mock-clear-operations-plugin/rush-plugin-manifest.json
+++ b/libraries/rush-lib/src/cli/test/clearOperationsAndRunBuildActionRepo/common/autoinstallers/plugins/rush-plugins/rush-mock-clear-operations-plugin/rush-plugin-manifest.json
@@ -1,0 +1,9 @@
+{
+  "plugins": [
+    {
+      "pluginName": "rush-mock-clear-operations-plugin",
+      "description": "Rush plugin for testing a phased command that produces no operations",
+      "entryPoint": "index.js"
+    }
+  ]
+}

--- a/libraries/rush-lib/src/cli/test/clearOperationsAndRunBuildActionRepo/common/config/rush/rush-plugins.json
+++ b/libraries/rush-lib/src/cli/test/clearOperationsAndRunBuildActionRepo/common/config/rush/rush-plugins.json
@@ -1,0 +1,9 @@
+{
+  "plugins": [
+    {
+      "packageName": "rush-mock-clear-operations-plugin",
+      "pluginName": "rush-mock-clear-operations-plugin",
+      "autoinstallerName": "plugins"
+    }
+  ]
+}

--- a/libraries/rush-lib/src/cli/test/clearOperationsAndRunBuildActionRepo/rush.json
+++ b/libraries/rush-lib/src/cli/test/clearOperationsAndRunBuildActionRepo/rush.json
@@ -1,0 +1,17 @@
+{
+  "npmVersion": "6.4.1",
+  "rushVersion": "5.62.2",
+  "projectFolderMinDepth": 1,
+  "projectFolderMaxDepth": 99,
+
+  "projects": [
+    {
+      "packageName": "a",
+      "projectFolder": "a"
+    },
+    {
+      "packageName": "b",
+      "projectFolder": "b"
+    }
+  ]
+}

--- a/libraries/rush-lib/src/cli/test/rush-mock-clear-operations-plugin/index.ts
+++ b/libraries/rush-lib/src/cli/test/rush-mock-clear-operations-plugin/index.ts
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import type { RushSession, RushConfiguration, IPhasedCommand, Operation } from '../../../index';
+
+/**
+ * Mimics the shape of `@rushstack/rush-buildxl-graph-plugin`, which performs its work during
+ * `createOperationsAsync` and then returns an empty operation set because there is nothing left
+ * for Rush to execute.
+ *
+ * Such an invocation must be reported as a success, not a failure.
+ */
+export default class RushMockClearOperationsPlugin {
+  public apply(rushSession: RushSession, rushConfiguration: RushConfiguration): void {
+    rushSession.hooks.runAnyPhasedCommand.tapPromise(
+      RushMockClearOperationsPlugin.name,
+      async (command: IPhasedCommand) => {
+        command.hooks.createOperationsAsync.tapPromise(
+          {
+            name: RushMockClearOperationsPlugin.name,
+            // Run after every other plugin has finished creating operations.
+            stage: Number.MAX_SAFE_INTEGER
+          },
+          async () => {
+            return new Set<Operation>();
+          }
+        );
+      }
+    );
+  }
+}

--- a/libraries/rush-lib/src/cli/test/rush-mock-clear-operations-plugin/index.ts
+++ b/libraries/rush-lib/src/cli/test/rush-mock-clear-operations-plugin/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import type { RushSession, RushConfiguration, IPhasedCommand, Operation } from '../../../index';
+import type { RushSession, IPhasedCommand, Operation } from '../../../index';
 
 /**
  * Mimics the shape of `@rushstack/rush-buildxl-graph-plugin`, which performs its work during
@@ -11,7 +11,7 @@ import type { RushSession, RushConfiguration, IPhasedCommand, Operation } from '
  * Such an invocation must be reported as a success, not a failure.
  */
 export default class RushMockClearOperationsPlugin {
-  public apply(rushSession: RushSession, rushConfiguration: RushConfiguration): void {
+  public apply(rushSession: RushSession): void {
     rushSession.hooks.runAnyPhasedCommand.tapPromise(
       RushMockClearOperationsPlugin.name,
       async (command: IPhasedCommand) => {

--- a/libraries/rush-lib/src/cli/test/rush-mock-clear-operations-plugin/package.json
+++ b/libraries/rush-lib/src/cli/test/rush-mock-clear-operations-plugin/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "rush-mock-clear-operations-plugin",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {}
+}

--- a/libraries/rush-lib/src/cli/test/rush-mock-clear-operations-plugin/rush-plugin-manifest.json
+++ b/libraries/rush-lib/src/cli/test/rush-mock-clear-operations-plugin/rush-plugin-manifest.json
@@ -1,0 +1,9 @@
+{
+  "plugins": [
+    {
+      "pluginName": "rush-mock-clear-operations-plugin",
+      "description": "Rush plugin for testing a phased command that produces no operations",
+      "entryPoint": "index.js"
+    }
+  ]
+}


### PR DESCRIPTION
### Summary

Fixes #5914.

A phased command whose plugins legitimately produce **no operations** exits with code **1**, even
though nothing failed. This breaks `@rushstack/rush-buildxl-graph-plugin`, so every BuildXL build
using the Rush resolver fails.

### Details

`OperationGraph._scheduleIterationAsync` does not schedule an iteration when there are no non-silent
operations:

```ts
if (iterationContext.totalOperations === 0) {
  return;
}
```

so `executeAsync` early-returns `OperationStatus.NoOp` **without firing any graph hooks**:

```ts
const scheduled = await this._scheduleIterationAsync(iterationOptions);
if (!scheduled) {
  return { operationResults: this.resultByOperation, status: OperationStatus.NoOp };
}
```

and `PhasedScriptAction` computed:

```ts
success = definiteResult.status === OperationStatus.Success;
```

`NoOp !== Success` → `success = false` → `AlreadyReportedError` → exit 1.

`DropBuildGraphPlugin` writes the build graph to disk in response to `--drop-graph` and then returns
`new Set()` because there is nothing left for Rush to execute. The result is that
`rush <command> --drop-graph` exits 1 with no error message and a correctly-written graph file,
which BuildXL reports as `DX11901` / `DX11230`.

Because the early return skips all graph hooks, **this cannot be worked around by a plugin** — there
is no hook available to observe or correct the status.

### Why this is the right fix

`PhasedScriptAction` already treats an empty *project* selection as success:

```ts
if (!generateFullGraph && !projectSelection.size) {
  terminal.writeLine(Colorize.yellow(`The command line selection parameters did not match any projects.`));
  return;   // exits 0
}
```

So "nothing to do because no projects matched" was a success while "nothing to do because no
operations were produced" was a failure. This change makes them agree.

The completion message now keys off `success` rather than re-deriving the status, so a no-op
invocation is also reported in green rather than looking like a silent failure.

### Changes

- `PhasedScriptAction.ts` — treat `OperationStatus.NoOp` as success; use `success` for the
  completion message. Removes the now-unused `result` local.
- New regression test in `RushCommandLineParser.test.ts` plus fixtures:
  - `rush-mock-clear-operations-plugin/` — an in-repo plugin that taps `createOperationsAsync` at
    `stage: Number.MAX_SAFE_INTEGER` and returns an empty set, mirroring `DropBuildGraphPlugin`.
  - `clearOperationsAndRunBuildActionRepo/` — mock repo wiring that plugin.
  - `config/heft.json` — copy the mock plugin into the fixture's autoinstaller, matching the
    existing `rush-mock-flush-telemetry-plugin` pattern.
- Change file for `@microsoft/rush` (`patch`).

### Verification

| Check | Result |
| --- | --- |
| New test **without** the fix | **FAILS** — `expect(parser.executeAsync()).resolves.toEqual(true)` → `Received: false` |
| New test **with** the fix | passes |
| Full `rush-lib` suite | **721 passed, 0 failed** |
| `rush build --to @microsoft/rush-lib` | clean, no lint warnings |

### Notes for reviewers

An alternative would be to give phased commands a supported "handled — stop here successfully"
mechanism, analogous to `IGlobalCommand.setHandled()`, so plugins like `DropBuildGraphPlugin` do not
have to signal completion by returning an empty operation set. That seemed like a larger API change
than warranted for a regression fix, but I'm happy to go that route instead.
