### PR TITLE
Fix js-yaml security advisories in rush-lib

### DIFF
--- a/apps/api-documenter/package.json
+++ b/apps/api-documenter/package.json
@@ -52,7 +52,7 @@
     "@rushstack/node-core-library": "workspace:*",
     "@rushstack/terminal": "workspace:*",
     "@rushstack/ts-command-line": "workspace:*",
-    "js-yaml": "~4.1.0",
+    "js-yaml": "~4.3.1",
     "resolve": "~1.22.1"
   },
   "devDependencies": {

--- a/apps/lockfile-explorer/package.json
+++ b/apps/lockfile-explorer/package.json
@@ -71,7 +71,7 @@
     "@rushstack/ts-command-line": "workspace:*",
     "cors": "~2.8.5",
     "express": "4.21.1",
-    "js-yaml": "~4.1.0",
+    "js-yaml": "~4.3.1",
     "semver": "~7.7.4"
   },
   "exports": {

--- a/common/changes/@microsoft/rush/fix-js-yaml-security_2026-08-20-22-19.json
+++ b/common/changes/@microsoft/rush/fix-js-yaml-security_2026-08-20-22-19.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Update js-yaml to ~4.3.1 to address CVE-2026-59869 and GHSA-5p4m-2wfm-xmqj.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/config/subspaces/build-tests-subspace/pnpm-lock.yaml
+++ b/common/config/subspaces/build-tests-subspace/pnpm-lock.yaml
@@ -2599,8 +2599,8 @@ packages:
     resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
     hasBin: true
 
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsdoc-type-pratt-parser@4.1.0:
@@ -3952,7 +3952,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.1.1
+      js-yaml: 4.3.1
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -4339,7 +4339,7 @@ snapshots:
       git-repo-info: 2.1.1
       https-proxy-agent: 5.0.1
       ignore: 5.1.9
-      js-yaml: 4.1.1
+      js-yaml: 4.3.1
       npm-package-arg: 6.1.1
       object-hash: 3.0.0
       pnpm-sync-lib: 0.3.4
@@ -7093,7 +7093,7 @@ snapshots:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.1.1:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -7622,7 +7622,7 @@ snapshots:
 
   read-yaml-file@2.1.0:
     dependencies:
-      js-yaml: 4.1.1
+      js-yaml: 4.3.1
       strip-bom: 4.0.0
 
   readable-stream@2.3.8:
@@ -8335,7 +8335,7 @@ snapshots:
 
   write-yaml-file@4.2.0:
     dependencies:
-      js-yaml: 4.1.1
+      js-yaml: 4.3.1
       write-file-atomic: 3.0.3
 
   xml@1.0.1: {}

--- a/common/config/subspaces/build-tests-subspace/repo-state.json
+++ b/common/config/subspaces/build-tests-subspace/repo-state.json
@@ -1,6 +1,6 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "4e7dc2a53df7dd2ee77e903f8f67c29f817ecd81",
+  "pnpmShrinkwrapHash": "3058be418b277acccf1aa815413c6245c71cbbde",
   "preferredVersionsHash": "550b4cee0bef4e97db6c6aad726df5149d20e7d9",
   "packageJsonInjectedDependenciesHash": "dacc324b7b6d9e35baf57460cae419ef162589d6"
 }

--- a/common/config/subspaces/default/pnpm-lock.yaml
+++ b/common/config/subspaces/default/pnpm-lock.yaml
@@ -37,8 +37,8 @@ importers:
         specifier: workspace:*
         version: link:../../libraries/ts-command-line
       js-yaml:
-        specifier: ~4.1.0
-        version: 4.1.1
+        specifier: ~4.3.1
+        version: 4.3.1
       resolve:
         specifier: ~1.22.1
         version: 1.22.11
@@ -221,8 +221,8 @@ importers:
         specifier: 4.21.1
         version: 4.21.1
       js-yaml:
-        specifier: ~4.1.0
-        version: 4.1.1
+        specifier: ~4.3.1
+        version: 4.3.1
       semver:
         specifier: ~7.7.4
         version: 7.7.4
@@ -4214,8 +4214,8 @@ importers:
         specifier: ~5.1.6
         version: 5.1.9
       js-yaml:
-        specifier: ~4.1.0
-        version: 4.1.1
+        specifier: ~4.3.1
+        version: 4.3.1
       npm-package-arg:
         specifier: ~6.1.0
         version: 6.1.1
@@ -4637,8 +4637,8 @@ importers:
         specifier: workspace:*
         version: link:../../libraries/node-core-library
       js-yaml:
-        specifier: ~4.1.0
-        version: 4.1.1
+        specifier: ~4.3.1
+        version: 4.3.1
     devDependencies:
       '@rushstack/heft':
         specifier: workspace:*
@@ -15080,8 +15080,8 @@ packages:
     resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
     hasBin: true
 
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jscodeshift@0.13.1:
@@ -19258,7 +19258,7 @@ snapshots:
     dependencies:
       '@jsdevtools/ono': 7.1.3
       '@types/json-schema': 7.0.15
-      js-yaml: 4.1.1
+      js-yaml: 4.3.1
 
   '@asamuzakjp/css-color@3.2.0':
     dependencies:
@@ -21460,7 +21460,7 @@ snapshots:
       globals: 13.24.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.1.1
+      js-yaml: 4.3.1
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -21474,7 +21474,7 @@ snapshots:
       globals: 13.24.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.1.1
+      js-yaml: 4.3.1
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -21488,7 +21488,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.1.1
+      js-yaml: 4.3.1
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -25117,7 +25117,7 @@ snapshots:
       express: 4.21.1
       fs-extra: 9.1.0
       immer: 9.0.21
-      js-yaml: 4.1.1
+      js-yaml: 4.3.1
       kysely: 0.21.6
       kysely-codegen: 0.6.2(kysely@0.21.6)
       kysely-data-api: 0.1.4(aws-sdk@2.1693.0)(kysely@0.21.6)
@@ -30975,7 +30975,7 @@ snapshots:
       imurmurhash: 0.1.4
       is-glob: 4.0.3
       js-sdsl: 4.4.2
-      js-yaml: 4.1.1
+      js-yaml: 4.3.1
       json-stable-stringify-without-jsonify: 1.0.1
       levn: 0.4.1
       lodash.merge: 4.6.2
@@ -31020,7 +31020,7 @@ snapshots:
       imurmurhash: 0.1.4
       is-glob: 4.0.3
       is-path-inside: 3.0.3
-      js-yaml: 4.1.1
+      js-yaml: 4.3.1
       json-stable-stringify-without-jsonify: 1.0.1
       levn: 0.4.1
       lodash.merge: 4.6.2
@@ -31058,7 +31058,7 @@ snapshots:
       import-fresh: 3.3.1
       imurmurhash: 0.1.4
       is-glob: 4.0.3
-      js-yaml: 4.1.1
+      js-yaml: 4.3.1
       json-stable-stringify-without-jsonify: 1.0.1
       levn: 0.4.1
       lodash.merge: 4.6.2
@@ -33686,7 +33686,7 @@ snapshots:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.1.1:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -33787,7 +33787,7 @@ snapshots:
       '@types/json-schema': 7.0.15
       '@types/lodash': 4.17.23
       is-glob: 4.0.3
-      js-yaml: 4.1.1
+      js-yaml: 4.3.1
       lodash: 4.18.1
       minimist: 1.2.8
       prettier: 3.8.1
@@ -34432,7 +34432,7 @@ snapshots:
       find-up: 5.0.0
       glob: 8.1.0
       he: 1.2.0
-      js-yaml: 4.1.1
+      js-yaml: 4.3.1
       log-symbols: 4.1.0
       minimatch: 5.1.9
       ms: 2.1.3
@@ -35901,7 +35901,7 @@ snapshots:
 
   read-yaml-file@2.1.0:
     dependencies:
-      js-yaml: 4.1.1
+      js-yaml: 4.3.1
       strip-bom: 4.0.0
 
   read@1.0.7:
@@ -38493,7 +38493,7 @@ snapshots:
 
   write-yaml-file@4.2.0:
     dependencies:
-      js-yaml: 4.1.1
+      js-yaml: 4.3.1
       write-file-atomic: 3.0.3
 
   write@1.0.3:

--- a/common/config/subspaces/default/repo-state.json
+++ b/common/config/subspaces/default/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "3a02f48687fcafbf4ecd96d74677d760f95a2e89",
+  "pnpmShrinkwrapHash": "a9da538929392ee31e330a8381ad3b1b9e7bc787",
   "preferredVersionsHash": "029c99bd6e65c5e1f25e2848340509811ff9753c"
 }

--- a/libraries/rush-lib/package.json
+++ b/libraries/rush-lib/package.json
@@ -68,7 +68,7 @@
     "@inquirer/input": "~5.0.11",
     "@inquirer/search": "~4.1.7",
     "@inquirer/select": "~5.1.3",
-    "js-yaml": "~4.1.0",
+    "js-yaml": "~4.3.1",
     "npm-package-arg": "~6.1.0",
     "object-hash": "3.0.0",
     "pnpm-sync-lib": "0.3.4",

--- a/repo-scripts/doc-plugin-rush-stack/package.json
+++ b/repo-scripts/doc-plugin-rush-stack/package.json
@@ -36,7 +36,7 @@
     "@microsoft/api-extractor-model": "workspace:*",
     "@microsoft/tsdoc": "~0.16.0",
     "@rushstack/node-core-library": "workspace:*",
-    "js-yaml": "~4.1.0"
+    "js-yaml": "~4.3.1"
   },
   "devDependencies": {
     "@rushstack/heft": "workspace:*",


### PR DESCRIPTION
Fixes #5843.

## Summary

- Upgrade the shared direct `js-yaml` dependency from `~4.1.0` to `~4.3.1`, including `@microsoft/rush-lib`.
- Refresh both PNPM subspace lockfiles and their Rush repository-state hashes.
- Add the required Rush change file.

## Security rationale

`~4.2.0`, as proposed by #5847, addresses [GHSA-h67p-54hq-rp68](https://github.com/advisories/GHSA-h67p-54hq-rp68) but is no longer a sufficient floor. [CVE-2026-59869](https://www.cve.org/CVERecord?id=CVE-2026-59869) is fixed in `js-yaml` 4.3.0, while [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj) requires 4.3.1. Using `~4.3.1` addresses all three advisories while remaining within the existing major version.

## Validation

- `rush check --subspace default`
- `rush install --to @microsoft/rush-lib --bypass-policy`
- `rush build --to @microsoft/rush-lib`
- Verified both generated lockfiles match their Rush `pnpmShrinkwrapHash` values and contain no `js-yaml@4.1.1` resolution.