### PR TITLE
Require Node.js 20 for package consumers

### DIFF
--- a/apps/api-documenter/package.json
+++ b/apps/api-documenter/package.json
@@ -7,6 +7,9 @@
     "url": "https://github.com/microsoft/rushstack.git",
     "directory": "apps/api-documenter"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "homepage": "https://api-extractor.com/",
   "license": "MIT",
   "scripts": {

--- a/apps/api-extractor/package.json
+++ b/apps/api-extractor/package.json
@@ -24,6 +24,9 @@
     "url": "https://github.com/microsoft/rushstack.git",
     "directory": "apps/api-extractor"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "homepage": "https://api-extractor.com",
   "main": "./lib-commonjs/index.js",
   "module": "./lib-esm/index.js",

--- a/apps/cpu-profile-summarizer/package.json
+++ b/apps/cpu-profile-summarizer/package.json
@@ -7,6 +7,9 @@
     "url": "https://github.com/microsoft/rushstack.git",
     "directory": "apps/cpu-profile-summarizer"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "bin": {
     "cpu-profile-summarizer": "./bin/cpu-profile-summarizer"
   },

--- a/apps/heft/package.json
+++ b/apps/heft/package.json
@@ -18,7 +18,7 @@
     "directory": "apps/heft"
   },
   "engines": {
-    "node": ">=10.13.0"
+    "node": ">=20.9.0"
   },
   "homepage": "https://rushstack.io/pages/heft/overview/",
   "main": "./lib-commonjs/index.js",

--- a/apps/lockfile-explorer/package.json
+++ b/apps/lockfile-explorer/package.json
@@ -22,6 +22,9 @@
     "url": "https://github.com/microsoft/rushstack.git",
     "directory": "apps/lockfile-explorer"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "homepage": "https://lfx.rushstack.io/",
   "license": "MIT",
   "bin": {

--- a/apps/playwright-browser-tunnel/package.json
+++ b/apps/playwright-browser-tunnel/package.json
@@ -34,7 +34,7 @@
     }
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=20.9.0"
   },
   "engineStrict": true,
   "homepage": "https://rushstack.io",

--- a/apps/rundown/package.json
+++ b/apps/rundown/package.json
@@ -8,7 +8,7 @@
     "directory": "apps/rundown"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=20.9.0"
   },
   "engineStrict": true,
   "homepage": "https://rushstack.io",

--- a/apps/rush-mcp-server/package.json
+++ b/apps/rush-mcp-server/package.json
@@ -41,7 +41,7 @@
     "directory": "apps/rush-mcp-server"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=20.9.0"
   },
   "engineStrict": true,
   "homepage": "https://rushstack.io",

--- a/apps/rush/package.json
+++ b/apps/rush/package.json
@@ -19,7 +19,7 @@
     "directory": "apps/rush"
   },
   "engines": {
-    "node": ">=5.6.0"
+    "node": ">=20.9.0"
   },
   "engineStrict": true,
   "homepage": "https://rushjs.io",

--- a/apps/trace-import/package.json
+++ b/apps/trace-import/package.json
@@ -7,6 +7,9 @@
     "url": "https://github.com/microsoft/rushstack.git",
     "directory": "apps/trace-import"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "bin": {
     "trace-import": "./bin/trace-import"
   },

--- a/apps/zipsync/package.json
+++ b/apps/zipsync/package.json
@@ -7,6 +7,9 @@
     "url": "https://github.com/microsoft/rushstack.git",
     "directory": "apps/zipsync"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "bin": {
     "zipsync": "./bin/zipsync"
   },

--- a/common/changes/@microsoft/api-documenter/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@microsoft/api-documenter/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-documenter",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@microsoft/api-extractor-model/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@microsoft/api-extractor-model/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor-model",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@microsoft/api-extractor/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@microsoft/api-extractor/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/api-extractor",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@microsoft/loader-load-themed-styles/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@microsoft/loader-load-themed-styles/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/loader-load-themed-styles",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@microsoft/rush/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@microsoft/rush/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Require Node.js 20.9 or newer for the Rush bootstrap and runtime.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@microsoft/webpack5-load-themed-styles-loader/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@microsoft/webpack5-load-themed-styles-loader/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/webpack5-load-themed-styles-loader",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/cpu-profile-summarizer/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/cpu-profile-summarizer/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/cpu-profile-summarizer",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/credential-cache/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/credential-cache/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/credential-cache",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/debug-certificate-manager/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/debug-certificate-manager/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/debug-certificate-manager",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/eslint-bulk/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/eslint-bulk/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-bulk",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/eslint-config/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/eslint-config/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-config",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/eslint-patch/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/eslint-patch/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-patch",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/eslint-plugin-packlets/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/eslint-plugin-packlets/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-plugin-packlets",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/eslint-plugin-security/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/eslint-plugin-security/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-plugin-security",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/eslint-plugin/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/eslint-plugin/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-plugin",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/hashed-folder-copy-plugin/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/hashed-folder-copy-plugin/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/hashed-folder-copy-plugin",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/heft-api-extractor-plugin/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/heft-api-extractor-plugin/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-api-extractor-plugin",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/heft-config-file/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/heft-config-file/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-config-file",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/heft-dev-cert-plugin/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/heft-dev-cert-plugin/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-dev-cert-plugin",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/heft-isolated-typescript-transpile-plugin/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/heft-isolated-typescript-transpile-plugin/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-isolated-typescript-transpile-plugin",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/heft-jest-plugin/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/heft-jest-plugin/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-jest-plugin",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/heft-json-schema-typings-plugin/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/heft-json-schema-typings-plugin/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-json-schema-typings-plugin",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/heft-lint-plugin/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/heft-lint-plugin/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-lint-plugin",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/heft-localization-typings-plugin/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/heft-localization-typings-plugin/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-localization-typings-plugin",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/heft-rspack-plugin/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/heft-rspack-plugin/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-rspack-plugin",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/heft-sass-load-themed-styles-plugin/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/heft-sass-load-themed-styles-plugin/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-sass-load-themed-styles-plugin",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/heft-sass-plugin/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/heft-sass-plugin/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-sass-plugin",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/heft-serverless-stack-plugin/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/heft-serverless-stack-plugin/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-serverless-stack-plugin",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/heft-static-asset-typings-plugin/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/heft-static-asset-typings-plugin/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-static-asset-typings-plugin",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/heft-storybook-plugin/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/heft-storybook-plugin/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-storybook-plugin",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/heft-typescript-plugin/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/heft-typescript-plugin/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-typescript-plugin",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/heft-vscode-extension-plugin/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/heft-vscode-extension-plugin/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-vscode-extension-plugin",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/heft-webpack4-plugin/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/heft-webpack4-plugin/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-webpack4-plugin",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/heft-webpack5-plugin/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/heft-webpack5-plugin/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-webpack5-plugin",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/heft/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/heft/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/loader-raw-script/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/loader-raw-script/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/loader-raw-script",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/localization-utilities/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/localization-utilities/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/localization-utilities",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/lockfile-explorer/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/lockfile-explorer/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/lockfile-explorer",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/lookup-by-path/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/lookup-by-path/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/lookup-by-path",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/mcp-server/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/mcp-server/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/mcp-server",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/module-minifier/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/module-minifier/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/module-minifier",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/node-core-library/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/node-core-library/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/node-core-library",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/npm-check-fork/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/npm-check-fork/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/npm-check-fork",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/operation-graph/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/operation-graph/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/operation-graph",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/package-deps-hash/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/package-deps-hash/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/package-deps-hash",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/package-extractor/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/package-extractor/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/package-extractor",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/playwright-browser-tunnel/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/playwright-browser-tunnel/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/playwright-browser-tunnel",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/problem-matcher/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/problem-matcher/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/problem-matcher",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/rig-package/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/rig-package/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/rig-package",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/rundown/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/rundown/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/rundown",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/rush-daemon-protocol/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/rush-daemon-protocol/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/rush-daemon-protocol",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/rush-daemon-transport/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/rush-daemon-transport/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/rush-daemon-transport",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/rush-daemon/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/rush-daemon/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/rush-daemon",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/rush-mcp-docs-plugin/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/rush-mcp-docs-plugin/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/rush-mcp-docs-plugin",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/rush-pnpm-kit-v10/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/rush-pnpm-kit-v10/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/rush-pnpm-kit-v10",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/rush-pnpm-kit-v8/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/rush-pnpm-kit-v8/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/rush-pnpm-kit-v8",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/rush-pnpm-kit-v9/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/rush-pnpm-kit-v9/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/rush-pnpm-kit-v9",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/rush-published-versions-json-plugin/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/rush-published-versions-json-plugin/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/rush-published-versions-json-plugin",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/rush-terminal-renderer/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/rush-terminal-renderer/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/rush-terminal-renderer",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/set-webpack-public-path-plugin/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/set-webpack-public-path-plugin/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/set-webpack-public-path-plugin",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/stream-collator/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/stream-collator/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/stream-collator",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/terminal/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/terminal/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/terminal",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/trace-import/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/trace-import/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/trace-import",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/tree-pattern/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/tree-pattern/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/tree-pattern",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/ts-command-line/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/ts-command-line/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/ts-command-line",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/typings-generator/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/typings-generator/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/typings-generator",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/webpack-embedded-dependencies-plugin/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/webpack-embedded-dependencies-plugin/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/webpack-embedded-dependencies-plugin",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/webpack-plugin-utilities/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/webpack-plugin-utilities/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/webpack-plugin-utilities",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/webpack-preserve-dynamic-require-plugin/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/webpack-preserve-dynamic-require-plugin/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/webpack-preserve-dynamic-require-plugin",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/webpack-workspace-resolve-plugin/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/webpack-workspace-resolve-plugin/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/webpack-workspace-resolve-plugin",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/webpack4-localization-plugin/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/webpack4-localization-plugin/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/webpack4-localization-plugin",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/webpack4-module-minifier-plugin/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/webpack4-module-minifier-plugin/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/webpack4-module-minifier-plugin",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/webpack5-localization-plugin/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/webpack5-localization-plugin/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/webpack5-localization-plugin",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/webpack5-module-minifier-plugin/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/webpack5-module-minifier-plugin/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/webpack5-module-minifier-plugin",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/worker-pool/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/worker-pool/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/worker-pool",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/zipsync/node20-consumer-contract_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/zipsync/node20-consumer-contract_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/zipsync",
+      "comment": "Require Node.js 20.9 or newer for package consumers.",
+      "type": "none"
+    }
+  ]
+}

--- a/eslint/eslint-bulk/package.json
+++ b/eslint/eslint-bulk/package.json
@@ -24,6 +24,9 @@
     "type": "git",
     "directory": "eslint/eslint-bulk"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "homepage": "https://rushstack.io",
   "bin": {
     "eslint-bulk": "./bin/eslint-bulk"

--- a/eslint/eslint-config/package.json
+++ b/eslint/eslint-config/package.json
@@ -8,6 +8,9 @@
     "type": "git",
     "directory": "eslint/eslint-config"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "homepage": "https://rushstack.io",
   "scripts": {
     "build": "",

--- a/eslint/eslint-patch/package.json
+++ b/eslint/eslint-patch/package.json
@@ -46,6 +46,9 @@
     "type": "git",
     "directory": "eslint/eslint-patch"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "homepage": "https://rushstack.io",
   "scripts": {
     "build": "heft build --clean",

--- a/eslint/eslint-plugin-packlets/package.json
+++ b/eslint/eslint-plugin-packlets/package.json
@@ -8,6 +8,9 @@
     "type": "git",
     "directory": "eslint/eslint-plugin-packlets"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "homepage": "https://rushstack.io",
   "keywords": [
     "eslint",

--- a/eslint/eslint-plugin-security/package.json
+++ b/eslint/eslint-plugin-security/package.json
@@ -8,6 +8,9 @@
     "type": "git",
     "directory": "eslint/eslint-plugin-security"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "homepage": "https://rushstack.io",
   "keywords": [
     "eslint",

--- a/eslint/eslint-plugin/package.json
+++ b/eslint/eslint-plugin/package.json
@@ -8,6 +8,9 @@
     "type": "git",
     "directory": "eslint/eslint-plugin"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "homepage": "https://rushstack.io",
   "keywords": [
     "eslint",

--- a/heft-plugins/heft-api-extractor-plugin/package.json
+++ b/heft-plugins/heft-api-extractor-plugin/package.json
@@ -7,6 +7,9 @@
     "url": "https://github.com/microsoft/rushstack.git",
     "directory": "heft-plugins/heft-api-extractor-plugin"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "homepage": "https://rushstack.io/pages/heft/overview/",
   "license": "MIT",
   "scripts": {

--- a/heft-plugins/heft-dev-cert-plugin/package.json
+++ b/heft-plugins/heft-dev-cert-plugin/package.json
@@ -7,6 +7,9 @@
     "url": "https://github.com/microsoft/rushstack.git",
     "directory": "heft-plugins/heft-dev-cert-plugin"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "homepage": "https://rushstack.io/pages/heft/overview/",
   "license": "MIT",
   "scripts": {

--- a/heft-plugins/heft-isolated-typescript-transpile-plugin/package.json
+++ b/heft-plugins/heft-isolated-typescript-transpile-plugin/package.json
@@ -7,6 +7,9 @@
     "url": "https://github.com/microsoft/rushstack.git",
     "directory": "heft-plugins/heft-isolated-typescript-transpile-plugin"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "homepage": "https://rushstack.io/pages/heft/overview/",
   "license": "MIT",
   "main": "./lib-commonjs/index.js",

--- a/heft-plugins/heft-jest-plugin/package.json
+++ b/heft-plugins/heft-jest-plugin/package.json
@@ -7,6 +7,9 @@
     "url": "https://github.com/microsoft/rushstack.git",
     "directory": "heft-plugins/heft-jest-plugin"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "homepage": "https://rushstack.io/pages/heft/overview/",
   "license": "MIT",
   "scripts": {

--- a/heft-plugins/heft-json-schema-typings-plugin/package.json
+++ b/heft-plugins/heft-json-schema-typings-plugin/package.json
@@ -7,6 +7,9 @@
     "url": "https://github.com/microsoft/rushstack.git",
     "directory": "heft-plugins/heft-json-schema-typings-plugin"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "homepage": "https://rushstack.io/pages/heft/overview/",
   "license": "MIT",
   "scripts": {

--- a/heft-plugins/heft-lint-plugin/package.json
+++ b/heft-plugins/heft-lint-plugin/package.json
@@ -7,6 +7,9 @@
     "url": "https://github.com/microsoft/rushstack.git",
     "directory": "heft-plugins/heft-lint-plugin"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "homepage": "https://rushstack.io/pages/heft/overview/",
   "license": "MIT",
   "scripts": {

--- a/heft-plugins/heft-localization-typings-plugin/package.json
+++ b/heft-plugins/heft-localization-typings-plugin/package.json
@@ -7,6 +7,9 @@
     "url": "https://github.com/microsoft/rushstack.git",
     "directory": "heft-plugins/heft-localization-typings-plugin"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "homepage": "https://rushstack.io/pages/heft/overview/",
   "license": "MIT",
   "scripts": {

--- a/heft-plugins/heft-rspack-plugin/package.json
+++ b/heft-plugins/heft-rspack-plugin/package.json
@@ -7,6 +7,9 @@
     "url": "https://github.com/microsoft/rushstack.git",
     "directory": "heft-plugins/heft-rspack-plugin"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "homepage": "https://rushstack.io/pages/heft/overview/",
   "main": "./lib-commonjs/index.js",
   "module": "./lib-esm/index.js",

--- a/heft-plugins/heft-sass-load-themed-styles-plugin/package.json
+++ b/heft-plugins/heft-sass-load-themed-styles-plugin/package.json
@@ -7,6 +7,9 @@
     "url": "https://github.com/microsoft/rushstack.git",
     "directory": "heft-plugins/heft-sass-load-themed-styles-plugin"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "homepage": "https://rushstack.io/pages/heft/overview/",
   "license": "MIT",
   "scripts": {

--- a/heft-plugins/heft-sass-plugin/package.json
+++ b/heft-plugins/heft-sass-plugin/package.json
@@ -7,6 +7,9 @@
     "url": "https://github.com/microsoft/rushstack.git",
     "directory": "heft-plugins/heft-sass-plugin"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "homepage": "https://rushstack.io/pages/heft/overview/",
   "license": "MIT",
   "scripts": {

--- a/heft-plugins/heft-serverless-stack-plugin/package.json
+++ b/heft-plugins/heft-serverless-stack-plugin/package.json
@@ -7,6 +7,9 @@
     "url": "https://github.com/microsoft/rushstack.git",
     "directory": "heft-plugins/heft-serverless-stack-plugin"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "license": "MIT",
   "scripts": {
     "build": "heft build --clean",

--- a/heft-plugins/heft-static-asset-typings-plugin/package.json
+++ b/heft-plugins/heft-static-asset-typings-plugin/package.json
@@ -13,6 +13,9 @@
     "url": "https://github.com/microsoft/rushstack.git",
     "directory": "heft-plugins/heft-static-asset-typings-plugin"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "homepage": "https://rushstack.io/pages/heft/overview/",
   "exports": {
     "./lib/*.schema.json": "./lib-commonjs/*.schema.json",

--- a/heft-plugins/heft-storybook-plugin/package.json
+++ b/heft-plugins/heft-storybook-plugin/package.json
@@ -7,6 +7,9 @@
     "url": "https://github.com/microsoft/rushstack.git",
     "directory": "heft-plugins/heft-storybook-plugin"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "homepage": "https://rushstack.io/pages/heft/overview/",
   "license": "MIT",
   "scripts": {

--- a/heft-plugins/heft-typescript-plugin/package.json
+++ b/heft-plugins/heft-typescript-plugin/package.json
@@ -7,6 +7,9 @@
     "url": "https://github.com/microsoft/rushstack.git",
     "directory": "heft-plugins/heft-typescript-plugin"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "homepage": "https://rushstack.io/pages/heft/overview/",
   "main": "./lib-commonjs/index.js",
   "module": "./lib-esm/index.js",

--- a/heft-plugins/heft-vscode-extension-plugin/package.json
+++ b/heft-plugins/heft-vscode-extension-plugin/package.json
@@ -7,6 +7,9 @@
     "url": "https://github.com/microsoft/rushstack.git",
     "directory": "heft-plugins/heft-vscode-extension-plugin"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "homepage": "https://rushstack.io/pages/heft/overview/",
   "license": "MIT",
   "scripts": {

--- a/heft-plugins/heft-webpack4-plugin/package.json
+++ b/heft-plugins/heft-webpack4-plugin/package.json
@@ -7,6 +7,9 @@
     "url": "https://github.com/microsoft/rushstack.git",
     "directory": "heft-plugins/heft-webpack4-plugin"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "homepage": "https://rushstack.io/pages/heft/overview/",
   "main": "./lib-commonjs/index.js",
   "module": "./lib-esm/index.js",

--- a/heft-plugins/heft-webpack5-plugin/package.json
+++ b/heft-plugins/heft-webpack5-plugin/package.json
@@ -7,6 +7,9 @@
     "url": "https://github.com/microsoft/rushstack.git",
     "directory": "heft-plugins/heft-webpack5-plugin"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "homepage": "https://rushstack.io/pages/heft/overview/",
   "main": "./lib-commonjs/index.js",
   "module": "./lib-esm/index.js",

--- a/libraries/api-extractor-model/package.json
+++ b/libraries/api-extractor-model/package.json
@@ -7,6 +7,9 @@
     "url": "https://github.com/microsoft/rushstack.git",
     "directory": "libraries/api-extractor-model"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "homepage": "https://api-extractor.com",
   "main": "./lib-commonjs/index.js",
   "module": "./lib-esm/index.js",

--- a/libraries/credential-cache/package.json
+++ b/libraries/credential-cache/package.json
@@ -34,6 +34,9 @@
     "type": "git",
     "directory": "libraries/credential-cache"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "scripts": {
     "build": "heft build --clean",
     "_phase:build": "heft run --only build -- --clean",

--- a/libraries/debug-certificate-manager/package.json
+++ b/libraries/debug-certificate-manager/package.json
@@ -33,6 +33,9 @@
     "type": "git",
     "directory": "libraries/debug-certificate-manager"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "scripts": {
     "build": "heft build --clean",
     "_phase:build": "heft run --only build -- --clean"

--- a/libraries/heft-config-file/package.json
+++ b/libraries/heft-config-file/package.json
@@ -8,7 +8,7 @@
     "directory": "libraries/heft-config-file"
   },
   "engines": {
-    "node": ">=10.13.0"
+    "node": ">=20.9.0"
   },
   "homepage": "https://rushstack.io/pages/heft/overview/",
   "main": "./lib-commonjs/index.js",

--- a/libraries/localization-utilities/package.json
+++ b/libraries/localization-utilities/package.json
@@ -34,6 +34,9 @@
     "url": "https://github.com/microsoft/rushstack.git",
     "directory": "libraries/localization-utilities"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "scripts": {
     "build": "heft build --clean",
     "_phase:build": "heft run --only build -- --clean",

--- a/libraries/lookup-by-path/package.json
+++ b/libraries/lookup-by-path/package.json
@@ -40,6 +40,9 @@
     "type": "git",
     "directory": "libraries/lookup-by-path"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "scripts": {
     "build": "heft build --clean",
     "_phase:build": "heft run --only build -- --clean",

--- a/libraries/module-minifier/package.json
+++ b/libraries/module-minifier/package.json
@@ -33,6 +33,9 @@
     "type": "git",
     "directory": "libraries/module-minifier"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "scripts": {
     "build": "heft build --clean",
     "_phase:build": "heft run --only build -- --clean",

--- a/libraries/node-core-library/package.json
+++ b/libraries/node-core-library/package.json
@@ -33,6 +33,9 @@
     "type": "git",
     "directory": "libraries/node-core-library"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "scripts": {
     "build": "heft build --clean",
     "_phase:build": "heft run --only build -- --clean",

--- a/libraries/npm-check-fork/package.json
+++ b/libraries/npm-check-fork/package.json
@@ -7,6 +7,9 @@
     "url": "https://github.com/microsoft/rushstack.git",
     "directory": "libraries/npm-check-fork"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "homepage": "https://github.com/dylang/npm-check",
   "main": "./lib-commonjs/index.js",
   "module": "./lib-esm/index.js",

--- a/libraries/operation-graph/package.json
+++ b/libraries/operation-graph/package.json
@@ -33,6 +33,9 @@
     "type": "git",
     "directory": "libraries/operation-graph"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "scripts": {
     "build": "heft build --clean",
     "_phase:build": "heft run --only build -- --clean",

--- a/libraries/package-deps-hash/package.json
+++ b/libraries/package-deps-hash/package.json
@@ -33,6 +33,9 @@
     "url": "https://github.com/microsoft/rushstack.git",
     "directory": "libraries/package-deps-hash"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "scripts": {
     "build": "heft build --clean",
     "_phase:build": "heft run --only build -- --clean",

--- a/libraries/package-extractor/package.json
+++ b/libraries/package-extractor/package.json
@@ -32,6 +32,9 @@
     "url": "https://github.com/microsoft/rushstack.git",
     "directory": "libraries/package-extractor"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "scripts": {
     "build": "heft build --clean",
     "test": "heft test --clean",

--- a/libraries/problem-matcher/package.json
+++ b/libraries/problem-matcher/package.json
@@ -33,6 +33,9 @@
     "type": "git",
     "directory": "libraries/problem-matcher"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "scripts": {
     "build": "heft build --clean",
     "_phase:build": "heft run --only build -- --clean",

--- a/libraries/rig-package/package.json
+++ b/libraries/rig-package/package.json
@@ -34,6 +34,9 @@
     "type": "git",
     "directory": "libraries/rig-package"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "scripts": {
     "build": "heft build --clean",
     "_phase:build": "heft run --only build -- --clean",

--- a/libraries/rush-daemon-protocol/package.json
+++ b/libraries/rush-daemon-protocol/package.json
@@ -41,6 +41,9 @@
     "type": "git",
     "directory": "libraries/rush-daemon-protocol"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "scripts": {
     "build": "heft build --clean",
     "_phase:build": "heft run --only build -- --clean",

--- a/libraries/rush-daemon-transport/package.json
+++ b/libraries/rush-daemon-transport/package.json
@@ -41,6 +41,9 @@
     "type": "git",
     "directory": "libraries/rush-daemon-transport"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "scripts": {
     "build": "heft build --clean",
     "_phase:build": "heft run --only build -- --clean",

--- a/libraries/rush-daemon/package.json
+++ b/libraries/rush-daemon/package.json
@@ -33,6 +33,9 @@
     "type": "git",
     "directory": "libraries/rush-daemon"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "scripts": {
     "build": "heft build --clean",
     "_phase:build": "heft run --only build -- --clean",

--- a/libraries/rush-lib/package.json
+++ b/libraries/rush-lib/package.json
@@ -8,7 +8,7 @@
     "directory": "libraries/rush-lib"
   },
   "engines": {
-    "node": ">=5.6.0"
+    "node": ">=20.9.0"
   },
   "engineStrict": true,
   "homepage": "https://rushjs.io",

--- a/libraries/rush-pnpm-kit-v10/package.json
+++ b/libraries/rush-pnpm-kit-v10/package.json
@@ -2,6 +2,9 @@
   "name": "@rushstack/rush-pnpm-kit-v10",
   "version": "0.2.24",
   "description": "rush pnpm kit v10",
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "license": "MIT",
   "main": "./lib-commonjs/index.js",
   "module": "./lib-esm/index.js",

--- a/libraries/rush-pnpm-kit-v8/package.json
+++ b/libraries/rush-pnpm-kit-v8/package.json
@@ -2,6 +2,9 @@
   "name": "@rushstack/rush-pnpm-kit-v8",
   "version": "0.2.24",
   "description": "rush pnpm kit v8",
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "license": "MIT",
   "main": "./lib-commonjs/index.js",
   "module": "./lib-esm/index.js",

--- a/libraries/rush-pnpm-kit-v9/package.json
+++ b/libraries/rush-pnpm-kit-v9/package.json
@@ -2,6 +2,9 @@
   "name": "@rushstack/rush-pnpm-kit-v9",
   "version": "0.2.24",
   "description": "rush pnpm kit v9",
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "license": "MIT",
   "main": "./lib-commonjs/index.js",
   "module": "./lib-esm/index.js",

--- a/libraries/rush-sdk/package.json
+++ b/libraries/rush-sdk/package.json
@@ -7,6 +7,9 @@
     "url": "https://github.com/microsoft/rushstack.git",
     "directory": "apps/rush-sdk"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "homepage": "https://rushjs.io",
   "main": "./lib-shim/index.js",
   "types": "./dist/rush-lib.d.ts",

--- a/libraries/rush-terminal-renderer/package.json
+++ b/libraries/rush-terminal-renderer/package.json
@@ -41,6 +41,9 @@
     "type": "git",
     "directory": "libraries/rush-terminal-renderer"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "scripts": {
     "build": "heft build --clean",
     "_phase:build": "heft run --only build -- --clean",

--- a/libraries/stream-collator/package.json
+++ b/libraries/stream-collator/package.json
@@ -7,6 +7,9 @@
     "url": "https://github.com/microsoft/rushstack.git",
     "directory": "libraries/stream-collator"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "main": "./lib-commonjs/index.js",
   "module": "./lib-esm/index.js",
   "types": "./dist/stream-collator.d.ts",

--- a/libraries/terminal/package.json
+++ b/libraries/terminal/package.json
@@ -33,6 +33,9 @@
     "type": "git",
     "directory": "libraries/terminal"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "scripts": {
     "build": "heft build --clean",
     "_phase:build": "heft run --only build -- --clean",

--- a/libraries/tree-pattern/package.json
+++ b/libraries/tree-pattern/package.json
@@ -33,6 +33,9 @@
     "type": "git",
     "directory": "libraries/tree-pattern"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "scripts": {
     "build": "heft build --clean",
     "_phase:build": "heft run --only build -- --clean",

--- a/libraries/ts-command-line/package.json
+++ b/libraries/ts-command-line/package.json
@@ -7,6 +7,9 @@
     "url": "https://github.com/microsoft/rushstack.git",
     "directory": "libraries/ts-command-line"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "main": "./lib-commonjs/index.js",
   "module": "./lib-esm/index.js",
   "types": "./dist/ts-command-line.d.ts",

--- a/libraries/typings-generator/package.json
+++ b/libraries/typings-generator/package.json
@@ -38,6 +38,9 @@
     "url": "https://github.com/microsoft/rushstack.git",
     "directory": "libraries/typings-generator"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "scripts": {
     "build": "heft build --clean",
     "_phase:build": "heft run --only build -- --clean",

--- a/libraries/worker-pool/package.json
+++ b/libraries/worker-pool/package.json
@@ -33,6 +33,9 @@
     "type": "git",
     "directory": "libraries/worker-pool"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "scripts": {
     "build": "heft build --clean",
     "_phase:build": "heft run --only build -- --clean",

--- a/rush-plugins/rush-amazon-s3-build-cache-plugin/package.json
+++ b/rush-plugins/rush-amazon-s3-build-cache-plugin/package.json
@@ -7,6 +7,9 @@
     "url": "https://github.com/microsoft/rushstack",
     "directory": "rush-plugins/rush-amazon-s3-build-cache-plugin"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "homepage": "https://rushjs.io",
   "main": "./lib-commonjs/index.js",
   "module": "./lib-esm/index.js",

--- a/rush-plugins/rush-azure-storage-build-cache-plugin/package.json
+++ b/rush-plugins/rush-azure-storage-build-cache-plugin/package.json
@@ -7,6 +7,9 @@
     "url": "https://github.com/microsoft/rushstack",
     "directory": "heft-plugins/heft-webpack5-plugin"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "homepage": "https://rushjs.io",
   "main": "./lib-commonjs/index.js",
   "module": "./lib-esm/index.js",

--- a/rush-plugins/rush-bridge-cache-plugin/package.json
+++ b/rush-plugins/rush-bridge-cache-plugin/package.json
@@ -10,6 +10,9 @@
     "type": "git",
     "directory": "rush-plugins/rush-bridge-cache-plugin"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "homepage": "https://rushjs.io",
   "types": "./lib-dts/index.d.ts",
   "exports": {

--- a/rush-plugins/rush-buildxl-graph-plugin/package.json
+++ b/rush-plugins/rush-buildxl-graph-plugin/package.json
@@ -7,6 +7,9 @@
     "url": "https://github.com/microsoft/rushstack",
     "directory": "rush-plugins/rush-buildxl-graph-plugin"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "homepage": "https://rushjs.io",
   "main": "./lib-commonjs/index.js",
   "module": "./lib-esm/index.js",

--- a/rush-plugins/rush-http-build-cache-plugin/package.json
+++ b/rush-plugins/rush-http-build-cache-plugin/package.json
@@ -7,6 +7,9 @@
     "url": "https://github.com/microsoft/rushstack",
     "directory": "rush-plugins/rush-http-build-cache-plugin"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "homepage": "https://rushjs.io",
   "main": "./lib-commonjs/index.js",
   "module": "./lib-esm/index.js",

--- a/rush-plugins/rush-mcp-docs-plugin/package.json
+++ b/rush-plugins/rush-mcp-docs-plugin/package.json
@@ -7,6 +7,9 @@
     "type": "git",
     "directory": "rush-plugins/rush-mcp-docs-plugin"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "homepage": "https://rushjs.io",
   "main": "./lib-commonjs/index.js",
   "module": "./lib-esm/index.js",

--- a/rush-plugins/rush-published-versions-json-plugin/package.json
+++ b/rush-plugins/rush-published-versions-json-plugin/package.json
@@ -8,6 +8,9 @@
     "type": "git",
     "directory": "rush-plugins/rush-published-versions-json-plugin"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "scripts": {
     "build": "heft test --clean",
     "_phase:build": "heft run --only build -- --clean"

--- a/rush-plugins/rush-redis-cobuild-plugin/package.json
+++ b/rush-plugins/rush-redis-cobuild-plugin/package.json
@@ -7,6 +7,9 @@
     "url": "https://github.com/microsoft/rushstack",
     "directory": "rush-plugins/rush-redis-cobuild-plugin"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "homepage": "https://rushjs.io",
   "main": "./lib-commonjs/index.js",
   "module": "./lib-esm/index.js",

--- a/rush-plugins/rush-resolver-cache-plugin/package.json
+++ b/rush-plugins/rush-resolver-cache-plugin/package.json
@@ -8,6 +8,9 @@
     "type": "git",
     "directory": "rush-plugins/rush-resolver-cache-plugin"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "main": "./lib-commonjs/index.js",
   "module": "./lib-esm/index.js",
   "types": "./dist/rush-resolver-cache-plugin.d.ts",

--- a/rush-plugins/rush-serve-plugin/package.json
+++ b/rush-plugins/rush-serve-plugin/package.json
@@ -8,6 +8,9 @@
     "type": "git",
     "directory": "rush-plugins/rush-serve-plugin"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "main": "./lib-commonjs/index.js",
   "module": "./lib-esm/index.js",
   "types": "./dist/index.d.ts",

--- a/webpack/hashed-folder-copy-plugin/package.json
+++ b/webpack/hashed-folder-copy-plugin/package.json
@@ -42,6 +42,9 @@
     "url": "https://github.com/microsoft/rushstack.git",
     "directory": "webpack/hashed-folder-copy-plugin"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "scripts": {
     "build": "heft build --clean",
     "_phase:build": "heft run --only build -- --clean",

--- a/webpack/loader-load-themed-styles/package.json
+++ b/webpack/loader-load-themed-styles/package.json
@@ -33,6 +33,9 @@
     "url": "https://github.com/microsoft/rushstack.git",
     "directory": "webpack/loader-load-themed-styles"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "scripts": {
     "build": "heft build --clean",
     "_phase:build": "heft run --only build -- --clean",

--- a/webpack/loader-raw-script/package.json
+++ b/webpack/loader-raw-script/package.json
@@ -33,6 +33,9 @@
     "url": "https://github.com/microsoft/rushstack.git",
     "directory": "webpack/loader-raw-script"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "scripts": {
     "build": "heft build --clean",
     "_phase:build": "heft run --only build -- --clean",

--- a/webpack/preserve-dynamic-require-plugin/package.json
+++ b/webpack/preserve-dynamic-require-plugin/package.json
@@ -34,7 +34,7 @@
     "directory": "webpack/preserve-dynamic-require-plugin"
   },
   "engines": {
-    "node": ">=10.17.1"
+    "node": ">=20.9.0"
   },
   "scripts": {
     "build": "heft build --clean",

--- a/webpack/set-webpack-public-path-plugin/package.json
+++ b/webpack/set-webpack-public-path-plugin/package.json
@@ -33,6 +33,9 @@
     "url": "https://github.com/microsoft/rushstack.git",
     "directory": "webpack/set-webpack-public-path-plugin"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "scripts": {
     "build": "heft build --clean",
     "_phase:build": "heft run --only build -- --clean"

--- a/webpack/webpack-embedded-dependencies-plugin/package.json
+++ b/webpack/webpack-embedded-dependencies-plugin/package.json
@@ -33,6 +33,9 @@
     "url": "https://github.com/microsoft/rushstack.git",
     "directory": "webpack/webpack-embedded-dependencies-plugin"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "scripts": {
     "build": "heft build --clean",
     "test": "heft run --only test",

--- a/webpack/webpack-plugin-utilities/package.json
+++ b/webpack/webpack-plugin-utilities/package.json
@@ -33,6 +33,9 @@
     "url": "https://github.com/microsoft/rushstack.git",
     "directory": "webpack/webpack-plugin-utilities"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "scripts": {
     "build": "heft build --clean",
     "test": "heft run --only test",

--- a/webpack/webpack-workspace-resolve-plugin/package.json
+++ b/webpack/webpack-workspace-resolve-plugin/package.json
@@ -34,7 +34,7 @@
     "directory": "webpack/webpack-workspace-resolve-plugin"
   },
   "engines": {
-    "node": ">=18.19.0"
+    "node": ">=20.9.0"
   },
   "scripts": {
     "build": "heft build --clean",

--- a/webpack/webpack4-localization-plugin/package.json
+++ b/webpack/webpack4-localization-plugin/package.json
@@ -33,6 +33,9 @@
     "url": "https://github.com/microsoft/rushstack.git",
     "directory": "webpack/webpack4-localization-plugin"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "scripts": {
     "build": "heft build --clean",
     "_phase:build": "heft run --only build -- --clean"

--- a/webpack/webpack4-module-minifier-plugin/package.json
+++ b/webpack/webpack4-module-minifier-plugin/package.json
@@ -34,7 +34,7 @@
     "directory": "webpack/webpack4-module-minifier-plugin"
   },
   "engines": {
-    "node": ">=10.17.1"
+    "node": ">=20.9.0"
   },
   "scripts": {
     "build": "heft build --clean",

--- a/webpack/webpack5-load-themed-styles-loader/package.json
+++ b/webpack/webpack5-load-themed-styles-loader/package.json
@@ -33,6 +33,9 @@
     "url": "https://github.com/microsoft/rushstack.git",
     "directory": "webpack/webpack5-loader-load-themed-styles"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "scripts": {
     "build": "heft build --clean",
     "_phase:build": "heft run --only build -- --clean",

--- a/webpack/webpack5-localization-plugin/package.json
+++ b/webpack/webpack5-localization-plugin/package.json
@@ -33,6 +33,9 @@
     "url": "https://github.com/microsoft/rushstack.git",
     "directory": "webpack/webpack5-localization-plugin"
   },
+  "engines": {
+    "node": ">=20.9.0"
+  },
   "scripts": {
     "build": "heft build --clean",
     "_phase:build": "heft run --only build -- --clean",

--- a/webpack/webpack5-module-minifier-plugin/package.json
+++ b/webpack/webpack5-module-minifier-plugin/package.json
@@ -34,7 +34,7 @@
     "directory": "webpack/webpack5-module-minifier-plugin"
   },
   "engines": {
-    "node": ">=14.19.0"
+    "node": ">=20.9.0"
   },
   "scripts": {
     "build": "heft build --clean",


### PR DESCRIPTION
## Summary

- Require Node.js 20.9 or newer for maintained runtime packages
- Align consumer-facing package metadata with the repository's supported Node.js range
- Add non-publishing change entries for newly declared engine requirements

## Validation

- `rush check`
- `rush change --verify --no-fetch`
