### PR TITLE
[rush-serve-dashboard] Preserve Ctrl+A in dashboard text fields

### DIFF
--- a/apps/rush-serve-dashboard/src/modules/mainBar.ts
+++ b/apps/rush-serve-dashboard/src/modules/mainBar.ts
@@ -20,6 +20,14 @@ export interface IMainBarActionWiringOptions {
   render: () => void;
 }
 
+function isTextEditingTarget(target: EventTarget | undefined): boolean {
+  return (
+    target instanceof HTMLInputElement ||
+    target instanceof HTMLTextAreaElement ||
+    (target instanceof HTMLElement && target.isContentEditable)
+  );
+}
+
 export function wireMainBarActions(options: IMainBarActionWiringOptions): void {
   const {
     connect,
@@ -94,7 +102,7 @@ export function wireMainBarActions(options: IMainBarActionWiringOptions): void {
   }
 
   window.addEventListener('keydown', (e: KeyboardEvent) => {
-    if (e.key === 'a' && (e.metaKey || e.ctrlKey)) {
+    if (e.key === 'a' && (e.metaKey || e.ctrlKey) && !isTextEditingTarget(e.target ?? undefined)) {
       e.preventDefault();
       setSelection(new Set(getOperationNames()));
       render();

--- a/apps/rush-serve-dashboard/src/test/actionWiring.test.ts
+++ b/apps/rush-serve-dashboard/src/test/actionWiring.test.ts
@@ -65,7 +65,7 @@ describe('action wiring', () => {
 
   it('wires manager commands and keyboard selection', () => {
     document.body.innerHTML =
-      '<button id="connect-btn"></button><button id="execute-btn"></button><button id="abort-execution-btn"></button>';
+      '<button id="connect-btn"></button><button id="execute-btn"></button><button id="abort-execution-btn"></button><input id="name-search">';
     const debugBtn: HTMLButtonElement = document.createElement('button');
     const verboseBtn: HTMLButtonElement = document.createElement('button');
     const parallelismInput: HTMLInputElement = document.createElement('input');
@@ -100,6 +100,18 @@ describe('action wiring', () => {
     verboseBtn.click();
     parallelismInput.dispatchEvent(new Event('change'));
     playPauseBtn.click();
+    const textField: HTMLInputElement = document.getElementById('name-search') as HTMLInputElement;
+    const textFieldSelectAllEvent: KeyboardEvent = new KeyboardEvent('keydown', {
+      key: 'a',
+      ctrlKey: true,
+      bubbles: true,
+      cancelable: true
+    });
+    textField.dispatchEvent(textFieldSelectAllEvent);
+    expect(textFieldSelectAllEvent.defaultPrevented).toBe(false);
+    expect(setSelection).not.toHaveBeenCalled();
+    expect(render).not.toHaveBeenCalled();
+
     window.dispatchEvent(new KeyboardEvent('keydown', { key: 'a', ctrlKey: true }));
     window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
 

--- a/common/changes/@microsoft/rush/rush-serve-dashboard-select-all_2026-08-07-15-26-00.json
+++ b/common/changes/@microsoft/rush/rush-serve-dashboard-select-all_2026-08-07-15-26-00.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Allow Ctrl+A and Command+A to select text in Rush serve dashboard fields.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}


### PR DESCRIPTION
## Summary

- preserve native Ctrl+A and Command+A behavior in input, textarea, and contenteditable fields
- keep global operation selection shortcut active outside text-editing controls
- add regression coverage and a Rush patch change file

## Testing

- `rush build --to @rushstack/rush-serve-dashboard`
- `rush change --verify --no-fetch`