### PR TITLE
Target ES2022 for Node.js packages

### DIFF
--- a/apps/api-documenter/src/plugin/MarkdownDocumenterFeature.ts
+++ b/apps/api-documenter/src/plugin/MarkdownDocumenterFeature.ts
@@ -75,7 +75,7 @@ const uuidMarkdownDocumenterFeature: string = '34196154-9eb3-4de0-a8c8-7e9539dfe
  */
 export class MarkdownDocumenterFeature extends PluginFeature {
   /** {@inheritdoc PluginFeature.context} */
-  public override context!: MarkdownDocumenterFeatureContext;
+  public declare context: MarkdownDocumenterFeatureContext;
 
   /**
    * This event occurs before each markdown file is written.  It provides an opportunity to customize the

--- a/build-tests/api-documenter-scenarios/src/inheritedMembers/index.ts
+++ b/build-tests/api-documenter-scenarios/src/inheritedMembers/index.ts
@@ -48,7 +48,7 @@ export class Class2<T> extends Namespace1.Class3 {
 export class Class1 extends Class2<number> {
   /** A second prop. Overrides `Class2.secondProp`. */
   // eslint-disable-next-line @typescript-eslint/explicit-member-accessibility
-  override secondProp: boolean;
+  declare secondProp: boolean;
 
   /** A fourth prop */
   // eslint-disable-next-line @typescript-eslint/explicit-member-accessibility

--- a/build-tests/localization-plugin-test-01/tsconfig.json
+++ b/build-tests/localization-plugin-test-01/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "./node_modules/local-node-rig/profiles/default/tsconfig-base.json",
   "compilerOptions": {
+    "target": "ES2019",
     "moduleResolution": "node",
     "rootDirs": ["src", "temp/loc-json-ts"]
   }

--- a/build-tests/localization-plugin-test-02/tsconfig.json
+++ b/build-tests/localization-plugin-test-02/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "./node_modules/local-node-rig/profiles/default/tsconfig-base.json",
   "compilerOptions": {
+    "target": "ES2019",
     "moduleResolution": "node",
     "rootDirs": ["src", "temp/loc-json-ts"]
   }

--- a/build-tests/localization-plugin-test-03/tsconfig.json
+++ b/build-tests/localization-plugin-test-03/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "./node_modules/local-node-rig/profiles/default/tsconfig-base.json",
   "compilerOptions": {
+    "target": "ES2019",
     "module": "esnext",
     "outDir": "lib-esm",
     "declarationDir": "lib-dts",

--- a/common/changes/@microsoft/rush/es2022-compiler-baseline_2026-08-18-03-14-04.json
+++ b/common/changes/@microsoft/rush/es2022-compiler-baseline_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Update class field declarations for ES2022 emit semantics.",
+      "type": "none"
+    }
+  ]
+}

--- a/common/changes/@rushstack/eslint-plugin/es2022-compiler-baseline_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/eslint-plugin/es2022-compiler-baseline_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-plugin",
+      "comment": "Compile package output for ES2022.",
+      "type": "patch"
+    }
+  ]
+}

--- a/common/changes/@rushstack/heft-jest-plugin/es2022-compiler-baseline_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/heft-jest-plugin/es2022-compiler-baseline_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-jest-plugin",
+      "comment": "Compile package output for ES2022.",
+      "type": "patch"
+    }
+  ]
+}

--- a/common/changes/@rushstack/heft-typescript-plugin/es2022-compiler-baseline_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/heft-typescript-plugin/es2022-compiler-baseline_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/heft-typescript-plugin",
+      "comment": "Use ES2022 library definitions during TypeScript compilation.",
+      "type": "patch"
+    }
+  ]
+}

--- a/common/changes/@rushstack/localization-utilities/es2022-compiler-baseline_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/localization-utilities/es2022-compiler-baseline_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/localization-utilities",
+      "comment": "Compile package output for ES2022.",
+      "type": "patch"
+    }
+  ]
+}

--- a/common/changes/@rushstack/lookup-by-path/es2022-compiler-baseline_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/lookup-by-path/es2022-compiler-baseline_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/lookup-by-path",
+      "comment": "Compile package output for ES2022.",
+      "type": "patch"
+    }
+  ]
+}

--- a/common/changes/@rushstack/module-minifier/es2022-compiler-baseline_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/module-minifier/es2022-compiler-baseline_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/module-minifier",
+      "comment": "Compile package output for ES2022.",
+      "type": "patch"
+    }
+  ]
+}

--- a/common/changes/@rushstack/operation-graph/es2022-compiler-baseline_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/operation-graph/es2022-compiler-baseline_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/operation-graph",
+      "comment": "Compile package output for ES2022.",
+      "type": "patch"
+    }
+  ]
+}

--- a/common/changes/@rushstack/rush-daemon/es2022-compiler-baseline_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/rush-daemon/es2022-compiler-baseline_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/rush-daemon",
+      "comment": "Compile package output for ES2022.",
+      "type": "patch"
+    }
+  ]
+}

--- a/common/changes/@rushstack/ts-command-line/es2022-compiler-baseline_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/ts-command-line/es2022-compiler-baseline_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/ts-command-line",
+      "comment": "Compile package output for ES2022.",
+      "type": "patch"
+    }
+  ]
+}

--- a/common/changes/@rushstack/webpack5-localization-plugin/es2022-compiler-baseline_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/webpack5-localization-plugin/es2022-compiler-baseline_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/webpack5-localization-plugin",
+      "comment": "Compile package output for ES2022.",
+      "type": "patch"
+    }
+  ]
+}

--- a/common/changes/@rushstack/worker-pool/es2022-compiler-baseline_2026-08-18-03-14-04.json
+++ b/common/changes/@rushstack/worker-pool/es2022-compiler-baseline_2026-08-18-03-14-04.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/worker-pool",
+      "comment": "Compile package output for ES2022.",
+      "type": "patch"
+    }
+  ]
+}

--- a/eslint/eslint-plugin/tsconfig.json
+++ b/eslint/eslint-plugin/tsconfig.json
@@ -2,10 +2,6 @@
   "extends": "./node_modules/decoupled-local-node-rig/profiles/default/tsconfig-base.json",
 
   "compilerOptions": {
-    "module": "Node16",
-
-    // TODO: Update the rest of the repo to target ES2020
-    "target": "ES2020",
-    "lib": ["ES2020"]
+    "module": "Node16"
   }
 }

--- a/heft-plugins/heft-jest-plugin/tsconfig.json
+++ b/heft-plugins/heft-jest-plugin/tsconfig.json
@@ -1,8 +1,3 @@
 {
-  "extends": "./node_modules/decoupled-local-node-rig/profiles/default/tsconfig-base.json",
-
-  "compilerOptions": {
-    // TODO: Remove when the repo is updated to ES2020
-    "target": "es2018"
-  }
+  "extends": "./node_modules/decoupled-local-node-rig/profiles/default/tsconfig-base.json"
 }

--- a/heft-plugins/heft-typescript-plugin/tsconfig.json
+++ b/heft-plugins/heft-typescript-plugin/tsconfig.json
@@ -1,8 +1,3 @@
 {
-  "extends": "./node_modules/decoupled-local-node-rig/profiles/default/tsconfig-base.json",
-
-  "compilerOptions": {
-    // TODO: Remove when the repo is updated to ES2020
-    "lib": ["ES2019"]
-  }
+  "extends": "./node_modules/decoupled-local-node-rig/profiles/default/tsconfig-base.json"
 }

--- a/libraries/localization-utilities/tsconfig.json
+++ b/libraries/localization-utilities/tsconfig.json
@@ -1,6 +1,3 @@
 {
-  "extends": "./node_modules/local-node-rig/profiles/default/tsconfig-base.json",
-  "compilerOptions": {
-    "target": "ES2019"
-  }
+  "extends": "./node_modules/local-node-rig/profiles/default/tsconfig-base.json"
 }

--- a/libraries/lookup-by-path/tsconfig.json
+++ b/libraries/lookup-by-path/tsconfig.json
@@ -1,7 +1,3 @@
 {
-  "extends": "./node_modules/local-node-rig/profiles/default/tsconfig-base.json",
-
-  "compilerOptions": {
-    "target": "ES2019"
-  }
+  "extends": "./node_modules/local-node-rig/profiles/default/tsconfig-base.json"
 }

--- a/libraries/module-minifier/tsconfig.json
+++ b/libraries/module-minifier/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "./node_modules/local-node-rig/profiles/default/tsconfig-base.json",
 
   "compilerOptions": {
-    "allowSyntheticDefaultImports": true,
-    "target": "ES2019"
+    "allowSyntheticDefaultImports": true
   }
 }

--- a/libraries/operation-graph/tsconfig.json
+++ b/libraries/operation-graph/tsconfig.json
@@ -3,9 +3,6 @@
 
   "compilerOptions": {
     // TODO: Consider turning this on for all projects, or removing it here
-    "allowSyntheticDefaultImports": true,
-    // TODO: update the rest of the repo to use ES2020
-    "target": "ES2020",
-    "lib": ["ES2020"]
+    "allowSyntheticDefaultImports": true
   }
 }

--- a/libraries/rush-daemon/tsconfig.json
+++ b/libraries/rush-daemon/tsconfig.json
@@ -1,8 +1,3 @@
 {
-  "extends": "./node_modules/local-node-rig/profiles/default/tsconfig-base.json",
-
-  "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["ES2020"]
-  }
+  "extends": "./node_modules/local-node-rig/profiles/default/tsconfig-base.json"
 }

--- a/libraries/rush-lib/src/cli/actions/BaseRushAction.ts
+++ b/libraries/rush-lib/src/cli/actions/BaseRushAction.ts
@@ -115,7 +115,7 @@ export abstract class BaseRushAction extends BaseConfiglessRushAction {
     return this._eventHooksManager;
   }
 
-  protected override readonly rushConfiguration!: RushConfiguration;
+  protected declare readonly rushConfiguration: RushConfiguration;
 
   protected override async onExecuteAsync(): Promise<void> {
     if (!this.rushConfiguration) {

--- a/libraries/ts-command-line/tsconfig.json
+++ b/libraries/ts-command-line/tsconfig.json
@@ -1,8 +1,3 @@
 {
-  "extends": "./node_modules/decoupled-local-node-rig/profiles/default/tsconfig-base.json",
-
-  "compilerOptions": {
-    // TODO: Remove when the repo is updated to ES2020
-    "target": "es2018"
-  }
+  "extends": "./node_modules/decoupled-local-node-rig/profiles/default/tsconfig-base.json"
 }

--- a/libraries/worker-pool/tsconfig.json
+++ b/libraries/worker-pool/tsconfig.json
@@ -1,7 +1,3 @@
 {
-  "extends": "./node_modules/local-node-rig/profiles/default/tsconfig-base.json",
-
-  "compilerOptions": {
-    "target": "ES2019"
-  }
+  "extends": "./node_modules/local-node-rig/profiles/default/tsconfig-base.json"
 }

--- a/rigs/decoupled-local-node-rig/profiles/default/tsconfig-base.json
+++ b/rigs/decoupled-local-node-rig/profiles/default/tsconfig-base.json
@@ -6,7 +6,8 @@
   "compilerOptions": {
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "target": "es2018",
+    "target": "es2022",
+    "lib": ["es2022"],
 
     "outDir": "${configDir}/lib-commonjs",
     "declarationDir": "${configDir}/lib-dts",

--- a/rigs/local-node-rig/profiles/default/tsconfig-base.json
+++ b/rigs/local-node-rig/profiles/default/tsconfig-base.json
@@ -7,7 +7,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noImplicitOverride": true,
-    "target": "es2018",
+    "target": "es2022",
+    "lib": ["es2022"],
 
     "outDir": "${configDir}/lib-commonjs",
     "declarationDir": "${configDir}/lib-dts",

--- a/webpack/webpack5-localization-plugin/tsconfig.json
+++ b/webpack/webpack5-localization-plugin/tsconfig.json
@@ -1,6 +1,3 @@
 {
-  "extends": "./node_modules/local-node-rig/profiles/default/tsconfig-base.json",
-  "compilerOptions": {
-    "target": "ES2019"
-  }
+  "extends": "./node_modules/local-node-rig/profiles/default/tsconfig-base.json"
 }


### PR DESCRIPTION
## Summary

- Raise the local and decoupled Node.js rigs to the ES2022 target and library baseline
- Remove stale package-level ES2019 and ES2020 overrides
- Preserve `BaseRushAction` property narrowing under native class field semantics

Stacked on #5930.

## Validation

- Built the Rush repository and representative Node.js rig consumers
- `rush change --verify --no-fetch`
