### PR TITLE
[rush-daemon][WS2.4][3/9] Route phased requests

### DIFF
--- a/common/changes/@rushstack/rush-daemon-protocol/mojazayeri-phased-request-contracts_2026-08-21-17-24.json
+++ b/common/changes/@rushstack/rush-daemon-protocol/mojazayeri-phased-request-contracts_2026-08-21-17-24.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/rush-daemon-protocol",
+      "comment": "Add typed resolved phased-request, enabled-state selection, engine-shape, and client-scoped operation result contracts.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/rush-daemon-protocol",
+  "email": "mojazayeri@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/rush-daemon/mojazayeri-route-phased-requests_2026-08-21-17-24.json
+++ b/common/changes/@rushstack/rush-daemon/mojazayeri-route-phased-requests_2026-08-21-17-24.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/rush-daemon",
+      "comment": "Add an opt-in phased request router that validates a caller-resolved selection, reconciles warm invalidations, runs one real graph iteration, scopes ordered streams and events to the client, and safely aborts on cancellation or disconnect.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/rush-daemon",
+  "email": "mojazayeri@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/rush-terminal-renderer/mojazayeri-authoritative-operation-headers_2026-08-25-13-53.json
+++ b/common/changes/@rushstack/rush-terminal-renderer/mojazayeri-authoritative-operation-headers_2026-08-25-13-53.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/rush-terminal-renderer",
+      "comment": "Use authoritative daemon operation-header counters when collating partial warm iterations.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/rush-terminal-renderer",
+  "email": "mojazayeri@users.noreply.github.com"
+}

--- a/common/config/subspaces/default/pnpm-lock.yaml
+++ b/common/config/subspaces/default/pnpm-lock.yaml
@@ -4103,6 +4103,9 @@ importers:
       '@rushstack/rush-daemon-transport':
         specifier: workspace:*
         version: link:../rush-daemon-transport
+      '@rushstack/terminal':
+        specifier: workspace:*
+        version: link:../terminal
     devDependencies:
       '@rushstack/heft':
         specifier: workspace:*
@@ -4721,7 +4724,7 @@ importers:
         version: 1.2.23(@types/node@20.17.19)
       '@rushstack/heft-node-rig':
         specifier: 2.11.46
-        version: 2.11.46(@rushstack/heft@1.2.23(@types/node@20.17.19))(@types/node@20.17.19)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.28.0))(jest-environment-jsdom@30.3.0)
+        version: 2.11.46(@rushstack/heft@1.2.23(@types/node@20.17.19))(@types/node@20.17.19)(esbuild-register@3.6.0(esbuild@0.28.0))(jest-environment-jsdom@30.3.0)
       '@types/jest':
         specifier: 30.0.0
         version: 30.0.0
@@ -7002,10 +7005,10 @@ packages:
     resolution: {integrity: sha1-OHAmXs/8c1LQHq1i2Ng9g1ii0DQ=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@emnapi/core/-/core-1.9.2.tgz}
 
   '@emnapi/runtime@1.9.2':
-    resolution: {integrity: sha1-i0aaPbFggXytsd6QUCEanR6oT6I=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@emnapi/runtime/-/runtime-1.9.2.tgz}
+    resolution: {integrity: sha1-i0aaPbFggXytsd6QUCEanR6oT6I=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@emnapi/runtime/-/runtime-1.9.2.tgz}
 
   '@emnapi/wasi-threads@1.2.1':
-    resolution: {integrity: sha1-KP7SGhuhznl8RKBwq8lNQvOuhUg=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz}
+    resolution: {integrity: sha1-KP7SGhuhznl8RKBwq8lNQvOuhUg=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz}
 
   '@emotion/cache@10.0.29':
     resolution: {integrity: sha512-fU2VtSVlHiF27empSbxi1O2JFdNWZO+2NFHfwO0pxgTep6Xa3uGb+3pVKfLww2l/IBGLNEZl5Xf/++A4wAYDYQ==}
@@ -7080,25 +7083,25 @@ packages:
     engines: {node: '>=16'}
 
   '@esbuild/aix-ppc64@0.25.12':
-    resolution: {integrity: sha1-gPy+NhMOWLdnBRHoiLjoiiWe12w=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz}
+    resolution: {integrity: sha1-gPy+NhMOWLdnBRHoiLjoiiWe12w=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
   '@esbuild/aix-ppc64@0.28.0':
-    resolution: {integrity: sha1-eiicFY4py/WeoK/IPMgPBtHIlAI=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz}
+    resolution: {integrity: sha1-eiicFY4py/WeoK/IPMgPBtHIlAI=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
   '@esbuild/android-arm64@0.25.12':
-    resolution: {integrity: sha1-iqSWX40KeYLcIXNL9mATI6Ztp1I=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz}
+    resolution: {integrity: sha1-iqSWX40KeYLcIXNL9mATI6Ztp1I=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
   '@esbuild/android-arm64@0.28.0':
-    resolution: {integrity: sha1-uIKNnt+jqSZgZE643m5PPCA9exc=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz}
+    resolution: {integrity: sha1-uIKNnt+jqSZgZE643m5PPCA9exc=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -7116,139 +7119,139 @@ packages:
     os: [android]
 
   '@esbuild/android-x64@0.25.12':
-    resolution: {integrity: sha1-h9+ycWEgK9yVjvSLthsJx1j67hY=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/android-x64/-/android-x64-0.25.12.tgz}
+    resolution: {integrity: sha1-h9+ycWEgK9yVjvSLthsJx1j67hY=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/android-x64/-/android-x64-0.25.12.tgz}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
   '@esbuild/android-x64@0.28.0':
-    resolution: {integrity: sha1-OQZCF1uI74K61MzgP4qxP+mxkS4=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/android-x64/-/android-x64-0.28.0.tgz}
+    resolution: {integrity: sha1-OQZCF1uI74K61MzgP4qxP+mxkS4=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/android-x64/-/android-x64-0.28.0.tgz}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
   '@esbuild/darwin-arm64@0.25.12':
-    resolution: {integrity: sha1-eRl4mOwf90XSHAceHHzDyALwwf0=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz}
+    resolution: {integrity: sha1-eRl4mOwf90XSHAceHHzDyALwwf0=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
   '@esbuild/darwin-arm64@0.28.0':
-    resolution: {integrity: sha1-rkUyWWDVlQzWlR5PlzlvTh/32NM=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz}
+    resolution: {integrity: sha1-rkUyWWDVlQzWlR5PlzlvTh/32NM=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.25.12':
-    resolution: {integrity: sha1-FGQAqFYhM/RcTS6tzzfd0JcYB54=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz}
+    resolution: {integrity: sha1-FGQAqFYhM/RcTS6tzzfd0JcYB54=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.28.0':
-    resolution: {integrity: sha1-wHkkfViba5lEllnZTwaVG4S/8uQ=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz}
+    resolution: {integrity: sha1-wHkkfViba5lEllnZTwaVG4S/8uQ=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
   '@esbuild/freebsd-arm64@0.25.12':
-    resolution: {integrity: sha1-HF+bpyBuFY/SskxZ+i0si7R8oP4=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz}
+    resolution: {integrity: sha1-HF+bpyBuFY/SskxZ+i0si7R8oP4=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
   '@esbuild/freebsd-arm64@0.28.0':
-    resolution: {integrity: sha1-RcRWIVpIZZPJSQApcgLcEciAo3o=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz}
+    resolution: {integrity: sha1-RcRWIVpIZZPJSQApcgLcEciAo3o=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.25.12':
-    resolution: {integrity: sha1-6mMfSja+qsS5J5+g/MbKKerusrM=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz}
+    resolution: {integrity: sha1-6mMfSja+qsS5J5+g/MbKKerusrM=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.28.0':
-    resolution: {integrity: sha1-A5lJTByF5DiOm3BAvWDUjypbDSw=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz}
+    resolution: {integrity: sha1-A5lJTByF5DiOm3BAvWDUjypbDSw=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
   '@esbuild/linux-arm64@0.25.12':
-    resolution: {integrity: sha1-4QZrzlg5TxsRQd7shVel8KIvWXc=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz}
+    resolution: {integrity: sha1-4QZrzlg5TxsRQd7shVel8KIvWXc=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
   '@esbuild/linux-arm64@0.28.0':
-    resolution: {integrity: sha1-1tnwnvDeVBFr9Fmk1TysfglS/jk=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz}
+    resolution: {integrity: sha1-1tnwnvDeVBFr9Fmk1TysfglS/jk=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
   '@esbuild/linux-arm@0.25.12':
-    resolution: {integrity: sha1-RSzWayCTLQi9xTqLYcDjC69DSLk=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz}
+    resolution: {integrity: sha1-RSzWayCTLQi9xTqLYcDjC69DSLk=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.28.0':
-    resolution: {integrity: sha1-e0L/qEwoiulP3EMcGyionjw7kng=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz}
+    resolution: {integrity: sha1-e0L/qEwoiulP3EMcGyionjw7kng=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-ia32@0.25.12':
-    resolution: {integrity: sha1-sk+KzEW89UGSx/LzvhtT5lUer+A=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz}
+    resolution: {integrity: sha1-sk+KzEW89UGSx/LzvhtT5lUer+A=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
   '@esbuild/linux-ia32@0.28.0':
-    resolution: {integrity: sha1-3rFdES7Y3WBTRra5U9I6If+BJT8=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz}
+    resolution: {integrity: sha1-3rFdES7Y3WBTRra5U9I6If+BJT8=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
   '@esbuild/linux-loong64@0.14.54':
-    resolution: {integrity: sha1-3ipL5ni9TQ0f+7hubed5zeWZkCg=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-loong64/-/linux-loong64-0.14.54.tgz}
+    resolution: {integrity: sha1-3ipL5ni9TQ0f+7hubed5zeWZkCg=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-loong64/-/linux-loong64-0.14.54.tgz}
     engines: {node: '>=12'}
     cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.25.12':
-    resolution: {integrity: sha1-+c//p/yDIlcfvEyLMmjK8VvYGtA=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz}
+    resolution: {integrity: sha1-+c//p/yDIlcfvEyLMmjK8VvYGtA=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.28.0':
-    resolution: {integrity: sha1-gfuJ0H7sx5sVfephAzdXcm/ODKQ=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz}
+    resolution: {integrity: sha1-gfuJ0H7sx5sVfephAzdXcm/ODKQ=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-mips64el@0.25.12':
-    resolution: {integrity: sha1-V1oUvXRkT/q4ka3H1+YNJ1KW8s0=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz}
+    resolution: {integrity: sha1-V1oUvXRkT/q4ka3H1+YNJ1KW8s0=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
   '@esbuild/linux-mips64el@0.28.0':
-    resolution: {integrity: sha1-0OQmkbP/evn7Ihe3D8AfNDvbYrs=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz}
+    resolution: {integrity: sha1-0OQmkbP/evn7Ihe3D8AfNDvbYrs=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.25.12':
-    resolution: {integrity: sha1-dbmccKlfvV93OddpK+/mBgFZGGk=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz}
+    resolution: {integrity: sha1-dbmccKlfvV93OddpK+/mBgFZGGk=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.28.0':
-    resolution: {integrity: sha1-OJ8+XpjxfUd8RnzIcTbhoHburYc=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz}
+    resolution: {integrity: sha1-OJ8+XpjxfUd8RnzIcTbhoHburYc=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -7266,37 +7269,37 @@ packages:
     os: [linux]
 
   '@esbuild/linux-s390x@0.25.12':
-    resolution: {integrity: sha1-F2dsq7/lko2lsqDW311YzQjbJmM=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz}
+    resolution: {integrity: sha1-F2dsq7/lko2lsqDW311YzQjbJmM=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.28.0':
-    resolution: {integrity: sha1-qsYGFjSHLkZ33mk7zoAw1zsf0FU=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz}
+    resolution: {integrity: sha1-qsYGFjSHLkZ33mk7zoAw1zsf0FU=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-x64@0.25.12':
-    resolution: {integrity: sha1-BYN3VoXKggZtBMNQfwlSTTzXowY=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz}
+    resolution: {integrity: sha1-BYN3VoXKggZtBMNQfwlSTTzXowY=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
   '@esbuild/linux-x64@0.28.0':
-    resolution: {integrity: sha1-TykXdHGI/ndjK87GWy2EtCJBl3k=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz}
+    resolution: {integrity: sha1-TykXdHGI/ndjK87GWy2EtCJBl3k=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
   '@esbuild/netbsd-arm64@0.25.12':
-    resolution: {integrity: sha1-8ExAScsuJS/paxb+2Q9wdGsT9KQ=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz}
+    resolution: {integrity: sha1-8ExAScsuJS/paxb+2Q9wdGsT9KQ=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
   '@esbuild/netbsd-arm64@0.28.0':
-    resolution: {integrity: sha1-gU3wrlegw4aBRJG4OX7rqCCUqUc=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz}
+    resolution: {integrity: sha1-gU3wrlegw4aBRJG4OX7rqCCUqUc=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -7314,25 +7317,25 @@ packages:
     os: [netbsd]
 
   '@esbuild/openbsd-arm64@0.25.12':
-    resolution: {integrity: sha1-Ypb1hnrt7yioGyKrIAnHhqlS3M0=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz}
+    resolution: {integrity: sha1-Ypb1hnrt7yioGyKrIAnHhqlS3M0=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
   '@esbuild/openbsd-arm64@0.28.0':
-    resolution: {integrity: sha1-ShXDaqzKaNLVpMkLcQwGdZ9MH/o=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz}
+    resolution: {integrity: sha1-ShXDaqzKaNLVpMkLcQwGdZ9MH/o=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.25.12':
-    resolution: {integrity: sha1-+NIzAzYOJ7Fs8GWyO7/0PBQUJnk=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz}
+    resolution: {integrity: sha1-+NIzAzYOJ7Fs8GWyO7/0PBQUJnk=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.28.0':
-    resolution: {integrity: sha1-R15hAUmKjszjAI18OIER16J8F70=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz}
+    resolution: {integrity: sha1-R15hAUmKjszjAI18OIER16J8F70=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
@@ -7350,37 +7353,37 @@ packages:
     os: [openharmony]
 
   '@esbuild/sunos-x64@0.25.12':
-    resolution: {integrity: sha1-pu19Z3jWflKMgfsWWyP0kRubE9Y=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz}
+    resolution: {integrity: sha1-pu19Z3jWflKMgfsWWyP0kRubE9Y=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
   '@esbuild/sunos-x64@0.28.0':
-    resolution: {integrity: sha1-oBPIVv7KzRw67Jhciv4dHLAXSX0=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz}
+    resolution: {integrity: sha1-oBPIVv7KzRw67Jhciv4dHLAXSX0=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
   '@esbuild/win32-arm64@0.25.12':
-    resolution: {integrity: sha1-msFMN44bZTrxfQjn0840yu9YcyM=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz}
+    resolution: {integrity: sha1-msFMN44bZTrxfQjn0840yu9YcyM=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
   '@esbuild/win32-arm64@0.28.0':
-    resolution: {integrity: sha1-6uBeDzUnHK04mLQxaNPpo7uvR+U=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz}
+    resolution: {integrity: sha1-6uBeDzUnHK04mLQxaNPpo7uvR+U=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
   '@esbuild/win32-ia32@0.25.12':
-    resolution: {integrity: sha1-kYlC3LuzXMFPyjmvuRteaj0Scmc=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz}
+    resolution: {integrity: sha1-kYlC3LuzXMFPyjmvuRteaj0Scmc=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
   '@esbuild/win32-ia32@0.28.0':
-    resolution: {integrity: sha1-BhYevFv3XAjWn+s8ayJWBRWROZg=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz}
+    resolution: {integrity: sha1-BhYevFv3XAjWn+s8ayJWBRWROZg=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
@@ -8649,10 +8652,10 @@ packages:
     engines: {node: '>=4'}
 
   '@napi-rs/wasm-runtime@0.2.12':
-    resolution: {integrity: sha1-PniouW5sM6bFF+GJTvvVOFp8tvI=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz}
+    resolution: {integrity: sha1-PniouW5sM6bFF+GJTvvVOFp8tvI=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz}
 
   '@napi-rs/wasm-runtime@1.0.7':
-    resolution: {integrity: sha1-3P6pmnXwYgmiNfPZQeNGClHpsUw=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@napi-rs/wasm-runtime/-/wasm-runtime-1.0.7.tgz}
+    resolution: {integrity: sha1-3P6pmnXwYgmiNfPZQeNGClHpsUw=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@napi-rs/wasm-runtime/-/wasm-runtime-1.0.7.tgz}
 
   '@noble/hashes@1.4.0':
     resolution: {integrity: sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==}
@@ -8717,7 +8720,7 @@ packages:
     engines: {node: '>=20.0.0'}
 
   '@pkgjs/parseargs@0.11.0':
-    resolution: {integrity: sha1-p36nQvqyV3UUVDTrHSMoz1ATrDM=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pkgjs/parseargs/-/parseargs-0.11.0.tgz}
+    resolution: {integrity: sha1-p36nQvqyV3UUVDTrHSMoz1ATrDM=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pkgjs/parseargs/-/parseargs-0.11.0.tgz}
     engines: {node: '>=14'}
 
   '@pkgr/core@0.2.9':
@@ -8860,7 +8863,7 @@ packages:
     engines: {node: '>=18.12'}
 
   '@pnpm/lockfile.types@1001.1.0':
-    resolution: {integrity: sha1-rhsx7V+7Du0y0CpfVlG8zilTW6E=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/lockfile.types/-/lockfile.types-1001.1.0.tgz}
+    resolution: {integrity: sha1-rhsx7V+7Du0y0CpfVlG8zilTW6E=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/lockfile.types/-/lockfile.types-1001.1.0.tgz}
     engines: {node: '>=18.12'}
 
   '@pnpm/lockfile.types@1002.0.1':
@@ -8912,7 +8915,7 @@ packages:
     engines: {node: '>=18.12'}
 
   '@pnpm/ramda@0.28.1':
-    resolution: {integrity: sha1-DzKrxSddWGoD4Nwd2QoAmsZo/zM=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/ramda/-/ramda-0.28.1.tgz}
+    resolution: {integrity: sha1-DzKrxSddWGoD4Nwd2QoAmsZo/zM=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/ramda/-/ramda-0.28.1.tgz}
 
   '@pnpm/read-modules-dir@2.0.3':
     resolution: {integrity: sha512-i9OgRvSlxrTS9a2oXokhDxvQzDtfqtsooJ9jaGoHkznue5aFCTSrNZFQ6M18o8hC03QWfnxaKi0BtOvNkKu2+A==}
@@ -8939,7 +8942,7 @@ packages:
     engines: {node: '>=18.12'}
 
   '@pnpm/types@1000.7.0':
-    resolution: {integrity: sha1-g1Hkb73+JfgP7Jdb/fWNDKStYkw=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/types/-/types-1000.7.0.tgz}
+    resolution: {integrity: sha1-g1Hkb73+JfgP7Jdb/fWNDKStYkw=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/types/-/types-1000.7.0.tgz}
     engines: {node: '>=18.12'}
 
   '@pnpm/types@1000.8.0':
@@ -8989,7 +8992,7 @@ packages:
     resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
 
   '@pothos/core@3.41.2':
-    resolution: {integrity: sha1-ruJt4pccOHJDU0S8NM4Kv5qUVL0=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pothos/core/-/core-3.41.2.tgz}
+    resolution: {integrity: sha1-ruJt4pccOHJDU0S8NM4Kv5qUVL0=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pothos/core/-/core-3.41.2.tgz}
     peerDependencies:
       graphql: '>=15.1.0'
 
@@ -9241,50 +9244,50 @@ packages:
     os: [darwin]
 
   '@rspack/binding-darwin-x64@1.6.8':
-    resolution: {integrity: sha1-E8gBzoIQ0Rt7C8Sse/A27DKGKTU=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rspack/binding-darwin-x64/-/binding-darwin-x64-1.6.8.tgz}
+    resolution: {integrity: sha1-E8gBzoIQ0Rt7C8Sse/A27DKGKTU=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rspack/binding-darwin-x64/-/binding-darwin-x64-1.6.8.tgz}
     cpu: [x64]
     os: [darwin]
 
   '@rspack/binding-linux-arm64-gnu@1.6.8':
-    resolution: {integrity: sha1-1wMhrFu9W8EB3potoBxvuYRgFWU=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.6.8.tgz}
+    resolution: {integrity: sha1-1wMhrFu9W8EB3potoBxvuYRgFWU=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.6.8.tgz}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
   '@rspack/binding-linux-arm64-musl@1.6.8':
-    resolution: {integrity: sha1-T5GWtiM2Sc5D5khaXScU7zjfxgM=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.6.8.tgz}
+    resolution: {integrity: sha1-T5GWtiM2Sc5D5khaXScU7zjfxgM=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.6.8.tgz}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
   '@rspack/binding-linux-x64-gnu@1.6.8':
-    resolution: {integrity: sha1-t45/YrQVezHhgf6J0xmmAXgqgCs=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.6.8.tgz}
+    resolution: {integrity: sha1-t45/YrQVezHhgf6J0xmmAXgqgCs=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.6.8.tgz}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
   '@rspack/binding-linux-x64-musl@1.6.8':
-    resolution: {integrity: sha1-xXj3MNip+rhm5KFZIEV++df9X1g=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-1.6.8.tgz}
+    resolution: {integrity: sha1-xXj3MNip+rhm5KFZIEV++df9X1g=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-1.6.8.tgz}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
   '@rspack/binding-wasm32-wasi@1.6.8':
-    resolution: {integrity: sha1-dtI1iewxrWurZ4TaiffMQsffAnU=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rspack/binding-wasm32-wasi/-/binding-wasm32-wasi-1.6.8.tgz}
+    resolution: {integrity: sha1-dtI1iewxrWurZ4TaiffMQsffAnU=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rspack/binding-wasm32-wasi/-/binding-wasm32-wasi-1.6.8.tgz}
     cpu: [wasm32]
 
   '@rspack/binding-win32-arm64-msvc@1.6.8':
-    resolution: {integrity: sha1-tCy6SrdYjOcvDBPJaNPWLophq0Y=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.6.8.tgz}
+    resolution: {integrity: sha1-tCy6SrdYjOcvDBPJaNPWLophq0Y=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.6.8.tgz}
     cpu: [arm64]
     os: [win32]
 
   '@rspack/binding-win32-ia32-msvc@1.6.8':
-    resolution: {integrity: sha1-KTojRIxqEfJamru5iWEwWcfaPsQ=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.6.8.tgz}
+    resolution: {integrity: sha1-KTojRIxqEfJamru5iWEwWcfaPsQ=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.6.8.tgz}
     cpu: [ia32]
     os: [win32]
 
   '@rspack/binding-win32-x64-msvc@1.6.8':
-    resolution: {integrity: sha1-9f0/AbZpTuCMvDgsO9QtZJCrlEY=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.6.8.tgz}
+    resolution: {integrity: sha1-9f0/AbZpTuCMvDgsO9QtZJCrlEY=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.6.8.tgz}
     cpu: [x64]
     os: [win32]
 
@@ -10125,65 +10128,65 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
 
   '@swc/core-darwin-arm64@1.7.10':
-    resolution: {integrity: sha1-PuU+21AbI7EERqmNH21tSH2Iodk=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@swc/core-darwin-arm64/-/core-darwin-arm64-1.7.10.tgz}
+    resolution: {integrity: sha1-PuU+21AbI7EERqmNH21tSH2Iodk=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@swc/core-darwin-arm64/-/core-darwin-arm64-1.7.10.tgz}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [darwin]
 
   '@swc/core-darwin-x64@1.7.10':
-    resolution: {integrity: sha1-cdNUFYDjbr73bTfwCBxJp/Gv6tY=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@swc/core-darwin-x64/-/core-darwin-x64-1.7.10.tgz}
+    resolution: {integrity: sha1-cdNUFYDjbr73bTfwCBxJp/Gv6tY=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@swc/core-darwin-x64/-/core-darwin-x64-1.7.10.tgz}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [darwin]
 
   '@swc/core-linux-arm-gnueabihf@1.7.10':
-    resolution: {integrity: sha1-ez86gp2R+FmlAP5gfmgUiY7oGdk=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.7.10.tgz}
+    resolution: {integrity: sha1-ez86gp2R+FmlAP5gfmgUiY7oGdk=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.7.10.tgz}
     engines: {node: '>=10'}
     cpu: [arm]
     os: [linux]
 
   '@swc/core-linux-arm64-gnu@1.7.10':
-    resolution: {integrity: sha1-vdDQ9kwrLAneqXa+ncJI/TWd5VE=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.7.10.tgz}
+    resolution: {integrity: sha1-vdDQ9kwrLAneqXa+ncJI/TWd5VE=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.7.10.tgz}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.7.10':
-    resolution: {integrity: sha1-vJgIuyS6Ek++l3KQGadFvV6IWas=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.7.10.tgz}
+    resolution: {integrity: sha1-vJgIuyS6Ek++l3KQGadFvV6IWas=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.7.10.tgz}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.7.10':
-    resolution: {integrity: sha1-EBpx3PkiTrLO7HgaJUqTd0xl/zE=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.7.10.tgz}
+    resolution: {integrity: sha1-EBpx3PkiTrLO7HgaJUqTd0xl/zE=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.7.10.tgz}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.7.10':
-    resolution: {integrity: sha1-b8Grv32BgzQ76Ur64L9ZaumNQEg=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.7.10.tgz}
+    resolution: {integrity: sha1-b8Grv32BgzQ76Ur64L9ZaumNQEg=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.7.10.tgz}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.7.10':
-    resolution: {integrity: sha1-XW7P2kzF6D7IZZEZ8WB7FmP3Cm0=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.7.10.tgz}
+    resolution: {integrity: sha1-XW7P2kzF6D7IZZEZ8WB7FmP3Cm0=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.7.10.tgz}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [win32]
 
   '@swc/core-win32-ia32-msvc@1.7.10':
-    resolution: {integrity: sha1-N/MXfaU7KLLcjIOu/vwgIFBk688=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.7.10.tgz}
+    resolution: {integrity: sha1-N/MXfaU7KLLcjIOu/vwgIFBk688=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.7.10.tgz}
     engines: {node: '>=10'}
     cpu: [ia32]
     os: [win32]
 
   '@swc/core-win32-x64-msvc@1.7.10':
-    resolution: {integrity: sha1-KBQzXAAylcSoCOwbnPGepU+a1uU=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.7.10.tgz}
+    resolution: {integrity: sha1-KBQzXAAylcSoCOwbnPGepU+a1uU=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.7.10.tgz}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [win32]
@@ -10232,7 +10235,7 @@ packages:
     resolution: {integrity: sha512-yw0omUrxGp8+gEAuieZFeXB4bCqFvmyCDL3GOBv+Q6+cK0m5824ViHZKPgK5DYG1ijN/lbi1hP3UVKywPN7rbQ==}
 
   '@tybys/wasm-util@0.10.1':
-    resolution: {integrity: sha1-7N3TIFzx4tUnRkn/Du3SmR7X9BQ=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@tybys/wasm-util/-/wasm-util-0.10.1.tgz}
+    resolution: {integrity: sha1-7N3TIFzx4tUnRkn/Du3SmR7X9BQ=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@tybys/wasm-util/-/wasm-util-0.10.1.tgz}
 
   '@types/argparse@1.0.38':
     resolution: {integrity: sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==}
@@ -10748,12 +10751,12 @@ packages:
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
-    resolution: {integrity: sha1-n1sEUDCI5qNUKV6OqP48uZ5Dr4E=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz}
+    resolution: {integrity: sha1-n1sEUDCI5qNUKV6OqP48uZ5Dr4E=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz}
     cpu: [arm]
     os: [android]
 
   '@unrs/resolver-binding-android-arm64@1.11.1':
-    resolution: {integrity: sha1-dBSIVDG9cXi5ia7cTSXMyzhlvJ8=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz}
+    resolution: {integrity: sha1-dBSIVDG9cXi5ia7cTSXMyzhlvJ8=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz}
     cpu: [arm64]
     os: [android]
 
@@ -10763,7 +10766,7 @@ packages:
     os: [darwin]
 
   '@unrs/resolver-binding-darwin-x64@1.11.1':
-    resolution: {integrity: sha1-/U2BJXsT9NGgg4kKahfADeVx8Nw=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz}
+    resolution: {integrity: sha1-/U2BJXsT9NGgg4kKahfADeVx8Nw=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz}
     cpu: [x64]
     os: [darwin]
 
@@ -10773,7 +10776,7 @@ packages:
     os: [freebsd]
 
   '@unrs/resolver-binding-linux-arm-gnueabihf@1.11.1':
-    resolution: {integrity: sha1-hE0mBdBXSI13+rCXBfKGa4YWTgo=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz}
+    resolution: {integrity: sha1-hE0mBdBXSI13+rCXBfKGa4YWTgo=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz}
     cpu: [arm]
     os: [linux]
 
@@ -10783,31 +10786,31 @@ packages:
     os: [linux]
 
   '@unrs/resolver-binding-linux-arm64-gnu@1.11.1':
-    resolution: {integrity: sha1-Aj6ww6rEYGahC+ej82Lns087350=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz}
+    resolution: {integrity: sha1-Aj6ww6rEYGahC+ej82Lns087350=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
-    resolution: {integrity: sha1-nm+auwZCTjFApgrJlhOXhvXZm+A=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz}
+    resolution: {integrity: sha1-nm+auwZCTjFApgrJlhOXhvXZm+A=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
-    resolution: {integrity: sha1-sRFBfxfJ0bAu++yOCDmPDFUnu0Q=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz}
+    resolution: {integrity: sha1-sRFBfxfJ0bAu++yOCDmPDFUnu0Q=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
-    resolution: {integrity: sha1-kv+/AnSK8+mYc5RcmoperQHVCKk=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz}
+    resolution: {integrity: sha1-kv+/AnSK8+mYc5RcmoperQHVCKk=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
-    resolution: {integrity: sha1-C+xvElj8OQ5rMF6f9EJWyyB94WU=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz}
+    resolution: {integrity: sha1-C+xvElj8OQ5rMF6f9EJWyyB94WU=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
@@ -10819,7 +10822,7 @@ packages:
     libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
-    resolution: {integrity: sha1-NvsxjuvdaQ9toyrF4EmadvqIGTU=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz}
+    resolution: {integrity: sha1-NvsxjuvdaQ9toyrF4EmadvqIGTU=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
@@ -10841,7 +10844,7 @@ packages:
     os: [win32]
 
   '@unrs/resolver-binding-win32-ia32-msvc@1.11.1':
-    resolution: {integrity: sha1-cvxXvHxk7Fw94NZO4NGBAxe8YKY=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz}
+    resolution: {integrity: sha1-cvxXvHxk7Fw94NZO4NGBAxe8YKY=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz}
     cpu: [ia32]
     os: [win32]
 
@@ -10878,12 +10881,12 @@ packages:
     engines: {node: '>=8.9.3'}
 
   '@vscode/vsce-sign-alpine-arm64@2.0.6':
-    resolution: {integrity: sha1-LNJEyvXo7FQ/QvuR1N87kzZByPo=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vscode/vsce-sign-alpine-arm64/-/vsce-sign-alpine-arm64-2.0.6.tgz}
+    resolution: {integrity: sha1-LNJEyvXo7FQ/QvuR1N87kzZByPo=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vscode/vsce-sign-alpine-arm64/-/vsce-sign-alpine-arm64-2.0.6.tgz}
     cpu: [arm64]
     os: [alpine]
 
   '@vscode/vsce-sign-alpine-x64@2.0.6':
-    resolution: {integrity: sha1-sOgKR5IAHGbif+7iwR6CGtH6FoA=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vscode/vsce-sign-alpine-x64/-/vsce-sign-alpine-x64-2.0.6.tgz}
+    resolution: {integrity: sha1-sOgKR5IAHGbif+7iwR6CGtH6FoA=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vscode/vsce-sign-alpine-x64/-/vsce-sign-alpine-x64-2.0.6.tgz}
     cpu: [x64]
     os: [alpine]
 
@@ -10893,32 +10896,32 @@ packages:
     os: [darwin]
 
   '@vscode/vsce-sign-darwin-x64@2.0.6':
-    resolution: {integrity: sha1-0skYbZUFSYJyy93YODuwOOvPWCA=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vscode/vsce-sign-darwin-x64/-/vsce-sign-darwin-x64-2.0.6.tgz}
+    resolution: {integrity: sha1-0skYbZUFSYJyy93YODuwOOvPWCA=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vscode/vsce-sign-darwin-x64/-/vsce-sign-darwin-x64-2.0.6.tgz}
     cpu: [x64]
     os: [darwin]
 
   '@vscode/vsce-sign-linux-arm64@2.0.6':
-    resolution: {integrity: sha1-s9hWAUQEC5INjG7dQ3QxS1glVIE=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vscode/vsce-sign-linux-arm64/-/vsce-sign-linux-arm64-2.0.6.tgz}
+    resolution: {integrity: sha1-s9hWAUQEC5INjG7dQ3QxS1glVIE=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vscode/vsce-sign-linux-arm64/-/vsce-sign-linux-arm64-2.0.6.tgz}
     cpu: [arm64]
     os: [linux]
 
   '@vscode/vsce-sign-linux-arm@2.0.6':
-    resolution: {integrity: sha1-CifEKkrbN+lu7HjNe/o4jNTp++8=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vscode/vsce-sign-linux-arm/-/vsce-sign-linux-arm-2.0.6.tgz}
+    resolution: {integrity: sha1-CifEKkrbN+lu7HjNe/o4jNTp++8=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vscode/vsce-sign-linux-arm/-/vsce-sign-linux-arm-2.0.6.tgz}
     cpu: [arm]
     os: [linux]
 
   '@vscode/vsce-sign-linux-x64@2.0.6':
-    resolution: {integrity: sha1-reEcru7VJPwWvWxDykmuoAKV3ow=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vscode/vsce-sign-linux-x64/-/vsce-sign-linux-x64-2.0.6.tgz}
+    resolution: {integrity: sha1-reEcru7VJPwWvWxDykmuoAKV3ow=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vscode/vsce-sign-linux-x64/-/vsce-sign-linux-x64-2.0.6.tgz}
     cpu: [x64]
     os: [linux]
 
   '@vscode/vsce-sign-win32-arm64@2.0.6':
-    resolution: {integrity: sha1-BoiWgUjgPrOSR5yEkcclBnIb7/w=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vscode/vsce-sign-win32-arm64/-/vsce-sign-win32-arm64-2.0.6.tgz}
+    resolution: {integrity: sha1-BoiWgUjgPrOSR5yEkcclBnIb7/w=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vscode/vsce-sign-win32-arm64/-/vsce-sign-win32-arm64-2.0.6.tgz}
     cpu: [arm64]
     os: [win32]
 
   '@vscode/vsce-sign-win32-x64@2.0.6':
-    resolution: {integrity: sha1-dEMO/0HSaBjCP5gmsEXYx1cy6us=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vscode/vsce-sign-win32-x64/-/vsce-sign-win32-x64-2.0.6.tgz}
+    resolution: {integrity: sha1-dEMO/0HSaBjCP5gmsEXYx1cy6us=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vscode/vsce-sign-win32-x64/-/vsce-sign-win32-x64-2.0.6.tgz}
     cpu: [x64]
     os: [win32]
 
@@ -11043,11 +11046,11 @@ packages:
     engines: {node: '>=10.13'}
 
   '@zkochan/js-yaml@0.0.11':
-    resolution: {integrity: sha1-T2aH2CGxW1MG1Z391Mu32K5wHI0=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@zkochan/js-yaml/-/js-yaml-0.0.11.tgz}
+    resolution: {integrity: sha1-T2aH2CGxW1MG1Z391Mu32K5wHI0=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@zkochan/js-yaml/-/js-yaml-0.0.11.tgz}
     hasBin: true
 
   '@zkochan/js-yaml@0.0.6':
-    resolution: {integrity: sha1-l18LMG5wXii4BooHc3+kbT/ASCY=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@zkochan/js-yaml/-/js-yaml-0.0.6.tgz}
+    resolution: {integrity: sha1-l18LMG5wXii4BooHc3+kbT/ASCY=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@zkochan/js-yaml/-/js-yaml-0.0.6.tgz}
     hasBin: true
 
   '@zkochan/rimraf@2.1.3':
@@ -11059,7 +11062,7 @@ packages:
     engines: {node: '>=18.12'}
 
   '@zkochan/which@2.0.3':
-    resolution: {integrity: sha1-okOQNZOQ04wVH6YHgbNiC8WhMtA=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@zkochan/which/-/which-2.0.3.tgz}
+    resolution: {integrity: sha1-okOQNZOQ04wVH6YHgbNiC8WhMtA=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@zkochan/which/-/which-2.0.3.tgz}
     engines: {node: '>= 8'}
     hasBin: true
 
@@ -11699,7 +11702,7 @@ packages:
     resolution: {integrity: sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==}
 
   bindings@1.5.0:
-    resolution: {integrity: sha1-EDU8npRTNLwFEabZCzj7x8nFBN8=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/bindings/-/bindings-1.5.0.tgz}
+    resolution: {integrity: sha1-EDU8npRTNLwFEabZCzj7x8nFBN8=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/bindings/-/bindings-1.5.0.tgz}
 
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
@@ -12160,7 +12163,7 @@ packages:
     engines: {node: '>= 12'}
 
   commander@9.5.0:
-    resolution: {integrity: sha1-vAjR61zt98y3l6lhmdQce8PmDTA=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/commander/-/commander-9.5.0.tgz}
+    resolution: {integrity: sha1-vAjR61zt98y3l6lhmdQce8PmDTA=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/commander/-/commander-9.5.0.tgz}
     engines: {node: ^12.20.0 || >=14}
 
   comment-parser@1.4.1:
@@ -12346,7 +12349,7 @@ packages:
     hasBin: true
 
   cross-spawn@6.0.6:
-    resolution: {integrity: sha1-MNDvoHEt2361p24ehyG/+vprXVc=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cross-spawn/-/cross-spawn-6.0.6.tgz}
+    resolution: {integrity: sha1-MNDvoHEt2361p24ehyG/+vprXVc=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cross-spawn/-/cross-spawn-6.0.6.tgz}
     engines: {node: '>=4.8'}
 
   cross-spawn@7.0.6:
@@ -12986,31 +12989,31 @@ packages:
     resolution: {integrity: sha512-Twf7I2v4/1tLoIXMT8HlqaBSS5H2wQTs2wx3MNYCI8K1R1/clXyCazrcVCPm/FuO9cyV8+leEaZOWD5C253NDg==}
 
   esbuild-android-64@0.14.54:
-    resolution: {integrity: sha1-UF9BgyiEMTu6/7J3BLi8qi2GFr4=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-android-64/-/esbuild-android-64-0.14.54.tgz}
+    resolution: {integrity: sha1-UF9BgyiEMTu6/7J3BLi8qi2GFr4=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-android-64/-/esbuild-android-64-0.14.54.tgz}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [android]
 
   esbuild-android-arm64@0.14.54:
-    resolution: {integrity: sha1-jOadfKuklkbgCZaP5XVKIamHF3E=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-android-arm64/-/esbuild-android-arm64-0.14.54.tgz}
+    resolution: {integrity: sha1-jOadfKuklkbgCZaP5XVKIamHF3E=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-android-arm64/-/esbuild-android-arm64-0.14.54.tgz}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
 
   esbuild-darwin-64@0.14.54:
-    resolution: {integrity: sha1-JLpnuajLiQo8CNkBj4h8wiHN2iU=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-darwin-64/-/esbuild-darwin-64-0.14.54.tgz}
+    resolution: {integrity: sha1-JLpnuajLiQo8CNkBj4h8wiHN2iU=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-darwin-64/-/esbuild-darwin-64-0.14.54.tgz}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [darwin]
 
   esbuild-darwin-arm64@0.14.54:
-    resolution: {integrity: sha1-P3zbeIiO4F5IjSUKK9qrH6Zxv3M=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.54.tgz}
+    resolution: {integrity: sha1-P3zbeIiO4F5IjSUKK9qrH6Zxv3M=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.54.tgz}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [darwin]
 
   esbuild-freebsd-64@0.14.54:
-    resolution: {integrity: sha1-CSUPmXpW7UZQ8+GXnJBf/EC76U0=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.54.tgz}
+    resolution: {integrity: sha1-CSUPmXpW7UZQ8+GXnJBf/EC76U0=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.54.tgz}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [freebsd]
@@ -13022,19 +13025,19 @@ packages:
     os: [freebsd]
 
   esbuild-linux-32@0.14.54:
-    resolution: {integrity: sha1-4qjEqO/cNVQFMlAz/OvrlB94H+U=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-linux-32/-/esbuild-linux-32-0.14.54.tgz}
+    resolution: {integrity: sha1-4qjEqO/cNVQFMlAz/OvrlB94H+U=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-linux-32/-/esbuild-linux-32-0.14.54.tgz}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [linux]
 
   esbuild-linux-64@0.14.54:
-    resolution: {integrity: sha1-3l/boclWZs9yNp9StAsDvnEiZlI=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-linux-64/-/esbuild-linux-64-0.14.54.tgz}
+    resolution: {integrity: sha1-3l/boclWZs9yNp9StAsDvnEiZlI=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-linux-64/-/esbuild-linux-64-0.14.54.tgz}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
 
   esbuild-linux-arm64@0.14.54:
-    resolution: {integrity: sha1-2uTNQq6Xh0aLalwVjaTIToOwzos=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.54.tgz}
+    resolution: {integrity: sha1-2uTNQq6Xh0aLalwVjaTIToOwzos=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.54.tgz}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [linux]
@@ -13046,37 +13049,37 @@ packages:
     os: [linux]
 
   esbuild-linux-mips64le@0.14.54:
-    resolution: {integrity: sha1-2ZGOnky5cvjW2ujoZVv57hMe2jQ=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.54.tgz}
+    resolution: {integrity: sha1-2ZGOnky5cvjW2ujoZVv57hMe2jQ=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.54.tgz}
     engines: {node: '>=12'}
     cpu: [mips64el]
     os: [linux]
 
   esbuild-linux-ppc64le@0.14.54:
-    resolution: {integrity: sha1-P5oPbUEHP7GmQGgIRcfeUplfE34=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.54.tgz}
+    resolution: {integrity: sha1-P5oPbUEHP7GmQGgIRcfeUplfE34=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.54.tgz}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [linux]
 
   esbuild-linux-riscv64@0.14.54:
-    resolution: {integrity: sha1-YYhTwCgXimGDe8eZ0gE9RpXkUcg=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.54.tgz}
+    resolution: {integrity: sha1-YYhTwCgXimGDe8eZ0gE9RpXkUcg=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.54.tgz}
     engines: {node: '>=12'}
     cpu: [riscv64]
     os: [linux]
 
   esbuild-linux-s390x@0.14.54:
-    resolution: {integrity: sha1-0YhcTFp2u7Wg/hguLIxg654p8qY=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.54.tgz}
+    resolution: {integrity: sha1-0YhcTFp2u7Wg/hguLIxg654p8qY=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.54.tgz}
     engines: {node: '>=12'}
     cpu: [s390x]
     os: [linux]
 
   esbuild-netbsd-64@0.14.54:
-    resolution: {integrity: sha1-aa6Rei/yQbffHb8iuvBL0zA0noE=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.54.tgz}
+    resolution: {integrity: sha1-aa6Rei/yQbffHb8iuvBL0zA0noE=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.54.tgz}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
 
   esbuild-openbsd-64@0.14.54:
-    resolution: {integrity: sha1-20yElSh6NQpnkN4i7eokelfF1Hs=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.54.tgz}
+    resolution: {integrity: sha1-20yElSh6NQpnkN4i7eokelfF1Hs=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.54.tgz}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [openbsd]
@@ -13093,19 +13096,19 @@ packages:
       esbuild: '*'
 
   esbuild-sunos-64@0.14.54:
-    resolution: {integrity: sha1-VCh+49pz04RLchwhvIDB3H4b99o=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-sunos-64/-/esbuild-sunos-64-0.14.54.tgz}
+    resolution: {integrity: sha1-VCh+49pz04RLchwhvIDB3H4b99o=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-sunos-64/-/esbuild-sunos-64-0.14.54.tgz}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [sunos]
 
   esbuild-windows-32@0.14.54:
-    resolution: {integrity: sha1-+Kr5pWZ2MLQPD7OqN78Bu9NAzjE=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-windows-32/-/esbuild-windows-32-0.14.54.tgz}
+    resolution: {integrity: sha1-+Kr5pWZ2MLQPD7OqN78Bu9NAzjE=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-windows-32/-/esbuild-windows-32-0.14.54.tgz}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
 
   esbuild-windows-64@0.14.54:
-    resolution: {integrity: sha1-v1S1G9PpsPGIb/2yJKQXYDHqCvQ=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-windows-64/-/esbuild-windows-64-0.14.54.tgz}
+    resolution: {integrity: sha1-v1S1G9PpsPGIb/2yJKQXYDHqCvQ=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-windows-64/-/esbuild-windows-64-0.14.54.tgz}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
@@ -13406,11 +13409,11 @@ packages:
     resolution: {integrity: sha512-nQn+hI3yp+oD0huYhKwvYI32+JFeq+XkNcD1GAo3Y/MjxsfVGmrrzrnzjWiNY6f+pUCP440fThsFh5gZrRAU/w==}
 
   execa@1.0.0:
-    resolution: {integrity: sha1-xiNqW7TfbW8V6I5/AXeYIWdJ3dg=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/execa/-/execa-1.0.0.tgz}
+    resolution: {integrity: sha1-xiNqW7TfbW8V6I5/AXeYIWdJ3dg=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/execa/-/execa-1.0.0.tgz}
     engines: {node: '>=6'}
 
   execa@5.1.1:
-    resolution: {integrity: sha1-+ArZy/Qpj3vR1MlVXCHpN0HEEd0=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/execa/-/execa-5.1.1.tgz}
+    resolution: {integrity: sha1-+ArZy/Qpj3vR1MlVXCHpN0HEEd0=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/execa/-/execa-5.1.1.tgz}
     engines: {node: '>=10'}
 
   exit-x@0.2.2:
@@ -13798,18 +13801,18 @@ packages:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
   fsevents@1.2.13:
-    resolution: {integrity: sha1-8yXLBFVZJCi88Rs4M3DvcOO/zDg=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fsevents/-/fsevents-1.2.13.tgz}
+    resolution: {integrity: sha1-8yXLBFVZJCi88Rs4M3DvcOO/zDg=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fsevents/-/fsevents-1.2.13.tgz}
     engines: {node: '>= 4.0'}
     os: [darwin]
     deprecated: Upgrade to fsevents v2 to mitigate potential security issues
 
   fsevents@2.3.2:
-    resolution: {integrity: sha1-ilJveLj99GI7cJ4Ll1xSwkwC/Ro=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fsevents/-/fsevents-2.3.2.tgz}
+    resolution: {integrity: sha1-ilJveLj99GI7cJ4Ll1xSwkwC/Ro=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fsevents/-/fsevents-2.3.2.tgz}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
   fsevents@2.3.3:
-    resolution: {integrity: sha1-ysZAd4XQNnWipeGlMFxpezR9kNY=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fsevents/-/fsevents-2.3.3.tgz}
+    resolution: {integrity: sha1-ysZAd4XQNnWipeGlMFxpezR9kNY=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fsevents/-/fsevents-2.3.3.tgz}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
@@ -13880,15 +13883,15 @@ packages:
     engines: {node: '>= 0.4'}
 
   get-stream@4.1.0:
-    resolution: {integrity: sha1-wbJVV189wh1Zv8ec09K0axw6VLU=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/get-stream/-/get-stream-4.1.0.tgz}
+    resolution: {integrity: sha1-wbJVV189wh1Zv8ec09K0axw6VLU=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/get-stream/-/get-stream-4.1.0.tgz}
     engines: {node: '>=6'}
 
   get-stream@5.2.0:
-    resolution: {integrity: sha1-SWaheV7lrOZecGxLe+txJX1uItM=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/get-stream/-/get-stream-5.2.0.tgz}
+    resolution: {integrity: sha1-SWaheV7lrOZecGxLe+txJX1uItM=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/get-stream/-/get-stream-5.2.0.tgz}
     engines: {node: '>=8'}
 
   get-stream@6.0.1:
-    resolution: {integrity: sha1-omLY7vZ6ztV8KFKtYWdSakPL97c=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/get-stream/-/get-stream-6.0.1.tgz}
+    resolution: {integrity: sha1-omLY7vZ6ztV8KFKtYWdSakPL97c=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/get-stream/-/get-stream-6.0.1.tgz}
     engines: {node: '>=10'}
 
   get-symbol-description@1.1.0:
@@ -14022,7 +14025,7 @@ packages:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
   graphql@16.13.2:
-    resolution: {integrity: sha1-TStz31eWsgHxvCdl9dcGf2ictV8=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/graphql/-/graphql-16.13.2.tgz}
+    resolution: {integrity: sha1-TStz31eWsgHxvCdl9dcGf2ictV8=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/graphql/-/graphql-16.13.2.tgz}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
 
   gzip-size@6.0.0:
@@ -14258,7 +14261,7 @@ packages:
     engines: {node: '>= 14'}
 
   human-signals@2.1.0:
-    resolution: {integrity: sha1-3JH8ukLk0G5Kuu0zs+ejwC9RTqA=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/human-signals/-/human-signals-2.1.0.tgz}
+    resolution: {integrity: sha1-3JH8ukLk0G5Kuu0zs+ejwC9RTqA=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/human-signals/-/human-signals-2.1.0.tgz}
     engines: {node: '>=10.17.0'}
 
   humanize-ms@1.2.1:
@@ -14655,11 +14658,11 @@ packages:
     engines: {node: '>= 0.4'}
 
   is-stream@1.1.0:
-    resolution: {integrity: sha1-EtSj3U5o4Lec6428hBc66A2RykQ=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-stream/-/is-stream-1.1.0.tgz}
+    resolution: {integrity: sha1-EtSj3U5o4Lec6428hBc66A2RykQ=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-stream/-/is-stream-1.1.0.tgz}
     engines: {node: '>=0.10.0'}
 
   is-stream@2.0.1:
-    resolution: {integrity: sha1-+sHj1TuXrVqdCunO8jifWBClwHc=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-stream/-/is-stream-2.0.1.tgz}
+    resolution: {integrity: sha1-+sHj1TuXrVqdCunO8jifWBClwHc=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-stream/-/is-stream-2.0.1.tgz}
     engines: {node: '>=8'}
 
   is-string@1.1.1:
@@ -14732,7 +14735,7 @@ packages:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
 
   isexe@2.0.0:
-    resolution: {integrity: sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/isexe/-/isexe-2.0.0.tgz}
+    resolution: {integrity: sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/isexe/-/isexe-2.0.0.tgz}
 
   isobject@2.1.0:
     resolution: {integrity: sha512-+OUdGJlgjOBZDfxnDjYYG6zp487z0JGNQq3cYQYg5f5hKR+syHMsaztzGeml/4kGG55CSpKSpWTY+jYGgsHLgA==}
@@ -15781,7 +15784,7 @@ packages:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
   nan@2.26.2:
-    resolution: {integrity: sha1-Ll4ldkIkxze5iXeQtXwylNTc7pw=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/nan/-/nan-2.26.2.tgz}
+    resolution: {integrity: sha1-Ll4ldkIkxze5iXeQtXwylNTc7pw=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/nan/-/nan-2.26.2.tgz}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -15935,7 +15938,7 @@ packages:
     engines: {node: '>=4'}
 
   npm-run-path@4.0.1:
-    resolution: {integrity: sha1-t+zR5e1T2o43pV4cImnguX7XSOo=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/npm-run-path/-/npm-run-path-4.0.1.tgz}
+    resolution: {integrity: sha1-t+zR5e1T2o43pV4cImnguX7XSOo=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/npm-run-path/-/npm-run-path-4.0.1.tgz}
     engines: {node: '>=8'}
 
   npmlog@4.1.2:
@@ -16046,7 +16049,7 @@ packages:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   onetime@5.1.2:
-    resolution: {integrity: sha1-0Oluu1awdHbfHdnEgG5SN5hcpF4=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/onetime/-/onetime-5.1.2.tgz}
+    resolution: {integrity: sha1-0Oluu1awdHbfHdnEgG5SN5hcpF4=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/onetime/-/onetime-5.1.2.tgz}
     engines: {node: '>=6'}
 
   open@10.2.0:
@@ -16265,7 +16268,7 @@ packages:
     engines: {node: '>=0.10.0'}
 
   path-key@2.0.1:
-    resolution: {integrity: sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/path-key/-/path-key-2.0.1.tgz}
+    resolution: {integrity: sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/path-key/-/path-key-2.0.1.tgz}
     engines: {node: '>=4'}
 
   path-key@3.1.1:
@@ -16273,7 +16276,7 @@ packages:
     engines: {node: '>=8'}
 
   path-name@1.0.0:
-    resolution: {integrity: sha1-jKBjpj3nmC36lXYO2v/RAhRJTyQ=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/path-name/-/path-name-1.0.0.tgz}
+    resolution: {integrity: sha1-jKBjpj3nmC36lXYO2v/RAhRJTyQ=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/path-name/-/path-name-1.0.0.tgz}
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
@@ -16867,7 +16870,7 @@ packages:
     resolution: {integrity: sha512-SbiLPU40JuJniHexQSAgad32hfwd+DRUdwF2PlVuI5RZD0/vahUco7R8vD86J/tcEKKF9vZrUVwgtmGCqlCKyA==}
 
   ramda@0.28.0:
-    resolution: {integrity: sha1-rNeFaQEAM36LBjyrNHABm+QnzJc=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ramda/-/ramda-0.28.0.tgz}
+    resolution: {integrity: sha1-rNeFaQEAM36LBjyrNHABm+QnzJc=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ramda/-/ramda-0.28.0.tgz}
 
   randombytes@2.1.0:
     resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
@@ -17348,7 +17351,7 @@ packages:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
   safe-execa@0.1.2:
-    resolution: {integrity: sha1-L7sKbxoAx6RexwM/gmWXV/kb6Mc=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/safe-execa/-/safe-execa-0.1.2.tgz}
+    resolution: {integrity: sha1-L7sKbxoAx6RexwM/gmWXV/kb6Mc=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/safe-execa/-/safe-execa-0.1.2.tgz}
     engines: {node: '>=12'}
 
   safe-push-apply@1.0.0:
@@ -17375,19 +17378,19 @@ packages:
     hasBin: true
 
   sass-embedded-android-arm64@1.85.1:
-    resolution: {integrity: sha1-HKnF4G6hqOz3T/f76mcXBs/lAyA=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sass-embedded-android-arm64/-/sass-embedded-android-arm64-1.85.1.tgz}
+    resolution: {integrity: sha1-HKnF4G6hqOz3T/f76mcXBs/lAyA=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sass-embedded-android-arm64/-/sass-embedded-android-arm64-1.85.1.tgz}
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [android]
 
   sass-embedded-android-arm@1.85.1:
-    resolution: {integrity: sha1-87zVn7BcKTGuoSaUlqCYj4C5Nq8=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sass-embedded-android-arm/-/sass-embedded-android-arm-1.85.1.tgz}
+    resolution: {integrity: sha1-87zVn7BcKTGuoSaUlqCYj4C5Nq8=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sass-embedded-android-arm/-/sass-embedded-android-arm-1.85.1.tgz}
     engines: {node: '>=14.0.0'}
     cpu: [arm]
     os: [android]
 
   sass-embedded-android-ia32@1.85.1:
-    resolution: {integrity: sha1-C0jPGwoVfAZtjWyPTHz102trIps=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sass-embedded-android-ia32/-/sass-embedded-android-ia32-1.85.1.tgz}
+    resolution: {integrity: sha1-C0jPGwoVfAZtjWyPTHz102trIps=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sass-embedded-android-ia32/-/sass-embedded-android-ia32-1.85.1.tgz}
     engines: {node: '>=14.0.0'}
     cpu: [ia32]
     os: [android]
@@ -17399,19 +17402,19 @@ packages:
     os: [android]
 
   sass-embedded-android-x64@1.85.1:
-    resolution: {integrity: sha1-xTkYMMuzw3jlF3vA4D6Up4LNHME=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sass-embedded-android-x64/-/sass-embedded-android-x64-1.85.1.tgz}
+    resolution: {integrity: sha1-xTkYMMuzw3jlF3vA4D6Up4LNHME=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sass-embedded-android-x64/-/sass-embedded-android-x64-1.85.1.tgz}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [android]
 
   sass-embedded-darwin-arm64@1.85.1:
-    resolution: {integrity: sha1-eay7aGfQFolvhDlxvfoKx24QHfg=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.85.1.tgz}
+    resolution: {integrity: sha1-eay7aGfQFolvhDlxvfoKx24QHfg=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.85.1.tgz}
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [darwin]
 
   sass-embedded-darwin-x64@1.85.1:
-    resolution: {integrity: sha1-FH7PSb8tGC295s7zN6WKBbepOrE=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.85.1.tgz}
+    resolution: {integrity: sha1-FH7PSb8tGC295s7zN6WKBbepOrE=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.85.1.tgz}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [darwin]
@@ -17423,31 +17426,31 @@ packages:
     os: [linux]
 
   sass-embedded-linux-arm@1.85.1:
-    resolution: {integrity: sha1-iZy6lLc+sRn2Q0aInkZt4xtvXTw=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.85.1.tgz}
+    resolution: {integrity: sha1-iZy6lLc+sRn2Q0aInkZt4xtvXTw=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.85.1.tgz}
     engines: {node: '>=14.0.0'}
     cpu: [arm]
     os: [linux]
 
   sass-embedded-linux-ia32@1.85.1:
-    resolution: {integrity: sha1-8bpT8DQ4ljWv6cEFm8Nqd5NkIbg=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sass-embedded-linux-ia32/-/sass-embedded-linux-ia32-1.85.1.tgz}
+    resolution: {integrity: sha1-8bpT8DQ4ljWv6cEFm8Nqd5NkIbg=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sass-embedded-linux-ia32/-/sass-embedded-linux-ia32-1.85.1.tgz}
     engines: {node: '>=14.0.0'}
     cpu: [ia32]
     os: [linux]
 
   sass-embedded-linux-musl-arm64@1.85.1:
-    resolution: {integrity: sha1-sUziYVx6tGJuiMuiZW+Ro6dI4c4=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sass-embedded-linux-musl-arm64/-/sass-embedded-linux-musl-arm64-1.85.1.tgz}
+    resolution: {integrity: sha1-sUziYVx6tGJuiMuiZW+Ro6dI4c4=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sass-embedded-linux-musl-arm64/-/sass-embedded-linux-musl-arm64-1.85.1.tgz}
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [linux]
 
   sass-embedded-linux-musl-arm@1.85.1:
-    resolution: {integrity: sha1-Qo5eKZqf9N/SC1eGHSRAQotfvfY=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sass-embedded-linux-musl-arm/-/sass-embedded-linux-musl-arm-1.85.1.tgz}
+    resolution: {integrity: sha1-Qo5eKZqf9N/SC1eGHSRAQotfvfY=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sass-embedded-linux-musl-arm/-/sass-embedded-linux-musl-arm-1.85.1.tgz}
     engines: {node: '>=14.0.0'}
     cpu: [arm]
     os: [linux]
 
   sass-embedded-linux-musl-ia32@1.85.1:
-    resolution: {integrity: sha1-BwYJr9mc0Pnq5yGGyfSi0M32lE0=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sass-embedded-linux-musl-ia32/-/sass-embedded-linux-musl-ia32-1.85.1.tgz}
+    resolution: {integrity: sha1-BwYJr9mc0Pnq5yGGyfSi0M32lE0=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sass-embedded-linux-musl-ia32/-/sass-embedded-linux-musl-ia32-1.85.1.tgz}
     engines: {node: '>=14.0.0'}
     cpu: [ia32]
     os: [linux]
@@ -17471,7 +17474,7 @@ packages:
     os: [linux]
 
   sass-embedded-linux-x64@1.85.1:
-    resolution: {integrity: sha1-BmTMiGuHgYrJ0pv06fKZ/mxj9SQ=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.85.1.tgz}
+    resolution: {integrity: sha1-BmTMiGuHgYrJ0pv06fKZ/mxj9SQ=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.85.1.tgz}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [linux]
@@ -17483,13 +17486,13 @@ packages:
     os: [win32]
 
   sass-embedded-win32-ia32@1.85.1:
-    resolution: {integrity: sha1-Xl8W4aMPjfMRSKr2WncimNcDfXA=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sass-embedded-win32-ia32/-/sass-embedded-win32-ia32-1.85.1.tgz}
+    resolution: {integrity: sha1-Xl8W4aMPjfMRSKr2WncimNcDfXA=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sass-embedded-win32-ia32/-/sass-embedded-win32-ia32-1.85.1.tgz}
     engines: {node: '>=14.0.0'}
     cpu: [ia32]
     os: [win32]
 
   sass-embedded-win32-x64@1.85.1:
-    resolution: {integrity: sha1-dY+5bBbncmWkt/JHSkOWLXHvX/0=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.85.1.tgz}
+    resolution: {integrity: sha1-dY+5bBbncmWkt/JHSkOWLXHvX/0=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.85.1.tgz}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [win32]
@@ -17731,10 +17734,10 @@ packages:
     engines: {node: '>= 0.4'}
 
   signal-exit@3.0.7:
-    resolution: {integrity: sha1-qaF2f4r4QVURTqq9c/mSc8j1mtk=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/signal-exit/-/signal-exit-3.0.7.tgz}
+    resolution: {integrity: sha1-qaF2f4r4QVURTqq9c/mSc8j1mtk=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/signal-exit/-/signal-exit-3.0.7.tgz}
 
   signal-exit@4.1.0:
-    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    resolution: {integrity: sha1-lSGIwcvVRgcOLdIND0HArgUwywQ=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/signal-exit/-/signal-exit-4.1.0.tgz}
     engines: {node: '>=14'}
 
   simple-concat@1.0.1:
@@ -18058,7 +18061,7 @@ packages:
     engines: {node: '>=0.10.0'}
 
   strip-final-newline@2.0.0:
-    resolution: {integrity: sha1-ibhS+y/L6Tb29LMYevsKEsGrWK0=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/strip-final-newline/-/strip-final-newline-2.0.0.tgz}
+    resolution: {integrity: sha1-ibhS+y/L6Tb29LMYevsKEsGrWK0=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/strip-final-newline/-/strip-final-newline-2.0.0.tgz}
     engines: {node: '>=6'}
 
   strip-indent@3.0.0:
@@ -18546,7 +18549,7 @@ packages:
     resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
 
   uglify-js@3.19.3:
-    resolution: {integrity: sha1-gjFem7xvKyWIiFis0f/4RBA1t38=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/uglify-js/-/uglify-js-3.19.3.tgz}
+    resolution: {integrity: sha1-gjFem7xvKyWIiFis0f/4RBA1t38=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/uglify-js/-/uglify-js-3.19.3.tgz}
     engines: {node: '>=0.8.0'}
     hasBin: true
 
@@ -24823,7 +24826,7 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@rushstack/heft-jest-plugin@2.0.13(@rushstack/heft@1.2.23(@types/node@20.17.19))(@types/jest@30.0.0)(@types/node@20.17.19)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.28.0))(jest-environment-jsdom@30.3.0)(jest-environment-node@30.3.0)':
+  '@rushstack/heft-jest-plugin@2.0.13(@rushstack/heft@1.2.23(@types/node@20.17.19))(@types/jest@30.0.0)(@types/node@20.17.19)(esbuild-register@3.6.0(esbuild@0.28.0))(jest-environment-jsdom@30.3.0)(jest-environment-node@30.3.0)':
     dependencies:
       '@jest/core': 30.3.0(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.28.0))
       '@jest/reporters': 30.3.0
@@ -24856,13 +24859,13 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@rushstack/heft-node-rig@2.11.46(@rushstack/heft@1.2.23(@types/node@20.17.19))(@types/node@20.17.19)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.28.0))(jest-environment-jsdom@30.3.0)':
+  '@rushstack/heft-node-rig@2.11.46(@rushstack/heft@1.2.23(@types/node@20.17.19))(@types/node@20.17.19)(esbuild-register@3.6.0(esbuild@0.28.0))(jest-environment-jsdom@30.3.0)':
     dependencies:
       '@microsoft/api-extractor': 7.58.12(@types/node@20.17.19)
       '@rushstack/eslint-config': 4.6.4(eslint@9.37.0)(typescript@5.8.2)
       '@rushstack/heft': 1.2.23(@types/node@20.17.19)
       '@rushstack/heft-api-extractor-plugin': 1.3.23(@rushstack/heft@1.2.23(@types/node@20.17.19))(@types/node@20.17.19)
-      '@rushstack/heft-jest-plugin': 2.0.13(@rushstack/heft@1.2.23(@types/node@20.17.19))(@types/jest@30.0.0)(@types/node@20.17.19)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.28.0))(jest-environment-jsdom@30.3.0)(jest-environment-node@30.3.0)
+      '@rushstack/heft-jest-plugin': 2.0.13(@rushstack/heft@1.2.23(@types/node@20.17.19))(@types/jest@30.0.0)(@types/node@20.17.19)(esbuild-register@3.6.0(esbuild@0.28.0))(jest-environment-jsdom@30.3.0)(jest-environment-node@30.3.0)
       '@rushstack/heft-lint-plugin': 1.2.23(@rushstack/heft@1.2.23(@types/node@20.17.19))(@types/node@20.17.19)
       '@rushstack/heft-typescript-plugin': 1.3.18(@rushstack/heft@1.2.23(@types/node@20.17.19))(@types/node@20.17.19)
       '@types/jest': 30.0.0
@@ -31003,7 +31006,7 @@ snapshots:
 
   eslint@8.57.1:
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.37.0)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@8.57.1)
       '@eslint-community/regexpp': 4.12.2
       '@eslint/eslintrc': 2.1.4
       '@eslint/js': 8.57.1

--- a/common/config/subspaces/default/pnpm-lock.yaml
+++ b/common/config/subspaces/default/pnpm-lock.yaml
@@ -4724,7 +4724,7 @@ importers:
         version: 1.2.23(@types/node@20.17.19)
       '@rushstack/heft-node-rig':
         specifier: 2.11.46
-        version: 2.11.46(@rushstack/heft@1.2.23(@types/node@20.17.19))(@types/node@20.17.19)(esbuild-register@3.6.0(esbuild@0.28.0))(jest-environment-jsdom@30.3.0)
+        version: 2.11.46(@rushstack/heft@1.2.23(@types/node@20.17.19))(@types/node@20.17.19)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.28.0))(jest-environment-jsdom@30.3.0)
       '@types/jest':
         specifier: 30.0.0
         version: 30.0.0
@@ -7005,10 +7005,10 @@ packages:
     resolution: {integrity: sha1-OHAmXs/8c1LQHq1i2Ng9g1ii0DQ=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@emnapi/core/-/core-1.9.2.tgz}
 
   '@emnapi/runtime@1.9.2':
-    resolution: {integrity: sha1-i0aaPbFggXytsd6QUCEanR6oT6I=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@emnapi/runtime/-/runtime-1.9.2.tgz}
+    resolution: {integrity: sha1-i0aaPbFggXytsd6QUCEanR6oT6I=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@emnapi/runtime/-/runtime-1.9.2.tgz}
 
   '@emnapi/wasi-threads@1.2.1':
-    resolution: {integrity: sha1-KP7SGhuhznl8RKBwq8lNQvOuhUg=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz}
+    resolution: {integrity: sha1-KP7SGhuhznl8RKBwq8lNQvOuhUg=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz}
 
   '@emotion/cache@10.0.29':
     resolution: {integrity: sha512-fU2VtSVlHiF27empSbxi1O2JFdNWZO+2NFHfwO0pxgTep6Xa3uGb+3pVKfLww2l/IBGLNEZl5Xf/++A4wAYDYQ==}
@@ -7083,25 +7083,25 @@ packages:
     engines: {node: '>=16'}
 
   '@esbuild/aix-ppc64@0.25.12':
-    resolution: {integrity: sha1-gPy+NhMOWLdnBRHoiLjoiiWe12w=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz}
+    resolution: {integrity: sha1-gPy+NhMOWLdnBRHoiLjoiiWe12w=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
   '@esbuild/aix-ppc64@0.28.0':
-    resolution: {integrity: sha1-eiicFY4py/WeoK/IPMgPBtHIlAI=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz}
+    resolution: {integrity: sha1-eiicFY4py/WeoK/IPMgPBtHIlAI=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
   '@esbuild/android-arm64@0.25.12':
-    resolution: {integrity: sha1-iqSWX40KeYLcIXNL9mATI6Ztp1I=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz}
+    resolution: {integrity: sha1-iqSWX40KeYLcIXNL9mATI6Ztp1I=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
   '@esbuild/android-arm64@0.28.0':
-    resolution: {integrity: sha1-uIKNnt+jqSZgZE643m5PPCA9exc=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz}
+    resolution: {integrity: sha1-uIKNnt+jqSZgZE643m5PPCA9exc=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -7119,139 +7119,139 @@ packages:
     os: [android]
 
   '@esbuild/android-x64@0.25.12':
-    resolution: {integrity: sha1-h9+ycWEgK9yVjvSLthsJx1j67hY=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/android-x64/-/android-x64-0.25.12.tgz}
+    resolution: {integrity: sha1-h9+ycWEgK9yVjvSLthsJx1j67hY=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/android-x64/-/android-x64-0.25.12.tgz}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
   '@esbuild/android-x64@0.28.0':
-    resolution: {integrity: sha1-OQZCF1uI74K61MzgP4qxP+mxkS4=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/android-x64/-/android-x64-0.28.0.tgz}
+    resolution: {integrity: sha1-OQZCF1uI74K61MzgP4qxP+mxkS4=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/android-x64/-/android-x64-0.28.0.tgz}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
   '@esbuild/darwin-arm64@0.25.12':
-    resolution: {integrity: sha1-eRl4mOwf90XSHAceHHzDyALwwf0=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz}
+    resolution: {integrity: sha1-eRl4mOwf90XSHAceHHzDyALwwf0=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
   '@esbuild/darwin-arm64@0.28.0':
-    resolution: {integrity: sha1-rkUyWWDVlQzWlR5PlzlvTh/32NM=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz}
+    resolution: {integrity: sha1-rkUyWWDVlQzWlR5PlzlvTh/32NM=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.25.12':
-    resolution: {integrity: sha1-FGQAqFYhM/RcTS6tzzfd0JcYB54=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz}
+    resolution: {integrity: sha1-FGQAqFYhM/RcTS6tzzfd0JcYB54=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.28.0':
-    resolution: {integrity: sha1-wHkkfViba5lEllnZTwaVG4S/8uQ=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz}
+    resolution: {integrity: sha1-wHkkfViba5lEllnZTwaVG4S/8uQ=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
   '@esbuild/freebsd-arm64@0.25.12':
-    resolution: {integrity: sha1-HF+bpyBuFY/SskxZ+i0si7R8oP4=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz}
+    resolution: {integrity: sha1-HF+bpyBuFY/SskxZ+i0si7R8oP4=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
   '@esbuild/freebsd-arm64@0.28.0':
-    resolution: {integrity: sha1-RcRWIVpIZZPJSQApcgLcEciAo3o=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz}
+    resolution: {integrity: sha1-RcRWIVpIZZPJSQApcgLcEciAo3o=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.25.12':
-    resolution: {integrity: sha1-6mMfSja+qsS5J5+g/MbKKerusrM=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz}
+    resolution: {integrity: sha1-6mMfSja+qsS5J5+g/MbKKerusrM=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.28.0':
-    resolution: {integrity: sha1-A5lJTByF5DiOm3BAvWDUjypbDSw=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz}
+    resolution: {integrity: sha1-A5lJTByF5DiOm3BAvWDUjypbDSw=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
   '@esbuild/linux-arm64@0.25.12':
-    resolution: {integrity: sha1-4QZrzlg5TxsRQd7shVel8KIvWXc=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz}
+    resolution: {integrity: sha1-4QZrzlg5TxsRQd7shVel8KIvWXc=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
   '@esbuild/linux-arm64@0.28.0':
-    resolution: {integrity: sha1-1tnwnvDeVBFr9Fmk1TysfglS/jk=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz}
+    resolution: {integrity: sha1-1tnwnvDeVBFr9Fmk1TysfglS/jk=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
   '@esbuild/linux-arm@0.25.12':
-    resolution: {integrity: sha1-RSzWayCTLQi9xTqLYcDjC69DSLk=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz}
+    resolution: {integrity: sha1-RSzWayCTLQi9xTqLYcDjC69DSLk=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.28.0':
-    resolution: {integrity: sha1-e0L/qEwoiulP3EMcGyionjw7kng=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz}
+    resolution: {integrity: sha1-e0L/qEwoiulP3EMcGyionjw7kng=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-ia32@0.25.12':
-    resolution: {integrity: sha1-sk+KzEW89UGSx/LzvhtT5lUer+A=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz}
+    resolution: {integrity: sha1-sk+KzEW89UGSx/LzvhtT5lUer+A=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
   '@esbuild/linux-ia32@0.28.0':
-    resolution: {integrity: sha1-3rFdES7Y3WBTRra5U9I6If+BJT8=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz}
+    resolution: {integrity: sha1-3rFdES7Y3WBTRra5U9I6If+BJT8=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
   '@esbuild/linux-loong64@0.14.54':
-    resolution: {integrity: sha1-3ipL5ni9TQ0f+7hubed5zeWZkCg=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-loong64/-/linux-loong64-0.14.54.tgz}
+    resolution: {integrity: sha1-3ipL5ni9TQ0f+7hubed5zeWZkCg=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-loong64/-/linux-loong64-0.14.54.tgz}
     engines: {node: '>=12'}
     cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.25.12':
-    resolution: {integrity: sha1-+c//p/yDIlcfvEyLMmjK8VvYGtA=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz}
+    resolution: {integrity: sha1-+c//p/yDIlcfvEyLMmjK8VvYGtA=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.28.0':
-    resolution: {integrity: sha1-gfuJ0H7sx5sVfephAzdXcm/ODKQ=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz}
+    resolution: {integrity: sha1-gfuJ0H7sx5sVfephAzdXcm/ODKQ=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-mips64el@0.25.12':
-    resolution: {integrity: sha1-V1oUvXRkT/q4ka3H1+YNJ1KW8s0=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz}
+    resolution: {integrity: sha1-V1oUvXRkT/q4ka3H1+YNJ1KW8s0=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
   '@esbuild/linux-mips64el@0.28.0':
-    resolution: {integrity: sha1-0OQmkbP/evn7Ihe3D8AfNDvbYrs=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz}
+    resolution: {integrity: sha1-0OQmkbP/evn7Ihe3D8AfNDvbYrs=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.25.12':
-    resolution: {integrity: sha1-dbmccKlfvV93OddpK+/mBgFZGGk=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz}
+    resolution: {integrity: sha1-dbmccKlfvV93OddpK+/mBgFZGGk=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.28.0':
-    resolution: {integrity: sha1-OJ8+XpjxfUd8RnzIcTbhoHburYc=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz}
+    resolution: {integrity: sha1-OJ8+XpjxfUd8RnzIcTbhoHburYc=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -7269,37 +7269,37 @@ packages:
     os: [linux]
 
   '@esbuild/linux-s390x@0.25.12':
-    resolution: {integrity: sha1-F2dsq7/lko2lsqDW311YzQjbJmM=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz}
+    resolution: {integrity: sha1-F2dsq7/lko2lsqDW311YzQjbJmM=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.28.0':
-    resolution: {integrity: sha1-qsYGFjSHLkZ33mk7zoAw1zsf0FU=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz}
+    resolution: {integrity: sha1-qsYGFjSHLkZ33mk7zoAw1zsf0FU=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-x64@0.25.12':
-    resolution: {integrity: sha1-BYN3VoXKggZtBMNQfwlSTTzXowY=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz}
+    resolution: {integrity: sha1-BYN3VoXKggZtBMNQfwlSTTzXowY=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
   '@esbuild/linux-x64@0.28.0':
-    resolution: {integrity: sha1-TykXdHGI/ndjK87GWy2EtCJBl3k=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz}
+    resolution: {integrity: sha1-TykXdHGI/ndjK87GWy2EtCJBl3k=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
   '@esbuild/netbsd-arm64@0.25.12':
-    resolution: {integrity: sha1-8ExAScsuJS/paxb+2Q9wdGsT9KQ=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz}
+    resolution: {integrity: sha1-8ExAScsuJS/paxb+2Q9wdGsT9KQ=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
   '@esbuild/netbsd-arm64@0.28.0':
-    resolution: {integrity: sha1-gU3wrlegw4aBRJG4OX7rqCCUqUc=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz}
+    resolution: {integrity: sha1-gU3wrlegw4aBRJG4OX7rqCCUqUc=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -7317,25 +7317,25 @@ packages:
     os: [netbsd]
 
   '@esbuild/openbsd-arm64@0.25.12':
-    resolution: {integrity: sha1-Ypb1hnrt7yioGyKrIAnHhqlS3M0=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz}
+    resolution: {integrity: sha1-Ypb1hnrt7yioGyKrIAnHhqlS3M0=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
   '@esbuild/openbsd-arm64@0.28.0':
-    resolution: {integrity: sha1-ShXDaqzKaNLVpMkLcQwGdZ9MH/o=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz}
+    resolution: {integrity: sha1-ShXDaqzKaNLVpMkLcQwGdZ9MH/o=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.25.12':
-    resolution: {integrity: sha1-+NIzAzYOJ7Fs8GWyO7/0PBQUJnk=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz}
+    resolution: {integrity: sha1-+NIzAzYOJ7Fs8GWyO7/0PBQUJnk=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.28.0':
-    resolution: {integrity: sha1-R15hAUmKjszjAI18OIER16J8F70=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz}
+    resolution: {integrity: sha1-R15hAUmKjszjAI18OIER16J8F70=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
@@ -7353,37 +7353,37 @@ packages:
     os: [openharmony]
 
   '@esbuild/sunos-x64@0.25.12':
-    resolution: {integrity: sha1-pu19Z3jWflKMgfsWWyP0kRubE9Y=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz}
+    resolution: {integrity: sha1-pu19Z3jWflKMgfsWWyP0kRubE9Y=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
   '@esbuild/sunos-x64@0.28.0':
-    resolution: {integrity: sha1-oBPIVv7KzRw67Jhciv4dHLAXSX0=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz}
+    resolution: {integrity: sha1-oBPIVv7KzRw67Jhciv4dHLAXSX0=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
   '@esbuild/win32-arm64@0.25.12':
-    resolution: {integrity: sha1-msFMN44bZTrxfQjn0840yu9YcyM=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz}
+    resolution: {integrity: sha1-msFMN44bZTrxfQjn0840yu9YcyM=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
   '@esbuild/win32-arm64@0.28.0':
-    resolution: {integrity: sha1-6uBeDzUnHK04mLQxaNPpo7uvR+U=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz}
+    resolution: {integrity: sha1-6uBeDzUnHK04mLQxaNPpo7uvR+U=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
   '@esbuild/win32-ia32@0.25.12':
-    resolution: {integrity: sha1-kYlC3LuzXMFPyjmvuRteaj0Scmc=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz}
+    resolution: {integrity: sha1-kYlC3LuzXMFPyjmvuRteaj0Scmc=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
   '@esbuild/win32-ia32@0.28.0':
-    resolution: {integrity: sha1-BhYevFv3XAjWn+s8ayJWBRWROZg=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz}
+    resolution: {integrity: sha1-BhYevFv3XAjWn+s8ayJWBRWROZg=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
@@ -8652,10 +8652,10 @@ packages:
     engines: {node: '>=4'}
 
   '@napi-rs/wasm-runtime@0.2.12':
-    resolution: {integrity: sha1-PniouW5sM6bFF+GJTvvVOFp8tvI=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz}
+    resolution: {integrity: sha1-PniouW5sM6bFF+GJTvvVOFp8tvI=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz}
 
   '@napi-rs/wasm-runtime@1.0.7':
-    resolution: {integrity: sha1-3P6pmnXwYgmiNfPZQeNGClHpsUw=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@napi-rs/wasm-runtime/-/wasm-runtime-1.0.7.tgz}
+    resolution: {integrity: sha1-3P6pmnXwYgmiNfPZQeNGClHpsUw=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@napi-rs/wasm-runtime/-/wasm-runtime-1.0.7.tgz}
 
   '@noble/hashes@1.4.0':
     resolution: {integrity: sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==}
@@ -8720,7 +8720,7 @@ packages:
     engines: {node: '>=20.0.0'}
 
   '@pkgjs/parseargs@0.11.0':
-    resolution: {integrity: sha1-p36nQvqyV3UUVDTrHSMoz1ATrDM=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pkgjs/parseargs/-/parseargs-0.11.0.tgz}
+    resolution: {integrity: sha1-p36nQvqyV3UUVDTrHSMoz1ATrDM=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pkgjs/parseargs/-/parseargs-0.11.0.tgz}
     engines: {node: '>=14'}
 
   '@pkgr/core@0.2.9':
@@ -8863,7 +8863,7 @@ packages:
     engines: {node: '>=18.12'}
 
   '@pnpm/lockfile.types@1001.1.0':
-    resolution: {integrity: sha1-rhsx7V+7Du0y0CpfVlG8zilTW6E=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/lockfile.types/-/lockfile.types-1001.1.0.tgz}
+    resolution: {integrity: sha1-rhsx7V+7Du0y0CpfVlG8zilTW6E=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/lockfile.types/-/lockfile.types-1001.1.0.tgz}
     engines: {node: '>=18.12'}
 
   '@pnpm/lockfile.types@1002.0.1':
@@ -8915,7 +8915,7 @@ packages:
     engines: {node: '>=18.12'}
 
   '@pnpm/ramda@0.28.1':
-    resolution: {integrity: sha1-DzKrxSddWGoD4Nwd2QoAmsZo/zM=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/ramda/-/ramda-0.28.1.tgz}
+    resolution: {integrity: sha1-DzKrxSddWGoD4Nwd2QoAmsZo/zM=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/ramda/-/ramda-0.28.1.tgz}
 
   '@pnpm/read-modules-dir@2.0.3':
     resolution: {integrity: sha512-i9OgRvSlxrTS9a2oXokhDxvQzDtfqtsooJ9jaGoHkznue5aFCTSrNZFQ6M18o8hC03QWfnxaKi0BtOvNkKu2+A==}
@@ -8942,7 +8942,7 @@ packages:
     engines: {node: '>=18.12'}
 
   '@pnpm/types@1000.7.0':
-    resolution: {integrity: sha1-g1Hkb73+JfgP7Jdb/fWNDKStYkw=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/types/-/types-1000.7.0.tgz}
+    resolution: {integrity: sha1-g1Hkb73+JfgP7Jdb/fWNDKStYkw=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/types/-/types-1000.7.0.tgz}
     engines: {node: '>=18.12'}
 
   '@pnpm/types@1000.8.0':
@@ -8992,7 +8992,7 @@ packages:
     resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
 
   '@pothos/core@3.41.2':
-    resolution: {integrity: sha1-ruJt4pccOHJDU0S8NM4Kv5qUVL0=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pothos/core/-/core-3.41.2.tgz}
+    resolution: {integrity: sha1-ruJt4pccOHJDU0S8NM4Kv5qUVL0=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pothos/core/-/core-3.41.2.tgz}
     peerDependencies:
       graphql: '>=15.1.0'
 
@@ -9244,50 +9244,50 @@ packages:
     os: [darwin]
 
   '@rspack/binding-darwin-x64@1.6.8':
-    resolution: {integrity: sha1-E8gBzoIQ0Rt7C8Sse/A27DKGKTU=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rspack/binding-darwin-x64/-/binding-darwin-x64-1.6.8.tgz}
+    resolution: {integrity: sha1-E8gBzoIQ0Rt7C8Sse/A27DKGKTU=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rspack/binding-darwin-x64/-/binding-darwin-x64-1.6.8.tgz}
     cpu: [x64]
     os: [darwin]
 
   '@rspack/binding-linux-arm64-gnu@1.6.8':
-    resolution: {integrity: sha1-1wMhrFu9W8EB3potoBxvuYRgFWU=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.6.8.tgz}
+    resolution: {integrity: sha1-1wMhrFu9W8EB3potoBxvuYRgFWU=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.6.8.tgz}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
   '@rspack/binding-linux-arm64-musl@1.6.8':
-    resolution: {integrity: sha1-T5GWtiM2Sc5D5khaXScU7zjfxgM=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.6.8.tgz}
+    resolution: {integrity: sha1-T5GWtiM2Sc5D5khaXScU7zjfxgM=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.6.8.tgz}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
   '@rspack/binding-linux-x64-gnu@1.6.8':
-    resolution: {integrity: sha1-t45/YrQVezHhgf6J0xmmAXgqgCs=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.6.8.tgz}
+    resolution: {integrity: sha1-t45/YrQVezHhgf6J0xmmAXgqgCs=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.6.8.tgz}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
   '@rspack/binding-linux-x64-musl@1.6.8':
-    resolution: {integrity: sha1-xXj3MNip+rhm5KFZIEV++df9X1g=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-1.6.8.tgz}
+    resolution: {integrity: sha1-xXj3MNip+rhm5KFZIEV++df9X1g=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-1.6.8.tgz}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
   '@rspack/binding-wasm32-wasi@1.6.8':
-    resolution: {integrity: sha1-dtI1iewxrWurZ4TaiffMQsffAnU=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rspack/binding-wasm32-wasi/-/binding-wasm32-wasi-1.6.8.tgz}
+    resolution: {integrity: sha1-dtI1iewxrWurZ4TaiffMQsffAnU=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rspack/binding-wasm32-wasi/-/binding-wasm32-wasi-1.6.8.tgz}
     cpu: [wasm32]
 
   '@rspack/binding-win32-arm64-msvc@1.6.8':
-    resolution: {integrity: sha1-tCy6SrdYjOcvDBPJaNPWLophq0Y=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.6.8.tgz}
+    resolution: {integrity: sha1-tCy6SrdYjOcvDBPJaNPWLophq0Y=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.6.8.tgz}
     cpu: [arm64]
     os: [win32]
 
   '@rspack/binding-win32-ia32-msvc@1.6.8':
-    resolution: {integrity: sha1-KTojRIxqEfJamru5iWEwWcfaPsQ=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.6.8.tgz}
+    resolution: {integrity: sha1-KTojRIxqEfJamru5iWEwWcfaPsQ=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.6.8.tgz}
     cpu: [ia32]
     os: [win32]
 
   '@rspack/binding-win32-x64-msvc@1.6.8':
-    resolution: {integrity: sha1-9f0/AbZpTuCMvDgsO9QtZJCrlEY=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.6.8.tgz}
+    resolution: {integrity: sha1-9f0/AbZpTuCMvDgsO9QtZJCrlEY=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.6.8.tgz}
     cpu: [x64]
     os: [win32]
 
@@ -10128,65 +10128,65 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
 
   '@swc/core-darwin-arm64@1.7.10':
-    resolution: {integrity: sha1-PuU+21AbI7EERqmNH21tSH2Iodk=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@swc/core-darwin-arm64/-/core-darwin-arm64-1.7.10.tgz}
+    resolution: {integrity: sha1-PuU+21AbI7EERqmNH21tSH2Iodk=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@swc/core-darwin-arm64/-/core-darwin-arm64-1.7.10.tgz}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [darwin]
 
   '@swc/core-darwin-x64@1.7.10':
-    resolution: {integrity: sha1-cdNUFYDjbr73bTfwCBxJp/Gv6tY=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@swc/core-darwin-x64/-/core-darwin-x64-1.7.10.tgz}
+    resolution: {integrity: sha1-cdNUFYDjbr73bTfwCBxJp/Gv6tY=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@swc/core-darwin-x64/-/core-darwin-x64-1.7.10.tgz}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [darwin]
 
   '@swc/core-linux-arm-gnueabihf@1.7.10':
-    resolution: {integrity: sha1-ez86gp2R+FmlAP5gfmgUiY7oGdk=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.7.10.tgz}
+    resolution: {integrity: sha1-ez86gp2R+FmlAP5gfmgUiY7oGdk=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.7.10.tgz}
     engines: {node: '>=10'}
     cpu: [arm]
     os: [linux]
 
   '@swc/core-linux-arm64-gnu@1.7.10':
-    resolution: {integrity: sha1-vdDQ9kwrLAneqXa+ncJI/TWd5VE=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.7.10.tgz}
+    resolution: {integrity: sha1-vdDQ9kwrLAneqXa+ncJI/TWd5VE=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.7.10.tgz}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.7.10':
-    resolution: {integrity: sha1-vJgIuyS6Ek++l3KQGadFvV6IWas=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.7.10.tgz}
+    resolution: {integrity: sha1-vJgIuyS6Ek++l3KQGadFvV6IWas=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.7.10.tgz}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.7.10':
-    resolution: {integrity: sha1-EBpx3PkiTrLO7HgaJUqTd0xl/zE=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.7.10.tgz}
+    resolution: {integrity: sha1-EBpx3PkiTrLO7HgaJUqTd0xl/zE=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.7.10.tgz}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.7.10':
-    resolution: {integrity: sha1-b8Grv32BgzQ76Ur64L9ZaumNQEg=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.7.10.tgz}
+    resolution: {integrity: sha1-b8Grv32BgzQ76Ur64L9ZaumNQEg=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.7.10.tgz}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.7.10':
-    resolution: {integrity: sha1-XW7P2kzF6D7IZZEZ8WB7FmP3Cm0=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.7.10.tgz}
+    resolution: {integrity: sha1-XW7P2kzF6D7IZZEZ8WB7FmP3Cm0=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.7.10.tgz}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [win32]
 
   '@swc/core-win32-ia32-msvc@1.7.10':
-    resolution: {integrity: sha1-N/MXfaU7KLLcjIOu/vwgIFBk688=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.7.10.tgz}
+    resolution: {integrity: sha1-N/MXfaU7KLLcjIOu/vwgIFBk688=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.7.10.tgz}
     engines: {node: '>=10'}
     cpu: [ia32]
     os: [win32]
 
   '@swc/core-win32-x64-msvc@1.7.10':
-    resolution: {integrity: sha1-KBQzXAAylcSoCOwbnPGepU+a1uU=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.7.10.tgz}
+    resolution: {integrity: sha1-KBQzXAAylcSoCOwbnPGepU+a1uU=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.7.10.tgz}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [win32]
@@ -10235,7 +10235,7 @@ packages:
     resolution: {integrity: sha512-yw0omUrxGp8+gEAuieZFeXB4bCqFvmyCDL3GOBv+Q6+cK0m5824ViHZKPgK5DYG1ijN/lbi1hP3UVKywPN7rbQ==}
 
   '@tybys/wasm-util@0.10.1':
-    resolution: {integrity: sha1-7N3TIFzx4tUnRkn/Du3SmR7X9BQ=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@tybys/wasm-util/-/wasm-util-0.10.1.tgz}
+    resolution: {integrity: sha1-7N3TIFzx4tUnRkn/Du3SmR7X9BQ=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@tybys/wasm-util/-/wasm-util-0.10.1.tgz}
 
   '@types/argparse@1.0.38':
     resolution: {integrity: sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==}
@@ -10751,12 +10751,12 @@ packages:
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
-    resolution: {integrity: sha1-n1sEUDCI5qNUKV6OqP48uZ5Dr4E=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz}
+    resolution: {integrity: sha1-n1sEUDCI5qNUKV6OqP48uZ5Dr4E=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz}
     cpu: [arm]
     os: [android]
 
   '@unrs/resolver-binding-android-arm64@1.11.1':
-    resolution: {integrity: sha1-dBSIVDG9cXi5ia7cTSXMyzhlvJ8=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz}
+    resolution: {integrity: sha1-dBSIVDG9cXi5ia7cTSXMyzhlvJ8=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz}
     cpu: [arm64]
     os: [android]
 
@@ -10766,7 +10766,7 @@ packages:
     os: [darwin]
 
   '@unrs/resolver-binding-darwin-x64@1.11.1':
-    resolution: {integrity: sha1-/U2BJXsT9NGgg4kKahfADeVx8Nw=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz}
+    resolution: {integrity: sha1-/U2BJXsT9NGgg4kKahfADeVx8Nw=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz}
     cpu: [x64]
     os: [darwin]
 
@@ -10776,7 +10776,7 @@ packages:
     os: [freebsd]
 
   '@unrs/resolver-binding-linux-arm-gnueabihf@1.11.1':
-    resolution: {integrity: sha1-hE0mBdBXSI13+rCXBfKGa4YWTgo=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz}
+    resolution: {integrity: sha1-hE0mBdBXSI13+rCXBfKGa4YWTgo=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz}
     cpu: [arm]
     os: [linux]
 
@@ -10786,31 +10786,31 @@ packages:
     os: [linux]
 
   '@unrs/resolver-binding-linux-arm64-gnu@1.11.1':
-    resolution: {integrity: sha1-Aj6ww6rEYGahC+ej82Lns087350=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz}
+    resolution: {integrity: sha1-Aj6ww6rEYGahC+ej82Lns087350=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
-    resolution: {integrity: sha1-nm+auwZCTjFApgrJlhOXhvXZm+A=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz}
+    resolution: {integrity: sha1-nm+auwZCTjFApgrJlhOXhvXZm+A=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
-    resolution: {integrity: sha1-sRFBfxfJ0bAu++yOCDmPDFUnu0Q=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz}
+    resolution: {integrity: sha1-sRFBfxfJ0bAu++yOCDmPDFUnu0Q=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
-    resolution: {integrity: sha1-kv+/AnSK8+mYc5RcmoperQHVCKk=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz}
+    resolution: {integrity: sha1-kv+/AnSK8+mYc5RcmoperQHVCKk=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
-    resolution: {integrity: sha1-C+xvElj8OQ5rMF6f9EJWyyB94WU=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz}
+    resolution: {integrity: sha1-C+xvElj8OQ5rMF6f9EJWyyB94WU=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
@@ -10822,7 +10822,7 @@ packages:
     libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
-    resolution: {integrity: sha1-NvsxjuvdaQ9toyrF4EmadvqIGTU=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz}
+    resolution: {integrity: sha1-NvsxjuvdaQ9toyrF4EmadvqIGTU=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
@@ -10844,7 +10844,7 @@ packages:
     os: [win32]
 
   '@unrs/resolver-binding-win32-ia32-msvc@1.11.1':
-    resolution: {integrity: sha1-cvxXvHxk7Fw94NZO4NGBAxe8YKY=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz}
+    resolution: {integrity: sha1-cvxXvHxk7Fw94NZO4NGBAxe8YKY=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz}
     cpu: [ia32]
     os: [win32]
 
@@ -10881,12 +10881,12 @@ packages:
     engines: {node: '>=8.9.3'}
 
   '@vscode/vsce-sign-alpine-arm64@2.0.6':
-    resolution: {integrity: sha1-LNJEyvXo7FQ/QvuR1N87kzZByPo=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vscode/vsce-sign-alpine-arm64/-/vsce-sign-alpine-arm64-2.0.6.tgz}
+    resolution: {integrity: sha1-LNJEyvXo7FQ/QvuR1N87kzZByPo=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vscode/vsce-sign-alpine-arm64/-/vsce-sign-alpine-arm64-2.0.6.tgz}
     cpu: [arm64]
     os: [alpine]
 
   '@vscode/vsce-sign-alpine-x64@2.0.6':
-    resolution: {integrity: sha1-sOgKR5IAHGbif+7iwR6CGtH6FoA=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vscode/vsce-sign-alpine-x64/-/vsce-sign-alpine-x64-2.0.6.tgz}
+    resolution: {integrity: sha1-sOgKR5IAHGbif+7iwR6CGtH6FoA=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vscode/vsce-sign-alpine-x64/-/vsce-sign-alpine-x64-2.0.6.tgz}
     cpu: [x64]
     os: [alpine]
 
@@ -10896,32 +10896,32 @@ packages:
     os: [darwin]
 
   '@vscode/vsce-sign-darwin-x64@2.0.6':
-    resolution: {integrity: sha1-0skYbZUFSYJyy93YODuwOOvPWCA=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vscode/vsce-sign-darwin-x64/-/vsce-sign-darwin-x64-2.0.6.tgz}
+    resolution: {integrity: sha1-0skYbZUFSYJyy93YODuwOOvPWCA=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vscode/vsce-sign-darwin-x64/-/vsce-sign-darwin-x64-2.0.6.tgz}
     cpu: [x64]
     os: [darwin]
 
   '@vscode/vsce-sign-linux-arm64@2.0.6':
-    resolution: {integrity: sha1-s9hWAUQEC5INjG7dQ3QxS1glVIE=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vscode/vsce-sign-linux-arm64/-/vsce-sign-linux-arm64-2.0.6.tgz}
+    resolution: {integrity: sha1-s9hWAUQEC5INjG7dQ3QxS1glVIE=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vscode/vsce-sign-linux-arm64/-/vsce-sign-linux-arm64-2.0.6.tgz}
     cpu: [arm64]
     os: [linux]
 
   '@vscode/vsce-sign-linux-arm@2.0.6':
-    resolution: {integrity: sha1-CifEKkrbN+lu7HjNe/o4jNTp++8=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vscode/vsce-sign-linux-arm/-/vsce-sign-linux-arm-2.0.6.tgz}
+    resolution: {integrity: sha1-CifEKkrbN+lu7HjNe/o4jNTp++8=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vscode/vsce-sign-linux-arm/-/vsce-sign-linux-arm-2.0.6.tgz}
     cpu: [arm]
     os: [linux]
 
   '@vscode/vsce-sign-linux-x64@2.0.6':
-    resolution: {integrity: sha1-reEcru7VJPwWvWxDykmuoAKV3ow=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vscode/vsce-sign-linux-x64/-/vsce-sign-linux-x64-2.0.6.tgz}
+    resolution: {integrity: sha1-reEcru7VJPwWvWxDykmuoAKV3ow=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vscode/vsce-sign-linux-x64/-/vsce-sign-linux-x64-2.0.6.tgz}
     cpu: [x64]
     os: [linux]
 
   '@vscode/vsce-sign-win32-arm64@2.0.6':
-    resolution: {integrity: sha1-BoiWgUjgPrOSR5yEkcclBnIb7/w=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vscode/vsce-sign-win32-arm64/-/vsce-sign-win32-arm64-2.0.6.tgz}
+    resolution: {integrity: sha1-BoiWgUjgPrOSR5yEkcclBnIb7/w=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vscode/vsce-sign-win32-arm64/-/vsce-sign-win32-arm64-2.0.6.tgz}
     cpu: [arm64]
     os: [win32]
 
   '@vscode/vsce-sign-win32-x64@2.0.6':
-    resolution: {integrity: sha1-dEMO/0HSaBjCP5gmsEXYx1cy6us=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vscode/vsce-sign-win32-x64/-/vsce-sign-win32-x64-2.0.6.tgz}
+    resolution: {integrity: sha1-dEMO/0HSaBjCP5gmsEXYx1cy6us=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vscode/vsce-sign-win32-x64/-/vsce-sign-win32-x64-2.0.6.tgz}
     cpu: [x64]
     os: [win32]
 
@@ -11046,11 +11046,11 @@ packages:
     engines: {node: '>=10.13'}
 
   '@zkochan/js-yaml@0.0.11':
-    resolution: {integrity: sha1-T2aH2CGxW1MG1Z391Mu32K5wHI0=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@zkochan/js-yaml/-/js-yaml-0.0.11.tgz}
+    resolution: {integrity: sha1-T2aH2CGxW1MG1Z391Mu32K5wHI0=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@zkochan/js-yaml/-/js-yaml-0.0.11.tgz}
     hasBin: true
 
   '@zkochan/js-yaml@0.0.6':
-    resolution: {integrity: sha1-l18LMG5wXii4BooHc3+kbT/ASCY=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@zkochan/js-yaml/-/js-yaml-0.0.6.tgz}
+    resolution: {integrity: sha1-l18LMG5wXii4BooHc3+kbT/ASCY=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@zkochan/js-yaml/-/js-yaml-0.0.6.tgz}
     hasBin: true
 
   '@zkochan/rimraf@2.1.3':
@@ -11062,7 +11062,7 @@ packages:
     engines: {node: '>=18.12'}
 
   '@zkochan/which@2.0.3':
-    resolution: {integrity: sha1-okOQNZOQ04wVH6YHgbNiC8WhMtA=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@zkochan/which/-/which-2.0.3.tgz}
+    resolution: {integrity: sha1-okOQNZOQ04wVH6YHgbNiC8WhMtA=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@zkochan/which/-/which-2.0.3.tgz}
     engines: {node: '>= 8'}
     hasBin: true
 
@@ -11702,7 +11702,7 @@ packages:
     resolution: {integrity: sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==}
 
   bindings@1.5.0:
-    resolution: {integrity: sha1-EDU8npRTNLwFEabZCzj7x8nFBN8=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/bindings/-/bindings-1.5.0.tgz}
+    resolution: {integrity: sha1-EDU8npRTNLwFEabZCzj7x8nFBN8=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/bindings/-/bindings-1.5.0.tgz}
 
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
@@ -12163,7 +12163,7 @@ packages:
     engines: {node: '>= 12'}
 
   commander@9.5.0:
-    resolution: {integrity: sha1-vAjR61zt98y3l6lhmdQce8PmDTA=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/commander/-/commander-9.5.0.tgz}
+    resolution: {integrity: sha1-vAjR61zt98y3l6lhmdQce8PmDTA=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/commander/-/commander-9.5.0.tgz}
     engines: {node: ^12.20.0 || >=14}
 
   comment-parser@1.4.1:
@@ -12349,7 +12349,7 @@ packages:
     hasBin: true
 
   cross-spawn@6.0.6:
-    resolution: {integrity: sha1-MNDvoHEt2361p24ehyG/+vprXVc=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cross-spawn/-/cross-spawn-6.0.6.tgz}
+    resolution: {integrity: sha1-MNDvoHEt2361p24ehyG/+vprXVc=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cross-spawn/-/cross-spawn-6.0.6.tgz}
     engines: {node: '>=4.8'}
 
   cross-spawn@7.0.6:
@@ -12989,31 +12989,31 @@ packages:
     resolution: {integrity: sha512-Twf7I2v4/1tLoIXMT8HlqaBSS5H2wQTs2wx3MNYCI8K1R1/clXyCazrcVCPm/FuO9cyV8+leEaZOWD5C253NDg==}
 
   esbuild-android-64@0.14.54:
-    resolution: {integrity: sha1-UF9BgyiEMTu6/7J3BLi8qi2GFr4=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-android-64/-/esbuild-android-64-0.14.54.tgz}
+    resolution: {integrity: sha1-UF9BgyiEMTu6/7J3BLi8qi2GFr4=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-android-64/-/esbuild-android-64-0.14.54.tgz}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [android]
 
   esbuild-android-arm64@0.14.54:
-    resolution: {integrity: sha1-jOadfKuklkbgCZaP5XVKIamHF3E=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-android-arm64/-/esbuild-android-arm64-0.14.54.tgz}
+    resolution: {integrity: sha1-jOadfKuklkbgCZaP5XVKIamHF3E=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-android-arm64/-/esbuild-android-arm64-0.14.54.tgz}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
 
   esbuild-darwin-64@0.14.54:
-    resolution: {integrity: sha1-JLpnuajLiQo8CNkBj4h8wiHN2iU=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-darwin-64/-/esbuild-darwin-64-0.14.54.tgz}
+    resolution: {integrity: sha1-JLpnuajLiQo8CNkBj4h8wiHN2iU=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-darwin-64/-/esbuild-darwin-64-0.14.54.tgz}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [darwin]
 
   esbuild-darwin-arm64@0.14.54:
-    resolution: {integrity: sha1-P3zbeIiO4F5IjSUKK9qrH6Zxv3M=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.54.tgz}
+    resolution: {integrity: sha1-P3zbeIiO4F5IjSUKK9qrH6Zxv3M=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.54.tgz}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [darwin]
 
   esbuild-freebsd-64@0.14.54:
-    resolution: {integrity: sha1-CSUPmXpW7UZQ8+GXnJBf/EC76U0=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.54.tgz}
+    resolution: {integrity: sha1-CSUPmXpW7UZQ8+GXnJBf/EC76U0=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.54.tgz}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [freebsd]
@@ -13025,19 +13025,19 @@ packages:
     os: [freebsd]
 
   esbuild-linux-32@0.14.54:
-    resolution: {integrity: sha1-4qjEqO/cNVQFMlAz/OvrlB94H+U=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-linux-32/-/esbuild-linux-32-0.14.54.tgz}
+    resolution: {integrity: sha1-4qjEqO/cNVQFMlAz/OvrlB94H+U=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-linux-32/-/esbuild-linux-32-0.14.54.tgz}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [linux]
 
   esbuild-linux-64@0.14.54:
-    resolution: {integrity: sha1-3l/boclWZs9yNp9StAsDvnEiZlI=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-linux-64/-/esbuild-linux-64-0.14.54.tgz}
+    resolution: {integrity: sha1-3l/boclWZs9yNp9StAsDvnEiZlI=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-linux-64/-/esbuild-linux-64-0.14.54.tgz}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
 
   esbuild-linux-arm64@0.14.54:
-    resolution: {integrity: sha1-2uTNQq6Xh0aLalwVjaTIToOwzos=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.54.tgz}
+    resolution: {integrity: sha1-2uTNQq6Xh0aLalwVjaTIToOwzos=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.54.tgz}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [linux]
@@ -13049,37 +13049,37 @@ packages:
     os: [linux]
 
   esbuild-linux-mips64le@0.14.54:
-    resolution: {integrity: sha1-2ZGOnky5cvjW2ujoZVv57hMe2jQ=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.54.tgz}
+    resolution: {integrity: sha1-2ZGOnky5cvjW2ujoZVv57hMe2jQ=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.54.tgz}
     engines: {node: '>=12'}
     cpu: [mips64el]
     os: [linux]
 
   esbuild-linux-ppc64le@0.14.54:
-    resolution: {integrity: sha1-P5oPbUEHP7GmQGgIRcfeUplfE34=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.54.tgz}
+    resolution: {integrity: sha1-P5oPbUEHP7GmQGgIRcfeUplfE34=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.54.tgz}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [linux]
 
   esbuild-linux-riscv64@0.14.54:
-    resolution: {integrity: sha1-YYhTwCgXimGDe8eZ0gE9RpXkUcg=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.54.tgz}
+    resolution: {integrity: sha1-YYhTwCgXimGDe8eZ0gE9RpXkUcg=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.54.tgz}
     engines: {node: '>=12'}
     cpu: [riscv64]
     os: [linux]
 
   esbuild-linux-s390x@0.14.54:
-    resolution: {integrity: sha1-0YhcTFp2u7Wg/hguLIxg654p8qY=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.54.tgz}
+    resolution: {integrity: sha1-0YhcTFp2u7Wg/hguLIxg654p8qY=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.54.tgz}
     engines: {node: '>=12'}
     cpu: [s390x]
     os: [linux]
 
   esbuild-netbsd-64@0.14.54:
-    resolution: {integrity: sha1-aa6Rei/yQbffHb8iuvBL0zA0noE=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.54.tgz}
+    resolution: {integrity: sha1-aa6Rei/yQbffHb8iuvBL0zA0noE=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.54.tgz}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
 
   esbuild-openbsd-64@0.14.54:
-    resolution: {integrity: sha1-20yElSh6NQpnkN4i7eokelfF1Hs=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.54.tgz}
+    resolution: {integrity: sha1-20yElSh6NQpnkN4i7eokelfF1Hs=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.54.tgz}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [openbsd]
@@ -13096,19 +13096,19 @@ packages:
       esbuild: '*'
 
   esbuild-sunos-64@0.14.54:
-    resolution: {integrity: sha1-VCh+49pz04RLchwhvIDB3H4b99o=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-sunos-64/-/esbuild-sunos-64-0.14.54.tgz}
+    resolution: {integrity: sha1-VCh+49pz04RLchwhvIDB3H4b99o=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-sunos-64/-/esbuild-sunos-64-0.14.54.tgz}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [sunos]
 
   esbuild-windows-32@0.14.54:
-    resolution: {integrity: sha1-+Kr5pWZ2MLQPD7OqN78Bu9NAzjE=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-windows-32/-/esbuild-windows-32-0.14.54.tgz}
+    resolution: {integrity: sha1-+Kr5pWZ2MLQPD7OqN78Bu9NAzjE=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-windows-32/-/esbuild-windows-32-0.14.54.tgz}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
 
   esbuild-windows-64@0.14.54:
-    resolution: {integrity: sha1-v1S1G9PpsPGIb/2yJKQXYDHqCvQ=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-windows-64/-/esbuild-windows-64-0.14.54.tgz}
+    resolution: {integrity: sha1-v1S1G9PpsPGIb/2yJKQXYDHqCvQ=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/esbuild-windows-64/-/esbuild-windows-64-0.14.54.tgz}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
@@ -13409,11 +13409,11 @@ packages:
     resolution: {integrity: sha512-nQn+hI3yp+oD0huYhKwvYI32+JFeq+XkNcD1GAo3Y/MjxsfVGmrrzrnzjWiNY6f+pUCP440fThsFh5gZrRAU/w==}
 
   execa@1.0.0:
-    resolution: {integrity: sha1-xiNqW7TfbW8V6I5/AXeYIWdJ3dg=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/execa/-/execa-1.0.0.tgz}
+    resolution: {integrity: sha1-xiNqW7TfbW8V6I5/AXeYIWdJ3dg=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/execa/-/execa-1.0.0.tgz}
     engines: {node: '>=6'}
 
   execa@5.1.1:
-    resolution: {integrity: sha1-+ArZy/Qpj3vR1MlVXCHpN0HEEd0=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/execa/-/execa-5.1.1.tgz}
+    resolution: {integrity: sha1-+ArZy/Qpj3vR1MlVXCHpN0HEEd0=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/execa/-/execa-5.1.1.tgz}
     engines: {node: '>=10'}
 
   exit-x@0.2.2:
@@ -13801,18 +13801,18 @@ packages:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
   fsevents@1.2.13:
-    resolution: {integrity: sha1-8yXLBFVZJCi88Rs4M3DvcOO/zDg=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fsevents/-/fsevents-1.2.13.tgz}
+    resolution: {integrity: sha1-8yXLBFVZJCi88Rs4M3DvcOO/zDg=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fsevents/-/fsevents-1.2.13.tgz}
     engines: {node: '>= 4.0'}
     os: [darwin]
     deprecated: Upgrade to fsevents v2 to mitigate potential security issues
 
   fsevents@2.3.2:
-    resolution: {integrity: sha1-ilJveLj99GI7cJ4Ll1xSwkwC/Ro=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fsevents/-/fsevents-2.3.2.tgz}
+    resolution: {integrity: sha1-ilJveLj99GI7cJ4Ll1xSwkwC/Ro=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fsevents/-/fsevents-2.3.2.tgz}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
   fsevents@2.3.3:
-    resolution: {integrity: sha1-ysZAd4XQNnWipeGlMFxpezR9kNY=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fsevents/-/fsevents-2.3.3.tgz}
+    resolution: {integrity: sha1-ysZAd4XQNnWipeGlMFxpezR9kNY=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fsevents/-/fsevents-2.3.3.tgz}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
@@ -13883,15 +13883,15 @@ packages:
     engines: {node: '>= 0.4'}
 
   get-stream@4.1.0:
-    resolution: {integrity: sha1-wbJVV189wh1Zv8ec09K0axw6VLU=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/get-stream/-/get-stream-4.1.0.tgz}
+    resolution: {integrity: sha1-wbJVV189wh1Zv8ec09K0axw6VLU=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/get-stream/-/get-stream-4.1.0.tgz}
     engines: {node: '>=6'}
 
   get-stream@5.2.0:
-    resolution: {integrity: sha1-SWaheV7lrOZecGxLe+txJX1uItM=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/get-stream/-/get-stream-5.2.0.tgz}
+    resolution: {integrity: sha1-SWaheV7lrOZecGxLe+txJX1uItM=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/get-stream/-/get-stream-5.2.0.tgz}
     engines: {node: '>=8'}
 
   get-stream@6.0.1:
-    resolution: {integrity: sha1-omLY7vZ6ztV8KFKtYWdSakPL97c=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/get-stream/-/get-stream-6.0.1.tgz}
+    resolution: {integrity: sha1-omLY7vZ6ztV8KFKtYWdSakPL97c=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/get-stream/-/get-stream-6.0.1.tgz}
     engines: {node: '>=10'}
 
   get-symbol-description@1.1.0:
@@ -14025,7 +14025,7 @@ packages:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
   graphql@16.13.2:
-    resolution: {integrity: sha1-TStz31eWsgHxvCdl9dcGf2ictV8=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/graphql/-/graphql-16.13.2.tgz}
+    resolution: {integrity: sha1-TStz31eWsgHxvCdl9dcGf2ictV8=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/graphql/-/graphql-16.13.2.tgz}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
 
   gzip-size@6.0.0:
@@ -14261,7 +14261,7 @@ packages:
     engines: {node: '>= 14'}
 
   human-signals@2.1.0:
-    resolution: {integrity: sha1-3JH8ukLk0G5Kuu0zs+ejwC9RTqA=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/human-signals/-/human-signals-2.1.0.tgz}
+    resolution: {integrity: sha1-3JH8ukLk0G5Kuu0zs+ejwC9RTqA=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/human-signals/-/human-signals-2.1.0.tgz}
     engines: {node: '>=10.17.0'}
 
   humanize-ms@1.2.1:
@@ -14658,11 +14658,11 @@ packages:
     engines: {node: '>= 0.4'}
 
   is-stream@1.1.0:
-    resolution: {integrity: sha1-EtSj3U5o4Lec6428hBc66A2RykQ=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-stream/-/is-stream-1.1.0.tgz}
+    resolution: {integrity: sha1-EtSj3U5o4Lec6428hBc66A2RykQ=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-stream/-/is-stream-1.1.0.tgz}
     engines: {node: '>=0.10.0'}
 
   is-stream@2.0.1:
-    resolution: {integrity: sha1-+sHj1TuXrVqdCunO8jifWBClwHc=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-stream/-/is-stream-2.0.1.tgz}
+    resolution: {integrity: sha1-+sHj1TuXrVqdCunO8jifWBClwHc=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-stream/-/is-stream-2.0.1.tgz}
     engines: {node: '>=8'}
 
   is-string@1.1.1:
@@ -14735,7 +14735,7 @@ packages:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
 
   isexe@2.0.0:
-    resolution: {integrity: sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/isexe/-/isexe-2.0.0.tgz}
+    resolution: {integrity: sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/isexe/-/isexe-2.0.0.tgz}
 
   isobject@2.1.0:
     resolution: {integrity: sha512-+OUdGJlgjOBZDfxnDjYYG6zp487z0JGNQq3cYQYg5f5hKR+syHMsaztzGeml/4kGG55CSpKSpWTY+jYGgsHLgA==}
@@ -15784,7 +15784,7 @@ packages:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
   nan@2.26.2:
-    resolution: {integrity: sha1-Ll4ldkIkxze5iXeQtXwylNTc7pw=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/nan/-/nan-2.26.2.tgz}
+    resolution: {integrity: sha1-Ll4ldkIkxze5iXeQtXwylNTc7pw=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/nan/-/nan-2.26.2.tgz}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -15938,7 +15938,7 @@ packages:
     engines: {node: '>=4'}
 
   npm-run-path@4.0.1:
-    resolution: {integrity: sha1-t+zR5e1T2o43pV4cImnguX7XSOo=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/npm-run-path/-/npm-run-path-4.0.1.tgz}
+    resolution: {integrity: sha1-t+zR5e1T2o43pV4cImnguX7XSOo=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/npm-run-path/-/npm-run-path-4.0.1.tgz}
     engines: {node: '>=8'}
 
   npmlog@4.1.2:
@@ -16049,7 +16049,7 @@ packages:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   onetime@5.1.2:
-    resolution: {integrity: sha1-0Oluu1awdHbfHdnEgG5SN5hcpF4=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/onetime/-/onetime-5.1.2.tgz}
+    resolution: {integrity: sha1-0Oluu1awdHbfHdnEgG5SN5hcpF4=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/onetime/-/onetime-5.1.2.tgz}
     engines: {node: '>=6'}
 
   open@10.2.0:
@@ -16268,7 +16268,7 @@ packages:
     engines: {node: '>=0.10.0'}
 
   path-key@2.0.1:
-    resolution: {integrity: sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/path-key/-/path-key-2.0.1.tgz}
+    resolution: {integrity: sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/path-key/-/path-key-2.0.1.tgz}
     engines: {node: '>=4'}
 
   path-key@3.1.1:
@@ -16276,7 +16276,7 @@ packages:
     engines: {node: '>=8'}
 
   path-name@1.0.0:
-    resolution: {integrity: sha1-jKBjpj3nmC36lXYO2v/RAhRJTyQ=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/path-name/-/path-name-1.0.0.tgz}
+    resolution: {integrity: sha1-jKBjpj3nmC36lXYO2v/RAhRJTyQ=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/path-name/-/path-name-1.0.0.tgz}
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
@@ -16870,7 +16870,7 @@ packages:
     resolution: {integrity: sha512-SbiLPU40JuJniHexQSAgad32hfwd+DRUdwF2PlVuI5RZD0/vahUco7R8vD86J/tcEKKF9vZrUVwgtmGCqlCKyA==}
 
   ramda@0.28.0:
-    resolution: {integrity: sha1-rNeFaQEAM36LBjyrNHABm+QnzJc=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ramda/-/ramda-0.28.0.tgz}
+    resolution: {integrity: sha1-rNeFaQEAM36LBjyrNHABm+QnzJc=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ramda/-/ramda-0.28.0.tgz}
 
   randombytes@2.1.0:
     resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
@@ -17351,7 +17351,7 @@ packages:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
   safe-execa@0.1.2:
-    resolution: {integrity: sha1-L7sKbxoAx6RexwM/gmWXV/kb6Mc=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/safe-execa/-/safe-execa-0.1.2.tgz}
+    resolution: {integrity: sha1-L7sKbxoAx6RexwM/gmWXV/kb6Mc=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/safe-execa/-/safe-execa-0.1.2.tgz}
     engines: {node: '>=12'}
 
   safe-push-apply@1.0.0:
@@ -17378,19 +17378,19 @@ packages:
     hasBin: true
 
   sass-embedded-android-arm64@1.85.1:
-    resolution: {integrity: sha1-HKnF4G6hqOz3T/f76mcXBs/lAyA=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sass-embedded-android-arm64/-/sass-embedded-android-arm64-1.85.1.tgz}
+    resolution: {integrity: sha1-HKnF4G6hqOz3T/f76mcXBs/lAyA=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sass-embedded-android-arm64/-/sass-embedded-android-arm64-1.85.1.tgz}
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [android]
 
   sass-embedded-android-arm@1.85.1:
-    resolution: {integrity: sha1-87zVn7BcKTGuoSaUlqCYj4C5Nq8=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sass-embedded-android-arm/-/sass-embedded-android-arm-1.85.1.tgz}
+    resolution: {integrity: sha1-87zVn7BcKTGuoSaUlqCYj4C5Nq8=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sass-embedded-android-arm/-/sass-embedded-android-arm-1.85.1.tgz}
     engines: {node: '>=14.0.0'}
     cpu: [arm]
     os: [android]
 
   sass-embedded-android-ia32@1.85.1:
-    resolution: {integrity: sha1-C0jPGwoVfAZtjWyPTHz102trIps=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sass-embedded-android-ia32/-/sass-embedded-android-ia32-1.85.1.tgz}
+    resolution: {integrity: sha1-C0jPGwoVfAZtjWyPTHz102trIps=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sass-embedded-android-ia32/-/sass-embedded-android-ia32-1.85.1.tgz}
     engines: {node: '>=14.0.0'}
     cpu: [ia32]
     os: [android]
@@ -17402,19 +17402,19 @@ packages:
     os: [android]
 
   sass-embedded-android-x64@1.85.1:
-    resolution: {integrity: sha1-xTkYMMuzw3jlF3vA4D6Up4LNHME=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sass-embedded-android-x64/-/sass-embedded-android-x64-1.85.1.tgz}
+    resolution: {integrity: sha1-xTkYMMuzw3jlF3vA4D6Up4LNHME=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sass-embedded-android-x64/-/sass-embedded-android-x64-1.85.1.tgz}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [android]
 
   sass-embedded-darwin-arm64@1.85.1:
-    resolution: {integrity: sha1-eay7aGfQFolvhDlxvfoKx24QHfg=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.85.1.tgz}
+    resolution: {integrity: sha1-eay7aGfQFolvhDlxvfoKx24QHfg=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.85.1.tgz}
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [darwin]
 
   sass-embedded-darwin-x64@1.85.1:
-    resolution: {integrity: sha1-FH7PSb8tGC295s7zN6WKBbepOrE=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.85.1.tgz}
+    resolution: {integrity: sha1-FH7PSb8tGC295s7zN6WKBbepOrE=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.85.1.tgz}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [darwin]
@@ -17426,31 +17426,31 @@ packages:
     os: [linux]
 
   sass-embedded-linux-arm@1.85.1:
-    resolution: {integrity: sha1-iZy6lLc+sRn2Q0aInkZt4xtvXTw=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.85.1.tgz}
+    resolution: {integrity: sha1-iZy6lLc+sRn2Q0aInkZt4xtvXTw=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.85.1.tgz}
     engines: {node: '>=14.0.0'}
     cpu: [arm]
     os: [linux]
 
   sass-embedded-linux-ia32@1.85.1:
-    resolution: {integrity: sha1-8bpT8DQ4ljWv6cEFm8Nqd5NkIbg=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sass-embedded-linux-ia32/-/sass-embedded-linux-ia32-1.85.1.tgz}
+    resolution: {integrity: sha1-8bpT8DQ4ljWv6cEFm8Nqd5NkIbg=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sass-embedded-linux-ia32/-/sass-embedded-linux-ia32-1.85.1.tgz}
     engines: {node: '>=14.0.0'}
     cpu: [ia32]
     os: [linux]
 
   sass-embedded-linux-musl-arm64@1.85.1:
-    resolution: {integrity: sha1-sUziYVx6tGJuiMuiZW+Ro6dI4c4=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sass-embedded-linux-musl-arm64/-/sass-embedded-linux-musl-arm64-1.85.1.tgz}
+    resolution: {integrity: sha1-sUziYVx6tGJuiMuiZW+Ro6dI4c4=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sass-embedded-linux-musl-arm64/-/sass-embedded-linux-musl-arm64-1.85.1.tgz}
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [linux]
 
   sass-embedded-linux-musl-arm@1.85.1:
-    resolution: {integrity: sha1-Qo5eKZqf9N/SC1eGHSRAQotfvfY=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sass-embedded-linux-musl-arm/-/sass-embedded-linux-musl-arm-1.85.1.tgz}
+    resolution: {integrity: sha1-Qo5eKZqf9N/SC1eGHSRAQotfvfY=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sass-embedded-linux-musl-arm/-/sass-embedded-linux-musl-arm-1.85.1.tgz}
     engines: {node: '>=14.0.0'}
     cpu: [arm]
     os: [linux]
 
   sass-embedded-linux-musl-ia32@1.85.1:
-    resolution: {integrity: sha1-BwYJr9mc0Pnq5yGGyfSi0M32lE0=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sass-embedded-linux-musl-ia32/-/sass-embedded-linux-musl-ia32-1.85.1.tgz}
+    resolution: {integrity: sha1-BwYJr9mc0Pnq5yGGyfSi0M32lE0=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sass-embedded-linux-musl-ia32/-/sass-embedded-linux-musl-ia32-1.85.1.tgz}
     engines: {node: '>=14.0.0'}
     cpu: [ia32]
     os: [linux]
@@ -17474,7 +17474,7 @@ packages:
     os: [linux]
 
   sass-embedded-linux-x64@1.85.1:
-    resolution: {integrity: sha1-BmTMiGuHgYrJ0pv06fKZ/mxj9SQ=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.85.1.tgz}
+    resolution: {integrity: sha1-BmTMiGuHgYrJ0pv06fKZ/mxj9SQ=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.85.1.tgz}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [linux]
@@ -17486,13 +17486,13 @@ packages:
     os: [win32]
 
   sass-embedded-win32-ia32@1.85.1:
-    resolution: {integrity: sha1-Xl8W4aMPjfMRSKr2WncimNcDfXA=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sass-embedded-win32-ia32/-/sass-embedded-win32-ia32-1.85.1.tgz}
+    resolution: {integrity: sha1-Xl8W4aMPjfMRSKr2WncimNcDfXA=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sass-embedded-win32-ia32/-/sass-embedded-win32-ia32-1.85.1.tgz}
     engines: {node: '>=14.0.0'}
     cpu: [ia32]
     os: [win32]
 
   sass-embedded-win32-x64@1.85.1:
-    resolution: {integrity: sha1-dY+5bBbncmWkt/JHSkOWLXHvX/0=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.85.1.tgz}
+    resolution: {integrity: sha1-dY+5bBbncmWkt/JHSkOWLXHvX/0=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.85.1.tgz}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [win32]
@@ -17734,10 +17734,10 @@ packages:
     engines: {node: '>= 0.4'}
 
   signal-exit@3.0.7:
-    resolution: {integrity: sha1-qaF2f4r4QVURTqq9c/mSc8j1mtk=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/signal-exit/-/signal-exit-3.0.7.tgz}
+    resolution: {integrity: sha1-qaF2f4r4QVURTqq9c/mSc8j1mtk=, tarball: https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/signal-exit/-/signal-exit-3.0.7.tgz}
 
   signal-exit@4.1.0:
-    resolution: {integrity: sha1-lSGIwcvVRgcOLdIND0HArgUwywQ=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/signal-exit/-/signal-exit-4.1.0.tgz}
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
   simple-concat@1.0.1:
@@ -18061,7 +18061,7 @@ packages:
     engines: {node: '>=0.10.0'}
 
   strip-final-newline@2.0.0:
-    resolution: {integrity: sha1-ibhS+y/L6Tb29LMYevsKEsGrWK0=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/strip-final-newline/-/strip-final-newline-2.0.0.tgz}
+    resolution: {integrity: sha1-ibhS+y/L6Tb29LMYevsKEsGrWK0=, tarball: https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/strip-final-newline/-/strip-final-newline-2.0.0.tgz}
     engines: {node: '>=6'}
 
   strip-indent@3.0.0:
@@ -18549,7 +18549,7 @@ packages:
     resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
 
   uglify-js@3.19.3:
-    resolution: {integrity: sha1-gjFem7xvKyWIiFis0f/4RBA1t38=, tarball: https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/uglify-js/-/uglify-js-3.19.3.tgz}
+    resolution: {integrity: sha1-gjFem7xvKyWIiFis0f/4RBA1t38=, tarball: https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/uglify-js/-/uglify-js-3.19.3.tgz}
     engines: {node: '>=0.8.0'}
     hasBin: true
 
@@ -24826,7 +24826,7 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@rushstack/heft-jest-plugin@2.0.13(@rushstack/heft@1.2.23(@types/node@20.17.19))(@types/jest@30.0.0)(@types/node@20.17.19)(esbuild-register@3.6.0(esbuild@0.28.0))(jest-environment-jsdom@30.3.0)(jest-environment-node@30.3.0)':
+  '@rushstack/heft-jest-plugin@2.0.13(@rushstack/heft@1.2.23(@types/node@20.17.19))(@types/jest@30.0.0)(@types/node@20.17.19)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.28.0))(jest-environment-jsdom@30.3.0)(jest-environment-node@30.3.0)':
     dependencies:
       '@jest/core': 30.3.0(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.28.0))
       '@jest/reporters': 30.3.0
@@ -24859,13 +24859,13 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@rushstack/heft-node-rig@2.11.46(@rushstack/heft@1.2.23(@types/node@20.17.19))(@types/node@20.17.19)(esbuild-register@3.6.0(esbuild@0.28.0))(jest-environment-jsdom@30.3.0)':
+  '@rushstack/heft-node-rig@2.11.46(@rushstack/heft@1.2.23(@types/node@20.17.19))(@types/node@20.17.19)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.28.0))(jest-environment-jsdom@30.3.0)':
     dependencies:
       '@microsoft/api-extractor': 7.58.12(@types/node@20.17.19)
       '@rushstack/eslint-config': 4.6.4(eslint@9.37.0)(typescript@5.8.2)
       '@rushstack/heft': 1.2.23(@types/node@20.17.19)
       '@rushstack/heft-api-extractor-plugin': 1.3.23(@rushstack/heft@1.2.23(@types/node@20.17.19))(@types/node@20.17.19)
-      '@rushstack/heft-jest-plugin': 2.0.13(@rushstack/heft@1.2.23(@types/node@20.17.19))(@types/jest@30.0.0)(@types/node@20.17.19)(esbuild-register@3.6.0(esbuild@0.28.0))(jest-environment-jsdom@30.3.0)(jest-environment-node@30.3.0)
+      '@rushstack/heft-jest-plugin': 2.0.13(@rushstack/heft@1.2.23(@types/node@20.17.19))(@types/jest@30.0.0)(@types/node@20.17.19)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.28.0))(jest-environment-jsdom@30.3.0)(jest-environment-node@30.3.0)
       '@rushstack/heft-lint-plugin': 1.2.23(@rushstack/heft@1.2.23(@types/node@20.17.19))(@types/node@20.17.19)
       '@rushstack/heft-typescript-plugin': 1.3.18(@rushstack/heft@1.2.23(@types/node@20.17.19))(@types/node@20.17.19)
       '@types/jest': 30.0.0
@@ -31006,7 +31006,7 @@ snapshots:
 
   eslint@8.57.1:
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@8.57.1)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.37.0)
       '@eslint-community/regexpp': 4.12.2
       '@eslint/eslintrc': 2.1.4
       '@eslint/js': 8.57.1

--- a/common/config/subspaces/default/repo-state.json
+++ b/common/config/subspaces/default/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "09068e8d50f8dae26938555320be968d7ed7861d",
+  "pnpmShrinkwrapHash": "7828a1fa8cadd2cfd83906d47b1915fddcb5aac9",
   "preferredVersionsHash": "029c99bd6e65c5e1f25e2848340509811ff9753c"
 }

--- a/common/config/subspaces/default/repo-state.json
+++ b/common/config/subspaces/default/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "7828a1fa8cadd2cfd83906d47b1915fddcb5aac9",
+  "pnpmShrinkwrapHash": "09068e8d50f8dae26938555320be968d7ed7861d",
   "preferredVersionsHash": "029c99bd6e65c5e1f25e2848340509811ff9753c"
 }

--- a/common/reviews/api/rush-daemon-protocol.api.md
+++ b/common/reviews/api/rush-daemon-protocol.api.md
@@ -101,6 +101,9 @@ export type DaemonJsonValue = string | number | boolean | DaemonJsonNull | reado
 };
 
 // @beta
+export type DaemonPhasedOperationEnabledState = true | 'ignore-dependency-changes';
+
+// @beta
 export class DaemonProtocolError extends Error {
     constructor(code: DaemonProtocolErrorCode, message: string, options?: IDaemonProtocolErrorOptions);
     readonly code: DaemonProtocolErrorCode;
@@ -276,6 +279,41 @@ export interface IDaemonOperationStatusChangedPayload {
 // @beta
 export interface IDaemonOperationStreamClosedPayload {
     readonly operationId: string;
+}
+
+// @beta
+export interface IDaemonPhasedEngineShape {
+    readonly phaseNames: ReadonlyArray<string>;
+    readonly pluginNames: ReadonlyArray<string>;
+}
+
+// @beta
+export interface IDaemonPhasedOperationResult {
+    readonly errorMessage?: string;
+    readonly operationId: string;
+    readonly status: string;
+}
+
+// @beta
+export interface IDaemonPhasedOperationSelection {
+    readonly enabledState: DaemonPhasedOperationEnabledState;
+    readonly operationId: string;
+}
+
+// @beta
+export interface IDaemonPhasedRequest {
+    readonly commandName: string;
+    readonly engineShape: IDaemonPhasedEngineShape;
+    readonly operationSelection: ReadonlyArray<IDaemonPhasedOperationSelection>;
+    readonly requestId: string;
+}
+
+// @beta
+export interface IDaemonPhasedRequestResult {
+    readonly aborted: boolean;
+    readonly operationResults: ReadonlyArray<IDaemonPhasedOperationResult>;
+    readonly requestId: string;
+    readonly scheduled: boolean;
 }
 
 // @beta

--- a/common/reviews/api/rush-daemon.api.md
+++ b/common/reviews/api/rush-daemon.api.md
@@ -64,6 +64,7 @@ export interface IMapWorkspaceInvalidationsOptions {
 // @beta
 export interface IPhasedRequestClient {
     readonly abortSignal: AbortSignal;
+    getNextEventSequence(): number;
     readonly sessionId: string;
     writeEventAsync(event: IDaemonEventEnvelope): Promise<void>;
     writeLogChunkAsync(operationId: string, stream: 'stdout' | 'stderr', chunk: Uint8Array): Promise<void>;

--- a/common/reviews/api/rush-daemon.api.md
+++ b/common/reviews/api/rush-daemon.api.md
@@ -7,7 +7,10 @@
 /// <reference types="node" />
 
 import type { GetInputsSnapshotAsyncFn } from '@microsoft/rush-lib';
+import type { IDaemonEventEnvelope } from '@rushstack/rush-daemon-protocol';
 import type { IDaemonPaths } from '@rushstack/rush-daemon-transport';
+import type { IDaemonPhasedRequest } from '@rushstack/rush-daemon-protocol';
+import type { IDaemonPhasedRequestResult } from '@rushstack/rush-daemon-protocol';
 import type { IInputsSnapshot } from '@microsoft/rush-lib';
 import type { IOperationGraph } from '@microsoft/rush-lib';
 import type { Operation } from '@microsoft/rush-lib';
@@ -56,6 +59,14 @@ export interface IMapWorkspaceInvalidationsOptions {
     readonly nextInputsSnapshot: IInputsSnapshot;
     // (undocumented)
     readonly operationGraph: IOperationGraph;
+}
+
+// @beta
+export interface IPhasedRequestClient {
+    readonly abortSignal: AbortSignal;
+    readonly sessionId: string;
+    writeEventAsync(event: IDaemonEventEnvelope): Promise<void>;
+    writeLogChunkAsync(operationId: string, stream: 'stdout' | 'stderr', chunk: Uint8Array): Promise<void>;
 }
 
 // @public
@@ -216,6 +227,12 @@ export interface IWorkspaceSessionOptions {
 
 // @beta
 export type MapWorkspaceInvalidationsToOperationsAsync = (options: IMapWorkspaceInvalidationsOptions) => Promise<Iterable<Operation>>;
+
+// @beta
+export class PhasedRequestRouter {
+    constructor(workspaceSession: IWorkspaceSession);
+    executeAsync(request: IDaemonPhasedRequest, client: IPhasedRequestClient): Promise<IDaemonPhasedRequestResult>;
+}
 
 // @public
 export enum RequestExclusivityClass {

--- a/common/reviews/api/rush-terminal-renderer.api.md
+++ b/common/reviews/api/rush-terminal-renderer.api.md
@@ -7,6 +7,7 @@
 import type { DaemonVerbosity } from '@rushstack/rush-daemon-protocol';
 import type { IDaemonClientCaps } from '@rushstack/rush-daemon-protocol';
 import type { IDaemonEventEnvelope } from '@rushstack/rush-daemon-protocol';
+import type { IDaemonOperationHeaderPayload } from '@rushstack/rush-daemon-protocol';
 import { ITerminalChunk } from '@rushstack/terminal';
 import { TerminalWritable } from '@rushstack/terminal';
 
@@ -82,6 +83,7 @@ export class OperationStreamRegistry {
     constructor(options: IOperationStreamRegistryOptions);
     closeOperation(operationId: string): void;
     registerOperation(): void;
+    setOperationHeader(header: IDaemonOperationHeaderPayload): void;
     writeChunk(operationId: string, chunk: ITerminalChunk): void;
 }
 

--- a/libraries/rush-daemon-protocol/README.md
+++ b/libraries/rush-daemon-protocol/README.md
@@ -17,6 +17,9 @@ The engine-agnostic **wire layer** spoken by every client of the Rush daemon (`r
   reference when the reporter package lands) plus namespaced `rushd.*` extension events.
 - **Per-subscription verbosity** — a pure filter applied at event serialization so each
   client receives its own verbosity subset without mutating shared engine state.
+- **Resolved phased-request contracts** — engine-agnostic request, enabled-state selection,
+  and client-scoped result types for integrations that have already parsed a command and
+  resolved it against a real warm operation graph.
 
 Part of the Rush 6 / rushd re-architecture:
 [microsoft/rushstack#5894](https://github.com/microsoft/rushstack/issues/5894).

--- a/libraries/rush-daemon-protocol/src/DaemonPhasedRequest.ts
+++ b/libraries/rush-daemon-protocol/src/DaemonPhasedRequest.ts
@@ -1,0 +1,83 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+/**
+ * The enabled state assigned to one selected operation by a phased request.
+ *
+ * @beta
+ */
+export type DaemonPhasedOperationEnabledState = true | 'ignore-dependency-changes';
+
+/**
+ * One caller-resolved operation selection.
+ *
+ * @remarks
+ * Operation identifiers come from the integration-owned real operation graph. Command-line parsing and graph
+ * construction remain outside the wire contract.
+ *
+ * @beta
+ */
+export interface IDaemonPhasedOperationSelection {
+  /** The non-disabled state to apply with the real graph's enabled-state API. */
+  readonly enabledState: DaemonPhasedOperationEnabledState;
+  /** The integration-resolved operation identifier. */
+  readonly operationId: string;
+}
+
+/**
+ * The explicit phase and plugin shape of the warm graph used by a phased request.
+ *
+ * @beta
+ */
+export interface IDaemonPhasedEngineShape {
+  /** Every phase represented by the warm graph. */
+  readonly phaseNames: ReadonlyArray<string>;
+  /** Every plugin applied when the warm graph was constructed. */
+  readonly pluginNames: ReadonlyArray<string>;
+}
+
+/**
+ * A typed phased request after an integration has parsed the command and resolved its operation selection.
+ *
+ * @beta
+ */
+export interface IDaemonPhasedRequest {
+  /** The parsed phased command name. */
+  readonly commandName: string;
+  /** The exact warm engine shape against which the selection was resolved. */
+  readonly engineShape: IDaemonPhasedEngineShape;
+  /** The caller-resolved selected operations and their enabled states. */
+  readonly operationSelection: ReadonlyArray<IDaemonPhasedOperationSelection>;
+  /** A client-generated identifier unique within the connection. */
+  readonly requestId: string;
+}
+
+/**
+ * The client-scoped result for one selected operation.
+ *
+ * @beta
+ */
+export interface IDaemonPhasedOperationResult {
+  /** The operation identifier used by the request and its streamed output. */
+  readonly operationId: string;
+  /** The raw Rush operation status. */
+  readonly status: string;
+  /** The operation error message, when execution produced one. */
+  readonly errorMessage?: string;
+}
+
+/**
+ * The result of routing one phased request through a warm operation graph.
+ *
+ * @beta
+ */
+export interface IDaemonPhasedRequestResult {
+  /** Whether cancellation or disconnect aborted the iteration. */
+  readonly aborted: boolean;
+  /** Results only for operations enabled for this client. */
+  readonly operationResults: ReadonlyArray<IDaemonPhasedOperationResult>;
+  /** The identifier copied from the request. */
+  readonly requestId: string;
+  /** Whether the real graph scheduled work for this iteration. */
+  readonly scheduled: boolean;
+}

--- a/libraries/rush-daemon-protocol/src/index.ts
+++ b/libraries/rush-daemon-protocol/src/index.ts
@@ -50,3 +50,11 @@ export { decodeDaemonEventFrame, encodeDaemonEventFrame, serializeDaemonEventFor
 export type { IDaemonActivityPayload, IDaemonOperationRegisteredPayload, IDaemonOperationStatusChangedPayload } from './DaemonOperationPayloads';
 export { RUSHD_OPERATION_HEADER, RUSHD_OPERATION_STREAM_CLOSED } from './DaemonRushdExtensions';
 export type { IDaemonExtensionEventPayload, IDaemonOperationHeaderPayload, IDaemonOperationStreamClosedPayload } from './DaemonRushdExtensions';
+export type {
+  DaemonPhasedOperationEnabledState,
+  IDaemonPhasedEngineShape,
+  IDaemonPhasedOperationResult,
+  IDaemonPhasedOperationSelection,
+  IDaemonPhasedRequest,
+  IDaemonPhasedRequestResult
+} from './DaemonPhasedRequest';

--- a/libraries/rush-daemon/README.md
+++ b/libraries/rush-daemon/README.md
@@ -27,3 +27,16 @@ no paths to classify and therefore remains a full invalidation. The routing laye
 workspace session rather than run a stale graph.
 The default daemon executable does not construct or route this graph while the command-independent plugin shape and per-iteration runner
 lifetime tracked by [rushstack#5895](https://github.com/microsoft/rushstack/issues/5895) remain incomplete.
+
+`PhasedRequestRouter` is the opt-in execution boundary once an integration has supplied that real warm graph. The
+integration parses the command and supplies an explicit phase/plugin shape plus operation enabled-state selection;
+the router validates both, reconciles retained invalidations, applies the selection with `IOperationGraph.setEnabledStates`,
+and runs at most one scheduled iteration. Requests are serialized until shared-build merging is implemented. A
+requesting client receives only its enabled dependency closure's WS1 raw chunks and structured events through
+backpressured, ordered callbacks, followed by client-scoped operation results. Cancellation or disconnect aborts the
+current iteration without closing daemon-owned runners or the graph.
+
+This layer deliberately does not add control-frame admission or reconstruct `PhasedScriptAction` command/plugin
+initialization. The typed phased request contract begins after an integration has produced a validated selection for
+the exact warm engine shape; full command parsing remains blocked by
+[rushstack#5895](https://github.com/microsoft/rushstack/issues/5895).

--- a/libraries/rush-daemon/package.json
+++ b/libraries/rush-daemon/package.json
@@ -48,7 +48,8 @@
     "@microsoft/rush-lib": "workspace:*",
     "@rushstack/node-core-library": "workspace:*",
     "@rushstack/rush-daemon-protocol": "workspace:*",
-    "@rushstack/rush-daemon-transport": "workspace:*"
+    "@rushstack/rush-daemon-transport": "workspace:*",
+    "@rushstack/terminal": "workspace:*"
   },
   "devDependencies": {
     "@rushstack/heft": "workspace:*",

--- a/libraries/rush-daemon/src/PhasedRequestClient.ts
+++ b/libraries/rush-daemon/src/PhasedRequestClient.ts
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import type { IDaemonEventEnvelope } from '@rushstack/rush-daemon-protocol';
+
+/**
+ * A client-scoped destination for one routed phased request.
+ *
+ * @remarks
+ * The client must abort `abortSignal` when its request is cancelled or its connection closes. Writes are invoked
+ * serially in engine order; each promise provides the destination's backpressure boundary.
+ *
+ * @beta
+ */
+export interface IPhasedRequestClient {
+  /** Aborted by the transport when the request is cancelled or disconnected. */
+  readonly abortSignal: AbortSignal;
+  /** The connection session identifier used in structured event envelopes. */
+  readonly sessionId: string;
+
+  /** Writes one structured event through the client's backpressured destination. */
+  writeEventAsync(event: IDaemonEventEnvelope): Promise<void>;
+
+  /** Writes one operation-scoped output chunk through the client's backpressured destination. */
+  writeLogChunkAsync(
+    operationId: string,
+    stream: 'stdout' | 'stderr',
+    chunk: Uint8Array
+  ): Promise<void>;
+}

--- a/libraries/rush-daemon/src/PhasedRequestClient.ts
+++ b/libraries/rush-daemon/src/PhasedRequestClient.ts
@@ -18,6 +18,9 @@ export interface IPhasedRequestClient {
   /** The connection session identifier used in structured event envelopes. */
   readonly sessionId: string;
 
+  /** Returns the next structured-event sequence number for this connection. */
+  getNextEventSequence(): number;
+
   /** Writes one structured event through the client's backpressured destination. */
   writeEventAsync(event: IDaemonEventEnvelope): Promise<void>;
 

--- a/libraries/rush-daemon/src/PhasedRequestEventMultiplexer.ts
+++ b/libraries/rush-daemon/src/PhasedRequestEventMultiplexer.ts
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import type {
+  IOperationExecutionResult,
+  OperationStatus,
+  _IOperationActivityOptions,
+  _IOperationGraphEventSink
+} from '@microsoft/rush-lib';
+import type { ITerminalChunk } from '@rushstack/terminal';
+
+export class PhasedRequestEventMultiplexer implements _IOperationGraphEventSink {
+  readonly #workspaceSink: _IOperationGraphEventSink | undefined;
+  #requestSink: _IOperationGraphEventSink | undefined;
+
+  public constructor(workspaceSink: _IOperationGraphEventSink | undefined) {
+    this.#workspaceSink = workspaceSink;
+  }
+
+  public subscribe(requestSink: _IOperationGraphEventSink): () => void {
+    if (this.#requestSink) {
+      throw new Error('A phased request event subscription is already active.');
+    }
+    this.#requestSink = requestSink;
+    let subscribed: boolean = true;
+    return () => {
+      if (subscribed) {
+        subscribed = false;
+        if (this.#requestSink === requestSink) {
+          this.#requestSink = undefined;
+        }
+      }
+    };
+  }
+
+  public onOperationRegistered(operationId: string, silent: boolean): void {
+    this.#workspaceSink?.onOperationRegistered?.(operationId, silent);
+    this.#requestSink?.onOperationRegistered?.(operationId, silent);
+  }
+
+  public onOperationStatusChanged(
+    result: IOperationExecutionResult,
+    previousStatus: OperationStatus
+  ): void {
+    this.#workspaceSink?.onOperationStatusChanged?.(result, previousStatus);
+    this.#requestSink?.onOperationStatusChanged?.(result, previousStatus);
+  }
+
+  public onOperationHeader(operationId: string, completed: number, total: number): void {
+    this.#workspaceSink?.onOperationHeader?.(operationId, completed, total);
+    this.#requestSink?.onOperationHeader?.(operationId, completed, total);
+  }
+
+  public onOperationChunk(operationId: string, chunk: ITerminalChunk): void {
+    this.#workspaceSink?.onOperationChunk?.(operationId, chunk);
+    this.#requestSink?.onOperationChunk?.(operationId, chunk);
+  }
+
+  public onOperationStreamClosed(operationId: string): void {
+    this.#workspaceSink?.onOperationStreamClosed?.(operationId);
+    this.#requestSink?.onOperationStreamClosed?.(operationId);
+  }
+
+  public onActivity(text: string, options?: _IOperationActivityOptions): void {
+    this.#workspaceSink?.onActivity?.(text, options);
+    this.#requestSink?.onActivity?.(text, options);
+  }
+}

--- a/libraries/rush-daemon/src/PhasedRequestEventSink.ts
+++ b/libraries/rush-daemon/src/PhasedRequestEventSink.ts
@@ -50,8 +50,8 @@ class OrderedClientWriter {
     this.#onFailure = onFailure;
   }
 
-  public writeEvent(event: IDaemonEventEnvelope): void {
-    this.#enqueue(() => this.#client.writeEventAsync(event));
+  public writeEvent(createEvent: () => IDaemonEventEnvelope): void {
+    this.#enqueue(() => this.#client.writeEventAsync(createEvent()));
   }
 
   public writeLogChunk(
@@ -159,10 +159,14 @@ export class PhasedRequestEventSink implements _IOperationGraphEventSink {
 
   public onOperationStreamClosed(operationId: string): void {
     if (this.#activeOperationIds.has(operationId)) {
-      this.#emitEvent('extension', {
-        data: { operationId },
-        name: RUSHD_OPERATION_STREAM_CLOSED
-      });
+      this.#emitEvent(
+        'extension',
+        {
+          data: { operationId },
+          name: RUSHD_OPERATION_STREAM_CLOSED
+        },
+        { required: true }
+      );
     }
   }
 
@@ -179,15 +183,14 @@ export class PhasedRequestEventSink implements _IOperationGraphEventSink {
   }
 
   #emitEvent(type: DaemonEventType, payload: unknown, options?: IEventOptions): void {
-    const sequence: number = this.#getNextSequence();
-    this.#writer.writeEvent({
+    this.#writer.writeEvent(() => ({
       eventId: randomUUID(),
       payload,
       privacy: 'public',
       protocolVersion: DAEMON_PROTOCOL_VERSION,
       required: options?.required ?? false,
       scope: options?.scope,
-      sequence,
+      sequence: this.#getNextSequence(),
       sessionId: this.#client.sessionId,
       source: {
         component: EVENT_SOURCE_COMPONENT,
@@ -196,6 +199,6 @@ export class PhasedRequestEventSink implements _IOperationGraphEventSink {
       },
       timestamp: new Date().toISOString(),
       type
-    });
+    }));
   }
 }

--- a/libraries/rush-daemon/src/PhasedRequestEventSink.ts
+++ b/libraries/rush-daemon/src/PhasedRequestEventSink.ts
@@ -1,0 +1,201 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { randomUUID } from 'node:crypto';
+
+import type {
+  IOperationExecutionResult,
+  Operation,
+  OperationStatus,
+  _IOperationActivityOptions,
+  _IOperationGraphEventSink
+} from '@microsoft/rush-lib';
+import {
+  DAEMON_PROTOCOL_VERSION,
+  RUSHD_OPERATION_HEADER,
+  RUSHD_OPERATION_STREAM_CLOSED
+} from '@rushstack/rush-daemon-protocol';
+import type {
+  DaemonEventType,
+  IDaemonEventEnvelope,
+  IDaemonEventScope
+} from '@rushstack/rush-daemon-protocol';
+import { TerminalChunkKind } from '@rushstack/terminal';
+import type { ITerminalChunk } from '@rushstack/terminal';
+
+import type { IPhasedRequestClient } from './PhasedRequestClient';
+
+const EVENT_SOURCE_PACKAGE: string = '@microsoft/rush-lib';
+const EVENT_SOURCE_COMPONENT: string = 'OperationGraph';
+const TEXT_ENCODER: InstanceType<typeof TextEncoder> = new TextEncoder();
+
+interface IObservedOperationResult {
+  readonly errorMessage: string | undefined;
+  readonly status: string;
+}
+
+interface IEventOptions {
+  readonly required?: boolean;
+  readonly scope?: IDaemonEventScope;
+}
+
+class OrderedClientWriter {
+  readonly #client: IPhasedRequestClient;
+  readonly #onFailure: () => void;
+  #failure: Error | undefined;
+  #tail: Promise<void> = Promise.resolve();
+
+  public constructor(client: IPhasedRequestClient, onFailure: () => void) {
+    this.#client = client;
+    this.#onFailure = onFailure;
+  }
+
+  public writeEvent(event: IDaemonEventEnvelope): void {
+    this.#enqueue(() => this.#client.writeEventAsync(event));
+  }
+
+  public writeLogChunk(
+    operationId: string,
+    stream: 'stdout' | 'stderr',
+    chunk: Uint8Array
+  ): void {
+    this.#enqueue(() => this.#client.writeLogChunkAsync(operationId, stream, chunk));
+  }
+
+  public async flushAsync(): Promise<void> {
+    await this.#tail;
+    if (this.#failure) {
+      throw this.#failure;
+    }
+  }
+
+  #enqueue(writeAsync: () => Promise<void>): void {
+    this.#tail = this.#tail.then(async () => {
+      if (this.#failure) {
+        return;
+      }
+      try {
+        await writeAsync();
+      } catch (error) {
+        this.#failure = error instanceof Error ? error : new Error(String(error));
+        this.#onFailure();
+      }
+    });
+  }
+}
+
+export class PhasedRequestEventSink implements _IOperationGraphEventSink {
+  readonly #activeOperationIds: ReadonlySet<string>;
+  readonly #client: IPhasedRequestClient;
+  readonly #getNextSequence: () => number;
+  readonly #observedResults: Map<Operation, IObservedOperationResult> = new Map();
+  readonly #rushVersion: string;
+  readonly #writer: OrderedClientWriter;
+
+  public constructor(options: {
+    activeOperationIds: ReadonlySet<string>;
+    client: IPhasedRequestClient;
+    getNextSequence: () => number;
+    onWriteFailure: () => void;
+    rushVersion: string;
+  }) {
+    this.#activeOperationIds = options.activeOperationIds;
+    this.#client = options.client;
+    this.#getNextSequence = options.getNextSequence;
+    this.#rushVersion = options.rushVersion;
+    this.#writer = new OrderedClientWriter(options.client, options.onWriteFailure);
+  }
+
+  public getObservedResult(operation: Operation): IObservedOperationResult | undefined {
+    return this.#observedResults.get(operation);
+  }
+
+  public flushAsync(): Promise<void> {
+    return this.#writer.flushAsync();
+  }
+
+  public onOperationRegistered(operationId: string, silent: boolean): void {
+    if (this.#activeOperationIds.has(operationId)) {
+      this.#emitEvent('operationRegistered', { operationId, silent });
+    }
+  }
+
+  public onOperationStatusChanged(
+    result: IOperationExecutionResult,
+    previousStatus: OperationStatus
+  ): void {
+    const operationId: string = result.operation.name;
+    if (!this.#activeOperationIds.has(operationId)) {
+      return;
+    }
+    this.#observedResults.set(result.operation, {
+      errorMessage: result.error?.message,
+      status: result.status
+    });
+    this.#emitEvent('operationStatusChanged', {
+      operationId,
+      previousStatus,
+      status: result.status
+    });
+  }
+
+  public onOperationHeader(operationId: string, completed: number, total: number): void {
+    if (this.#activeOperationIds.has(operationId)) {
+      this.#emitEvent('extension', {
+        data: { completedOperations: completed, operationId, totalOperations: total },
+        name: RUSHD_OPERATION_HEADER
+      });
+    }
+  }
+
+  public onOperationChunk(operationId: string, chunk: ITerminalChunk): void {
+    if (!this.#activeOperationIds.has(operationId)) {
+      return;
+    }
+    const stream: 'stdout' | 'stderr' =
+      chunk.kind === TerminalChunkKind.Stderr ? 'stderr' : 'stdout';
+    this.#writer.writeLogChunk(operationId, stream, TEXT_ENCODER.encode(chunk.text));
+  }
+
+  public onOperationStreamClosed(operationId: string): void {
+    if (this.#activeOperationIds.has(operationId)) {
+      this.#emitEvent('extension', {
+        data: { operationId },
+        name: RUSHD_OPERATION_STREAM_CLOSED
+      });
+    }
+  }
+
+  public onActivity(text: string, options?: _IOperationActivityOptions): void {
+    const operationId: string | undefined = options?.operationId;
+    if (!operationId || !this.#activeOperationIds.has(operationId)) {
+      return;
+    }
+    this.#emitEvent(
+      'activityChanged',
+      { stream: options?.stderr === true ? 'stderr' : 'stdout', text },
+      { required: true, scope: { operationId } }
+    );
+  }
+
+  #emitEvent(type: DaemonEventType, payload: unknown, options?: IEventOptions): void {
+    const sequence: number = this.#getNextSequence();
+    this.#writer.writeEvent({
+      eventId: randomUUID(),
+      payload,
+      privacy: 'public',
+      protocolVersion: DAEMON_PROTOCOL_VERSION,
+      required: options?.required ?? false,
+      scope: options?.scope,
+      sequence,
+      sessionId: this.#client.sessionId,
+      source: {
+        component: EVENT_SOURCE_COMPONENT,
+        packageName: EVENT_SOURCE_PACKAGE,
+        packageVersion: this.#rushVersion
+      },
+      timestamp: new Date().toISOString(),
+      type
+    });
+  }
+}

--- a/libraries/rush-daemon/src/PhasedRequestEventSink.ts
+++ b/libraries/rush-daemon/src/PhasedRequestEventSink.ts
@@ -30,7 +30,7 @@ const EVENT_SOURCE_COMPONENT: string = 'OperationGraph';
 const TEXT_ENCODER: InstanceType<typeof TextEncoder> = new TextEncoder();
 
 interface IObservedOperationResult {
-  readonly errorMessage: string | undefined;
+  readonly executionResult: IOperationExecutionResult;
   readonly status: string;
 }
 
@@ -129,7 +129,7 @@ export class PhasedRequestEventSink implements _IOperationGraphEventSink {
       return;
     }
     this.#observedResults.set(result.operation, {
-      errorMessage: result.error?.message,
+      executionResult: result,
       status: result.status
     });
     this.#emitEvent('operationStatusChanged', {
@@ -141,10 +141,14 @@ export class PhasedRequestEventSink implements _IOperationGraphEventSink {
 
   public onOperationHeader(operationId: string, completed: number, total: number): void {
     if (this.#activeOperationIds.has(operationId)) {
-      this.#emitEvent('extension', {
-        data: { completedOperations: completed, operationId, totalOperations: total },
-        name: RUSHD_OPERATION_HEADER
-      });
+      this.#emitEvent(
+        'extension',
+        {
+          data: { completedOperations: completed, operationId, totalOperations: total },
+          name: RUSHD_OPERATION_HEADER
+        },
+        { required: true }
+      );
     }
   }
 
@@ -172,13 +176,13 @@ export class PhasedRequestEventSink implements _IOperationGraphEventSink {
 
   public onActivity(text: string, options?: _IOperationActivityOptions): void {
     const operationId: string | undefined = options?.operationId;
-    if (!operationId || !this.#activeOperationIds.has(operationId)) {
+    if (operationId !== undefined && !this.#activeOperationIds.has(operationId)) {
       return;
     }
     this.#emitEvent(
       'activityChanged',
       { stream: options?.stderr === true ? 'stderr' : 'stdout', text },
-      { required: true, scope: { operationId } }
+      { required: true, scope: operationId === undefined ? undefined : { operationId } }
     );
   }
 

--- a/libraries/rush-daemon/src/PhasedRequestRouter.ts
+++ b/libraries/rush-daemon/src/PhasedRequestRouter.ts
@@ -39,12 +39,10 @@ interface IResolvedSelection {
 }
 
 interface IGraphRoutingState {
-  readonly eventSequenceBySessionId: Map<string, number>;
   readonly multiplexer: PhasedRequestEventMultiplexer;
   readonly scheduler: RequestScheduler;
 }
 
-const FIRST_SEQUENCE: number = 1;
 const ROUTING_STATE_BY_GRAPH: WeakMap<IOperationGraph, IGraphRoutingState> = new WeakMap();
 
 /**
@@ -139,7 +137,7 @@ export class PhasedRequestRouter {
     const requestSink: PhasedRequestEventSink = new PhasedRequestEventSink({
       activeOperationIds,
       client,
-      getNextSequence: () => getNextEventSequence(routingState, client.sessionId),
+      getNextSequence: () => client.getNextEventSequence(),
       onWriteFailure: abortIteration,
       rushVersion: this.#workspaceSession.metadata.rushVersion
     });
@@ -232,19 +230,13 @@ function getGraphRoutingState(graph: IDualEmitOperationGraph): IGraphRoutingStat
     const multiplexer: PhasedRequestEventMultiplexer = new PhasedRequestEventMultiplexer(
       getGraphEventSink(graph)
     );
-    state = { eventSequenceBySessionId: new Map(), multiplexer, scheduler: new RequestScheduler() };
+    state = { multiplexer, scheduler: new RequestScheduler() };
     ROUTING_STATE_BY_GRAPH.set(graph, state);
     setGraphEventSink(graph, multiplexer);
   } else if (getGraphEventSink(graph) !== state.multiplexer) {
     throw new Error('The workspace operation graph event sink changed after routing began.');
   }
   return state;
-}
-
-function getNextEventSequence(state: IGraphRoutingState, sessionId: string): number {
-  const sequence: number = state.eventSequenceBySessionId.get(sessionId) ?? FIRST_SEQUENCE;
-  state.eventSequenceBySessionId.set(sessionId, sequence + 1);
-  return sequence;
 }
 
 function validateRequestIdentity(request: IDaemonPhasedRequest): void {
@@ -344,6 +336,11 @@ function applySelection(graph: IOperationGraph, selection: IResolvedSelection): 
     'safe'
   );
   graph.setEnabledStates(selection.enabledOperations, true, 'safe');
+  graph.setEnabledStates(
+    selection.ignoreDependencyOperations,
+    'ignore-dependency-changes',
+    'unsafe'
+  );
 }
 
 function collectOperationResults(
@@ -360,7 +357,9 @@ function collectOperationResults(
     if (status === undefined) {
       continue;
     }
-    const errorMessage: string | undefined = observed?.errorMessage ?? retained?.error?.message;
+    const errorMessage: string | undefined = observed
+      ? observed.errorMessage
+      : retained?.error?.message;
     results.push({ operationId: operation.name, status, errorMessage });
   }
   return results;

--- a/libraries/rush-daemon/src/PhasedRequestRouter.ts
+++ b/libraries/rush-daemon/src/PhasedRequestRouter.ts
@@ -1,0 +1,392 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import type {
+  IOperationExecutionResult,
+  IOperationGraph,
+  Operation,
+  _IOperationGraphEventSink
+} from '@microsoft/rush-lib';
+import { OperationStatus } from '@microsoft/rush-lib';
+import type {
+  DaemonPhasedOperationEnabledState,
+  IDaemonPhasedEngineShape,
+  IDaemonPhasedOperationResult,
+  IDaemonPhasedOperationSelection,
+  IDaemonPhasedRequest,
+  IDaemonPhasedRequestResult
+} from '@rushstack/rush-daemon-protocol';
+
+import { PhasedRequestEventSink } from './PhasedRequestEventSink';
+import { PhasedRequestEventMultiplexer } from './PhasedRequestEventMultiplexer';
+import type { IPhasedRequestClient } from './PhasedRequestClient';
+import {
+  RequestExclusivityClass,
+  RequestScheduler,
+  RequestSchedulerError,
+  RequestSchedulerErrorCode
+} from './RequestScheduler';
+import type { IRequestLease } from './RequestScheduler';
+import type { IWorkspaceEngineShape } from './WorkspaceEngineComponentFactory';
+import type { IWorkspaceSession } from './WorkspaceSession';
+
+interface IDualEmitOperationGraph extends IOperationGraph {
+  eventSink: _IOperationGraphEventSink | undefined;
+}
+
+interface IResolvedSelection {
+  readonly enabledOperations: ReadonlyArray<Operation>;
+  readonly ignoreDependencyOperations: ReadonlyArray<Operation>;
+}
+
+interface IGraphRoutingState {
+  readonly eventSequenceBySessionId: Map<string, number>;
+  readonly multiplexer: PhasedRequestEventMultiplexer;
+  readonly scheduler: RequestScheduler;
+}
+
+const FIRST_SEQUENCE: number = 1;
+const ROUTING_STATE_BY_GRAPH: WeakMap<IOperationGraph, IGraphRoutingState> = new WeakMap();
+
+/**
+ * Routes one caller-resolved phased request through a real warm workspace operation graph.
+ *
+ * @remarks
+ * Command parsing, plugin loading, and graph construction remain integration-owned. Requests are serialized because
+ * shared-build selection merging is a later layer. Cancellation aborts only the current iteration and never closes
+ * the daemon-owned graph or its runners.
+ *
+ * @beta
+ */
+export class PhasedRequestRouter {
+  readonly #workspaceSession: IWorkspaceSession;
+
+  public constructor(workspaceSession: IWorkspaceSession) {
+    this.#workspaceSession = workspaceSession;
+  }
+
+  /** Validates and executes one resolved phased request against the warm graph. */
+  public async executeAsync(
+    request: IDaemonPhasedRequest,
+    client: IPhasedRequestClient
+  ): Promise<IDaemonPhasedRequestResult> {
+    const graph: IDualEmitOperationGraph = getDualEmitGraph(this.#workspaceSession);
+    const routingState: IGraphRoutingState = getGraphRoutingState(graph);
+    let lease: IRequestLease;
+    try {
+      lease = await routingState.scheduler.acquireAsync({
+        abortSignal: client.abortSignal,
+        exclusivityClass: RequestExclusivityClass.Exclusive
+      });
+    } catch (error) {
+      if (
+        error instanceof RequestSchedulerError &&
+        error.code === RequestSchedulerErrorCode.Aborted
+      ) {
+        return createAbortedResult(request.requestId);
+      }
+      throw error;
+    }
+
+    try {
+      return await this.#executeAdmittedAsync(request, client, graph, routingState);
+    } finally {
+      lease.release();
+    }
+  }
+
+  async #executeAdmittedAsync(
+    request: IDaemonPhasedRequest,
+    client: IPhasedRequestClient,
+    graph: IDualEmitOperationGraph,
+    routingState: IGraphRoutingState
+  ): Promise<IDaemonPhasedRequestResult> {
+    validateRequestIdentity(request);
+    validateEngineShape(request.engineShape, this.#workspaceSession.engineShape);
+    const operationById: ReadonlyMap<string, Operation> = indexOperations(graph.operations);
+    const selection: IResolvedSelection = resolveSelection(request.operationSelection, operationById);
+
+    if (client.abortSignal.aborted) {
+      return createAbortedResult(request.requestId);
+    }
+    if (graph.hasScheduledIteration || graph.status === OperationStatus.Executing) {
+      throw new Error('The warm workspace operation graph is not idle.');
+    }
+    await this.#workspaceSession.reconcileInvalidationsAsync();
+    if (client.abortSignal.aborted) {
+      return createAbortedResult(request.requestId);
+    }
+
+    applySelection(graph, selection);
+    const activeOperations: ReadonlyArray<Operation> = Array.from(graph.operations).filter(
+      (operation: Operation) => operation.enabled !== false
+    );
+    const activeOperationIds: ReadonlySet<string> = new Set(
+      activeOperations.map((operation: Operation) => operation.name)
+    );
+
+    let abortTail: Promise<void> = Promise.resolve();
+    const abortErrors: unknown[] = [];
+    let wasAborted: boolean = false;
+    const abortIteration = (): void => {
+      wasAborted = true;
+      abortTail = abortTail
+        .then(() => graph.abortCurrentIterationAsync())
+        .catch((error: unknown) => {
+          abortErrors.push(error);
+        });
+    };
+    const previousPauseNextIteration: boolean = graph.pauseNextIteration;
+    const requestSink: PhasedRequestEventSink = new PhasedRequestEventSink({
+      activeOperationIds,
+      client,
+      getNextSequence: () => getNextEventSequence(routingState, client.sessionId),
+      onWriteFailure: abortIteration,
+      rushVersion: this.#workspaceSession.metadata.rushVersion
+    });
+    const unsubscribe: () => void = routingState.multiplexer.subscribe(requestSink);
+    setPauseNextIteration(graph, true);
+    client.abortSignal.addEventListener('abort', abortIteration, { once: true });
+
+    let scheduled: boolean = false;
+    let executionError: unknown;
+    const iterationCleanupErrors: unknown[] = [];
+    try {
+      scheduled = await graph.scheduleIterationAsync({
+        inputsSnapshot: this.#workspaceSession.inputsSnapshot
+      });
+      if (scheduled) {
+        const executionPromise: Promise<boolean> = graph.executeScheduledIterationAsync();
+        if (wasAborted || client.abortSignal.aborted) {
+          await Promise.resolve();
+          abortIteration();
+        }
+        await executionPromise;
+      }
+    } catch (error) {
+      executionError = error;
+      if (graph.hasScheduledIteration) {
+        try {
+          const failedExecutionPromise: Promise<boolean> = graph.executeScheduledIterationAsync();
+          await Promise.resolve();
+          abortIteration();
+          await failedExecutionPromise;
+        } catch (cleanupError) {
+          iterationCleanupErrors.push(cleanupError);
+        }
+      }
+    }
+
+    await abortTail;
+    unsubscribe();
+    setPauseNextIteration(graph, previousPauseNextIteration);
+    client.abortSignal.removeEventListener('abort', abortIteration);
+    const cleanupErrors: unknown[] = [...iterationCleanupErrors, ...abortErrors];
+    const observedAbortErrorCount: number = abortErrors.length;
+    try {
+      await requestSink.flushAsync();
+    } catch (error) {
+      cleanupErrors.push(error);
+    }
+    await abortTail;
+    cleanupErrors.push(...abortErrors.slice(observedAbortErrorCount));
+    throwCombinedErrors(executionError, cleanupErrors);
+
+    return {
+      aborted: wasAborted || client.abortSignal.aborted,
+      operationResults: collectOperationResults(activeOperations, graph, requestSink),
+      requestId: request.requestId,
+      scheduled
+    };
+  }
+}
+
+function getDualEmitGraph(workspaceSession: IWorkspaceSession): IDualEmitOperationGraph {
+  const graph: IOperationGraph | undefined = workspaceSession.operationGraph;
+  if (!graph) {
+    throw new Error('The workspace session does not provide a reusable operation graph.');
+  }
+  if (!('eventSink' in graph)) {
+    throw new Error('The workspace operation graph does not support Rush dual-emit events.');
+  }
+  return graph as IDualEmitOperationGraph;
+}
+
+function getGraphEventSink(graph: IDualEmitOperationGraph): _IOperationGraphEventSink | undefined {
+  return graph.eventSink;
+}
+
+function setGraphEventSink(
+  graph: IDualEmitOperationGraph,
+  eventSink: _IOperationGraphEventSink | undefined
+): void {
+  graph.eventSink = eventSink;
+}
+
+function setPauseNextIteration(graph: IOperationGraph, pauseNextIteration: boolean): void {
+  graph.pauseNextIteration = pauseNextIteration;
+}
+
+function getGraphRoutingState(graph: IDualEmitOperationGraph): IGraphRoutingState {
+  let state: IGraphRoutingState | undefined = ROUTING_STATE_BY_GRAPH.get(graph);
+  if (!state) {
+    const multiplexer: PhasedRequestEventMultiplexer = new PhasedRequestEventMultiplexer(
+      getGraphEventSink(graph)
+    );
+    state = { eventSequenceBySessionId: new Map(), multiplexer, scheduler: new RequestScheduler() };
+    ROUTING_STATE_BY_GRAPH.set(graph, state);
+    setGraphEventSink(graph, multiplexer);
+  } else if (getGraphEventSink(graph) !== state.multiplexer) {
+    throw new Error('The workspace operation graph event sink changed after routing began.');
+  }
+  return state;
+}
+
+function getNextEventSequence(state: IGraphRoutingState, sessionId: string): number {
+  const sequence: number = state.eventSequenceBySessionId.get(sessionId) ?? FIRST_SEQUENCE;
+  state.eventSequenceBySessionId.set(sessionId, sequence + 1);
+  return sequence;
+}
+
+function validateRequestIdentity(request: IDaemonPhasedRequest): void {
+  validateNonemptyName(request.requestId, 'request id');
+  validateNonemptyName(request.commandName, 'command name');
+}
+
+function validateNonemptyName(value: string, kind: string): void {
+  if (value.length === 0 || value.trim() !== value) {
+    throw new Error(`Invalid phased request ${kind}: "${value}".`);
+  }
+}
+
+function validateEngineShape(
+  requestShape: IDaemonPhasedEngineShape,
+  workspaceShape: IWorkspaceEngineShape | undefined
+): void {
+  if (!workspaceShape) {
+    throw new Error('The workspace session does not declare a reusable engine shape.');
+  }
+  validateNameSet(requestShape.phaseNames, workspaceShape.phaseNames, 'phase');
+  validateNameSet(requestShape.pluginNames, workspaceShape.pluginNames, 'plugin');
+}
+
+function validateNameSet(
+  requestedNames: ReadonlyArray<string>,
+  workspaceNames: ReadonlyArray<string>,
+  kind: string
+): void {
+  const requested: Set<string> = new Set(requestedNames);
+  if (
+    requested.size !== requestedNames.length ||
+    requested.size !== workspaceNames.length ||
+    workspaceNames.some((name: string) => !requested.has(name))
+  ) {
+    throw new Error(`The phased request ${kind} shape does not match the warm workspace engine.`);
+  }
+}
+
+function indexOperations(operations: ReadonlySet<Operation>): ReadonlyMap<string, Operation> {
+  const operationById: Map<string, Operation> = new Map();
+  for (const operation of operations) {
+    const operationId: string = operation.name;
+    if (operationById.has(operationId)) {
+      throw new Error(`The workspace graph contains duplicate operation id "${operationId}".`);
+    }
+    operationById.set(operationId, operation);
+  }
+  return operationById;
+}
+
+function resolveSelection(
+  requestedSelection: ReadonlyArray<IDaemonPhasedOperationSelection>,
+  operationById: ReadonlyMap<string, Operation>
+): IResolvedSelection {
+  if (requestedSelection.length === 0) {
+    throw new Error('A phased request must select at least one operation.');
+  }
+  const selectedIds: Set<string> = new Set();
+  const enabledOperations: Operation[] = [];
+  const ignoreDependencyOperations: Operation[] = [];
+  for (const selection of requestedSelection) {
+    validateNonemptyName(selection.operationId, 'operation id');
+    if (selectedIds.has(selection.operationId)) {
+      throw new Error(`Duplicate phased request operation id "${selection.operationId}".`);
+    }
+    selectedIds.add(selection.operationId);
+    const operation: Operation | undefined = operationById.get(selection.operationId);
+    if (!operation) {
+      throw new Error(`Unknown phased request operation id "${selection.operationId}".`);
+    }
+    addSelectedOperation(selection.enabledState, operation, enabledOperations, ignoreDependencyOperations);
+  }
+  return { enabledOperations, ignoreDependencyOperations };
+}
+
+function addSelectedOperation(
+  enabledState: DaemonPhasedOperationEnabledState,
+  operation: Operation,
+  enabledOperations: Operation[],
+  ignoreDependencyOperations: Operation[]
+): void {
+  if (enabledState === true) {
+    enabledOperations.push(operation);
+  } else {
+    ignoreDependencyOperations.push(operation);
+  }
+}
+
+function applySelection(graph: IOperationGraph, selection: IResolvedSelection): void {
+  graph.setEnabledStates(graph.operations, false, 'unsafe');
+  graph.setEnabledStates(
+    selection.ignoreDependencyOperations,
+    'ignore-dependency-changes',
+    'safe'
+  );
+  graph.setEnabledStates(selection.enabledOperations, true, 'safe');
+}
+
+function collectOperationResults(
+  activeOperations: ReadonlyArray<Operation>,
+  graph: IOperationGraph,
+  requestSink: PhasedRequestEventSink
+): ReadonlyArray<IDaemonPhasedOperationResult> {
+  const results: IDaemonPhasedOperationResult[] = [];
+  for (const operation of [...activeOperations].sort(compareOperations)) {
+    const observed: ReturnType<PhasedRequestEventSink['getObservedResult']> =
+      requestSink.getObservedResult(operation);
+    const retained: IOperationExecutionResult | undefined = graph.resultByOperation.get(operation);
+    const status: string | undefined = observed?.status ?? retained?.status;
+    if (status === undefined) {
+      continue;
+    }
+    const errorMessage: string | undefined = observed?.errorMessage ?? retained?.error?.message;
+    results.push({ operationId: operation.name, status, errorMessage });
+  }
+  return results;
+}
+
+function compareOperations(left: Operation, right: Operation): number {
+  return left.name.localeCompare(right.name);
+}
+
+function createAbortedResult(requestId: string): IDaemonPhasedRequestResult {
+  return { aborted: true, operationResults: [], requestId, scheduled: false };
+}
+
+function throwCombinedErrors(executionError: unknown, cleanupErrors: unknown[]): void {
+  if (executionError !== undefined && cleanupErrors.length > 0) {
+    throw new AggregateError(
+      [executionError, ...cleanupErrors],
+      'The phased request failed and could not clean up its client subscription.'
+    );
+  }
+  if (executionError !== undefined) {
+    throw executionError;
+  }
+  if (cleanupErrors.length === 1) {
+    throw cleanupErrors[0];
+  }
+  if (cleanupErrors.length > 1) {
+    throw new AggregateError(cleanupErrors, 'Failed to clean up the phased request client subscription.');
+  }
+}

--- a/libraries/rush-daemon/src/PhasedRequestRouter.ts
+++ b/libraries/rush-daemon/src/PhasedRequestRouter.ts
@@ -9,7 +9,6 @@ import type {
 } from '@microsoft/rush-lib';
 import { OperationStatus } from '@microsoft/rush-lib';
 import type {
-  DaemonPhasedOperationEnabledState,
   IDaemonPhasedEngineShape,
   IDaemonPhasedOperationResult,
   IDaemonPhasedOperationSelection,
@@ -323,15 +322,17 @@ function resolveSelection(
 }
 
 function addSelectedOperation(
-  enabledState: DaemonPhasedOperationEnabledState,
+  enabledState: unknown,
   operation: Operation,
   enabledOperations: Operation[],
   ignoreDependencyOperations: Operation[]
 ): void {
   if (enabledState === true) {
     enabledOperations.push(operation);
-  } else {
+  } else if (enabledState === 'ignore-dependency-changes') {
     ignoreDependencyOperations.push(operation);
+  } else {
+    throw new Error(`Invalid phased request enabled state: "${String(enabledState)}".`);
   }
 }
 

--- a/libraries/rush-daemon/src/PhasedRequestRouter.ts
+++ b/libraries/rush-daemon/src/PhasedRequestRouter.ts
@@ -358,7 +358,7 @@ function collectOperationResults(
       continue;
     }
     const errorMessage: string | undefined = observed
-      ? observed.errorMessage
+      ? observed.executionResult.error?.message
       : retained?.error?.message;
     results.push({ operationId: operation.name, status, errorMessage });
   }

--- a/libraries/rush-daemon/src/index.ts
+++ b/libraries/rush-daemon/src/index.ts
@@ -42,3 +42,5 @@ export {
   WorkspaceInvalidationTracker,
   type IWorkspaceInvalidationSnapshot
 } from './WorkspaceInvalidationTracker';
+export { type IPhasedRequestClient } from './PhasedRequestClient';
+export { PhasedRequestRouter } from './PhasedRequestRouter';

--- a/libraries/rush-daemon/src/test/PhasedRequestEventSink.test.ts
+++ b/libraries/rush-daemon/src/test/PhasedRequestEventSink.test.ts
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import type { IDaemonEventEnvelope } from '@rushstack/rush-daemon-protocol';
+
+import { PhasedRequestEventSink } from '../PhasedRequestEventSink';
+import { TestPhasedRequestClient } from './PhasedRequestRouterTestUtilities';
+
+const ACTIVE_OPERATION: string = 'project-a (_phase:test)';
+const OTHER_OPERATION: string = 'project-b (_phase:test)';
+
+function createSink(client: TestPhasedRequestClient): PhasedRequestEventSink {
+  return new PhasedRequestEventSink({
+    activeOperationIds: new Set([ACTIVE_OPERATION]),
+    client,
+    getNextSequence: () => client.getNextEventSequence(),
+    onWriteFailure: () => undefined,
+    rushVersion: '5.178.1'
+  });
+}
+
+it('forwards unscoped and active activity while filtering other operation activity', async () => {
+  const client: TestPhasedRequestClient = new TestPhasedRequestClient();
+  const sink: PhasedRequestEventSink = createSink(client);
+  sink.onActivity('request summary');
+  sink.onActivity('active detail', { operationId: ACTIVE_OPERATION });
+  sink.onActivity('other detail', { operationId: OTHER_OPERATION });
+
+  await sink.flushAsync();
+
+  const activities: IDaemonEventEnvelope[] = client.writes
+    .map(({ event }) => event)
+    .filter(
+      (event: IDaemonEventEnvelope | undefined): event is IDaemonEventEnvelope =>
+        event?.type === 'activityChanged'
+    );
+  expect(activities.map(({ payload }) => payload)).toEqual([
+    { stream: 'stdout', text: 'request summary' },
+    { stream: 'stdout', text: 'active detail' }
+  ]);
+  expect(activities.map(({ scope }) => scope)).toEqual([
+    undefined,
+    { operationId: ACTIVE_OPERATION }
+  ]);
+  expect(activities.every(({ required }) => required)).toBe(true);
+});

--- a/libraries/rush-daemon/src/test/PhasedRequestRouter.test.ts
+++ b/libraries/rush-daemon/src/test/PhasedRequestRouter.test.ts
@@ -7,6 +7,7 @@ import type {
   IDaemonPhasedOperationSelection,
   IDaemonPhasedRequest
 } from '@rushstack/rush-daemon-protocol';
+import { RUSHD_OPERATION_STREAM_CLOSED } from '@rushstack/rush-daemon-protocol';
 import { OperationStatus } from '@microsoft/rush-lib';
 
 import { PhasedRequestRouter } from '../PhasedRequestRouter';
@@ -143,6 +144,23 @@ describe(PhasedRequestRouter.name, () => {
     expect(ignoredDependencyFixture.operations.get(OPERATION_A)?.enabled).toBe(
       'ignore-dependency-changes'
     );
+
+    const mixedFixture: ITestRoutingFixture = createThreeOperationFixture();
+    await new PhasedRequestRouter(mixedFixture.session).executeAsync(
+      createRequest([
+        {
+          enabledState: 'ignore-dependency-changes',
+          operationId: OPERATION_A
+        },
+        select(OPERATION_B)
+      ]),
+      new TestPhasedRequestClient()
+    );
+
+    expect(mixedFixture.operations.get(OPERATION_A)?.enabled).toBe(
+      'ignore-dependency-changes'
+    );
+    expect(mixedFixture.operations.get(OPERATION_B)?.enabled).toBe(true);
   });
 
   it('reconciles invalidations, applies the safe dependency closure, and runs one iteration', async () => {
@@ -220,6 +238,50 @@ describe(PhasedRequestRouter.name, () => {
       .map(getEventOperationId)
       .filter((operationId: string | undefined): operationId is string => !!operationId);
     expect(new Set(eventOperationIds)).toEqual(new Set([OPERATION_A]));
+    const streamClosedEvent: IDaemonEventEnvelope | undefined = client.writes
+      .map((write: ITestClientWrite) => write.event)
+      .find(
+        (event: IDaemonEventEnvelope | undefined) =>
+          (event?.payload as { name?: unknown } | undefined)?.name ===
+          RUSHD_OPERATION_STREAM_CLOSED
+      );
+    expect(streamClosedEvent?.required).toBe(true);
+  });
+
+  it('allocates event sequences when queued writes are invoked', async () => {
+    let releaseFirstEvent: (() => void) | undefined;
+    let markFirstEventStarted: (() => void) | undefined;
+    const firstEventStarted: Promise<void> = new Promise<void>((resolve) => {
+      markFirstEventStarted = resolve;
+    });
+    const fixture: ITestRoutingFixture = createThreeOperationFixture();
+    const client: TestPhasedRequestClient = new TestPhasedRequestClient();
+    let hasBlockedEvent: boolean = false;
+    client.onWriteAsync = async (write: ITestClientWrite): Promise<void> => {
+      if (write.event && !hasBlockedEvent) {
+        hasBlockedEvent = true;
+        markFirstEventStarted?.();
+        await new Promise<void>((resolve) => {
+          releaseFirstEvent = resolve;
+        });
+      }
+    };
+
+    const requestPromise = new PhasedRequestRouter(fixture.session).executeAsync(
+      createRequest([select(OPERATION_A)]),
+      client
+    );
+    await firstEventStarted;
+    const interleavedSequence: number = client.getNextEventSequence();
+    releaseFirstEvent?.();
+    await requestPromise;
+
+    const routedSequences: number[] = client.writes
+      .map(({ event }) => event?.sequence)
+      .filter((sequence: number | undefined): sequence is number => sequence !== undefined);
+    expect(routedSequences[0]).toBe(1);
+    expect(interleavedSequence).toBe(2);
+    expect(routedSequences.slice(1).every((sequence) => sequence > interleavedSequence)).toBe(true);
   });
 
   it('returns client-scoped failures without converting them to routing errors', async () => {
@@ -287,6 +349,48 @@ describe(PhasedRequestRouter.name, () => {
       new TestPhasedRequestClient()
     );
     expect(followUp.operationResults[0]?.status).toBe(OperationStatus.Success);
+  });
+
+  it('does not combine an observed result with an error retained from a prior iteration', async () => {
+    let invocation: number = 0;
+    let releaseOperationA: (() => void) | undefined;
+    let markOperationAStarted: (() => void) | undefined;
+    const operationAStarted: Promise<void> = new Promise<void>((resolve) => {
+      markOperationAStarted = resolve;
+    });
+    const fixture: ITestRoutingFixture = createThreeOperationFixture({
+      actionAAsync: async (): Promise<void> => {
+        if (invocation++ === 0) {
+          throw new Error('first iteration failure');
+        }
+        markOperationAStarted?.();
+        await new Promise<void>((resolve) => {
+          releaseOperationA = resolve;
+        });
+      }
+    });
+    const router: PhasedRequestRouter = new PhasedRequestRouter(fixture.session);
+    const first = await router.executeAsync(
+      createRequest([select(OPERATION_B)]),
+      new TestPhasedRequestClient()
+    );
+    expect(
+      first.operationResults.find(({ operationId }) => operationId === OPERATION_A)?.errorMessage
+    ).toBe('first iteration failure');
+
+    const secondClient: TestPhasedRequestClient = new TestPhasedRequestClient();
+    const secondPromise = router.executeAsync(
+      { ...createRequest([select(OPERATION_B)]), requestId: 'request-2' },
+      secondClient
+    );
+    await operationAStarted;
+    secondClient.abortController.abort();
+    releaseOperationA?.();
+    const second = await secondPromise;
+
+    expect(
+      second.operationResults.find(({ operationId }) => operationId === OPERATION_A)?.errorMessage
+    ).toBeUndefined();
   });
 
   it('aborts and unsubscribes when a disconnected client rejects a write', async () => {
@@ -398,8 +502,9 @@ describe(PhasedRequestRouter.name, () => {
       }
     });
     const router: PhasedRequestRouter = new PhasedRequestRouter(fixture.session);
-    const firstClient: TestPhasedRequestClient = new TestPhasedRequestClient();
-    const secondClient: TestPhasedRequestClient = new TestPhasedRequestClient();
+    const sequenceState: { next: number } = { next: 1 };
+    const firstClient: TestPhasedRequestClient = new TestPhasedRequestClient(sequenceState);
+    const secondClient: TestPhasedRequestClient = new TestPhasedRequestClient(sequenceState);
 
     const first = await router.executeAsync(
       createRequest([select(OPERATION_A)]),

--- a/libraries/rush-daemon/src/test/PhasedRequestRouter.test.ts
+++ b/libraries/rush-daemon/src/test/PhasedRequestRouter.test.ts
@@ -1,0 +1,387 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import type { ITerminal } from '@rushstack/terminal';
+import type {
+  IDaemonEventEnvelope,
+  IDaemonPhasedOperationSelection,
+  IDaemonPhasedRequest
+} from '@rushstack/rush-daemon-protocol';
+import { OperationStatus } from '@microsoft/rush-lib';
+
+import { PhasedRequestRouter } from '../PhasedRequestRouter';
+import {
+  TEST_ENGINE_SHAPE,
+  TestOperationRunner,
+  TestPhasedRequestClient,
+  createRoutingFixture
+} from './PhasedRequestRouterTestUtilities';
+import type {
+  ITestClientWrite,
+  ITestRoutingFixture
+} from './PhasedRequestRouterTestUtilities';
+
+const OPERATION_A: string = 'project-a (_phase:test)';
+const OPERATION_B: string = 'project-b (_phase:test)';
+const OPERATION_C: string = 'project-c (_phase:test)';
+
+function createRequest(
+  operationSelection: ReadonlyArray<IDaemonPhasedOperationSelection>
+): IDaemonPhasedRequest {
+  return {
+    commandName: 'build',
+    engineShape: TEST_ENGINE_SHAPE,
+    operationSelection,
+    requestId: 'request-1'
+  };
+}
+
+function select(operationId: string): IDaemonPhasedOperationSelection {
+  return { enabledState: true, operationId };
+}
+
+function createThreeOperationFixture(options?: {
+  actionAAsync?: (terminal: ITerminal) => Promise<void>;
+  statusA?: OperationStatus;
+}): ITestRoutingFixture {
+  return createRoutingFixture(
+    new Map([
+      [
+        OPERATION_A,
+        new TestOperationRunner(
+          OPERATION_A,
+          options?.statusA ?? OperationStatus.Success,
+          options?.actionAAsync
+        )
+      ],
+      [OPERATION_B, new TestOperationRunner(OPERATION_B)],
+      [OPERATION_C, new TestOperationRunner(OPERATION_C)]
+    ]),
+    [[OPERATION_B, OPERATION_A]]
+  );
+}
+
+function getEventOperationId(event: IDaemonEventEnvelope): string | undefined {
+  if (event.scope?.operationId) {
+    return event.scope.operationId;
+  }
+  const payload: unknown = event.payload;
+  if (typeof payload !== 'object' || payload === null) {
+    return undefined;
+  }
+  const operationId: unknown = (payload as { operationId?: unknown }).operationId;
+  if (typeof operationId === 'string') {
+    return operationId;
+  }
+  const data: unknown = (payload as { data?: unknown }).data;
+  if (typeof data !== 'object' || data === null) {
+    return undefined;
+  }
+  const nestedOperationId: unknown = (data as { operationId?: unknown }).operationId;
+  return typeof nestedOperationId === 'string' ? nestedOperationId : undefined;
+}
+
+describe(PhasedRequestRouter.name, () => {
+  it('rejects invalid selections and an engine-shape mismatch before scheduling', async () => {
+    const fixture: ITestRoutingFixture = createThreeOperationFixture();
+    const router: PhasedRequestRouter = new PhasedRequestRouter(fixture.session);
+    const client: TestPhasedRequestClient = new TestPhasedRequestClient();
+    const scheduleSpy: jest.SpyInstance = jest.spyOn(fixture.graph, 'scheduleIterationAsync');
+
+    await expect(router.executeAsync(createRequest([]), client)).rejects.toThrow(
+      'must select at least one operation'
+    );
+    await expect(
+      router.executeAsync(createRequest([select('unknown operation')]), client)
+    ).rejects.toThrow('Unknown phased request operation id');
+    await expect(
+      router.executeAsync(createRequest([select(OPERATION_A), select(OPERATION_A)]), client)
+    ).rejects.toThrow('Duplicate phased request operation id');
+    await expect(
+      router.executeAsync(
+        { ...createRequest([select(OPERATION_A)]), engineShape: { phaseNames: ['other'], pluginNames: [] } },
+        client
+      )
+    ).rejects.toThrow('phase shape does not match');
+    expect(scheduleSpy).not.toHaveBeenCalled();
+  });
+
+  it('reconciles invalidations, applies the safe dependency closure, and runs one iteration', async () => {
+    const order: string[] = [];
+    const fixture: ITestRoutingFixture = createThreeOperationFixture({
+      actionAAsync: async (): Promise<void> => {
+        order.push('run');
+      }
+    });
+    fixture.session.onReconcileAsync = async (): Promise<void> => {
+      order.push('reconcile');
+    };
+    fixture.graph.hooks.onIterationScheduled.tap('test', () => {
+      order.push('schedule');
+    });
+    const scheduleSpy: jest.SpyInstance = jest.spyOn(fixture.graph, 'scheduleIterationAsync');
+    const executeSpy: jest.SpyInstance = jest.spyOn(
+      fixture.graph,
+      'executeScheduledIterationAsync'
+    );
+
+    const result = await new PhasedRequestRouter(fixture.session).executeAsync(
+      createRequest([select(OPERATION_B)]),
+      new TestPhasedRequestClient()
+    );
+
+    expect(order).toEqual(['reconcile', 'schedule', 'run']);
+    expect(scheduleSpy).toHaveBeenCalledTimes(1);
+    expect(executeSpy).toHaveBeenCalledTimes(1);
+    expect(fixture.runners.get(OPERATION_A)?.runCount).toBe(1);
+    expect(fixture.runners.get(OPERATION_B)?.runCount).toBe(1);
+    expect(fixture.runners.get(OPERATION_C)?.runCount).toBe(0);
+    expect(result.operationResults.map(({ operationId }) => operationId)).toEqual([
+      OPERATION_A,
+      OPERATION_B
+    ]);
+    expect(result.scheduled).toBe(true);
+  });
+
+  it('forwards only enabled operations with ordered client backpressure', async () => {
+    const fixture: ITestRoutingFixture = createThreeOperationFixture({
+      actionAAsync: async (terminal: ITerminal): Promise<void> => {
+        terminal.writeLine('stdout-a');
+        terminal.writeErrorLine('stderr-a');
+      }
+    });
+    const client: TestPhasedRequestClient = new TestPhasedRequestClient();
+    let concurrentWrites: number = 0;
+    let maximumConcurrentWrites: number = 0;
+    client.onWriteAsync = async (): Promise<void> => {
+      concurrentWrites++;
+      maximumConcurrentWrites = Math.max(maximumConcurrentWrites, concurrentWrites);
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      concurrentWrites--;
+    };
+
+    await new PhasedRequestRouter(fixture.session).executeAsync(
+      createRequest([select(OPERATION_A)]),
+      client
+    );
+
+    expect(maximumConcurrentWrites).toBe(1);
+    const logWrites: ITestClientWrite[] = client.writes.filter(
+      (write: ITestClientWrite) => write.text !== undefined
+    );
+    expect(logWrites.map(({ operationId }) => operationId)).toEqual([
+      OPERATION_A,
+      OPERATION_A
+    ]);
+    expect(logWrites.map(({ stream }) => stream)).toEqual(['stdout', 'stderr']);
+    expect(logWrites.map(({ text }) => text)).toEqual(['stdout-a\n', 'stderr-a\n']);
+    const eventOperationIds: string[] = client.writes
+      .map((write: ITestClientWrite) => write.event)
+      .filter((event: IDaemonEventEnvelope | undefined): event is IDaemonEventEnvelope => !!event)
+      .map(getEventOperationId)
+      .filter((operationId: string | undefined): operationId is string => !!operationId);
+    expect(new Set(eventOperationIds)).toEqual(new Set([OPERATION_A]));
+  });
+
+  it('returns client-scoped failures without converting them to routing errors', async () => {
+    const fixture: ITestRoutingFixture = createThreeOperationFixture({
+      statusA: OperationStatus.Failure
+    });
+
+    const result = await new PhasedRequestRouter(fixture.session).executeAsync(
+      createRequest([select(OPERATION_A)]),
+      new TestPhasedRequestClient()
+    );
+
+    expect(result.operationResults).toEqual([
+      { errorMessage: undefined, operationId: OPERATION_A, status: OperationStatus.Failure }
+    ]);
+  });
+
+  it('aborts a cancelled iteration, restores subscriptions, and keeps runners reusable', async () => {
+    let releaseOperationA: (() => void) | undefined;
+    let markOperationAStarted: (() => void) | undefined;
+    const operationAStarted: Promise<void> = new Promise<void>((resolve) => {
+      markOperationAStarted = resolve;
+    });
+    const fixture: ITestRoutingFixture = createThreeOperationFixture({
+      actionAAsync: async (): Promise<void> => {
+        markOperationAStarted?.();
+        await new Promise<void>((resolve) => {
+          releaseOperationA = resolve;
+        });
+      }
+    });
+    let workspaceStatusEventCount: number = 0;
+    const previousSink = {
+      onOperationStatusChanged: (): void => {
+        workspaceStatusEventCount++;
+      }
+    };
+    fixture.graph.eventSink = previousSink;
+    const client: TestPhasedRequestClient = new TestPhasedRequestClient();
+    const router: PhasedRequestRouter = new PhasedRequestRouter(fixture.session);
+    const requestPromise = router.executeAsync(
+      createRequest([select(OPERATION_B)]),
+      client
+    );
+    await operationAStarted;
+    client.abortController.abort();
+    releaseOperationA?.();
+
+    const result = await requestPromise;
+
+    expect(result.aborted).toBe(true);
+    expect(
+      result.operationResults.find(({ operationId }) => operationId === OPERATION_B)?.status
+    ).toBe(OperationStatus.Aborted);
+    expect(fixture.graph.pauseNextIteration).toBe(false);
+    expect(fixture.runners.get(OPERATION_A)?.closeCount).toBe(0);
+    expect(fixture.runners.get(OPERATION_B)?.closeCount).toBe(0);
+    const completedClientWriteCount: number = client.writes.length;
+    fixture.graph.invalidateOperations(undefined, 'after request');
+    expect(client.writes).toHaveLength(completedClientWriteCount);
+    expect(workspaceStatusEventCount).toBeGreaterThan(0);
+
+    const followUp = await router.executeAsync(
+      createRequest([select(OPERATION_C)]),
+      new TestPhasedRequestClient()
+    );
+    expect(followUp.operationResults[0]?.status).toBe(OperationStatus.Success);
+  });
+
+  it('aborts and unsubscribes when a disconnected client rejects a write', async () => {
+    let releaseOperationA: (() => void) | undefined;
+    const fixture: ITestRoutingFixture = createThreeOperationFixture({
+      actionAAsync: async (terminal: ITerminal): Promise<void> => {
+        terminal.writeLine('disconnect');
+        await new Promise<void>((resolve) => {
+          releaseOperationA = resolve;
+        });
+      }
+    });
+    const client: TestPhasedRequestClient = new TestPhasedRequestClient();
+    client.onWriteAsync = async (write: ITestClientWrite): Promise<void> => {
+      if (write.text !== undefined) {
+        releaseOperationA?.();
+        throw new Error('client disconnected');
+      }
+    };
+
+    await expect(
+      new PhasedRequestRouter(fixture.session).executeAsync(
+        createRequest([select(OPERATION_B)]),
+        client
+      )
+    ).rejects.toThrow('client disconnected');
+    expect(fixture.graph.pauseNextIteration).toBe(false);
+    expect(fixture.runners.get(OPERATION_A)?.closeCount).toBe(0);
+  });
+
+  it('re-aborts after an early write failure crosses the schedule boundary', async () => {
+    const fixture: ITestRoutingFixture = createThreeOperationFixture();
+    const client: TestPhasedRequestClient = new TestPhasedRequestClient();
+    client.onWriteAsync = async (): Promise<void> => {
+      throw new Error('client disconnected before execution');
+    };
+
+    await expect(
+      new PhasedRequestRouter(fixture.session).executeAsync(
+        createRequest([select(OPERATION_B)]),
+        client
+      )
+    ).rejects.toThrow('client disconnected before execution');
+    expect(fixture.runners.get(OPERATION_B)?.runCount).toBe(0);
+    expect(fixture.graph.hasScheduledIteration).toBe(false);
+  });
+
+  it('serializes independent router instances that share one warm graph', async () => {
+    let releaseOperationA: (() => void) | undefined;
+    let markOperationAStarted: (() => void) | undefined;
+    const operationAStarted: Promise<void> = new Promise<void>((resolve) => {
+      markOperationAStarted = resolve;
+    });
+    const fixture: ITestRoutingFixture = createThreeOperationFixture({
+      actionAAsync: async (): Promise<void> => {
+        markOperationAStarted?.();
+        await new Promise<void>((resolve) => {
+          releaseOperationA = resolve;
+        });
+      }
+    });
+    const firstPromise = new PhasedRequestRouter(fixture.session).executeAsync(
+      createRequest([select(OPERATION_A)]),
+      new TestPhasedRequestClient()
+    );
+    await operationAStarted;
+    const secondPromise = new PhasedRequestRouter(fixture.session).executeAsync(
+      { ...createRequest([select(OPERATION_C)]), requestId: 'request-2' },
+      new TestPhasedRequestClient()
+    );
+    await Promise.resolve();
+    expect(fixture.runners.get(OPERATION_C)?.runCount).toBe(0);
+    releaseOperationA?.();
+
+    await Promise.all([firstPromise, secondPromise]);
+    expect(fixture.runners.get(OPERATION_C)?.runCount).toBe(1);
+  });
+
+  it('drains and aborts a scheduled iteration when a scheduling hook fails', async () => {
+    const fixture: ITestRoutingFixture = createThreeOperationFixture();
+    fixture.graph.hooks.onIterationScheduled.tap('throwing test hook', () => {
+      throw new Error('scheduling hook failed');
+    });
+
+    await expect(
+      new PhasedRequestRouter(fixture.session).executeAsync(
+        createRequest([select(OPERATION_A)]),
+        new TestPhasedRequestClient()
+      )
+    ).rejects.toThrow('scheduling hook failed');
+    expect(fixture.graph.hasScheduledIteration).toBe(false);
+    expect(fixture.graph.status).not.toBe(OperationStatus.Executing);
+    const completedRunCount: number = fixture.runners.get(OPERATION_A)?.runCount ?? 0;
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(fixture.runners.get(OPERATION_A)?.runCount).toBe(completedRunCount);
+  });
+
+  it('returns retained results when real graph hooks collapse a repeated warm request to no work', async () => {
+    const fixture: ITestRoutingFixture = createThreeOperationFixture();
+    let iteration: number = 0;
+    fixture.graph.hooks.configureIteration.tap('warm no-op', (records, previousResults) => {
+      if (iteration++ === 0) {
+        return;
+      }
+      for (const record of records.values()) {
+        if (previousResults.has(record.operation)) {
+          record.enabled = false;
+        }
+      }
+    });
+    const router: PhasedRequestRouter = new PhasedRequestRouter(fixture.session);
+    const firstClient: TestPhasedRequestClient = new TestPhasedRequestClient();
+    const secondClient: TestPhasedRequestClient = new TestPhasedRequestClient();
+
+    const first = await router.executeAsync(
+      createRequest([select(OPERATION_A)]),
+      firstClient
+    );
+    const second = await router.executeAsync(
+      { ...createRequest([select(OPERATION_A)]), requestId: 'request-2' },
+      secondClient
+    );
+
+    expect(first.scheduled).toBe(true);
+    expect(second.scheduled).toBe(false);
+    expect(second.operationResults).toEqual(first.operationResults);
+    expect(fixture.runners.get(OPERATION_A)?.runCount).toBe(1);
+    const firstSequences: number[] = firstClient.writes
+      .map(({ event }) => event?.sequence)
+      .filter((sequence: number | undefined): sequence is number => sequence !== undefined);
+    const secondSequences: number[] = secondClient.writes
+      .map(({ event }) => event?.sequence)
+      .filter((sequence: number | undefined): sequence is number => sequence !== undefined);
+    expect(firstSequences.length).toBeGreaterThan(0);
+    expect(secondSequences[0]).toBeGreaterThan(firstSequences[firstSequences.length - 1]);
+  });
+});

--- a/libraries/rush-daemon/src/test/PhasedRequestRouter.test.ts
+++ b/libraries/rush-daemon/src/test/PhasedRequestRouter.test.ts
@@ -7,7 +7,10 @@ import type {
   IDaemonPhasedOperationSelection,
   IDaemonPhasedRequest
 } from '@rushstack/rush-daemon-protocol';
-import { RUSHD_OPERATION_STREAM_CLOSED } from '@rushstack/rush-daemon-protocol';
+import {
+  RUSHD_OPERATION_HEADER,
+  RUSHD_OPERATION_STREAM_CLOSED
+} from '@rushstack/rush-daemon-protocol';
 import { OperationStatus } from '@microsoft/rush-lib';
 
 import { PhasedRequestRouter } from '../PhasedRequestRouter';
@@ -204,7 +207,7 @@ describe(PhasedRequestRouter.name, () => {
     const fixture: ITestRoutingFixture = createThreeOperationFixture({
       actionAAsync: async (terminal: ITerminal): Promise<void> => {
         terminal.writeLine('stdout-a');
-        terminal.writeErrorLine('stderr-a');
+        terminal.writeErrorLine('stderr-a', { doNotOverrideSgrCodes: true });
       }
     });
     const client: TestPhasedRequestClient = new TestPhasedRequestClient();
@@ -527,5 +530,41 @@ describe(PhasedRequestRouter.name, () => {
       .filter((sequence: number | undefined): sequence is number => sequence !== undefined);
     expect(firstSequences.length).toBeGreaterThan(0);
     expect(secondSequences[0]).toBeGreaterThan(firstSequences[firstSequences.length - 1]);
+  });
+
+  it('uses authoritative header totals after a partial warm iteration', async () => {
+    const fixture: ITestRoutingFixture = createThreeOperationFixture();
+    let iteration: number = 0;
+    fixture.graph.hooks.configureIteration.tap('partial warm iteration', (records, previousResults) => {
+      if (iteration++ === 0) {
+        return;
+      }
+      for (const record of records.values()) {
+        if (record.operation.name === OPERATION_A && previousResults.has(record.operation)) {
+          record.enabled = false;
+        }
+      }
+    });
+    const router: PhasedRequestRouter = new PhasedRequestRouter(fixture.session);
+    await router.executeAsync(createRequest([select(OPERATION_B)]), new TestPhasedRequestClient());
+    const client: TestPhasedRequestClient = new TestPhasedRequestClient();
+
+    await router.executeAsync(
+      { ...createRequest([select(OPERATION_B)]), requestId: 'request-2' },
+      client
+    );
+
+    const headers: IDaemonEventEnvelope[] = client.writes
+      .map(({ event }) => event)
+      .filter(
+        (event: IDaemonEventEnvelope | undefined): event is IDaemonEventEnvelope =>
+          (event?.payload as { name?: unknown } | undefined)?.name === RUSHD_OPERATION_HEADER
+      );
+    expect(headers).toHaveLength(1);
+    expect(headers[0]?.required).toBe(true);
+    expect(headers[0]?.payload).toEqual({
+      data: { completedOperations: 1, operationId: OPERATION_B, totalOperations: 1 },
+      name: RUSHD_OPERATION_HEADER
+    });
   });
 });

--- a/libraries/rush-daemon/src/test/PhasedRequestRouter.test.ts
+++ b/libraries/rush-daemon/src/test/PhasedRequestRouter.test.ts
@@ -40,6 +40,13 @@ function select(operationId: string): IDaemonPhasedOperationSelection {
   return { enabledState: true, operationId };
 }
 
+function selectRuntimeValue(
+  operationId: string,
+  enabledState: unknown
+): IDaemonPhasedOperationSelection {
+  return { enabledState, operationId } as unknown as IDaemonPhasedOperationSelection;
+}
+
 function createThreeOperationFixture(options?: {
   actionAAsync?: (terminal: ITerminal) => Promise<void>;
   statusA?: OperationStatus;
@@ -97,6 +104,14 @@ describe(PhasedRequestRouter.name, () => {
     await expect(
       router.executeAsync(createRequest([select(OPERATION_A), select(OPERATION_A)]), client)
     ).rejects.toThrow('Duplicate phased request operation id');
+    for (const enabledState of [false, 'invalid-state']) {
+      await expect(
+        router.executeAsync(
+          createRequest([selectRuntimeValue(OPERATION_A, enabledState)]),
+          client
+        )
+      ).rejects.toThrow(`Invalid phased request enabled state: "${String(enabledState)}"`);
+    }
     await expect(
       router.executeAsync(
         { ...createRequest([select(OPERATION_A)]), engineShape: { phaseNames: ['other'], pluginNames: [] } },
@@ -104,6 +119,30 @@ describe(PhasedRequestRouter.name, () => {
       )
     ).rejects.toThrow('phase shape does not match');
     expect(scheduleSpy).not.toHaveBeenCalled();
+  });
+
+  it('accepts both enabled states declared by the protocol', async () => {
+    const trueFixture: ITestRoutingFixture = createThreeOperationFixture();
+    await new PhasedRequestRouter(trueFixture.session).executeAsync(
+      createRequest([select(OPERATION_A)]),
+      new TestPhasedRequestClient()
+    );
+
+    const ignoredDependencyFixture: ITestRoutingFixture = createThreeOperationFixture();
+    await new PhasedRequestRouter(ignoredDependencyFixture.session).executeAsync(
+      createRequest([
+        {
+          enabledState: 'ignore-dependency-changes',
+          operationId: OPERATION_A
+        }
+      ]),
+      new TestPhasedRequestClient()
+    );
+
+    expect(trueFixture.operations.get(OPERATION_A)?.enabled).toBe(true);
+    expect(ignoredDependencyFixture.operations.get(OPERATION_A)?.enabled).toBe(
+      'ignore-dependency-changes'
+    );
   });
 
   it('reconciles invalidations, applies the safe dependency closure, and runs one iteration', async () => {

--- a/libraries/rush-daemon/src/test/PhasedRequestRouterTestUtilities.ts
+++ b/libraries/rush-daemon/src/test/PhasedRequestRouterTestUtilities.ts
@@ -1,0 +1,222 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { MockWritable } from '@rushstack/terminal';
+import type { ITerminal } from '@rushstack/terminal';
+import type {
+  IInputsSnapshot,
+  IOperationGraph,
+  IOperationRunner,
+  IOperationRunnerContext,
+  IPhase,
+  RushConfiguration,
+  RushSession
+} from '@microsoft/rush-lib';
+import { Operation, OperationStatus } from '@microsoft/rush-lib';
+import { OperationGraph } from '@microsoft/rush-lib/lib/logic/operations/OperationGraph';
+import type { IOperationGraphOptions } from '@microsoft/rush-lib/lib/logic/operations/OperationGraph';
+import type { IDaemonEventEnvelope } from '@rushstack/rush-daemon-protocol';
+
+import type { IPhasedRequestClient } from '../PhasedRequestClient';
+import type {
+  IWorkspaceEngineShape,
+  IWorkspaceInvalidationReconciliation
+} from '../WorkspaceEngineComponentFactory';
+import type {
+  IWorkspaceSession,
+  IWorkspaceSessionMetadata
+} from '../WorkspaceSession';
+import { WorkspaceInvalidationTracker } from '../WorkspaceInvalidationTracker';
+import { TEST_RUSH_CONFIGURATION, TEST_REPO_ROOT } from './TestWorkspaceSession';
+
+export const TEST_ENGINE_SHAPE: IWorkspaceEngineShape = {
+  phaseNames: ['_phase:test'],
+  pluginNames: ['test-plugin']
+};
+
+const TEST_PHASE: IPhase = {
+  allowWarningsOnSuccess: false,
+  associatedParameters: new Set(),
+  dependencies: { self: new Set(), upstream: new Set() },
+  isSynthetic: false,
+  logFilenameIdentifier: '_phase_test',
+  missingScriptBehavior: 'silent',
+  name: TEST_ENGINE_SHAPE.phaseNames[0]
+};
+
+export interface ITestClientWrite {
+  readonly event?: IDaemonEventEnvelope;
+  readonly operationId?: string;
+  readonly stream?: 'stdout' | 'stderr';
+  readonly text?: string;
+}
+
+export class TestPhasedRequestClient implements IPhasedRequestClient {
+  public readonly abortController: AbortController = new AbortController();
+  public readonly sessionId: string = 'test-session';
+  public readonly writes: ITestClientWrite[] = [];
+  public onWriteAsync: ((write: ITestClientWrite) => Promise<void>) | undefined;
+
+  public get abortSignal(): AbortSignal {
+    return this.abortController.signal;
+  }
+
+  public async writeEventAsync(event: IDaemonEventEnvelope): Promise<void> {
+    const write: ITestClientWrite = { event };
+    await this.onWriteAsync?.(write);
+    this.writes.push(write);
+  }
+
+  public async writeLogChunkAsync(
+    operationId: string,
+    stream: 'stdout' | 'stderr',
+    chunk: Uint8Array
+  ): Promise<void> {
+    const write: ITestClientWrite = {
+      operationId,
+      stream,
+      text: new TextDecoder().decode(chunk)
+    };
+    await this.onWriteAsync?.(write);
+    this.writes.push(write);
+  }
+}
+
+export class TestOperationRunner implements IOperationRunner {
+  public readonly cacheable: boolean = false;
+  public readonly reportTiming: boolean = true;
+  public readonly silent: boolean = false;
+  public readonly warningsAreAllowed: boolean = false;
+  public closeCount: number = 0;
+  public runCount: number = 0;
+
+  readonly #actionAsync: ((terminal: ITerminal) => Promise<void>) | undefined;
+  readonly #status: OperationStatus;
+  public readonly name: string;
+
+  public constructor(
+    name: string,
+    status: OperationStatus = OperationStatus.Success,
+    actionAsync?: (terminal: ITerminal) => Promise<void>
+  ) {
+    this.name = name;
+    this.#status = status;
+    this.#actionAsync = actionAsync;
+  }
+
+  public closeAsync(): Promise<void> {
+    this.closeCount++;
+    return Promise.resolve();
+  }
+
+  public executeAsync(context: IOperationRunnerContext): Promise<OperationStatus> {
+    this.runCount++;
+    return context.runWithTerminalAsync(
+      async (terminal: ITerminal): Promise<OperationStatus> => {
+        await this.#actionAsync?.(terminal);
+        return this.#status;
+      },
+      { createLogFile: false, logFileSuffix: '' }
+    );
+  }
+
+  public getConfigHash(): string {
+    return this.name;
+  }
+}
+
+export interface ITestRoutingFixture {
+  readonly graph: OperationGraph;
+  readonly operations: ReadonlyMap<string, Operation>;
+  readonly runners: ReadonlyMap<string, TestOperationRunner>;
+  readonly session: TestRoutingWorkspaceSession;
+}
+
+export class TestRoutingWorkspaceSession implements IWorkspaceSession {
+  public readonly engineShape: IWorkspaceEngineShape = TEST_ENGINE_SHAPE;
+  public readonly inputsSnapshot: IInputsSnapshot | undefined = undefined;
+  public readonly invalidations: WorkspaceInvalidationTracker = new WorkspaceInvalidationTracker();
+  public readonly metadata: IWorkspaceSessionMetadata = {
+    projectCount: 3,
+    projectNames: ['project-a', 'project-b', 'project-c'],
+    repoRoot: TEST_REPO_ROOT,
+    rushJsonFile: TEST_RUSH_CONFIGURATION.rushJsonFile,
+    rushVersion: '5.178.1'
+  };
+  public readonly rushConfiguration: RushConfiguration = TEST_RUSH_CONFIGURATION;
+  public readonly rushSession: RushSession | undefined = undefined;
+  public readonly operationGraph: IOperationGraph;
+  public onReconcileAsync: (() => Promise<void>) | undefined;
+
+  public constructor(operationGraph: IOperationGraph) {
+    this.operationGraph = operationGraph;
+  }
+
+  public async reconcileInvalidationsAsync(): Promise<
+    IWorkspaceInvalidationReconciliation | undefined
+  > {
+    await this.onReconcileAsync?.();
+    return undefined;
+  }
+
+  public async [Symbol.asyncDispose](): Promise<void> {
+    this.operationGraph.abortController.abort();
+    await this.operationGraph.abortCurrentIterationAsync();
+    await this.operationGraph.closeRunnersAsync();
+  }
+}
+
+export function createRoutingFixture(
+  runnerById: ReadonlyMap<string, TestOperationRunner>,
+  dependencies: ReadonlyArray<readonly [string, string]> = []
+): ITestRoutingFixture {
+  const operations: Map<string, Operation> = new Map();
+  const runners: Map<string, TestOperationRunner> = new Map(runnerById);
+  let projectIndex: number = 0;
+  for (const [operationId, runner] of runners) {
+    const project = TEST_RUSH_CONFIGURATION.projects[projectIndex++];
+    if (!project) {
+      throw new Error('The test Rush configuration does not have enough projects.');
+    }
+    operations.set(
+      operationId,
+      new Operation({
+        logFilenameIdentifier: operationId,
+        phase: TEST_PHASE,
+        project,
+        runner
+      })
+    );
+  }
+  for (const [consumerId, dependencyId] of dependencies) {
+    const consumer: Operation | undefined = operations.get(consumerId);
+    const dependency: Operation | undefined = operations.get(dependencyId);
+    if (!consumer || !dependency) {
+      throw new Error('The test dependency references an unknown operation.');
+    }
+    consumer.addDependency(dependency);
+  }
+
+  const graphOptions: IOperationGraphOptions = {
+    abortController: new AbortController(),
+    allowOversubscription: true,
+    debugMode: false,
+    destinations: [new MockWritable()],
+    parallelism: 1,
+    pauseNextIteration: false,
+    quietMode: false
+  };
+  // The package's bundled public declarations and deep-import declarations describe the same runtime classes,
+  // but TypeScript assigns them distinct recursive identities.
+  const graph: OperationGraph = new OperationGraph(
+    new Set(operations.values()) as unknown as ConstructorParameters<typeof OperationGraph>[0],
+    graphOptions
+  );
+  const publicGraph: IOperationGraph = graph as unknown as IOperationGraph;
+  return {
+    graph,
+    operations,
+    runners,
+    session: new TestRoutingWorkspaceSession(publicGraph)
+  };
+}

--- a/libraries/rush-daemon/src/test/PhasedRequestRouterTestUtilities.ts
+++ b/libraries/rush-daemon/src/test/PhasedRequestRouterTestUtilities.ts
@@ -56,9 +56,20 @@ export class TestPhasedRequestClient implements IPhasedRequestClient {
   public readonly sessionId: string = 'test-session';
   public readonly writes: ITestClientWrite[] = [];
   public onWriteAsync: ((write: ITestClientWrite) => Promise<void>) | undefined;
+  readonly #sequenceState: { next: number };
+
+  public constructor(sequenceState: { next: number } = { next: 1 }) {
+    this.#sequenceState = sequenceState;
+  }
 
   public get abortSignal(): AbortSignal {
     return this.abortController.signal;
+  }
+
+  public getNextEventSequence(): number {
+    const sequence: number = this.#sequenceState.next;
+    this.#sequenceState.next = sequence + 1;
+    return sequence;
   }
 
   public async writeEventAsync(event: IDaemonEventEnvelope): Promise<void> {

--- a/libraries/rush-terminal-renderer/src/HostEventRouter.ts
+++ b/libraries/rush-terminal-renderer/src/HostEventRouter.ts
@@ -5,8 +5,10 @@ import {
   type DaemonVerbosity,
   type IDaemonEventEnvelope,
   type IDaemonExtensionEventPayload,
+  type IDaemonOperationHeaderPayload,
   type IDaemonOperationRegisteredPayload,
   type IDaemonOperationStreamClosedPayload,
+  RUSHD_OPERATION_HEADER,
   RUSHD_OPERATION_STREAM_CLOSED,
   shouldSerializeDaemonEvent
 } from '@rushstack/rush-daemon-protocol';
@@ -20,11 +22,7 @@ function readScopeOperationId(envelope: IDaemonEventEnvelope): string | undefine
   return scope === undefined ? undefined : scope.operationId;
 }
 
-/**
- * Routes decoded event envelopes between the collator (stream-affecting and
- * operation-scoped events) and the verbosity-filtered renderer.
- * @internal
- */
+/** Routes decoded events between the operation collator and renderer. @internal */
 export class HostEventRouter {
   private readonly _streams: OperationStreamRegistry;
   private readonly _renderer: IDaemonRenderer;
@@ -40,7 +38,6 @@ export class HostEventRouter {
     this._verbosity = verbosity;
   }
 
-  /** Routes one decoded `0x05` event envelope. */
   public routeEvent(envelope: IDaemonEventEnvelope): void {
     this._trackOperationLifecycle(envelope);
     if (this._routeScopedActivity(envelope)) {
@@ -67,6 +64,10 @@ export class HostEventRouter {
   }
 
   private _trackExtension(payload: IDaemonExtensionEventPayload): void {
+    if (payload.name === RUSHD_OPERATION_HEADER) {
+      this._streams.setOperationHeader(payload.data as IDaemonOperationHeaderPayload);
+      return;
+    }
     if (payload.name === RUSHD_OPERATION_STREAM_CLOSED) {
       const data: IDaemonOperationStreamClosedPayload =
         payload.data as IDaemonOperationStreamClosedPayload;
@@ -74,9 +75,6 @@ export class HostEventRouter {
     }
   }
 
-  // Operation-scoped activity lines are part of the operation's output block
-  // (legacy writes them to the operation's collated stream, bypassing the
-  // quiet-mode stdout discard), so they route to the collator, not the renderer.
   private _routeScopedActivity(envelope: IDaemonEventEnvelope): boolean {
     const operationId: string | undefined = readScopeOperationId(envelope);
     if (envelope.type !== 'activityChanged' || operationId === undefined) {

--- a/libraries/rush-terminal-renderer/src/OperationHeaderTracker.ts
+++ b/libraries/rush-terminal-renderer/src/OperationHeaderTracker.ts
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import type { IDaemonOperationHeaderPayload } from '@rushstack/rush-daemon-protocol';
+
+const INITIAL_OPERATION_COUNT: number = 0;
+const OPERATION_COUNT_INCREMENT: number = 1;
+
+export class OperationHeaderTracker {
+  private readonly _headerByOperation: Map<string, IDaemonOperationHeaderPayload> = new Map();
+  private _completedOperations: number = INITIAL_OPERATION_COUNT;
+  private _totalOperations: number = INITIAL_OPERATION_COUNT;
+
+  public registerOperation(): void {
+    this._totalOperations += OPERATION_COUNT_INCREMENT;
+  }
+
+  public setOperationHeader(header: IDaemonOperationHeaderPayload): void {
+    this._headerByOperation.set(header.operationId, header);
+  }
+
+  public takeOperationHeader(operationId: string): IDaemonOperationHeaderPayload {
+    const header: IDaemonOperationHeaderPayload | undefined =
+      this._headerByOperation.get(operationId);
+    if (header !== undefined) {
+      this._headerByOperation.delete(operationId);
+      this._completedOperations = header.completedOperations;
+      this._totalOperations = header.totalOperations;
+      return header;
+    }
+    this._completedOperations += OPERATION_COUNT_INCREMENT;
+    return {
+      completedOperations: this._completedOperations,
+      operationId,
+      totalOperations: this._totalOperations
+    };
+  }
+}

--- a/libraries/rush-terminal-renderer/src/OperationStreamRegistry.ts
+++ b/libraries/rush-terminal-renderer/src/OperationStreamRegistry.ts
@@ -2,11 +2,13 @@
 // See LICENSE in the project root for license information.
 
 import { NewlineKind } from '@rushstack/node-core-library';
+import type { IDaemonOperationHeaderPayload } from '@rushstack/rush-daemon-protocol';
 import { CollatedTerminal, StreamCollator } from '@rushstack/stream-collator';
 import type { CollatedWriter } from '@rushstack/stream-collator';
 import { TextRewriterTransform } from '@rushstack/terminal';
 import type { ITerminalChunk, TerminalWritable } from '@rushstack/terminal';
 
+import { OperationHeaderTracker } from './OperationHeaderTracker';
 import { formatDaemonOperationHeader } from './RendererHeader';
 
 /** Options for {@link OperationStreamRegistry}. @beta */
@@ -29,16 +31,12 @@ export interface IOperationStreamRegistryOptions {
 export class OperationStreamRegistry {
   private readonly _collator: StreamCollator;
   private readonly _collatedTerminal: CollatedTerminal;
-  private readonly _writers: Map<string, CollatedWriter>;
+  private readonly _headers: OperationHeaderTracker = new OperationHeaderTracker();
+  private readonly _writers: Map<string, CollatedWriter> = new Map();
   private readonly _quiet: boolean;
-  private _completedOperations: number;
-  private _totalOperations: number;
 
   public constructor(options: IOperationStreamRegistryOptions) {
-    this._writers = new Map();
     this._quiet = options.quiet;
-    this._completedOperations = 0;
-    this._totalOperations = 0;
     const transform: TextRewriterTransform = new TextRewriterTransform({
       destination: options.destination,
       normalizeNewlines: NewlineKind.OsDefault,
@@ -53,7 +51,12 @@ export class OperationStreamRegistry {
 
   /** Increments the total-operation count shown in headers. */
   public registerOperation(): void {
-    this._totalOperations += 1;
+    this._headers.registerOperation();
+  }
+
+  /** Records engine-authoritative counters before an operation's stream activates. */
+  public setOperationHeader(header: IDaemonOperationHeaderPayload): void {
+    this._headers.setOperationHeader(header);
   }
 
   /** Writes one raw chunk to the operation's collated stream. */
@@ -78,11 +81,13 @@ export class OperationStreamRegistry {
     if (writer === undefined) {
       return;
     }
-    this._completedOperations += 1;
+    const counters: IDaemonOperationHeaderPayload = this._headers.takeOperationHeader(
+      writer.taskName
+    );
     const header: string = formatDaemonOperationHeader(
       writer.taskName,
-      this._completedOperations,
-      this._totalOperations
+      counters.completedOperations,
+      counters.totalOperations
     );
     this._collatedTerminal.writeStdoutLine(`\n${header}`);
     if (!this._quiet) {

--- a/libraries/rush-terminal-renderer/src/test/RendererOperationHeader.test.ts
+++ b/libraries/rush-terminal-renderer/src/test/RendererOperationHeader.test.ts
@@ -1,0 +1,66 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import type { DaemonVerbosity, IDaemonEventEnvelope } from '@rushstack/rush-daemon-protocol';
+import {
+  RUSHD_OPERATION_HEADER,
+  RUSHD_OPERATION_STREAM_CLOSED
+} from '@rushstack/rush-daemon-protocol';
+
+import { DaemonRendererHost } from '../DaemonRendererHost';
+
+import { TestTerminal } from './TestTerminal';
+
+const OPERATION_ID: string = 'op-a';
+const PROTOCOL_MAJOR: number = 0;
+const PROTOCOL_MINOR: number = 1;
+const EVENT_SEQUENCE: number = 1;
+const VERBOSITIES: ReadonlyArray<DaemonVerbosity> = ['quiet', 'normal', 'verbose', 'debug'];
+
+const BASE_ENVELOPE = {
+  eventId: 'event',
+  privacy: 'public',
+  protocolVersion: { major: PROTOCOL_MAJOR, minor: PROTOCOL_MINOR },
+  required: false,
+  sequence: EVENT_SEQUENCE,
+  sessionId: 'session',
+  source: { packageName: 'test', packageVersion: '0' },
+  timestamp: '2026-08-25T00:00:00.000Z'
+} as const;
+
+function extension(name: string, data: unknown): IDaemonEventEnvelope {
+  return {
+    ...BASE_ENVELOPE,
+    payload: { data, name },
+    required: true,
+    type: 'extension'
+  };
+}
+
+it('uses authoritative partial-warm header counters at every verbosity', async () => {
+  for (const verbosity of VERBOSITIES) {
+    const terminal: TestTerminal = new TestTerminal();
+    const host: DaemonRendererHost = new DaemonRendererHost({ terminal, verbosity });
+    await host.initializeAsync();
+    for (const operationId of [OPERATION_ID, 'warm-op']) {
+      host.handleEvent({
+        ...BASE_ENVELOPE,
+        payload: { operationId, silent: false },
+        type: 'operationRegistered'
+      });
+    }
+    host.handleEvent(
+      extension(RUSHD_OPERATION_HEADER, {
+        completedOperations: EVENT_SEQUENCE,
+        operationId: OPERATION_ID,
+        totalOperations: EVENT_SEQUENCE
+      })
+    );
+    host.handleLogChunk(OPERATION_ID, 'stderr', new TextEncoder().encode('failure\n'));
+    host.handleEvent(extension(RUSHD_OPERATION_STREAM_CLOSED, { operationId: OPERATION_ID }));
+
+    expect(terminal.stdout).toContain('1 of 1');
+    expect(terminal.stdout).not.toContain('1 of 2');
+    await host.closeAsync();
+  }
+});


### PR DESCRIPTION
## Summary

Routes caller-resolved phased requests through the warm Rush daemon workspace graph, including request-scoped event and output forwarding, cancellation, result collection, and safe enabled-state selection.

This PR supersedes mojaza/rushstack#2 and follows the merged microsoft/rushstack#5949. It references microsoft/rushstack#5897 and PBI https://onedrive.visualstudio.com/EFun/_workitems/edit/3216020.

## Details

- Adds phased request and result contracts to `@rushstack/rush-daemon-protocol`.
- Adds the phased request router, client boundary, graph event multiplexer, and request-scoped event sink to `@rushstack/rush-daemon`.
- Preserves explicit enabled states after dependency closure, keeps retained warm results distinct from current observed results, and makes stream-close delivery authoritative for every verbosity.
- Keeps structured event sequences connection-owned and allocates them when queued writes are invoked, avoiding warm-graph session retention and out-of-order interleaving.
- Includes API reports, README updates, change files, focused routing tests, and the current-main lockfile importer update.

## Limitations

microsoft/rushstack#5895 remains open and limits this layer: the upstream engine prerequisites are not yet complete, notably host-controlled per-iteration persistent versus one-shot runner lifetime. Shared-build merging, broader admission scheduling, and final daemon cutover remain follow-up work under microsoft/rushstack#5897.

This draft awaits human review and is not ready to merge.

## How it was tested

- `node common/scripts/install-run-rush.js install --from @rushstack/rush-daemon`
- `node common/scripts/install-run-rush.js test --to @rushstack/rush-daemon`
- `node common/scripts/install-run-rush.js test --only @rushstack/rush-daemon`
- API Extractor generated-file validation for `@rushstack/rush-daemon` completed cleanly on the final run.