### PR TITLE
[rush] Fix manual ESRP publish pipeline runs

### DIFF
--- a/common/config/azure-pipelines/esrp-publish-rush.yaml
+++ b/common/config/azure-pipelines/esrp-publish-rush.yaml
@@ -29,7 +29,7 @@ parameters:
   - name: CommitShaOverride
     displayName: 'Commit SHA Override (for testing)'
     type: string
-    default: ''
+    default: $(Build.SourceVersion)
 
 variables:
   - name: FORCE_COLOR

--- a/common/config/azure-pipelines/esrp-publish-rushstack.yaml
+++ b/common/config/azure-pipelines/esrp-publish-rushstack.yaml
@@ -29,7 +29,7 @@ parameters:
   - name: CommitShaOverride
     displayName: 'Commit SHA Override (for testing)'
     type: string
-    default: ''
+    default: $(Build.SourceVersion)
 
 variables:
   - name: FORCE_COLOR


### PR DESCRIPTION
## Summary

Azure DevOps disabled manual runs for the Rush and Rush Stack ESRP publish pipelines because their string parameter default was empty and therefore treated as required. Default the commit SHA override to the queued build's source version so both pipelines can be run without supplying a testing override.

## Details

Set `CommitShaOverride` to `$(Build.SourceVersion)` in both ESRP publish pipeline entry points. Callers can still replace it with another SHA for testing, while normal automatic and manual runs use the source commit selected when queuing the build.

This does not change published package behavior or compatibility.

## How it was tested

Validated the final YAML diff and confirmed both pipeline definitions now provide a non-empty default while retaining the existing override flow.

## Impacted documentation

N/A