### PR TITLE
Fix no-new-null for native private members

### DIFF
--- a/common/changes/@rushstack/eslint-plugin/native-private-null_2026-08-19-22-58-08.json
+++ b/common/changes/@rushstack/eslint-plugin/native-private-null_2026-08-19-22-58-08.json
@@ -1,0 +1,9 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/eslint-plugin",
+      "comment": "Fix no-new-null false positives for ECMAScript private class members.",
+      "type": "patch"
+    }
+  ]
+}

--- a/eslint/eslint-plugin/src/no-new-null.ts
+++ b/eslint/eslint-plugin/src/no-new-null.ts
@@ -9,6 +9,7 @@ type Options = [];
 
 interface IAccessible {
   accessibility?: TSESTree.Accessibility;
+  key?: TSESTree.Node;
 }
 
 const noNewNullRule: TSESLint.RuleModule<MessageIds, Options> = {
@@ -37,11 +38,15 @@ const noNewNullRule: TSESLint.RuleModule<MessageIds, Options> = {
 
   create: (context: TSESLint.RuleContext<MessageIds, Options>) => {
     /**
-     * Returns true if the accessibility is not explicitly set to private or protected, e.g. class properties, methods.
+     * Returns true unless a class member uses protected, TypeScript-private, or ECMAScript-private syntax.
      */
     function isPubliclyAccessible(node?: IAccessible): boolean {
       const accessibility: TSESTree.Accessibility | undefined = node?.accessibility;
-      return !(accessibility === 'private' || accessibility === 'protected');
+      return (
+        accessibility !== 'private' &&
+        accessibility !== 'protected' &&
+        node?.key?.type !== AST_NODE_TYPES.PrivateIdentifier
+      );
     }
 
     /**

--- a/eslint/eslint-plugin/src/test/no-new-null.test.ts
+++ b/eslint/eslint-plugin/src/test/no-new-null.test.ts
@@ -104,6 +104,17 @@ ruleTester.run('no-new-null', noNewNullRule, {
         '  }',
         '}'
       ].join('\n')
+    },
+    {
+      code: [
+        'class NativePrivateNulls {',
+        '  #field: string | null;',
+        '  #propertyFunc: (value: string | null) => void;',
+        '  #method(value: string | null): string | null { return value; }',
+        '  get #value(): string | null { return this.#field; }',
+        '  set #value(value: string | null) { this.#field = value; }',
+        '}'
+      ].join('\n')
     }
   ]
 });


### PR DESCRIPTION
## Summary

- treat class members keyed by an ECMAScript `PrivateIdentifier` as private
- stop `@rushstack/no-new-null` from reporting `null` types that cannot escape through native private fields, methods, getters, or setters
- add regression coverage for each native private member form

## Validation

- reproduced six false positives with the regression test before the fix
- `rush build --to @rushstack/eslint-plugin --verbose`
- `rush test --only @rushstack/eslint-plugin --verbose` (197 tests)

## Dependents

#5939, #5941, #5942, and #5943 are stacked on this fix because their native-private migrations expose the false positive.