### PR TITLE
[rush] Omit registry URLs from the bootstrap lockfile

### DIFF
--- a/common/config/rush/.npmrc
+++ b/common/config/rush/.npmrc
@@ -1,0 +1,1 @@
+omit-lockfile-registry-resolved=true

--- a/common/config/validation/rush-package-lock.json
+++ b/common/config/validation/rush-package-lock.json
@@ -14,7 +14,6 @@
     },
     "node_modules/@azure/abort-controller": {
       "version": "2.2.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@azure/abort-controller/-/abort-controller-2.2.0.tgz",
       "integrity": "sha1-k+DoKwGGLn6jtbaZWHGdPz/SyKw=",
       "license": "MIT",
       "dependencies": {
@@ -26,7 +25,6 @@
     },
     "node_modules/@azure/core-auth": {
       "version": "1.11.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@azure/core-auth/-/core-auth-1.11.0.tgz",
       "integrity": "sha1-Ha7/32LRqHHSK4ZfnzFkpj6h9XU=",
       "license": "MIT",
       "dependencies": {
@@ -40,7 +38,6 @@
     },
     "node_modules/@azure/core-client": {
       "version": "1.11.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@azure/core-client/-/core-client-1.11.0.tgz",
       "integrity": "sha1-5z0JrHl33l17QVaWt+1F0/3rZ7A=",
       "license": "MIT",
       "dependencies": {
@@ -58,7 +55,6 @@
     },
     "node_modules/@azure/core-http-compat": {
       "version": "2.5.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@azure/core-http-compat/-/core-http-compat-2.5.0.tgz",
       "integrity": "sha1-14BmGln4pDL+yyt8b6LVgi3KHeo=",
       "license": "MIT",
       "dependencies": {
@@ -74,7 +70,6 @@
     },
     "node_modules/@azure/core-lro": {
       "version": "2.7.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@azure/core-lro/-/core-lro-2.7.2.tgz",
       "integrity": "sha1-eHEFAnog5Fx3ZRqYsBpNOwG3Wgg=",
       "license": "MIT",
       "dependencies": {
@@ -89,7 +84,6 @@
     },
     "node_modules/@azure/core-paging": {
       "version": "1.7.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@azure/core-paging/-/core-paging-1.7.0.tgz",
       "integrity": "sha1-WVl6L1Q4ujxsh4n8hw9p4OeFMag=",
       "license": "MIT",
       "dependencies": {
@@ -101,7 +95,6 @@
     },
     "node_modules/@azure/core-rest-pipeline": {
       "version": "1.25.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@azure/core-rest-pipeline/-/core-rest-pipeline-1.25.0.tgz",
       "integrity": "sha1-kupJEu27H3OV9IKaMAYxF0qoLwg=",
       "license": "MIT",
       "dependencies": {
@@ -119,7 +112,6 @@
     },
     "node_modules/@azure/core-tracing": {
       "version": "1.4.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@azure/core-tracing/-/core-tracing-1.4.0.tgz",
       "integrity": "sha1-1lenAOJNJW0ZXmKKeV22qMxHXqs=",
       "license": "MIT",
       "dependencies": {
@@ -131,7 +123,6 @@
     },
     "node_modules/@azure/core-util": {
       "version": "1.14.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@azure/core-util/-/core-util-1.14.0.tgz",
       "integrity": "sha1-fOn+V5WPEy3UIlc4VuWkXHIyuwQ=",
       "license": "MIT",
       "dependencies": {
@@ -145,7 +136,6 @@
     },
     "node_modules/@azure/core-xml": {
       "version": "1.6.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@azure/core-xml/-/core-xml-1.6.0.tgz",
       "integrity": "sha1-EI8JIOG834owuffoh5ibOhIIK9k=",
       "license": "MIT",
       "dependencies": {
@@ -158,7 +148,6 @@
     },
     "node_modules/@azure/identity": {
       "version": "4.13.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@azure/identity/-/identity-4.13.1.tgz",
       "integrity": "sha1-vcCRZYuqWaR+6furSHpLsBhym8M=",
       "license": "MIT",
       "dependencies": {
@@ -180,7 +169,6 @@
     },
     "node_modules/@azure/logger": {
       "version": "1.4.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@azure/logger/-/logger-1.4.0.tgz",
       "integrity": "sha1-PVpif+WaJ27OdIenndkq1cUIwzk=",
       "license": "MIT",
       "dependencies": {
@@ -193,7 +181,6 @@
     },
     "node_modules/@azure/msal-browser": {
       "version": "5.18.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@azure/msal-browser/-/msal-browser-5.18.0.tgz",
       "integrity": "sha1-RGubQmeKIgQZ70MFT9/BOFWhLC4=",
       "license": "MIT",
       "dependencies": {
@@ -205,7 +192,6 @@
     },
     "node_modules/@azure/msal-common": {
       "version": "16.12.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@azure/msal-common/-/msal-common-16.12.0.tgz",
       "integrity": "sha1-XL1Y25GUj5I4LoxijzSlf0adOnQ=",
       "license": "MIT",
       "engines": {
@@ -214,7 +200,6 @@
     },
     "node_modules/@azure/msal-node": {
       "version": "5.5.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@azure/msal-node/-/msal-node-5.5.0.tgz",
       "integrity": "sha1-1JivIxqllWZkKJve00fAVrX357M=",
       "license": "MIT",
       "dependencies": {
@@ -227,7 +212,6 @@
     },
     "node_modules/@azure/storage-blob": {
       "version": "12.31.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@azure/storage-blob/-/storage-blob-12.31.0.tgz",
       "integrity": "sha1-l7Cb4r9qtZc5uGLt2BJHmDYs5yA=",
       "license": "MIT",
       "dependencies": {
@@ -252,7 +236,6 @@
     },
     "node_modules/@azure/storage-common": {
       "version": "12.5.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@azure/storage-common/-/storage-common-12.5.0.tgz",
       "integrity": "sha1-nbHWmPJu9LVqVKYABGp2XqG7oxY=",
       "license": "MIT",
       "dependencies": {
@@ -272,7 +255,6 @@
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/code-frame/-/code-frame-7.29.7.tgz",
       "integrity": "sha1-8vu/6ofESiFZDsUVt3iywm2IZuc=",
       "license": "MIT",
       "dependencies": {
@@ -286,7 +268,6 @@
     },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.29.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
       "integrity": "sha1-vYcITO0MeW7Ea9pJLeboPSnon8I=",
       "license": "MIT",
       "engines": {
@@ -295,7 +276,6 @@
     },
     "node_modules/@inquirer/ansi": {
       "version": "2.0.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@inquirer/ansi/-/ansi-2.0.7.tgz",
       "integrity": "sha1-ht4igQysPtQG7BD41mAWgVuCJrQ=",
       "license": "MIT",
       "engines": {
@@ -304,7 +284,6 @@
     },
     "node_modules/@inquirer/checkbox": {
       "version": "5.1.5",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@inquirer/checkbox/-/checkbox-5.1.5.tgz",
       "integrity": "sha1-NiRyudv43e6Gm2HkzMaxmLl1yVU=",
       "license": "MIT",
       "dependencies": {
@@ -327,7 +306,6 @@
     },
     "node_modules/@inquirer/confirm": {
       "version": "6.0.13",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@inquirer/confirm/-/confirm-6.0.13.tgz",
       "integrity": "sha1-immMo4uqtkrkaPufBOfogA70Nnw=",
       "license": "MIT",
       "dependencies": {
@@ -348,7 +326,6 @@
     },
     "node_modules/@inquirer/core": {
       "version": "11.2.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@inquirer/core/-/core-11.2.1.tgz",
       "integrity": "sha1-VMzY99R4UhQLYGbL131jssKxaP0=",
       "license": "MIT",
       "dependencies": {
@@ -374,7 +351,6 @@
     },
     "node_modules/@inquirer/figures": {
       "version": "2.0.7",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@inquirer/figures/-/figures-2.0.7.tgz",
       "integrity": "sha1-9cxYQ3MqgTBNBqDbS1PMfb2hVUE=",
       "license": "MIT",
       "engines": {
@@ -383,7 +359,6 @@
     },
     "node_modules/@inquirer/input": {
       "version": "5.0.13",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@inquirer/input/-/input-5.0.13.tgz",
       "integrity": "sha1-5Vy9Zv997m2VjFK751Z15l1mRwc=",
       "license": "MIT",
       "dependencies": {
@@ -404,7 +379,6 @@
     },
     "node_modules/@inquirer/search": {
       "version": "4.1.9",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@inquirer/search/-/search-4.1.9.tgz",
       "integrity": "sha1-GoBygS9SRLeHxj+TiKbXrCbVfko=",
       "license": "MIT",
       "dependencies": {
@@ -426,7 +400,6 @@
     },
     "node_modules/@inquirer/select": {
       "version": "5.1.5",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@inquirer/select/-/select-5.1.5.tgz",
       "integrity": "sha1-PwtMWt1ALmy5WKE1oqhTrk1C0yM=",
       "license": "MIT",
       "dependencies": {
@@ -449,7 +422,6 @@
     },
     "node_modules/@inquirer/type": {
       "version": "4.0.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@inquirer/type/-/type-4.0.7.tgz",
       "integrity": "sha1-nG8NhX/mrVSaOpMjQ7ZOdqyzSxA=",
       "license": "MIT",
       "engines": {
@@ -466,7 +438,6 @@
     },
     "node_modules/@isaacs/fs-minipass": {
       "version": "4.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
       "integrity": "sha1-LVmuOrSzj7QnC/oj0w+OLobH/jI=",
       "license": "ISC",
       "dependencies": {
@@ -478,7 +449,6 @@
     },
     "node_modules/@isaacs/fs-minipass/node_modules/minipass": {
       "version": "7.1.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minipass/-/minipass-7.1.3.tgz",
       "integrity": "sha1-eTibTrG7LQA6m7qH1JLyvTe9xls=",
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -487,7 +457,6 @@
     },
     "node_modules/@jsep-plugin/assignment": {
       "version": "1.3.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jsep-plugin/assignment/-/assignment-1.3.0.tgz",
       "integrity": "sha1-/PxUF6BJM/fO7nhuirSYqjziskI=",
       "license": "MIT",
       "engines": {
@@ -499,7 +468,6 @@
     },
     "node_modules/@jsep-plugin/regex": {
       "version": "1.0.4",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@jsep-plugin/regex/-/regex-1.0.4.tgz",
       "integrity": "sha1-yy/EIyIPpxxgkyO5un99NEp1X8w=",
       "license": "MIT",
       "engines": {
@@ -511,7 +479,6 @@
     },
     "node_modules/@microsoft/rush": {
       "version": "5.178.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@microsoft/rush/-/rush-5.178.1.tgz",
       "integrity": "sha1-iopDJ1uJsSWVPewobCunLErxjPI=",
       "license": "MIT",
       "dependencies": {
@@ -531,7 +498,6 @@
     },
     "node_modules/@microsoft/rush-lib": {
       "version": "5.178.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@microsoft/rush-lib/-/rush-lib-5.178.1.tgz",
       "integrity": "sha1-DyM61vcyAm8tsJGkden7kQf99Dc=",
       "license": "MIT",
       "dependencies": {
@@ -584,7 +550,6 @@
     },
     "node_modules/@nodable/entities": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@nodable/entities/-/entities-3.0.0.tgz",
       "integrity": "sha1-aUcDvIZNMOrtVcLj3vANvWFJNnA=",
       "funding": [
         {
@@ -596,7 +561,6 @@
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha1-dhnC6yGyVIP20WdUi0z9WnSIw9U=",
       "license": "MIT",
       "dependencies": {
@@ -609,7 +573,6 @@
     },
     "node_modules/@nodelib/fs.stat": {
       "version": "2.0.5",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha1-W9Jir5Tp0lvR5xsF3u1Eh2oiLos=",
       "license": "MIT",
       "engines": {
@@ -618,7 +581,6 @@
     },
     "node_modules/@nodelib/fs.walk": {
       "version": "1.2.8",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha1-6Vc36LtnRt3t9pxVaVNJTxlv5po=",
       "license": "MIT",
       "dependencies": {
@@ -631,7 +593,6 @@
     },
     "node_modules/@pnpm/constants": {
       "version": "1001.3.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/constants/-/constants-1001.3.1.tgz",
       "integrity": "sha1-viYLiQIckXK1VhLGnPDoWNBLfD0=",
       "license": "MIT",
       "engines": {
@@ -643,7 +604,6 @@
     },
     "node_modules/@pnpm/crypto.base32-hash": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/crypto.base32-hash/-/crypto.base32-hash-2.0.0.tgz",
       "integrity": "sha1-MxmVlH6jyHOQ8yQ+JlIV1Tl8RsM=",
       "license": "MIT",
       "dependencies": {
@@ -658,7 +618,6 @@
     },
     "node_modules/@pnpm/crypto.hash": {
       "version": "1000.1.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/crypto.hash/-/crypto.hash-1000.1.1.tgz",
       "integrity": "sha1-YOYV8guiwzPAv4KYZ1uTZ/WxRUc=",
       "license": "MIT",
       "dependencies": {
@@ -675,7 +634,6 @@
     },
     "node_modules/@pnpm/crypto.hash/node_modules/minipass": {
       "version": "7.1.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minipass/-/minipass-7.1.3.tgz",
       "integrity": "sha1-eTibTrG7LQA6m7qH1JLyvTe9xls=",
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -684,7 +642,6 @@
     },
     "node_modules/@pnpm/crypto.hash/node_modules/ssri": {
       "version": "10.0.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ssri/-/ssri-10.0.5.tgz",
       "integrity": "sha1-5J781uNjhRlstRXToq1sPwJl74w=",
       "license": "ISC",
       "dependencies": {
@@ -696,7 +653,6 @@
     },
     "node_modules/@pnpm/crypto.polyfill": {
       "version": "1000.1.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/crypto.polyfill/-/crypto.polyfill-1000.1.0.tgz",
       "integrity": "sha1-r48nmjCe/1eAH6vWgtpA/ZoE5aA=",
       "license": "MIT",
       "engines": {
@@ -708,7 +664,6 @@
     },
     "node_modules/@pnpm/dependency-path": {
       "version": "1001.1.11",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/dependency-path/-/dependency-path-1001.1.11.tgz",
       "integrity": "sha1-AD2NXloO9SCZ/TGdlo5utxNeZtY=",
       "license": "MIT",
       "dependencies": {
@@ -726,7 +681,6 @@
     "node_modules/@pnpm/dependency-path-pnpm-v10": {
       "name": "@pnpm/dependency-path",
       "version": "1000.0.9",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/dependency-path/-/dependency-path-1000.0.9.tgz",
       "integrity": "sha1-BycnqFkF4RIQeAXmERrlHekMYYA=",
       "license": "MIT",
       "dependencies": {
@@ -743,7 +697,6 @@
     },
     "node_modules/@pnpm/dependency-path-pnpm-v10/node_modules/@pnpm/types": {
       "version": "1000.6.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/types/-/types-1000.6.0.tgz",
       "integrity": "sha1-gli2kl9i04FsrGwDDElHfsTL8NY=",
       "license": "MIT",
       "engines": {
@@ -756,7 +709,6 @@
     "node_modules/@pnpm/dependency-path-pnpm-v8": {
       "name": "@pnpm/dependency-path",
       "version": "2.1.8",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/dependency-path/-/dependency-path-2.1.8.tgz",
       "integrity": "sha1-l06jxmckkWzPFTGpCKyMIGvgyPQ=",
       "license": "MIT",
       "dependencies": {
@@ -774,7 +726,6 @@
     },
     "node_modules/@pnpm/dependency-path-pnpm-v8/node_modules/@pnpm/types": {
       "version": "9.4.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/types/-/types-9.4.2.tgz",
       "integrity": "sha1-CjTDxB1UUkYdjYlYN0pyf5xGz7I=",
       "license": "MIT",
       "engines": {
@@ -787,7 +738,6 @@
     "node_modules/@pnpm/dependency-path-pnpm-v9": {
       "name": "@pnpm/dependency-path",
       "version": "5.1.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/dependency-path/-/dependency-path-5.1.7.tgz",
       "integrity": "sha1-QfX0+QujGOTzmSll8AQMpGEvXYE=",
       "license": "MIT",
       "dependencies": {
@@ -804,7 +754,6 @@
     },
     "node_modules/@pnpm/dependency-path-pnpm-v9/node_modules/@pnpm/crypto.base32-hash": {
       "version": "3.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/crypto.base32-hash/-/crypto.base32-hash-3.0.1.tgz",
       "integrity": "sha1-10Om1yuXF16gAUZHVKjztoxV2Bk=",
       "license": "MIT",
       "dependencies": {
@@ -820,7 +769,6 @@
     },
     "node_modules/@pnpm/dependency-path-pnpm-v9/node_modules/@pnpm/crypto.polyfill": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/crypto.polyfill/-/crypto.polyfill-1.0.0.tgz",
       "integrity": "sha1-Jva+zF9tkPGDz2aSkUyxeZk+EEI=",
       "license": "MIT",
       "engines": {
@@ -832,7 +780,6 @@
     },
     "node_modules/@pnpm/dependency-path-pnpm-v9/node_modules/@pnpm/types": {
       "version": "12.2.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/types/-/types-12.2.0.tgz",
       "integrity": "sha1-lE+xjtDRF9Vw7YY1jsydbz3T5sI=",
       "license": "MIT",
       "engines": {
@@ -844,7 +791,6 @@
     },
     "node_modules/@pnpm/dependency-path/node_modules/@pnpm/crypto.hash": {
       "version": "1000.2.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/crypto.hash/-/crypto.hash-1000.2.2.tgz",
       "integrity": "sha1-6oo1fFgk3CXTq29pdSta2/yEWE0=",
       "license": "MIT",
       "dependencies": {
@@ -861,7 +807,6 @@
     },
     "node_modules/@pnpm/dependency-path/node_modules/@pnpm/graceful-fs": {
       "version": "1000.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/graceful-fs/-/graceful-fs-1000.1.0.tgz",
       "integrity": "sha1-zIvSiDOSXvmejTnfWhg5K89DSIU=",
       "license": "MIT",
       "dependencies": {
@@ -876,7 +821,6 @@
     },
     "node_modules/@pnpm/dependency-path/node_modules/@pnpm/types": {
       "version": "1001.3.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/types/-/types-1001.3.1.tgz",
       "integrity": "sha1-MY4t+y34jBxndQK+nRcBuWXtwmA=",
       "license": "MIT",
       "engines": {
@@ -888,13 +832,11 @@
     },
     "node_modules/@pnpm/dependency-path/node_modules/graceful-fs": {
       "version": "4.2.11",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha1-QYPk6L8Iu24Fu7L30uDI9xLKQOM=",
       "license": "ISC"
     },
     "node_modules/@pnpm/dependency-path/node_modules/minipass": {
       "version": "7.1.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minipass/-/minipass-7.1.3.tgz",
       "integrity": "sha1-eTibTrG7LQA6m7qH1JLyvTe9xls=",
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -903,7 +845,6 @@
     },
     "node_modules/@pnpm/dependency-path/node_modules/ssri": {
       "version": "10.0.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ssri/-/ssri-10.0.5.tgz",
       "integrity": "sha1-5J781uNjhRlstRXToq1sPwJl74w=",
       "license": "ISC",
       "dependencies": {
@@ -915,7 +856,6 @@
     },
     "node_modules/@pnpm/error": {
       "version": "1.4.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/error/-/error-1.4.0.tgz",
       "integrity": "sha1-ajzpii4/GwYU3rrd0zpsZZe0k/M=",
       "license": "MIT",
       "engines": {
@@ -927,7 +867,6 @@
     },
     "node_modules/@pnpm/git-utils": {
       "version": "1000.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/git-utils/-/git-utils-1000.0.0.tgz",
       "integrity": "sha1-TrbKY79t7kgv6/lPfoa41Q0KX4Q=",
       "license": "MIT",
       "dependencies": {
@@ -942,7 +881,6 @@
     },
     "node_modules/@pnpm/graceful-fs": {
       "version": "1000.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/graceful-fs/-/graceful-fs-1000.0.0.tgz",
       "integrity": "sha1-p7ipKN/u8oXZfR2xBzyTbcPAb7s=",
       "license": "MIT",
       "dependencies": {
@@ -957,13 +895,11 @@
     },
     "node_modules/@pnpm/graceful-fs/node_modules/graceful-fs": {
       "version": "4.2.11",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha1-QYPk6L8Iu24Fu7L30uDI9xLKQOM=",
       "license": "ISC"
     },
     "node_modules/@pnpm/link-bins": {
       "version": "5.3.25",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/link-bins/-/link-bins-5.3.25.tgz",
       "integrity": "sha1-9KuGElq4fSZ2sJ7hSXIdecZ/d/E=",
       "license": "MIT",
       "dependencies": {
@@ -990,7 +926,6 @@
     },
     "node_modules/@pnpm/lockfile-types": {
       "version": "5.1.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/lockfile-types/-/lockfile-types-5.1.5.tgz",
       "integrity": "sha1-FLhcl23c90dPWmopNRy1eZWdDsg=",
       "license": "MIT",
       "dependencies": {
@@ -1006,7 +941,6 @@
     "node_modules/@pnpm/lockfile-types-pnpm-lock-v6": {
       "name": "@pnpm/lockfile-types",
       "version": "5.1.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/lockfile-types/-/lockfile-types-5.1.5.tgz",
       "integrity": "sha1-FLhcl23c90dPWmopNRy1eZWdDsg=",
       "license": "MIT",
       "dependencies": {
@@ -1021,7 +955,6 @@
     },
     "node_modules/@pnpm/lockfile-types-pnpm-lock-v6/node_modules/@pnpm/types": {
       "version": "9.4.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/types/-/types-9.4.2.tgz",
       "integrity": "sha1-CjTDxB1UUkYdjYlYN0pyf5xGz7I=",
       "license": "MIT",
       "engines": {
@@ -1033,7 +966,6 @@
     },
     "node_modules/@pnpm/lockfile-types/node_modules/@pnpm/types": {
       "version": "9.4.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/types/-/types-9.4.2.tgz",
       "integrity": "sha1-CjTDxB1UUkYdjYlYN0pyf5xGz7I=",
       "license": "MIT",
       "engines": {
@@ -1046,7 +978,6 @@
     "node_modules/@pnpm/lockfile.fs-pnpm-lock-v9": {
       "name": "@pnpm/lockfile.fs",
       "version": "1001.1.35",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/lockfile.fs/-/lockfile.fs-1001.1.35.tgz",
       "integrity": "sha1-D45duzJcL1G/aD2p47H1Ho0wg00=",
       "license": "MIT",
       "dependencies": {
@@ -1080,7 +1011,6 @@
     },
     "node_modules/@pnpm/lockfile.fs-pnpm-lock-v9/node_modules/@pnpm/error": {
       "version": "1000.1.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/error/-/error-1000.1.0.tgz",
       "integrity": "sha1-+FjGoy+zZSjiaYs9eBALwyX1U3M=",
       "license": "MIT",
       "dependencies": {
@@ -1095,7 +1025,6 @@
     },
     "node_modules/@pnpm/lockfile.fs-pnpm-lock-v9/node_modules/@pnpm/types": {
       "version": "1001.3.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/types/-/types-1001.3.1.tgz",
       "integrity": "sha1-MY4t+y34jBxndQK+nRcBuWXtwmA=",
       "license": "MIT",
       "engines": {
@@ -1107,14 +1036,12 @@
     },
     "node_modules/@pnpm/lockfile.fs-pnpm-lock-v9/node_modules/argparse": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha1-JG9Q88p4oyQPbJl+ipvR6sSeSzg=",
       "license": "Python-2.0"
     },
     "node_modules/@pnpm/lockfile.fs-pnpm-lock-v9/node_modules/js-yaml": {
       "name": "@zkochan/js-yaml",
       "version": "0.0.11",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@zkochan/js-yaml/-/js-yaml-0.0.11.tgz",
       "integrity": "sha1-T2aH2CGxW1MG1Z391Mu32K5wHI0=",
       "license": "MIT",
       "dependencies": {
@@ -1127,7 +1054,6 @@
     "node_modules/@pnpm/lockfile.fs-pnpm-lock-v9/node_modules/ramda": {
       "name": "@pnpm/ramda",
       "version": "0.28.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/ramda/-/ramda-0.28.1.tgz",
       "integrity": "sha1-DzKrxSddWGoD4Nwd2QoAmsZo/zM=",
       "license": "MIT",
       "funding": {
@@ -1137,7 +1063,6 @@
     },
     "node_modules/@pnpm/lockfile.fs-pnpm-lock-v9/node_modules/write-file-atomic": {
       "version": "5.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
       "integrity": "sha1-aN9HF8Vcb6QoGnhgtMK6Cm0rEec=",
       "license": "ISC",
       "dependencies": {
@@ -1150,7 +1075,6 @@
     },
     "node_modules/@pnpm/lockfile.merger": {
       "version": "1001.0.22",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/lockfile.merger/-/lockfile.merger-1001.0.22.tgz",
       "integrity": "sha1-/T3h9FYKk+/syn+u3ibQLKBDt9k=",
       "license": "MIT",
       "dependencies": {
@@ -1169,7 +1093,6 @@
     },
     "node_modules/@pnpm/lockfile.merger/node_modules/@pnpm/types": {
       "version": "1001.3.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/types/-/types-1001.3.1.tgz",
       "integrity": "sha1-MY4t+y34jBxndQK+nRcBuWXtwmA=",
       "license": "MIT",
       "engines": {
@@ -1182,7 +1105,6 @@
     "node_modules/@pnpm/lockfile.merger/node_modules/ramda": {
       "name": "@pnpm/ramda",
       "version": "0.28.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/ramda/-/ramda-0.28.1.tgz",
       "integrity": "sha1-DzKrxSddWGoD4Nwd2QoAmsZo/zM=",
       "license": "MIT",
       "funding": {
@@ -1192,7 +1114,6 @@
     },
     "node_modules/@pnpm/lockfile.types": {
       "version": "1002.1.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/lockfile.types/-/lockfile.types-1002.1.2.tgz",
       "integrity": "sha1-GZhB8XvW/q5KI8WU+paKh3gKWq8=",
       "license": "MIT",
       "dependencies": {
@@ -1210,7 +1131,6 @@
     "node_modules/@pnpm/lockfile.types-900": {
       "name": "@pnpm/lockfile.types",
       "version": "900.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/lockfile.types/-/lockfile.types-900.0.0.tgz",
       "integrity": "sha1-r+ZWP2++XpHWqF3bg40QOViZjN0=",
       "license": "MIT",
       "dependencies": {
@@ -1226,7 +1146,6 @@
     },
     "node_modules/@pnpm/lockfile.types-900/node_modules/@pnpm/patching.types": {
       "version": "900.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/patching.types/-/patching.types-900.0.0.tgz",
       "integrity": "sha1-orATANvm8Ur2BJkdc7XFPzSzAvY=",
       "license": "MIT",
       "engines": {
@@ -1238,7 +1157,6 @@
     },
     "node_modules/@pnpm/lockfile.types-900/node_modules/@pnpm/types": {
       "version": "900.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/types/-/types-900.0.0.tgz",
       "integrity": "sha1-og6LnKAgZjsCLATRKM0Ve492oFo=",
       "license": "MIT",
       "engines": {
@@ -1251,7 +1169,6 @@
     "node_modules/@pnpm/lockfile.types-pnpm-lock-v9": {
       "name": "@pnpm/lockfile.types",
       "version": "1001.1.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/lockfile.types/-/lockfile.types-1001.1.0.tgz",
       "integrity": "sha1-rhsx7V+7Du0y0CpfVlG8zilTW6E=",
       "license": "MIT",
       "dependencies": {
@@ -1267,7 +1184,6 @@
     },
     "node_modules/@pnpm/lockfile.types-pnpm-lock-v9/node_modules/@pnpm/types": {
       "version": "1000.7.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/types/-/types-1000.7.0.tgz",
       "integrity": "sha1-g1Hkb73+JfgP7Jdb/fWNDKStYkw=",
       "license": "MIT",
       "engines": {
@@ -1279,7 +1195,6 @@
     },
     "node_modules/@pnpm/lockfile.types/node_modules/@pnpm/types": {
       "version": "1001.3.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/types/-/types-1001.3.1.tgz",
       "integrity": "sha1-MY4t+y34jBxndQK+nRcBuWXtwmA=",
       "license": "MIT",
       "engines": {
@@ -1291,7 +1206,6 @@
     },
     "node_modules/@pnpm/lockfile.utils": {
       "version": "1004.0.6",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/lockfile.utils/-/lockfile.utils-1004.0.6.tgz",
       "integrity": "sha1-EdGC+B6gYyBsDVJiFF8ejvmvfA8=",
       "license": "MIT",
       "dependencies": {
@@ -1312,7 +1226,6 @@
     },
     "node_modules/@pnpm/lockfile.utils/node_modules/@pnpm/error": {
       "version": "1000.1.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/error/-/error-1000.1.0.tgz",
       "integrity": "sha1-+FjGoy+zZSjiaYs9eBALwyX1U3M=",
       "license": "MIT",
       "dependencies": {
@@ -1327,7 +1240,6 @@
     },
     "node_modules/@pnpm/lockfile.utils/node_modules/@pnpm/types": {
       "version": "1001.3.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/types/-/types-1001.3.1.tgz",
       "integrity": "sha1-MY4t+y34jBxndQK+nRcBuWXtwmA=",
       "license": "MIT",
       "engines": {
@@ -1340,7 +1252,6 @@
     "node_modules/@pnpm/lockfile.utils/node_modules/ramda": {
       "name": "@pnpm/ramda",
       "version": "0.28.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/ramda/-/ramda-0.28.1.tgz",
       "integrity": "sha1-DzKrxSddWGoD4Nwd2QoAmsZo/zM=",
       "license": "MIT",
       "funding": {
@@ -1350,7 +1261,6 @@
     },
     "node_modules/@pnpm/logger": {
       "version": "1001.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/logger/-/logger-1001.0.1.tgz",
       "integrity": "sha1-hOmVA4uf4LTx45kGo+CT0htTGjM=",
       "license": "MIT",
       "dependencies": {
@@ -1366,7 +1276,6 @@
     },
     "node_modules/@pnpm/merge-lockfile-changes": {
       "version": "5.0.7",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/merge-lockfile-changes/-/merge-lockfile-changes-5.0.7.tgz",
       "integrity": "sha1-uWZNtLSWrwCxoBAeGQUyMw4eGxI=",
       "license": "MIT",
       "dependencies": {
@@ -1385,7 +1294,6 @@
     "node_modules/@pnpm/merge-lockfile-changes/node_modules/ramda": {
       "name": "@pnpm/ramda",
       "version": "0.28.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/ramda/-/ramda-0.28.1.tgz",
       "integrity": "sha1-DzKrxSddWGoD4Nwd2QoAmsZo/zM=",
       "license": "MIT",
       "funding": {
@@ -1395,7 +1303,6 @@
     },
     "node_modules/@pnpm/object.key-sorting": {
       "version": "1000.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/object.key-sorting/-/object.key-sorting-1000.0.1.tgz",
       "integrity": "sha1-MA2B+9Entoq+IKjsDVMyWDICIYk=",
       "license": "MIT",
       "dependencies": {
@@ -1411,7 +1318,6 @@
     },
     "node_modules/@pnpm/package-bins": {
       "version": "4.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/package-bins/-/package-bins-4.1.0.tgz",
       "integrity": "sha1-9ayA8KmRAyun+LFKCCuy7gLyp/I=",
       "license": "MIT",
       "dependencies": {
@@ -1428,7 +1334,6 @@
     },
     "node_modules/@pnpm/patching.types": {
       "version": "1000.1.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/patching.types/-/patching.types-1000.1.0.tgz",
       "integrity": "sha1-1AOzl0N4A7hZx/sullgMiXtitx4=",
       "license": "MIT",
       "engines": {
@@ -1440,7 +1345,6 @@
     },
     "node_modules/@pnpm/read-modules-dir": {
       "version": "2.0.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/read-modules-dir/-/read-modules-dir-2.0.3.tgz",
       "integrity": "sha1-B/8K5/xdj87+f1woSKguK9iyCAI=",
       "license": "MIT",
       "dependencies": {
@@ -1455,7 +1359,6 @@
     },
     "node_modules/@pnpm/read-package-json": {
       "version": "4.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/read-package-json/-/read-package-json-4.0.0.tgz",
       "integrity": "sha1-P+xMEH4vgZnP+Xv9TOrT5qo4lYA=",
       "license": "MIT",
       "dependencies": {
@@ -1473,7 +1376,6 @@
     },
     "node_modules/@pnpm/read-project-manifest": {
       "version": "1.1.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/read-project-manifest/-/read-project-manifest-1.1.7.tgz",
       "integrity": "sha1-Tu4l0owaZIA5cS4UqAU13YrVquA=",
       "license": "MIT",
       "dependencies": {
@@ -1499,7 +1401,6 @@
     },
     "node_modules/@pnpm/resolver-base": {
       "version": "1005.4.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/resolver-base/-/resolver-base-1005.4.3.tgz",
       "integrity": "sha1-+CpbKXa828BI2LeoGA0Viz4i2Uk=",
       "license": "MIT",
       "dependencies": {
@@ -1514,7 +1415,6 @@
     },
     "node_modules/@pnpm/resolver-base/node_modules/@pnpm/types": {
       "version": "1001.3.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/types/-/types-1001.3.1.tgz",
       "integrity": "sha1-MY4t+y34jBxndQK+nRcBuWXtwmA=",
       "license": "MIT",
       "engines": {
@@ -1526,7 +1426,6 @@
     },
     "node_modules/@pnpm/types": {
       "version": "6.4.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/types/-/types-6.4.0.tgz",
       "integrity": "sha1-MSw78LQ7ADUIyyG9OBVAbqDztmk=",
       "license": "MIT",
       "engines": {
@@ -1538,7 +1437,6 @@
     },
     "node_modules/@pnpm/util.lex-comparator": {
       "version": "3.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/util.lex-comparator/-/util.lex-comparator-3.0.2.tgz",
       "integrity": "sha1-UmhowKypnOlGZkWM+MKLlyBx0Nw=",
       "license": "MIT",
       "engines": {
@@ -1547,7 +1445,6 @@
     },
     "node_modules/@pnpm/write-project-manifest": {
       "version": "1.1.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/write-project-manifest/-/write-project-manifest-1.1.7.tgz",
       "integrity": "sha1-vDthASoChs85wrgs+srAlqS/FAs=",
       "license": "MIT",
       "dependencies": {
@@ -1566,7 +1463,6 @@
     },
     "node_modules/@rushstack/credential-cache": {
       "version": "0.2.22",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rushstack/credential-cache/-/credential-cache-0.2.22.tgz",
       "integrity": "sha1-2QXB0nvafBlMBiQAu0J6d5J+s1s=",
       "license": "MIT",
       "dependencies": {
@@ -1575,7 +1471,6 @@
     },
     "node_modules/@rushstack/heft-config-file": {
       "version": "0.20.12",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rushstack/heft-config-file/-/heft-config-file-0.20.12.tgz",
       "integrity": "sha1-HweCRSvjXlebxAAMdDMC/B+HsdU=",
       "license": "MIT",
       "dependencies": {
@@ -1590,7 +1485,6 @@
     },
     "node_modules/@rushstack/lookup-by-path": {
       "version": "0.10.11",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rushstack/lookup-by-path/-/lookup-by-path-0.10.11.tgz",
       "integrity": "sha1-FpYSGPLwmVdI4aE2CP0K+wZJCcA=",
       "license": "MIT",
       "peerDependencies": {
@@ -1604,7 +1498,6 @@
     },
     "node_modules/@rushstack/node-core-library": {
       "version": "5.23.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rushstack/node-core-library/-/node-core-library-5.23.3.tgz",
       "integrity": "sha1-UXOEogpIpjO0pGTDStXFVKVDIN0=",
       "license": "MIT",
       "dependencies": {
@@ -1628,7 +1521,6 @@
     },
     "node_modules/@rushstack/npm-check-fork": {
       "version": "0.2.22",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rushstack/npm-check-fork/-/npm-check-fork-0.2.22.tgz",
       "integrity": "sha1-KcXacSzcWiQ7Vs57gWOSVovcoJk=",
       "license": "MIT",
       "dependencies": {
@@ -1638,7 +1530,6 @@
     },
     "node_modules/@rushstack/package-deps-hash": {
       "version": "4.7.24",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rushstack/package-deps-hash/-/package-deps-hash-4.7.24.tgz",
       "integrity": "sha1-8BB/063FH8usGrPHTKb74W4lOLk=",
       "license": "MIT",
       "dependencies": {
@@ -1647,7 +1538,6 @@
     },
     "node_modules/@rushstack/package-extractor": {
       "version": "0.13.10",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rushstack/package-extractor/-/package-extractor-0.13.10.tgz",
       "integrity": "sha1-9LXLVDrUjX4VyGKeBYzNrtB6zcM=",
       "license": "MIT",
       "dependencies": {
@@ -1664,7 +1554,6 @@
     },
     "node_modules/@rushstack/problem-matcher": {
       "version": "0.2.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rushstack/problem-matcher/-/problem-matcher-0.2.1.tgz",
       "integrity": "sha1-6fbKwt1qiC1g52qNRGK30ktPF+U=",
       "license": "MIT",
       "peerDependencies": {
@@ -1678,7 +1567,6 @@
     },
     "node_modules/@rushstack/rig-package": {
       "version": "0.7.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rushstack/rig-package/-/rig-package-0.7.3.tgz",
       "integrity": "sha1-0opUQLHp9DBGcnunAJ0Y2ZMU8lE=",
       "license": "MIT",
       "dependencies": {
@@ -1688,7 +1576,6 @@
     },
     "node_modules/@rushstack/rush-amazon-s3-build-cache-plugin": {
       "version": "5.178.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rushstack/rush-amazon-s3-build-cache-plugin/-/rush-amazon-s3-build-cache-plugin-5.178.1.tgz",
       "integrity": "sha1-B73DSbRTJ+sY9SFhWrKizd3UPDU=",
       "license": "MIT",
       "dependencies": {
@@ -1701,7 +1588,6 @@
     },
     "node_modules/@rushstack/rush-azure-storage-build-cache-plugin": {
       "version": "5.178.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rushstack/rush-azure-storage-build-cache-plugin/-/rush-azure-storage-build-cache-plugin-5.178.1.tgz",
       "integrity": "sha1-SXzvLLkCbhNIEw0hfNy6w8fgd3g=",
       "license": "MIT",
       "dependencies": {
@@ -1715,7 +1601,6 @@
     },
     "node_modules/@rushstack/rush-http-build-cache-plugin": {
       "version": "5.178.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rushstack/rush-http-build-cache-plugin/-/rush-http-build-cache-plugin-5.178.1.tgz",
       "integrity": "sha1-fKj7vgRUUpIR/RZ3hQxgTrcNTv4=",
       "license": "MIT",
       "dependencies": {
@@ -1727,7 +1612,6 @@
     },
     "node_modules/@rushstack/rush-pnpm-kit-v10": {
       "version": "0.2.23",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rushstack/rush-pnpm-kit-v10/-/rush-pnpm-kit-v10-0.2.23.tgz",
       "integrity": "sha1-5ORpgjm3qUpOwyEDfY5BAqnQiAE=",
       "license": "MIT",
       "dependencies": {
@@ -1738,7 +1622,6 @@
     },
     "node_modules/@rushstack/rush-pnpm-kit-v8": {
       "version": "0.2.23",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rushstack/rush-pnpm-kit-v8/-/rush-pnpm-kit-v8-0.2.23.tgz",
       "integrity": "sha1-9rJyPTMW2o21MAj1b7GDeEocrh4=",
       "license": "MIT",
       "dependencies": {
@@ -1749,7 +1632,6 @@
     },
     "node_modules/@rushstack/rush-pnpm-kit-v8/node_modules/@pnpm/constants": {
       "version": "7.1.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/constants/-/constants-7.1.1.tgz",
       "integrity": "sha1-PbJhQl/hVCWqITorAD9PYMk3i0M=",
       "license": "MIT",
       "engines": {
@@ -1761,7 +1643,6 @@
     },
     "node_modules/@rushstack/rush-pnpm-kit-v8/node_modules/@pnpm/dependency-path": {
       "version": "2.1.8",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/dependency-path/-/dependency-path-2.1.8.tgz",
       "integrity": "sha1-l06jxmckkWzPFTGpCKyMIGvgyPQ=",
       "license": "MIT",
       "dependencies": {
@@ -1779,7 +1660,6 @@
     },
     "node_modules/@rushstack/rush-pnpm-kit-v8/node_modules/@pnpm/error": {
       "version": "5.0.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/error/-/error-5.0.3.tgz",
       "integrity": "sha1-TbufSssLMMNzs8pQJM30lfA/Q4A=",
       "license": "MIT",
       "dependencies": {
@@ -1794,7 +1674,6 @@
     },
     "node_modules/@rushstack/rush-pnpm-kit-v8/node_modules/@pnpm/git-utils": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/git-utils/-/git-utils-1.0.0.tgz",
       "integrity": "sha1-hHFKdppjcWCRYk/+juQi146jl6k=",
       "license": "MIT",
       "dependencies": {
@@ -1810,7 +1689,6 @@
     "node_modules/@rushstack/rush-pnpm-kit-v8/node_modules/@pnpm/lockfile-file-pnpm-lock-v6": {
       "name": "@pnpm/lockfile-file",
       "version": "8.1.8",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/lockfile-file/-/lockfile-file-8.1.8.tgz",
       "integrity": "sha1-XNY28vDj/ZipBcI7chdQHGb3aDs=",
       "license": "MIT",
       "dependencies": {
@@ -1844,7 +1722,6 @@
     },
     "node_modules/@rushstack/rush-pnpm-kit-v8/node_modules/@pnpm/logger": {
       "version": "5.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/logger/-/logger-5.0.0.tgz",
       "integrity": "sha1-msglTUDY1bXmdnQtxmuMrBrzgL8=",
       "license": "MIT",
       "dependencies": {
@@ -1857,7 +1734,6 @@
     },
     "node_modules/@rushstack/rush-pnpm-kit-v8/node_modules/@pnpm/types": {
       "version": "9.4.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/types/-/types-9.4.2.tgz",
       "integrity": "sha1-CjTDxB1UUkYdjYlYN0pyf5xGz7I=",
       "license": "MIT",
       "engines": {
@@ -1869,7 +1745,6 @@
     },
     "node_modules/@rushstack/rush-pnpm-kit-v8/node_modules/@pnpm/util.lex-comparator": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/util.lex-comparator/-/util.lex-comparator-1.0.0.tgz",
       "integrity": "sha1-bRfa0vGiPhN/04QCs6FBmWnk0JA=",
       "license": "MIT",
       "engines": {
@@ -1878,7 +1753,6 @@
     },
     "node_modules/@rushstack/rush-pnpm-kit-v8/node_modules/@zkochan/rimraf": {
       "version": "2.1.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@zkochan/rimraf/-/rimraf-2.1.3.tgz",
       "integrity": "sha1-EHTLctbkmXJ1KFsEKWo0O2rHBGs=",
       "license": "MIT",
       "dependencies": {
@@ -1890,14 +1764,12 @@
     },
     "node_modules/@rushstack/rush-pnpm-kit-v8/node_modules/argparse": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha1-JG9Q88p4oyQPbJl+ipvR6sSeSzg=",
       "license": "Python-2.0"
     },
     "node_modules/@rushstack/rush-pnpm-kit-v8/node_modules/js-yaml": {
       "name": "@zkochan/js-yaml",
       "version": "0.0.6",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@zkochan/js-yaml/-/js-yaml-0.0.6.tgz",
       "integrity": "sha1-l18LMG5wXii4BooHc3+kbT/ASCY=",
       "license": "MIT",
       "dependencies": {
@@ -1910,7 +1782,6 @@
     "node_modules/@rushstack/rush-pnpm-kit-v8/node_modules/ramda": {
       "name": "@pnpm/ramda",
       "version": "0.28.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/ramda/-/ramda-0.28.1.tgz",
       "integrity": "sha1-DzKrxSddWGoD4Nwd2QoAmsZo/zM=",
       "license": "MIT",
       "funding": {
@@ -1920,7 +1791,6 @@
     },
     "node_modules/@rushstack/rush-pnpm-kit-v8/node_modules/write-file-atomic": {
       "version": "5.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
       "integrity": "sha1-aN9HF8Vcb6QoGnhgtMK6Cm0rEec=",
       "license": "ISC",
       "dependencies": {
@@ -1933,7 +1803,6 @@
     },
     "node_modules/@rushstack/rush-pnpm-kit-v9": {
       "version": "0.2.23",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rushstack/rush-pnpm-kit-v9/-/rush-pnpm-kit-v9-0.2.23.tgz",
       "integrity": "sha1-x1kf/l0yjcMuCC7QE1IsXlbYsMs=",
       "license": "MIT",
       "dependencies": {
@@ -1944,7 +1813,6 @@
     },
     "node_modules/@rushstack/rush-sdk": {
       "version": "5.178.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rushstack/rush-sdk/-/rush-sdk-5.178.1.tgz",
       "integrity": "sha1-f/23byNSeLVYWHEBIxO+ORgI4Qs=",
       "license": "MIT",
       "dependencies": {
@@ -1959,7 +1827,6 @@
     },
     "node_modules/@rushstack/stream-collator": {
       "version": "4.2.22",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rushstack/stream-collator/-/stream-collator-4.2.22.tgz",
       "integrity": "sha1-XvBFp4J1Yy9p51LFTalxcivCbpY=",
       "license": "MIT",
       "dependencies": {
@@ -1969,7 +1836,6 @@
     },
     "node_modules/@rushstack/terminal": {
       "version": "0.24.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rushstack/terminal/-/terminal-0.24.2.tgz",
       "integrity": "sha1-lkrTn6heZmj8KrplL8sEK5YTRCU=",
       "license": "MIT",
       "dependencies": {
@@ -1988,7 +1854,6 @@
     },
     "node_modules/@rushstack/ts-command-line": {
       "version": "5.3.12",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@rushstack/ts-command-line/-/ts-command-line-5.3.12.tgz",
       "integrity": "sha1-fW3YB3rn441hrp/lsJBtw/bOplA=",
       "license": "MIT",
       "dependencies": {
@@ -2000,13 +1865,11 @@
     },
     "node_modules/@types/argparse": {
       "version": "1.0.38",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/argparse/-/argparse-1.0.38.tgz",
       "integrity": "sha1-qB/YYG1IH4c6OADG665PHXaKVqk=",
       "license": "MIT"
     },
     "node_modules/@typespec/ts-http-runtime": {
       "version": "0.3.8",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.8.tgz",
       "integrity": "sha1-tN7lpeeXGu3HCVO7fS2/V4P0LTg=",
       "license": "MIT",
       "dependencies": {
@@ -2020,7 +1883,6 @@
     },
     "node_modules/@typespec/ts-http-runtime/node_modules/https-proxy-agent": {
       "version": "7.0.6",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha1-2o3+rH2hMLBcK6S1nJts1mYRprk=",
       "license": "MIT",
       "dependencies": {
@@ -2033,13 +1895,11 @@
     },
     "node_modules/@yarnpkg/lockfile": {
       "version": "1.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@yarnpkg/lockfile/-/lockfile-1.0.2.tgz",
       "integrity": "sha1-gz0WNoChUdJEGiSJ9f5fqHrIdyY=",
       "license": "BSD-2-Clause"
     },
     "node_modules/@zkochan/cmd-shim": {
       "version": "5.4.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@zkochan/cmd-shim/-/cmd-shim-5.4.1.tgz",
       "integrity": "sha1-ox+D8Acuh8ZcNjxA4dBTE9KdU3c=",
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -2053,13 +1913,11 @@
     },
     "node_modules/@zkochan/cmd-shim/node_modules/graceful-fs": {
       "version": "4.2.11",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha1-QYPk6L8Iu24Fu7L30uDI9xLKQOM=",
       "license": "ISC"
     },
     "node_modules/@zkochan/rimraf": {
       "version": "3.0.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@zkochan/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha1-3ym2W/PS/D4ON3Q/G8/jhVn40bo=",
       "license": "MIT",
       "engines": {
@@ -2068,7 +1926,6 @@
     },
     "node_modules/@zkochan/which": {
       "version": "2.0.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@zkochan/which/-/which-2.0.3.tgz",
       "integrity": "sha1-okOQNZOQ04wVH6YHgbNiC8WhMtA=",
       "license": "ISC",
       "dependencies": {
@@ -2083,7 +1940,6 @@
     },
     "node_modules/agent-base": {
       "version": "7.1.4",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha1-48121MVI7oldPD/Y3B9sW5Ay56g=",
       "license": "MIT",
       "engines": {
@@ -2092,7 +1948,6 @@
     },
     "node_modules/ajv": {
       "version": "8.20.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha1-MEs2Nq3Yi6fZNnYN1Q7OAG3qlfk=",
       "license": "MIT",
       "dependencies": {
@@ -2108,7 +1963,6 @@
     },
     "node_modules/ajv-draft-04": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
       "integrity": "sha1-O2R2GyaLoLnmaPC0G6U/zgrXf8g=",
       "license": "MIT",
       "peerDependencies": {
@@ -2122,7 +1976,6 @@
     },
     "node_modules/ajv-formats": {
       "version": "3.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ajv-formats/-/ajv-formats-3.0.1.tgz",
       "integrity": "sha1-PV3HYryhdnnDwup+kK1rdTIwlXg=",
       "license": "MIT",
       "dependencies": {
@@ -2139,13 +1992,11 @@
     },
     "node_modules/any-promise": {
       "version": "1.3.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8=",
       "license": "MIT"
     },
     "node_modules/anynum": {
       "version": "1.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/anynum/-/anynum-1.0.1.tgz",
       "integrity": "sha1-KqwA4I3603JsHUYuYNvC+DFlmkQ=",
       "funding": [
         {
@@ -2157,7 +2008,6 @@
     },
     "node_modules/argparse": {
       "version": "1.0.10",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
       "license": "MIT",
       "dependencies": {
@@ -2166,13 +2016,11 @@
     },
     "node_modules/asap": {
       "version": "2.0.6",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/asap/-/asap-2.0.6.tgz",
       "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
       "license": "MIT"
     },
     "node_modules/balanced-match": {
       "version": "4.0.4",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha1-v7EGYv7tgZaixi58aOF3IMJ0F5o=",
       "license": "MIT",
       "engines": {
@@ -2181,7 +2029,6 @@
     },
     "node_modules/better-path-resolve": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/better-path-resolve/-/better-path-resolve-1.0.0.tgz",
       "integrity": "sha1-E6NaEQTN1Ip7dL+HWPlqHuYT+Z0=",
       "license": "MIT",
       "dependencies": {
@@ -2193,7 +2040,6 @@
     },
     "node_modules/bole": {
       "version": "5.0.29",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/bole/-/bole-5.0.29.tgz",
       "integrity": "sha1-W+filLqotowCf0h0qqEEpyD68Aw=",
       "license": "MIT",
       "dependencies": {
@@ -2203,7 +2049,6 @@
     },
     "node_modules/brace-expansion": {
       "version": "5.0.9",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/brace-expansion/-/brace-expansion-5.0.9.tgz",
       "integrity": "sha1-fHJDiAm1+lur9UGZofHCgaaYT88=",
       "license": "MIT",
       "dependencies": {
@@ -2215,7 +2060,6 @@
     },
     "node_modules/braces": {
       "version": "3.0.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/braces/-/braces-3.0.3.tgz",
       "integrity": "sha1-SQMy9AkZRSJy1VqEgK3AxEE1h4k=",
       "license": "MIT",
       "dependencies": {
@@ -2227,19 +2071,16 @@
     },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=",
       "license": "BSD-3-Clause"
     },
     "node_modules/builtins": {
       "version": "1.0.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/builtins/-/builtins-1.0.3.tgz",
       "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
       "license": "MIT"
     },
     "node_modules/bundle-name": {
       "version": "4.1.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/bundle-name/-/bundle-name-4.1.0.tgz",
       "integrity": "sha1-87lrNBYNZDGhnXaIE1r3z7h5eIk=",
       "license": "MIT",
       "dependencies": {
@@ -2254,7 +2095,6 @@
     },
     "node_modules/chownr": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/chownr/-/chownr-3.0.0.tgz",
       "integrity": "sha1-mFXmTs0kCpzEJnzopKpdJKHaFeQ=",
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -2263,7 +2103,6 @@
     },
     "node_modules/cli-width": {
       "version": "4.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cli-width/-/cli-width-4.1.0.tgz",
       "integrity": "sha1-QtqsQdPCVO84rYrAN2chMBc2kcU=",
       "license": "ISC",
       "engines": {
@@ -2272,7 +2111,6 @@
     },
     "node_modules/cmd-extension": {
       "version": "1.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cmd-extension/-/cmd-extension-1.0.2.tgz",
       "integrity": "sha1-bM4CM5OPAvA9GKEZjeXf5UbICoI=",
       "license": "MIT",
       "engines": {
@@ -2281,7 +2119,6 @@
     },
     "node_modules/comver-to-semver": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/comver-to-semver/-/comver-to-semver-1.0.0.tgz",
       "integrity": "sha1-bD86+dehFVu9fteFtA9PSocGYZU=",
       "license": "MIT",
       "engines": {
@@ -2290,19 +2127,16 @@
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "license": "MIT"
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha1-pgQtNjTCsn6TKPg3uWX6yDgI24U=",
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha1-ilj+ePANzXDDcEUXWd+/rwPo7p8=",
       "license": "MIT",
       "dependencies": {
@@ -2316,7 +2150,6 @@
     },
     "node_modules/debug": {
       "version": "4.4.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/debug/-/debug-4.4.3.tgz",
       "integrity": "sha1-xq5DLZvZZiWC/OCHCbA4xY6ePWo=",
       "license": "MIT",
       "dependencies": {
@@ -2333,7 +2166,6 @@
     },
     "node_modules/debuglog": {
       "version": "1.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/debuglog/-/debuglog-1.0.1.tgz",
       "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
       "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
       "license": "MIT",
@@ -2343,7 +2175,6 @@
     },
     "node_modules/default-browser": {
       "version": "5.5.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/default-browser/-/default-browser-5.5.0.tgz",
       "integrity": "sha1-J5LohvJCKJRUWUfMgOGkRElsWXY=",
       "license": "MIT",
       "dependencies": {
@@ -2359,7 +2190,6 @@
     },
     "node_modules/default-browser-id": {
       "version": "5.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/default-browser-id/-/default-browser-id-5.0.1.tgz",
       "integrity": "sha1-96fMuPUQS/jg9xujscz6Xq/bIeg=",
       "license": "MIT",
       "engines": {
@@ -2371,7 +2201,6 @@
     },
     "node_modules/define-lazy-prop": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
       "integrity": "sha1-27Ga37dG1/xtc0oGty9KANAhJV8=",
       "license": "MIT",
       "engines": {
@@ -2383,7 +2212,6 @@
     },
     "node_modules/dependency-path": {
       "version": "9.2.8",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/dependency-path/-/dependency-path-9.2.8.tgz",
       "integrity": "sha1-n+Bb6Naa0ZQ6IITk2G8wY8S1DAE=",
       "license": "MIT",
       "dependencies": {
@@ -2401,7 +2229,6 @@
     },
     "node_modules/dependency-path/node_modules/@pnpm/crypto.base32-hash": {
       "version": "1.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/crypto.base32-hash/-/crypto.base32-hash-1.0.1.tgz",
       "integrity": "sha1-4O7/Suc20qeB5BBBIGpl/nhwT/0=",
       "license": "MIT",
       "dependencies": {
@@ -2416,7 +2243,6 @@
     },
     "node_modules/dependency-path/node_modules/@pnpm/types": {
       "version": "8.9.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@pnpm/types/-/types-8.9.0.tgz",
       "integrity": "sha1-ljbV8GQnk0MvcmCbeUWMqb4EmwI=",
       "license": "MIT",
       "engines": {
@@ -2428,7 +2254,6 @@
     },
     "node_modules/detect-indent": {
       "version": "6.1.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/detect-indent/-/detect-indent-6.1.0.tgz",
       "integrity": "sha1-WSSF67v2s7GrK+F1yDk9BMoNV+Y=",
       "license": "MIT",
       "engines": {
@@ -2437,7 +2262,6 @@
     },
     "node_modules/dezalgo": {
       "version": "1.0.4",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/dezalgo/-/dezalgo-1.0.4.tgz",
       "integrity": "sha1-dRI1JgRpCEwTIVffqFfzhtTDPYE=",
       "license": "ISC",
       "dependencies": {
@@ -2447,7 +2271,6 @@
     },
     "node_modules/dotenv": {
       "version": "16.4.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/dotenv/-/dotenv-16.4.7.tgz",
       "integrity": "sha1-DiDFuClQFAqpm+NgqKX1IzX1PCY=",
       "license": "BSD-2-Clause",
       "engines": {
@@ -2459,7 +2282,6 @@
     },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
       "integrity": "sha1-rg8PothQRe8UqBfao86azQSJ5b8=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -2468,7 +2290,6 @@
     },
     "node_modules/encode-registry": {
       "version": "3.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/encode-registry/-/encode-registry-3.0.1.tgz",
       "integrity": "sha1-y5JdDbFM5ZsYiCtixnEzchsIRtE=",
       "license": "MIT",
       "dependencies": {
@@ -2480,7 +2301,6 @@
     },
     "node_modules/error-ex": {
       "version": "1.3.4",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/error-ex/-/error-ex-1.3.4.tgz",
       "integrity": "sha1-s6jYu2+S7swWKePifTyGB6ijJBQ=",
       "license": "MIT",
       "dependencies": {
@@ -2489,7 +2309,6 @@
     },
     "node_modules/es-errors": {
       "version": "1.3.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha1-BfdaJdq5jk+x3NXhRywFRtUFfI8=",
       "license": "MIT",
       "engines": {
@@ -2498,7 +2317,6 @@
     },
     "node_modules/events": {
       "version": "3.3.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/events/-/events-3.3.0.tgz",
       "integrity": "sha1-Mala0Kkk4tLEGagTrrLE6HjqdAA=",
       "license": "MIT",
       "engines": {
@@ -2508,7 +2326,6 @@
     "node_modules/execa": {
       "name": "safe-execa",
       "version": "0.1.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/safe-execa/-/safe-execa-0.1.2.tgz",
       "integrity": "sha1-L7sKbxoAx6RexwM/gmWXV/kb6Mc=",
       "license": "MIT",
       "dependencies": {
@@ -2522,7 +2339,6 @@
     },
     "node_modules/execa/node_modules/execa": {
       "version": "5.1.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/execa/-/execa-5.1.1.tgz",
       "integrity": "sha1-+ArZy/Qpj3vR1MlVXCHpN0HEEd0=",
       "license": "MIT",
       "dependencies": {
@@ -2545,19 +2361,16 @@
     },
     "node_modules/execa/node_modules/signal-exit": {
       "version": "3.0.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha1-qaF2f4r4QVURTqq9c/mSc8j1mtk=",
       "license": "ISC"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU=",
       "license": "MIT"
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fast-glob/-/fast-glob-3.3.3.tgz",
       "integrity": "sha1-0G1YXOjbqQoWsFBcVDw8z7OuuBg=",
       "license": "MIT",
       "dependencies": {
@@ -2573,19 +2386,16 @@
     },
     "node_modules/fast-safe-stringify": {
       "version": "2.1.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
       "integrity": "sha1-xAaoO25w2eNc47MKgRQd8wrrqIQ=",
       "license": "MIT"
     },
     "node_modules/fast-string-truncated-width": {
       "version": "3.0.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
       "integrity": "sha1-I6/g2mfXUsoHJ1OPHmlndZcozkk=",
       "license": "MIT"
     },
     "node_modules/fast-string-width": {
       "version": "3.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fast-string-width/-/fast-string-width-3.0.2.tgz",
       "integrity": "sha1-FturtJHOVYW17LZ1tlwWXXFojus=",
       "license": "MIT",
       "dependencies": {
@@ -2594,7 +2404,6 @@
     },
     "node_modules/fast-uri": {
       "version": "3.1.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fast-uri/-/fast-uri-3.1.5.tgz",
       "integrity": "sha1-YQ83QZoDAnBDDOzWjXTj1NlnJdA=",
       "funding": [
         {
@@ -2610,7 +2419,6 @@
     },
     "node_modules/fast-wrap-ansi": {
       "version": "0.2.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
       "integrity": "sha1-lelSoBRbzj9ZrVbhefhMSNQHKTU=",
       "license": "MIT",
       "dependencies": {
@@ -2619,7 +2427,6 @@
     },
     "node_modules/fast-xml-builder": {
       "version": "1.3.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fast-xml-builder/-/fast-xml-builder-1.3.0.tgz",
       "integrity": "sha1-vISYBHlv5Hv5FQIt2Tmw/DC6RV0=",
       "funding": [
         {
@@ -2635,7 +2442,6 @@
     },
     "node_modules/fast-xml-parser": {
       "version": "5.10.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fast-xml-parser/-/fast-xml-parser-5.10.1.tgz",
       "integrity": "sha1-GTE/fJOGxH+kod5SdUe3PtLPzt4=",
       "funding": [
         {
@@ -2658,7 +2464,6 @@
     },
     "node_modules/fastq": {
       "version": "1.20.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fastq/-/fastq-1.20.1.tgz",
       "integrity": "sha1-ynUKENySW8ixiDn9ID4+9LPO1nU=",
       "license": "ISC",
       "dependencies": {
@@ -2667,7 +2472,6 @@
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha1-RCZdPKwH4+p9wkdRY4BkN1SgUpI=",
       "license": "MIT",
       "dependencies": {
@@ -2679,7 +2483,6 @@
     },
     "node_modules/fs-extra": {
       "version": "11.3.6",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fs-extra/-/fs-extra-11.3.6.tgz",
       "integrity": "sha1-98uA6d9VDNHbb1N/pc3VaNPnDRA=",
       "license": "MIT",
       "dependencies": {
@@ -2693,13 +2496,11 @@
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "license": "ISC"
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha1-LALYZNl/PqbIgwxGTL0Rq26rehw=",
       "license": "MIT",
       "funding": {
@@ -2708,7 +2509,6 @@
     },
     "node_modules/get-npm-tarball-url": {
       "version": "2.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/get-npm-tarball-url/-/get-npm-tarball-url-2.1.0.tgz",
       "integrity": "sha1-y9a7JYhGIrwxkcdhRmyTrIM0MhM=",
       "license": "MIT",
       "engines": {
@@ -2717,7 +2517,6 @@
     },
     "node_modules/get-stream": {
       "version": "6.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/get-stream/-/get-stream-6.0.1.tgz",
       "integrity": "sha1-omLY7vZ6ztV8KFKtYWdSakPL97c=",
       "license": "MIT",
       "engines": {
@@ -2729,7 +2528,6 @@
     },
     "node_modules/git-repo-info": {
       "version": "2.1.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/git-repo-info/-/git-repo-info-2.1.1.tgz",
       "integrity": "sha1-Ig/+2MuudO+KgOMFLyzLUXmu0Fg=",
       "license": "MIT",
       "engines": {
@@ -2738,7 +2536,6 @@
     },
     "node_modules/glob": {
       "version": "8.1.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/glob/-/glob-8.1.0.tgz",
       "integrity": "sha1-04j2Vlk+9wjuPjRkD9+5mp/Rwz4=",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "license": "ISC",
@@ -2758,7 +2555,6 @@
     },
     "node_modules/glob-parent": {
       "version": "5.1.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha1-hpgyxYA0/mikCTwX3BXoNA2EAcQ=",
       "license": "ISC",
       "dependencies": {
@@ -2770,13 +2566,11 @@
     },
     "node_modules/glob/node_modules/balanced-match": {
       "version": "1.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4=",
       "license": "MIT"
     },
     "node_modules/glob/node_modules/brace-expansion": {
       "version": "2.1.4",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/brace-expansion/-/brace-expansion-2.1.4.tgz",
       "integrity": "sha1-WJ2rEcABjQNmvmTNi/Esjb7MgyY=",
       "license": "MIT",
       "dependencies": {
@@ -2785,7 +2579,6 @@
     },
     "node_modules/glob/node_modules/minimatch": {
       "version": "5.1.9",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minimatch/-/minimatch-5.1.9.tgz",
       "integrity": "sha1-EpPvFdsAmLOUVA6Pn3RPn9qN7ks=",
       "license": "ISC",
       "dependencies": {
@@ -2797,13 +2590,11 @@
     },
     "node_modules/graceful-fs": {
       "version": "4.2.4",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/graceful-fs/-/graceful-fs-4.2.4.tgz",
       "integrity": "sha1-Ila94U02MpWMRl68ltxGfKB6Kfs=",
       "license": "ISC"
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
       "license": "MIT",
       "engines": {
@@ -2812,7 +2603,6 @@
     },
     "node_modules/hasown": {
       "version": "2.0.4",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hasown/-/hasown-2.0.4.tgz",
       "integrity": "sha1-jGLYy5C+sqrV0KW2dYGtmFTD8AM=",
       "license": "MIT",
       "dependencies": {
@@ -2824,7 +2614,6 @@
     },
     "node_modules/hosted-git-info": {
       "version": "4.1.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
       "integrity": "sha1-gnuChn6f8cjQxNnVOIA5fSyG0iQ=",
       "license": "ISC",
       "dependencies": {
@@ -2836,7 +2625,6 @@
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
       "integrity": "sha1-mosfJGhmwChQlIZYX2K48sGMJw4=",
       "license": "MIT",
       "dependencies": {
@@ -2849,7 +2637,6 @@
     },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha1-xZ7yJKBP6LdU89sAY6Jeow0ABdY=",
       "license": "MIT",
       "dependencies": {
@@ -2862,7 +2649,6 @@
     },
     "node_modules/https-proxy-agent/node_modules/agent-base": {
       "version": "6.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha1-Sf/1hXfP7j83F2/qtMIuAPhtf3c=",
       "license": "MIT",
       "dependencies": {
@@ -2874,7 +2660,6 @@
     },
     "node_modules/human-signals": {
       "version": "2.1.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/human-signals/-/human-signals-2.1.0.tgz",
       "integrity": "sha1-3JH8ukLk0G5Kuu0zs+ejwC9RTqA=",
       "license": "Apache-2.0",
       "engines": {
@@ -2883,7 +2668,6 @@
     },
     "node_modules/ignore": {
       "version": "5.1.9",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ignore/-/ignore-5.1.9.tgz",
       "integrity": "sha1-nsGly+jhRG7GDUQgBg1Dqm5zgvs=",
       "license": "MIT",
       "engines": {
@@ -2892,7 +2676,6 @@
     },
     "node_modules/ignore-walk": {
       "version": "5.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ignore-walk/-/ignore-walk-5.0.1.tgz",
       "integrity": "sha1-XxmeI+Eoj1GNkDWNRhOHeIoVR3Y=",
       "license": "ISC",
       "dependencies": {
@@ -2904,13 +2687,11 @@
     },
     "node_modules/ignore-walk/node_modules/balanced-match": {
       "version": "1.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4=",
       "license": "MIT"
     },
     "node_modules/ignore-walk/node_modules/brace-expansion": {
       "version": "2.1.4",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/brace-expansion/-/brace-expansion-2.1.4.tgz",
       "integrity": "sha1-WJ2rEcABjQNmvmTNi/Esjb7MgyY=",
       "license": "MIT",
       "dependencies": {
@@ -2919,7 +2700,6 @@
     },
     "node_modules/ignore-walk/node_modules/minimatch": {
       "version": "5.1.9",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minimatch/-/minimatch-5.1.9.tgz",
       "integrity": "sha1-EpPvFdsAmLOUVA6Pn3RPn9qN7ks=",
       "license": "ISC",
       "dependencies": {
@@ -2931,13 +2711,11 @@
     },
     "node_modules/immediate": {
       "version": "3.0.6",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/immediate/-/immediate-3.0.6.tgz",
       "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=",
       "license": "MIT"
     },
     "node_modules/import-lazy": {
       "version": "4.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/import-lazy/-/import-lazy-4.0.0.tgz",
       "integrity": "sha1-6OtidIOgpD2jwD8+NVSL5csMwVM=",
       "license": "MIT",
       "engines": {
@@ -2946,7 +2724,6 @@
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "license": "MIT",
       "engines": {
@@ -2955,12 +2732,10 @@
     },
     "node_modules/individual": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/individual/-/individual-3.0.0.tgz",
       "integrity": "sha1-58pPhfiVewGHNPKFdQ3CLsL5hi0="
     },
     "node_modules/inflight": {
       "version": "1.0.6",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
       "license": "ISC",
@@ -2971,19 +2746,16 @@
     },
     "node_modules/inherits": {
       "version": "2.0.4",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
       "license": "ISC"
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "license": "MIT"
     },
     "node_modules/is-core-module": {
       "version": "2.16.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-core-module/-/is-core-module-2.16.2.tgz",
       "integrity": "sha1-PgdFCoCA684/vwysSU9NKrMk4II=",
       "license": "MIT",
       "dependencies": {
@@ -2998,7 +2770,6 @@
     },
     "node_modules/is-docker": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-docker/-/is-docker-3.0.0.tgz",
       "integrity": "sha1-kAk6oxBid9inelkQ265xdH4VogA=",
       "license": "MIT",
       "bin": {
@@ -3013,7 +2784,6 @@
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
       "license": "MIT",
       "engines": {
@@ -3022,7 +2792,6 @@
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha1-ZPYeQsu7LuwgcanawLKLoeZdUIQ=",
       "license": "MIT",
       "dependencies": {
@@ -3034,7 +2803,6 @@
     },
     "node_modules/is-inside-container": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-inside-container/-/is-inside-container-1.0.0.tgz",
       "integrity": "sha1-6B+6aZZi6zHb2vJnZqYdSBRxfqQ=",
       "license": "MIT",
       "dependencies": {
@@ -3052,7 +2820,6 @@
     },
     "node_modules/is-number": {
       "version": "7.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss=",
       "license": "MIT",
       "engines": {
@@ -3061,7 +2828,6 @@
     },
     "node_modules/is-plain-obj": {
       "version": "2.1.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
       "integrity": "sha1-ReQuN/zPH0Dajl927iFRWEDAkoc=",
       "license": "MIT",
       "engines": {
@@ -3070,7 +2836,6 @@
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha1-+sHj1TuXrVqdCunO8jifWBClwHc=",
       "license": "MIT",
       "engines": {
@@ -3082,7 +2847,6 @@
     },
     "node_modules/is-subdir": {
       "version": "1.2.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-subdir/-/is-subdir-1.2.0.tgz",
       "integrity": "sha1-t5HNKPq1IC6RoIKA1R2dclT9INQ=",
       "license": "MIT",
       "dependencies": {
@@ -3094,13 +2858,11 @@
     },
     "node_modules/is-typedarray": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "license": "MIT"
     },
     "node_modules/is-unsafe": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-unsafe/-/is-unsafe-2.0.0.tgz",
       "integrity": "sha1-wNzk4GdCZi3eJjYBYOQU6kh9ouk=",
       "funding": [
         {
@@ -3112,7 +2874,6 @@
     },
     "node_modules/is-windows": {
       "version": "1.0.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-windows/-/is-windows-1.0.2.tgz",
       "integrity": "sha1-0YUOuXkezRjmGCzhKjDzlmNLsZ0=",
       "license": "MIT",
       "engines": {
@@ -3121,7 +2882,6 @@
     },
     "node_modules/is-wsl": {
       "version": "3.1.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/is-wsl/-/is-wsl-3.1.1.tgz",
       "integrity": "sha1-MniXsmgyo+sRfabCdJLQTKEyWU8=",
       "license": "MIT",
       "dependencies": {
@@ -3136,31 +2896,26 @@
     },
     "node_modules/isarray": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "license": "ISC"
     },
     "node_modules/jju": {
       "version": "1.4.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/jju/-/jju-1.4.0.tgz",
       "integrity": "sha1-o6vicYryQaKykE+EpiWXDzia4yo=",
       "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk=",
       "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "4.1.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha1-hUwpJGdwW2mUduGi3swMijRYgGs=",
       "license": "MIT",
       "dependencies": {
@@ -3172,13 +2927,11 @@
     },
     "node_modules/js-yaml/node_modules/argparse": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha1-JG9Q88p4oyQPbJl+ipvR6sSeSzg=",
       "license": "Python-2.0"
     },
     "node_modules/jsep": {
       "version": "1.4.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/jsep/-/jsep-1.4.0.tgz",
       "integrity": "sha1-Gf7Mv6Udinn3JIC0uOQM4uFxUvA=",
       "license": "MIT",
       "engines": {
@@ -3187,25 +2940,21 @@
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha1-fEeAWpQxmSjgV3dAXcEuH3pO4C0=",
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha1-rnvLNlard6c7pcSb9lTzjmtoYOI=",
       "license": "MIT"
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "license": "ISC"
     },
     "node_modules/json5": {
       "version": "2.2.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/json5/-/json5-2.2.3.tgz",
       "integrity": "sha1-eM1vGhm9wStz21rQxh79ZsHikoM=",
       "license": "MIT",
       "bin": {
@@ -3217,7 +2966,6 @@
     },
     "node_modules/jsonfile": {
       "version": "6.2.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/jsonfile/-/jsonfile-6.2.1.tgz",
       "integrity": "sha1-tuMXF/Isw3MwsIHOAFHtXeU68vY=",
       "license": "MIT",
       "dependencies": {
@@ -3229,7 +2977,6 @@
     },
     "node_modules/jsonpath-plus": {
       "version": "10.3.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/jsonpath-plus/-/jsonpath-plus-10.3.0.tgz",
       "integrity": "sha1-WeIuT6IpjGjfzXBlm7R/DK1SUjg=",
       "license": "MIT",
       "dependencies": {
@@ -3247,7 +2994,6 @@
     },
     "node_modules/jsonwebtoken": {
       "version": "9.0.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
       "integrity": "sha1-bNV6sB6bCsB8uEfVPTybbuMfeuI=",
       "license": "MIT",
       "dependencies": {
@@ -3269,7 +3015,6 @@
     },
     "node_modules/jszip": {
       "version": "3.8.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/jszip/-/jszip-3.8.0.tgz",
       "integrity": "sha1-oqw8M/6Wp2SJdlFoITZVhQJU1Rs=",
       "license": "(MIT OR GPL-3.0-or-later)",
       "dependencies": {
@@ -3281,7 +3026,6 @@
     },
     "node_modules/jwa": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/jwa/-/jwa-2.0.1.tgz",
       "integrity": "sha1-v4F20a0M1y4PP1gzhZWhPhELyAQ=",
       "license": "MIT",
       "dependencies": {
@@ -3292,7 +3036,6 @@
     },
     "node_modules/jws": {
       "version": "4.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/jws/-/jws-4.0.1.tgz",
       "integrity": "sha1-B+3Bvo+sIOZ3soPs4mFJi9OPBpA=",
       "license": "MIT",
       "dependencies": {
@@ -3302,7 +3045,6 @@
     },
     "node_modules/lie": {
       "version": "3.3.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lie/-/lie-3.3.0.tgz",
       "integrity": "sha1-3Pgt7lRfRgdNryAMfBxaCOD0D2o=",
       "license": "MIT",
       "dependencies": {
@@ -3311,13 +3053,11 @@
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha1-7KKE910pZQeTCdwK2SVauy68FjI=",
       "license": "MIT"
     },
     "node_modules/load-json-file": {
       "version": "6.2.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/load-json-file/-/load-json-file-6.2.0.tgz",
       "integrity": "sha1-XHdwtCyvqXB0yihIcHxhZi9CUaE=",
       "license": "MIT",
       "dependencies": {
@@ -3332,49 +3072,41 @@
     },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lodash.includes/-/lodash.includes-4.3.0.tgz",
       "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=",
       "license": "MIT"
     },
     "node_modules/lodash.isboolean": {
       "version": "3.0.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
       "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY=",
       "license": "MIT"
     },
     "node_modules/lodash.isinteger": {
       "version": "4.0.4",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
       "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M=",
       "license": "MIT"
     },
     "node_modules/lodash.isnumber": {
       "version": "3.0.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
       "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w=",
       "license": "MIT"
     },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
       "license": "MIT"
     },
     "node_modules/lodash.isstring": {
       "version": "4.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
       "license": "MIT"
     },
     "node_modules/lodash.once": {
       "version": "4.1.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=",
       "license": "MIT"
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha1-bW/mVw69lqr5D8rR2vo7JWbbOpQ=",
       "license": "ISC",
       "dependencies": {
@@ -3386,7 +3118,6 @@
     },
     "node_modules/map-age-cleaner": {
       "version": "0.1.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
       "integrity": "sha1-fVg6cwZDTAVf5HSw9FB45uG0uSo=",
       "license": "MIT",
       "dependencies": {
@@ -3398,7 +3129,6 @@
     },
     "node_modules/mem": {
       "version": "8.1.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mem/-/mem-8.1.1.tgz",
       "integrity": "sha1-zxGLNXxlq3t+CBe98AyAYil8ASI=",
       "license": "MIT",
       "dependencies": {
@@ -3414,13 +3144,11 @@
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha1-UoI2KaFN0AyXcPtq1H3GMQ8sH2A=",
       "license": "MIT"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha1-Q2iJL4hekHRVpv19xVwMnUBJkK4=",
       "license": "MIT",
       "engines": {
@@ -3429,7 +3157,6 @@
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha1-1m+hjzpHB2eJMgubGvMr2G2fogI=",
       "license": "MIT",
       "dependencies": {
@@ -3442,7 +3169,6 @@
     },
     "node_modules/mimic-fn": {
       "version": "3.1.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mimic-fn/-/mimic-fn-3.1.0.tgz",
       "integrity": "sha1-ZXVRRbvz42lUuUnBZFBCdFHVynQ=",
       "license": "MIT",
       "engines": {
@@ -3451,7 +3177,6 @@
     },
     "node_modules/minimatch": {
       "version": "10.2.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minimatch/-/minimatch-10.2.3.tgz",
       "integrity": "sha1-wO9YLyEHGwEjpbvydSUuvakh+/Y=",
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -3466,7 +3191,6 @@
     },
     "node_modules/minimist": {
       "version": "1.2.8",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha1-waRk52kzAuCCoHXO4MBXdBrEdyw=",
       "license": "MIT",
       "funding": {
@@ -3475,7 +3199,6 @@
     },
     "node_modules/minipass": {
       "version": "3.3.6",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minipass/-/minipass-3.3.6.tgz",
       "integrity": "sha1-e7o4TbOhUg0YycDlJRw0ROld2Uo=",
       "license": "ISC",
       "dependencies": {
@@ -3487,7 +3210,6 @@
     },
     "node_modules/minizlib": {
       "version": "3.1.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minizlib/-/minizlib-3.1.0.tgz",
       "integrity": "sha1-atdsOo8QInybUdHJrI4wsn9aJRw=",
       "license": "MIT",
       "dependencies": {
@@ -3499,7 +3221,6 @@
     },
     "node_modules/minizlib/node_modules/minipass": {
       "version": "7.1.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minipass/-/minipass-7.1.3.tgz",
       "integrity": "sha1-eTibTrG7LQA6m7qH1JLyvTe9xls=",
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -3508,13 +3229,11 @@
     },
     "node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ms/-/ms-2.1.3.tgz",
       "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
       "license": "MIT"
     },
     "node_modules/mute-stream": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mute-stream/-/mute-stream-3.0.0.tgz",
       "integrity": "sha1-zYAU3SrLcuHpG7Z8dPABnmILotE=",
       "license": "ISC",
       "engines": {
@@ -3523,7 +3242,6 @@
     },
     "node_modules/mz": {
       "version": "2.7.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mz/-/mz-2.7.0.tgz",
       "integrity": "sha1-lQCAV6Vsr63CvGPd5/n/aVWUjjI=",
       "license": "MIT",
       "dependencies": {
@@ -3534,7 +3252,6 @@
     },
     "node_modules/ndjson": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ndjson/-/ndjson-2.0.0.tgz",
       "integrity": "sha1-MgrIb2/lP1aBiXNJuGrG9Dv6Ohk=",
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -3553,7 +3270,6 @@
     },
     "node_modules/ndjson/node_modules/readable-stream": {
       "version": "3.6.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha1-VqmzbqllwAxak+8x6xEaDxEFaWc=",
       "license": "MIT",
       "dependencies": {
@@ -3567,7 +3283,6 @@
     },
     "node_modules/ndjson/node_modules/split2": {
       "version": "3.2.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/split2/-/split2-3.2.2.tgz",
       "integrity": "sha1-vyzyo32DgxLCSciSBv16F90SNl8=",
       "license": "ISC",
       "dependencies": {
@@ -3576,7 +3291,6 @@
     },
     "node_modules/normalize-package-data": {
       "version": "3.0.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
       "integrity": "sha1-28w+LaWVCaCYNCKITNFy7v36Ul4=",
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -3591,7 +3305,6 @@
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha1-Dc1p/yOhybEf0JeDFmRKA4ghamU=",
       "license": "MIT",
       "engines": {
@@ -3600,7 +3313,6 @@
     },
     "node_modules/npm-bundled": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/npm-bundled/-/npm-bundled-2.0.1.tgz",
       "integrity": "sha1-lBE/frNCzXpn3h54n4lrBNLGAPQ=",
       "license": "ISC",
       "dependencies": {
@@ -3612,7 +3324,6 @@
     },
     "node_modules/npm-normalize-package-bin": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/npm-normalize-package-bin/-/npm-normalize-package-bin-2.0.0.tgz",
       "integrity": "sha1-lEehrar4nYrQq+JMbIStYUpnX/8=",
       "license": "ISC",
       "engines": {
@@ -3621,7 +3332,6 @@
     },
     "node_modules/npm-package-arg": {
       "version": "6.1.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/npm-package-arg/-/npm-package-arg-6.1.1.tgz",
       "integrity": "sha1-AhaMsKSaK3W/mIooaY3ntSnfXLc=",
       "license": "ISC",
       "dependencies": {
@@ -3633,13 +3343,11 @@
     },
     "node_modules/npm-package-arg/node_modules/hosted-git-info": {
       "version": "2.8.9",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
       "integrity": "sha1-3/wL+aIcAiCQkPKqaUKeFBTa8/k=",
       "license": "ISC"
     },
     "node_modules/npm-package-arg/node_modules/semver": {
       "version": "5.7.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/semver/-/semver-5.7.2.tgz",
       "integrity": "sha1-SNVdtzfDKHzUg14X+hP+rOHEHvg=",
       "license": "ISC",
       "bin": {
@@ -3648,7 +3356,6 @@
     },
     "node_modules/npm-packlist": {
       "version": "5.1.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/npm-packlist/-/npm-packlist-5.1.3.tgz",
       "integrity": "sha1-adJT5v1mS5BYuFAFkFAS4A5pJ0s=",
       "license": "ISC",
       "dependencies": {
@@ -3666,7 +3373,6 @@
     },
     "node_modules/npm-run-path": {
       "version": "4.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/npm-run-path/-/npm-run-path-4.0.1.tgz",
       "integrity": "sha1-t+zR5e1T2o43pV4cImnguX7XSOo=",
       "license": "MIT",
       "dependencies": {
@@ -3678,7 +3384,6 @@
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "license": "MIT",
       "engines": {
@@ -3687,7 +3392,6 @@
     },
     "node_modules/object-hash": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha1-c/l/dT57r/wOLMnW4HkHl0Ssguk=",
       "license": "MIT",
       "engines": {
@@ -3696,7 +3400,6 @@
     },
     "node_modules/once": {
       "version": "1.4.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "license": "ISC",
       "dependencies": {
@@ -3705,7 +3408,6 @@
     },
     "node_modules/onetime": {
       "version": "5.1.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/onetime/-/onetime-5.1.2.tgz",
       "integrity": "sha1-0Oluu1awdHbfHdnEgG5SN5hcpF4=",
       "license": "MIT",
       "dependencies": {
@@ -3720,7 +3422,6 @@
     },
     "node_modules/onetime/node_modules/mimic-fn": {
       "version": "2.1.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha1-ftLCzMyvhNP/y3pptXcR/CCDQBs=",
       "license": "MIT",
       "engines": {
@@ -3729,7 +3430,6 @@
     },
     "node_modules/open": {
       "version": "10.2.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/open/-/open-10.2.0.tgz",
       "integrity": "sha1-udhVvgB2IOgLb7BfrJgUH+Yttzw=",
       "license": "MIT",
       "dependencies": {
@@ -3747,7 +3447,6 @@
     },
     "node_modules/os-homedir": {
       "version": "1.0.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "license": "MIT",
       "engines": {
@@ -3756,7 +3455,6 @@
     },
     "node_modules/os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "license": "MIT",
       "engines": {
@@ -3765,7 +3463,6 @@
     },
     "node_modules/osenv": {
       "version": "0.1.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/osenv/-/osenv-0.1.5.tgz",
       "integrity": "sha1-hc36+uso6Gd/QW4odZK18/SepBA=",
       "deprecated": "This package is no longer supported.",
       "license": "ISC",
@@ -3776,7 +3473,6 @@
     },
     "node_modules/p-defer": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/p-defer/-/p-defer-1.0.0.tgz",
       "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
       "license": "MIT",
       "engines": {
@@ -3785,7 +3481,6 @@
     },
     "node_modules/p-limit": {
       "version": "2.3.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/p-limit/-/p-limit-2.3.0.tgz",
       "integrity": "sha1-PdM8ZHohT9//2DWTPrCG2g3CHbE=",
       "license": "MIT",
       "dependencies": {
@@ -3800,7 +3495,6 @@
     },
     "node_modules/p-reflect": {
       "version": "2.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/p-reflect/-/p-reflect-2.1.0.tgz",
       "integrity": "sha1-XWfHs8V3xOeAuUUfyRKWdb2Z/mc=",
       "license": "MIT",
       "engines": {
@@ -3809,7 +3503,6 @@
     },
     "node_modules/p-settle": {
       "version": "4.1.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/p-settle/-/p-settle-4.1.1.tgz",
       "integrity": "sha1-N/vOsrAsnvwoZY/I02lJkiJmA18=",
       "license": "MIT",
       "dependencies": {
@@ -3825,7 +3518,6 @@
     },
     "node_modules/p-try": {
       "version": "2.2.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
       "license": "MIT",
       "engines": {
@@ -3834,13 +3526,11 @@
     },
     "node_modules/pako": {
       "version": "1.0.11",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/pako/-/pako-1.0.11.tgz",
       "integrity": "sha1-bJWZ00DVTf05RjgCUqNXBaa5kr8=",
       "license": "(MIT AND Zlib)"
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/parse-json/-/parse-json-5.2.0.tgz",
       "integrity": "sha1-x2/Gbe5UIxyWKyK8yKcs8vmXU80=",
       "license": "MIT",
       "dependencies": {
@@ -3858,7 +3548,6 @@
     },
     "node_modules/path-expression-matcher": {
       "version": "1.6.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz",
       "integrity": "sha1-VnxzwHGX6dzvJOkO3NxXEFZZkWg=",
       "funding": [
         {
@@ -3873,7 +3562,6 @@
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "license": "MIT",
       "engines": {
@@ -3882,7 +3570,6 @@
     },
     "node_modules/path-key": {
       "version": "3.1.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha1-WB9q3mWMu6ZaDTOA3ndTKVBU83U=",
       "license": "MIT",
       "engines": {
@@ -3891,25 +3578,21 @@
     },
     "node_modules/path-name": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/path-name/-/path-name-1.0.0.tgz",
       "integrity": "sha1-jKBjpj3nmC36lXYO2v/RAhRJTyQ=",
       "license": "MIT"
     },
     "node_modules/path-parse": {
       "version": "1.0.7",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha1-+8EUtgykKzDZ2vWFjkvWi77bZzU=",
       "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha1-PTIa8+q5ObCDyPkpodEs2oHCa2s=",
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha1-WpQpFeJrNy3A8OZ1MUmhbmscVgE=",
       "license": "MIT",
       "engines": {
@@ -3921,7 +3604,6 @@
     },
     "node_modules/pnpm-sync-lib": {
       "version": "0.3.4",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/pnpm-sync-lib/-/pnpm-sync-lib-0.3.4.tgz",
       "integrity": "sha1-WqvCl3akqkRBeaO4auAdpdCtTU8=",
       "license": "MIT",
       "dependencies": {
@@ -3935,13 +3617,11 @@
     },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha1-eCDZsWEgzFXKmud5JoCufbptf+I=",
       "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha1-SSkii7xyTfrEPg77BYyve2z7YkM=",
       "funding": [
         {
@@ -3961,13 +3641,11 @@
     },
     "node_modules/ramda": {
       "version": "0.27.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ramda/-/ramda-0.27.2.tgz",
       "integrity": "sha1-hEYyJvfzbcM1kvb07WN0xIMGw/E=",
       "license": "MIT"
     },
     "node_modules/read-package-json": {
       "version": "2.1.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/read-package-json/-/read-package-json-2.1.2.tgz",
       "integrity": "sha1-aZKytmxxdyWf646qxzw6zSi5Iio=",
       "deprecated": "This package is no longer supported. Please use @npmcli/package-json instead.",
       "license": "ISC",
@@ -3980,13 +3658,11 @@
     },
     "node_modules/read-package-json/node_modules/balanced-match": {
       "version": "1.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4=",
       "license": "MIT"
     },
     "node_modules/read-package-json/node_modules/brace-expansion": {
       "version": "1.1.18",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/brace-expansion/-/brace-expansion-1.1.18.tgz",
       "integrity": "sha1-POdNiYhRNr4VNTQfjD1EJcKaXKs=",
       "license": "MIT",
       "dependencies": {
@@ -3996,7 +3672,6 @@
     },
     "node_modules/read-package-json/node_modules/glob": {
       "version": "7.2.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/glob/-/glob-7.2.3.tgz",
       "integrity": "sha1-uN8PuAK7+o6JvR2Ti04WV47UTys=",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "license": "ISC",
@@ -4017,13 +3692,11 @@
     },
     "node_modules/read-package-json/node_modules/hosted-git-info": {
       "version": "2.8.9",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
       "integrity": "sha1-3/wL+aIcAiCQkPKqaUKeFBTa8/k=",
       "license": "ISC"
     },
     "node_modules/read-package-json/node_modules/minimatch": {
       "version": "3.1.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha1-WAyI+NVEXyvWqo88re+g3nn71p4=",
       "license": "ISC",
       "dependencies": {
@@ -4035,7 +3708,6 @@
     },
     "node_modules/read-package-json/node_modules/normalize-package-data": {
       "version": "2.5.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
       "integrity": "sha1-5m2xg4sgDB38IzIl0SyzZSDiNKg=",
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -4047,13 +3719,11 @@
     },
     "node_modules/read-package-json/node_modules/npm-normalize-package-bin": {
       "version": "1.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
       "integrity": "sha1-bnmkHyP9I1wGIyGCKNp9nCO49uI=",
       "license": "ISC"
     },
     "node_modules/read-package-json/node_modules/semver": {
       "version": "5.7.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/semver/-/semver-5.7.2.tgz",
       "integrity": "sha1-SNVdtzfDKHzUg14X+hP+rOHEHvg=",
       "license": "ISC",
       "bin": {
@@ -4062,7 +3732,6 @@
     },
     "node_modules/read-package-tree": {
       "version": "5.1.6",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/read-package-tree/-/read-package-tree-5.1.6.tgz",
       "integrity": "sha1-TwPoPQSGhW+2DZfJSIKEHCp7G3o=",
       "deprecated": "The functionality that this package provided is now in @npmcli/arborist",
       "license": "ISC",
@@ -4076,7 +3745,6 @@
     },
     "node_modules/read-yaml-file": {
       "version": "2.1.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/read-yaml-file/-/read-yaml-file-2.1.0.tgz",
       "integrity": "sha1-xYZnEtue9TQ7TQLCQTutpTxBxKk=",
       "license": "MIT",
       "dependencies": {
@@ -4089,7 +3757,6 @@
     },
     "node_modules/readable-stream": {
       "version": "2.3.8",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/readable-stream/-/readable-stream-2.3.8.tgz",
       "integrity": "sha1-kRJegEK7obmIf0k0X2J3Anzovps=",
       "license": "MIT",
       "dependencies": {
@@ -4104,13 +3771,11 @@
     },
     "node_modules/readable-stream/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
       "license": "MIT"
     },
     "node_modules/readdir-scoped-modules": {
       "version": "1.1.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/readdir-scoped-modules/-/readdir-scoped-modules-1.1.0.tgz",
       "integrity": "sha1-jUVAe0+HCg3K68DihnDRjnRRQwk=",
       "deprecated": "This functionality has been moved to @npmcli/fs",
       "license": "ISC",
@@ -4123,7 +3788,6 @@
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha1-iaf92TgmEmcxjq/hT5wy5ZjDaQk=",
       "license": "MIT",
       "engines": {
@@ -4132,7 +3796,6 @@
     },
     "node_modules/resolve": {
       "version": "1.22.12",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/resolve/-/resolve-1.22.12.tgz",
       "integrity": "sha1-9bKmgIl8acI4oTzRaxVnH4tzVJ8=",
       "license": "MIT",
       "dependencies": {
@@ -4153,7 +3816,6 @@
     },
     "node_modules/reusify": {
       "version": "1.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/reusify/-/reusify-1.1.0.tgz",
       "integrity": "sha1-D+E7lSLhRz9RtVjueW4I8R+bSJ8=",
       "license": "MIT",
       "engines": {
@@ -4163,13 +3825,11 @@
     },
     "node_modules/rfc4648": {
       "version": "1.5.4",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/rfc4648/-/rfc4648-1.5.4.tgz",
       "integrity": "sha1-EXTAr7pyQjoLcMOG7P64CqYbBco=",
       "license": "MIT"
     },
     "node_modules/rimraf": {
       "version": "3.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha1-8aVAK6YiCtUswSgrrBrjqkn9Bho=",
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "license": "ISC",
@@ -4185,13 +3845,11 @@
     },
     "node_modules/rimraf/node_modules/balanced-match": {
       "version": "1.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4=",
       "license": "MIT"
     },
     "node_modules/rimraf/node_modules/brace-expansion": {
       "version": "1.1.18",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/brace-expansion/-/brace-expansion-1.1.18.tgz",
       "integrity": "sha1-POdNiYhRNr4VNTQfjD1EJcKaXKs=",
       "license": "MIT",
       "dependencies": {
@@ -4201,7 +3859,6 @@
     },
     "node_modules/rimraf/node_modules/glob": {
       "version": "7.2.3",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/glob/-/glob-7.2.3.tgz",
       "integrity": "sha1-uN8PuAK7+o6JvR2Ti04WV47UTys=",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "license": "ISC",
@@ -4222,7 +3879,6 @@
     },
     "node_modules/rimraf/node_modules/minimatch": {
       "version": "3.1.5",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha1-WAyI+NVEXyvWqo88re+g3nn71p4=",
       "license": "ISC",
       "dependencies": {
@@ -4234,7 +3890,6 @@
     },
     "node_modules/run-applescript": {
       "version": "7.1.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/run-applescript/-/run-applescript-7.1.0.tgz",
       "integrity": "sha1-Lp5UxGZOwxBsW1Yw4knT1llcSRE=",
       "license": "MIT",
       "engines": {
@@ -4246,7 +3901,6 @@
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha1-ZtE2jae9+SHrnZW9GpIp5/IaQ+4=",
       "funding": [
         {
@@ -4269,7 +3923,6 @@
     },
     "node_modules/rxjs": {
       "version": "6.6.7",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/rxjs/-/rxjs-6.6.7.tgz",
       "integrity": "sha1-kKwBisq/SRv2UEQjXVhjxNq4BMk=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -4281,13 +3934,11 @@
     },
     "node_modules/rxjs/node_modules/tslib": {
       "version": "1.14.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha1-zy04vcNKE0vK8QkcQfZhni9nLQA=",
       "license": "0BSD"
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha1-Hq+fqb2x/dTsdfWPnNtOa3gn7sY=",
       "funding": [
         {
@@ -4307,7 +3958,6 @@
     },
     "node_modules/semver": {
       "version": "7.7.4",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/semver/-/semver-7.7.4.tgz",
       "integrity": "sha1-KEZONgYOmR+noR0CedLT87V6foo=",
       "license": "ISC",
       "bin": {
@@ -4319,7 +3969,6 @@
     },
     "node_modules/set-immediate-shim": {
       "version": "1.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
       "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
       "license": "MIT",
       "engines": {
@@ -4328,7 +3977,6 @@
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha1-zNCvT4g1+9wmW4JGGq8MNmY/NOo=",
       "license": "MIT",
       "dependencies": {
@@ -4340,7 +3988,6 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha1-rhbxZE2HPsrYQ7AwexQzYtTEIXI=",
       "license": "MIT",
       "engines": {
@@ -4349,7 +3996,6 @@
     },
     "node_modules/signal-exit": {
       "version": "4.1.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha1-lSGIwcvVRgcOLdIND0HArgUwywQ=",
       "license": "ISC",
       "engines": {
@@ -4361,7 +4007,6 @@
     },
     "node_modules/sort-keys": {
       "version": "4.2.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sort-keys/-/sort-keys-4.2.0.tgz",
       "integrity": "sha1-a3Y4zuQsUG//jBzs3nN20hMVvhg=",
       "license": "MIT",
       "dependencies": {
@@ -4376,7 +4021,6 @@
     },
     "node_modules/spdx-correct": {
       "version": "3.2.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/spdx-correct/-/spdx-correct-3.2.0.tgz",
       "integrity": "sha1-T1qwZo8AWeNPnADc4zF4ShLeTpw=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -4386,13 +4030,11 @@
     },
     "node_modules/spdx-exceptions": {
       "version": "2.5.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
       "integrity": "sha1-XWB9J/yAb2bXtkp2ZlD6iQ8E7WY=",
       "license": "CC-BY-3.0"
     },
     "node_modules/spdx-expression-parse": {
       "version": "3.0.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
       "integrity": "sha1-z3D1BILu/cmOPOCmgz5KU87rpnk=",
       "license": "MIT",
       "dependencies": {
@@ -4402,13 +4044,11 @@
     },
     "node_modules/spdx-license-ids": {
       "version": "3.0.23",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
       "integrity": "sha1-sGnmh7EpGjLxJok+12onp0XuITM=",
       "license": "CC0-1.0"
     },
     "node_modules/split2": {
       "version": "4.2.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/split2/-/split2-4.2.0.tgz",
       "integrity": "sha1-ycWSCQTRSLqwufZxRfJFqGqtv6Q=",
       "license": "ISC",
       "engines": {
@@ -4417,13 +4057,11 @@
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "license": "BSD-3-Clause"
     },
     "node_modules/ssri": {
       "version": "8.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ssri/-/ssri-8.0.1.tgz",
       "integrity": "sha1-Y45OQ54v+9LNKJd21cpFfE9Roq8=",
       "license": "ISC",
       "dependencies": {
@@ -4435,7 +4073,6 @@
     },
     "node_modules/strict-uri-encode": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
       "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY=",
       "license": "MIT",
       "engines": {
@@ -4444,7 +4081,6 @@
     },
     "node_modules/string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
       "license": "MIT",
       "dependencies": {
@@ -4453,13 +4089,11 @@
     },
     "node_modules/string_decoder/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
       "license": "MIT"
     },
     "node_modules/string-argv": {
       "version": "0.3.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/string-argv/-/string-argv-0.3.2.tgz",
       "integrity": "sha1-K20O8ktlYnTZV9VOCku/YVPcArY=",
       "license": "MIT",
       "engines": {
@@ -4468,7 +4102,6 @@
     },
     "node_modules/strip-bom": {
       "version": "4.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/strip-bom/-/strip-bom-4.0.0.tgz",
       "integrity": "sha1-nDUFwdtFvO3KPZz3oW9cWqOQGHg=",
       "license": "MIT",
       "engines": {
@@ -4477,7 +4110,6 @@
     },
     "node_modules/strip-final-newline": {
       "version": "2.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
       "integrity": "sha1-ibhS+y/L6Tb29LMYevsKEsGrWK0=",
       "license": "MIT",
       "engines": {
@@ -4486,7 +4118,6 @@
     },
     "node_modules/strnum": {
       "version": "2.4.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/strnum/-/strnum-2.4.1.tgz",
       "integrity": "sha1-hUF/aDETut6g/n4XInZ2+In/flg=",
       "funding": [
         {
@@ -4501,7 +4132,6 @@
     },
     "node_modules/supports-color": {
       "version": "8.1.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/supports-color/-/supports-color-8.1.1.tgz",
       "integrity": "sha1-zW/BfihQDP9WwbhsCn/UpUpzAFw=",
       "license": "MIT",
       "dependencies": {
@@ -4516,7 +4146,6 @@
     },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha1-btpL00SjyUrqN21MwxvHcxEDngk=",
       "license": "MIT",
       "engines": {
@@ -4528,7 +4157,6 @@
     },
     "node_modules/tapable": {
       "version": "2.2.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tapable/-/tapable-2.2.1.tgz",
       "integrity": "sha1-GWenPvQGCoLxKrlq+G1S/bdu7KA=",
       "license": "MIT",
       "engines": {
@@ -4537,7 +4165,6 @@
     },
     "node_modules/tar": {
       "version": "7.5.22",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tar/-/tar-7.5.22.tgz",
       "integrity": "sha1-ppb5mBNucUh9w/hpqFu6LGeXG6k=",
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -4553,7 +4180,6 @@
     },
     "node_modules/tar/node_modules/minipass": {
       "version": "7.1.3",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/minipass/-/minipass-7.1.3.tgz",
       "integrity": "sha1-eTibTrG7LQA6m7qH1JLyvTe9xls=",
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -4562,7 +4188,6 @@
     },
     "node_modules/tar/node_modules/yallist": {
       "version": "5.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/yallist/-/yallist-5.0.0.tgz",
       "integrity": "sha1-AOLeRDY57Q14/YfeDSdGn7z/tTM=",
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -4571,7 +4196,6 @@
     },
     "node_modules/thenify": {
       "version": "3.3.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/thenify/-/thenify-3.3.1.tgz",
       "integrity": "sha1-iTLmhqQGYDigFt2eLKRq3Zg4qV8=",
       "license": "MIT",
       "dependencies": {
@@ -4580,7 +4204,6 @@
     },
     "node_modules/thenify-all": {
       "version": "1.6.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/thenify-all/-/thenify-all-1.6.0.tgz",
       "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
       "license": "MIT",
       "dependencies": {
@@ -4592,7 +4215,6 @@
     },
     "node_modules/through2": {
       "version": "4.0.2",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/through2/-/through2-4.0.2.tgz",
       "integrity": "sha1-p846wqeosLlmyA58SfBITDsjl2Q=",
       "license": "MIT",
       "dependencies": {
@@ -4601,7 +4223,6 @@
     },
     "node_modules/through2/node_modules/readable-stream": {
       "version": "3.6.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha1-VqmzbqllwAxak+8x6xEaDxEFaWc=",
       "license": "MIT",
       "dependencies": {
@@ -4615,7 +4236,6 @@
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha1-FkjESq58jZiKMmAY7XL1tN0DkuQ=",
       "license": "MIT",
       "dependencies": {
@@ -4627,19 +4247,16 @@
     },
     "node_modules/true-case-path": {
       "version": "2.2.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/true-case-path/-/true-case-path-2.2.1.tgz",
       "integrity": "sha1-xb8EpbvsP9EYvkCERhs6J8TXlr8=",
       "license": "Apache-2.0"
     },
     "node_modules/tslib": {
       "version": "2.8.1",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha1-YS7+TtI11Wfoq6Xypfq3AoCt6D8=",
       "license": "0BSD"
     },
     "node_modules/type-fest": {
       "version": "0.6.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/type-fest/-/type-fest-0.6.0.tgz",
       "integrity": "sha1-jSojcNPfiG61yQraHFv2GIrPg4s=",
       "license": "(MIT OR CC0-1.0)",
       "engines": {
@@ -4648,7 +4265,6 @@
     },
     "node_modules/typedarray-to-buffer": {
       "version": "3.1.5",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
       "integrity": "sha1-qX7nqf9CaRufeD/xvFES/j/KkIA=",
       "license": "MIT",
       "dependencies": {
@@ -4657,7 +4273,6 @@
     },
     "node_modules/universalify": {
       "version": "2.0.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha1-Fo78IYCWTmOG0GHglN9hr+I5sY0=",
       "license": "MIT",
       "engines": {
@@ -4666,13 +4281,11 @@
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "license": "MIT"
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
       "integrity": "sha1-/JH2uce6FchX9MssXe/uw51PQQo=",
       "license": "Apache-2.0",
       "dependencies": {
@@ -4682,7 +4295,6 @@
     },
     "node_modules/validate-npm-package-name": {
       "version": "3.0.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
       "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
       "license": "ISC",
       "dependencies": {
@@ -4691,7 +4303,6 @@
     },
     "node_modules/which": {
       "version": "2.0.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/which/-/which-2.0.2.tgz",
       "integrity": "sha1-fGqN0KY2oDJ+ELWckobu6T8/UbE=",
       "license": "ISC",
       "dependencies": {
@@ -4706,13 +4317,11 @@
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {
       "version": "3.0.3",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
       "integrity": "sha1-Vr1cWlxwSBzRnFcb05q5ZaXeVug=",
       "license": "ISC",
       "dependencies": {
@@ -4724,13 +4333,11 @@
     },
     "node_modules/write-file-atomic/node_modules/signal-exit": {
       "version": "3.0.7",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha1-qaF2f4r4QVURTqq9c/mSc8j1mtk=",
       "license": "ISC"
     },
     "node_modules/write-yaml-file": {
       "version": "4.2.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/write-yaml-file/-/write-yaml-file-4.2.0.tgz",
       "integrity": "sha1-hvygopdma/WcQNzZbhbb39FyKMI=",
       "license": "MIT",
       "dependencies": {
@@ -4743,7 +4350,6 @@
     },
     "node_modules/wsl-utils": {
       "version": "0.1.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/wsl-utils/-/wsl-utils-0.1.0.tgz",
       "integrity": "sha1-h4PU32cdTVA2W+LuTHGRegVXuqs=",
       "license": "MIT",
       "dependencies": {
@@ -4758,7 +4364,6 @@
     },
     "node_modules/xml-naming": {
       "version": "0.3.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/xml-naming/-/xml-naming-0.3.0.tgz",
       "integrity": "sha1-RsHhi/4oWEeZgt0qzPNNFudJ7aI=",
       "funding": [
         {
@@ -4773,13 +4378,11 @@
     },
     "node_modules/yallist": {
       "version": "4.0.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha1-m7knkNnA7/7GO+c1GeEaNQGaOnI=",
       "license": "ISC"
     },
     "node_modules/yaml": {
       "version": "2.9.0",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/yaml/-/yaml-2.9.0.tgz",
       "integrity": "sha1-eCdK/ZNZih391hMN9qVm3vy/mqQ=",
       "license": "ISC",
       "bin": {


### PR DESCRIPTION
## Summary

The checked-in `install-run-rush` lockfile records registry URLs from the package feed proxy. This adds `omit-lockfile-registry-resolved=true` to the Rush npm configuration and removes those URLs from `common/config/validation/rush-package-lock.json`.

## Details

`install-run-rush` copies `common/config/rush/.npmrc` into its temporary npm project before installing Rush. I regenerated the validation lockfile from that bootstrap project with npm 11.19.0 and the package feed proxy used by the post-publish pipeline.

A fresh unseeded install selected newer transitive versions, so I rejected that output. To keep the existing dependency graph, I made a temporary copy of the current lockfile without `resolved` fields and seeded the bootstrap `npm install` with it. The intermediate file stayed outside the repository. The final lockfile matches the original structure after ignoring `resolved` fields, so dependency versions, integrity hashes, lockfile version 3, and platform metadata are unchanged. The diff removes 397 `resolved` entries and adds the npm setting.

## How it was tested

- Generated twice through `node common/scripts/install-run-rush.js --help` with an isolated `RUSH_TEMP_FOLDER`; both outputs were byte-identical.
- Ran `install-run-rush` with `INSTALL_RUN_RUSH_LOCKFILE_PATH` pointing to the regenerated lockfile. Its `npm ci` bootstrap completed successfully.
- Confirmed `npm config get omit-lockfile-registry-resolved` returns `true` in the bootstrap project.
- Confirmed the validation lockfile contains no `resolved` fields or `pkgs.visualstudio.com` URLs.
- Ran `node common/scripts/install-run-rush.js change --verify`.
- Ran `node common/scripts/install-run-rush.js install --to repo-toolbox`.
- Ran `node common/scripts/install-run-rush.js build --to repo-toolbox --verbose`.
- The pre-commit `rush prettier` check passed.
