### PR TITLE
[playwright-browser-tunnel] Fix stopAsync hanging while waiting for a connection

### DIFF
--- a/apps/playwright-browser-tunnel/src/PlaywrightBrowserTunnel.ts
+++ b/apps/playwright-browser-tunnel/src/PlaywrightBrowserTunnel.ts
@@ -87,6 +87,15 @@ interface IBrowserServerProxy {
  * Hosts a Playwright browser server and forwards traffic over a WebSocket tunnel.
  * @beta
  */
+/**
+ * Thrown internally to settle a connection wait that was still pending when the tunnel was stopped.
+ */
+class TunnelStoppedError extends Error {
+  public constructor() {
+    super('The tunnel was stopped while waiting for a connection');
+  }
+}
+
 export class PlaywrightTunnel {
   private readonly _terminal: ITerminal;
   private readonly _onStatusChange: (status: TunnelStatus) => void;
@@ -97,6 +106,7 @@ export class PlaywrightTunnel {
   private readonly _playwrightInstallPath: string;
   private _status: TunnelStatus = 'stopped';
   private _initWsPromise?: Promise<WebSocket>;
+  private _cancelPollConnection?: (error: Error) => void;
   private _keepRunning: boolean = false;
   private _ws?: WebSocket;
   private _mode: TunnelMode;
@@ -163,7 +173,14 @@ export class PlaywrightTunnel {
       } else {
         terminal.writeLine(`Tunnel is already running with status: ${this.status}`);
       }
-      await this.waitForCloseAsync();
+      try {
+        await this.waitForCloseAsync();
+      } catch (error) {
+        // stopAsync() settles a pending connection wait; that is an ordinary shutdown, not a failure
+        if (this._keepRunning || !(error instanceof TunnelStoppedError)) {
+          throw error;
+        }
+      }
     }
   }
 
@@ -173,9 +190,28 @@ export class PlaywrightTunnel {
       clearInterval(this._pollInterval);
       this._pollInterval = undefined;
     }
-    await this._initWsPromise?.finally(() => {
-      this._ws?.close(WebSocketCloseCode.NORMAL_CLOSURE, 'Tunnel stopped');
-    });
+    this._pendingConnectionAttempt = undefined;
+
+    // In poll-connection mode the init promise only settles once a client connects. Clearing the
+    // interval stops the polling but leaves that promise pending forever, so stopping before any
+    // client arrived would never complete. Settle it explicitly as part of the teardown.
+    const cancelPollConnection: ((error: Error) => void) | undefined = this._cancelPollConnection;
+    this._cancelPollConnection = undefined;
+    cancelPollConnection?.(new TunnelStoppedError());
+
+    const initWsPromise: Promise<WebSocket> | undefined = this._initWsPromise;
+    this._initWsPromise = undefined;
+    try {
+      await initWsPromise?.finally(() => {
+        this._ws?.close(WebSocketCloseCode.NORMAL_CLOSURE, 'Tunnel stopped');
+      });
+    } catch (error) {
+      if (!(error instanceof TunnelStoppedError)) {
+        throw error;
+      }
+    }
+
+    this.status = 'stopped';
   }
 
   public async [Symbol.asyncDispose](): Promise<void> {
@@ -272,6 +308,14 @@ export class PlaywrightTunnel {
   private async _pollConnectionAsync(): Promise<WebSocket> {
     this._terminal.writeLine(`Waiting for WebSocket connection`);
     return await new Promise((resolve, reject) => {
+      this._cancelPollConnection = (error: Error): void => {
+        if (this._pollInterval) {
+          clearInterval(this._pollInterval);
+          this._pollInterval = undefined;
+        }
+        this._pendingConnectionAttempt = undefined;
+        reject(error);
+      };
       this._pollInterval = setInterval(() => {
         if (this._pendingConnectionAttempt) {
           return; // Skip if a connection attempt is already in progress
@@ -284,6 +328,7 @@ export class PlaywrightTunnel {
             this._pollInterval = undefined;
             ws.removeAllListeners();
             this._pendingConnectionAttempt = undefined;
+            this._cancelPollConnection = undefined;
             resolve(ws);
           })
           .catch(() => {

--- a/apps/playwright-browser-tunnel/src/PlaywrightBrowserTunnel.ts
+++ b/apps/playwright-browser-tunnel/src/PlaywrightBrowserTunnel.ts
@@ -84,10 +84,6 @@ interface IBrowserServerProxy {
 }
 
 /**
- * Hosts a Playwright browser server and forwards traffic over a WebSocket tunnel.
- * @beta
- */
-/**
  * Thrown internally to settle a connection wait that was still pending when the tunnel was stopped.
  */
 class TunnelStoppedError extends Error {
@@ -96,6 +92,10 @@ class TunnelStoppedError extends Error {
   }
 }
 
+/**
+ * Hosts a Playwright browser server and forwards traffic over a WebSocket tunnel.
+ * @beta
+ */
 export class PlaywrightTunnel {
   private readonly _terminal: ITerminal;
   private readonly _onStatusChange: (status: TunnelStatus) => void;

--- a/apps/playwright-browser-tunnel/src/PlaywrightBrowserTunnel.ts
+++ b/apps/playwright-browser-tunnel/src/PlaywrightBrowserTunnel.ts
@@ -107,6 +107,9 @@ export class PlaywrightTunnel {
   private _status: TunnelStatus = 'stopped';
   private _initWsPromise?: Promise<WebSocket>;
   private _cancelPollConnection?: (error: Error) => void;
+  /// Bumped whenever polling starts or is cancelled, so an attempt that resolves
+  /// after a stop or restart can recognise that it no longer owns the shared state.
+  private _pollGeneration: number = 0;
   private _keepRunning: boolean = false;
   private _ws?: WebSocket;
   private _mode: TunnelMode;
@@ -307,8 +310,13 @@ export class PlaywrightTunnel {
   // Need to support multiple simultaneous connections for parallel tests.
   private async _pollConnectionAsync(): Promise<WebSocket> {
     this._terminal.writeLine(`Waiting for WebSocket connection`);
+    const generation: number = ++this._pollGeneration;
+    const ownsPollState = (): boolean => this._pollGeneration === generation;
     return await new Promise((resolve, reject) => {
       this._cancelPollConnection = (error: Error): void => {
+        // Retire this generation so an attempt still in flight cannot clear the
+        // interval or the canceller belonging to whatever starts next.
+        this._pollGeneration += 1;
         if (this._pollInterval) {
           clearInterval(this._pollInterval);
           this._pollInterval = undefined;
@@ -324,6 +332,13 @@ export class PlaywrightTunnel {
         this._pendingConnectionAttempt = connectionPromise;
         connectionPromise
           .then((ws: WebSocket) => {
+            if (!ownsPollState()) {
+              // Stopped or restarted while this attempt was in flight: the socket
+              // belongs to nobody now, so close it rather than leave it open.
+              ws.removeAllListeners();
+              ws.close(WebSocketCloseCode.NORMAL_CLOSURE, 'Tunnel stopped');
+              return;
+            }
             clearInterval(this._pollInterval);
             this._pollInterval = undefined;
             ws.removeAllListeners();
@@ -333,7 +348,9 @@ export class PlaywrightTunnel {
           })
           .catch(() => {
             // no-op - will retry on next interval
-            this._pendingConnectionAttempt = undefined;
+            if (ownsPollState()) {
+              this._pendingConnectionAttempt = undefined;
+            }
           });
       }, 500);
     });

--- a/common/changes/@rushstack/playwright-browser-tunnel/fix-playwright-tunnel-stop-while-waiting_2026-08-18-08-27-59.json
+++ b/common/changes/@rushstack/playwright-browser-tunnel/fix-playwright-tunnel-stop-while-waiting_2026-08-18-08-27-59.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "comment": "Fix `PlaywrightTunnel.stopAsync()` hanging when the tunnel is stopped in poll-connection mode before any client has connected.",
+      "type": "patch",
+      "packageName": "@rushstack/playwright-browser-tunnel"
+    }
+  ],
+  "packageName": "@rushstack/playwright-browser-tunnel"
+}


### PR DESCRIPTION
## Summary

Fixes #5853

`PlaywrightTunnel.stopAsync()` never completes when the tunnel is stopped in `poll-connection` mode before any client has connected. The tunnel is left in `waiting-for-connection` and the caller waits forever.

## Details

`_pollConnectionAsync()` returns a promise that is only resolved from inside the polling interval, when `_tryConnectAsync()` finally succeeds — its `reject` is never called. `startAsync()` stores that promise as `_initWsPromise`, and `stopAsync()` clears the interval and then awaits it. Clearing the interval stops the polling but leaves the promise pending, so the await has nothing to wait for.

The fix records a canceller while the poll is in flight and settles it during teardown:

- `_pollConnectionAsync()` registers `_cancelPollConnection`, which clears the poll state and rejects the pending wait; it is dropped as soon as a client connects.
- `stopAsync()` invokes it before awaiting `_initWsPromise`, swallows that expected rejection, clears `_initWsPromise`, and sets the status to `stopped`.
- The `startAsync()` loop treats such a cancellation as an ordinary shutdown, so stopping the tunnel does not surface as a failure to whoever awaited `startAsync()`.

This is the case @justinTM's #5851 explicitly does not cover — that PR fixes the Start/Stop race in the VS Code extension, while this one is in the tunnel itself, so the two do not touch the same files.

## How it was tested

Against the published `@rushstack/playwright-browser-tunnel` 0.3.27, driving a tunnel at an endpoint where nothing is listening, so it stays in `waiting-for-connection`:

```console
$ node repro.cjs
  status -> waiting-for-connection
Waiting for WebSocket connection
calling stopAsync() while status = waiting-for-connection
stopAsync STILL HANGING after 8005ms          # 8s race guard, it never settles
```

With this change applied to the package's compiled output, the same script:

```console
  status -> waiting-for-connection
Waiting for WebSocket connection
calling stopAsync() while status = waiting-for-connection
  startAsync resolved cleanly
  status -> stopped
stopAsync RESOLVED after 0ms
```

The package currently has no unit tests, so I did not add one rather than introduce a test harness in a bug-fix PR — glad to add one if you would like it here. I also could not compile the monorepo locally, so that is worth confirming in CI.
