### PR TITLE
Wire rush-reporter package dependencies

### DIFF
--- a/apps/rush/package.json
+++ b/apps/rush/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "@microsoft/rush-lib": "workspace:*",
     "@rushstack/node-core-library": "workspace:*",
+    "@rushstack/rush-reporter": "workspace:*",
     "@rushstack/terminal": "workspace:*",
     "semver": "~7.7.4"
   },

--- a/common/changes/@microsoft/rush/copilot-reporter-r1a-package-wiring_2026-08-28-02-20.json
+++ b/common/changes/@microsoft/rush/copilot-reporter-r1a-package-wiring_2026-08-28-02-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add the rush-reporter package dependency to the Rush frontend and engine without changing default output.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "TheLarkInn@users.noreply.github.com"
+}

--- a/common/config/rush/browser-approved-packages.json
+++ b/common/config/rush/browser-approved-packages.json
@@ -55,6 +55,10 @@
       "allowedCategories": [ "libraries", "tests" ]
     },
     {
+      "name": "@rushstack/rush-reporter",
+      "allowedCategories": [ "libraries" ]
+    },
+    {
       "name": "@rushstack/rush-serve-dashboard",
       "allowedCategories": [ "libraries" ]
     },

--- a/common/config/subspaces/build-tests-subspace/pnpm-lock.yaml
+++ b/common/config/subspaces/build-tests-subspace/pnpm-lock.yaml
@@ -1027,6 +1027,14 @@ packages:
     resolution: {directory: ../../../libraries/rush-pnpm-kit-v9, type: directory}
     engines: {node: '>=20.9.0'}
 
+  '@rushstack/rush-reporter@file:../../../libraries/reporter':
+    resolution: {directory: ../../../libraries/reporter, type: directory}
+    peerDependencies:
+      '@types/node': '*'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@rushstack/rush-sdk@file:../../../libraries/rush-sdk':
     resolution: {directory: ../../../libraries/rush-sdk, type: directory}
     engines: {node: '>=20.9.0'}
@@ -4357,6 +4365,7 @@ snapshots:
       '@rushstack/rush-pnpm-kit-v10': file:../../../libraries/rush-pnpm-kit-v10
       '@rushstack/rush-pnpm-kit-v8': file:../../../libraries/rush-pnpm-kit-v8
       '@rushstack/rush-pnpm-kit-v9': file:../../../libraries/rush-pnpm-kit-v9
+      '@rushstack/rush-reporter': file:../../../libraries/reporter(@types/node@20.17.19)
       '@rushstack/stream-collator': file:../../../libraries/stream-collator(@types/node@20.17.19)
       '@rushstack/terminal': file:../../../libraries/terminal(@types/node@20.17.19)
       '@rushstack/ts-command-line': file:../../../libraries/ts-command-line(@types/node@20.17.19)
@@ -4967,6 +4976,12 @@ snapshots:
       '@pnpm/dependency-path-pnpm-v9': '@pnpm/dependency-path@5.1.7'
       '@pnpm/lockfile.fs-pnpm-lock-v9': '@pnpm/lockfile.fs@1001.1.32(@pnpm/logger@1001.0.1)'
       '@pnpm/logger': 1001.0.1
+
+  '@rushstack/rush-reporter@file:../../../libraries/reporter(@types/node@20.17.19)':
+    dependencies:
+      semver: 7.7.4
+    optionalDependencies:
+      '@types/node': 20.17.19
 
   '@rushstack/rush-sdk@file:../../../libraries/rush-sdk(@types/node@20.17.19)':
     dependencies:

--- a/common/config/subspaces/build-tests-subspace/repo-state.json
+++ b/common/config/subspaces/build-tests-subspace/repo-state.json
@@ -1,6 +1,6 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "6c9692e3e1eac781ccc4d397fb350ea393be2118",
+  "pnpmShrinkwrapHash": "2f7908424d103b2f677e95bcd5d85a385b75eda2",
   "preferredVersionsHash": "550b4cee0bef4e97db6c6aad726df5149d20e7d9",
-  "packageJsonInjectedDependenciesHash": "e31d2a6b0cc6937616e99bfd2aa6f566d11a8681"
+  "packageJsonInjectedDependenciesHash": "e8fe4109038ad6e9b1e97cbb83e63d9094d37fe4"
 }

--- a/common/config/subspaces/default/pnpm-lock.yaml
+++ b/common/config/subspaces/default/pnpm-lock.yaml
@@ -383,6 +383,9 @@ importers:
       '@rushstack/node-core-library':
         specifier: workspace:*
         version: link:../../libraries/node-core-library
+      '@rushstack/rush-reporter':
+        specifier: workspace:*
+        version: link:../../libraries/reporter
       '@rushstack/terminal':
         specifier: workspace:*
         version: link:../../libraries/terminal
@@ -4205,6 +4208,9 @@ importers:
       '@rushstack/rush-pnpm-kit-v9':
         specifier: workspace:*
         version: link:../rush-pnpm-kit-v9
+      '@rushstack/rush-reporter':
+        specifier: workspace:*
+        version: link:../reporter
       '@rushstack/stream-collator':
         specifier: workspace:*
         version: link:../stream-collator

--- a/libraries/reporter/src/test/PackageBoundaries.test.ts
+++ b/libraries/reporter/src/test/PackageBoundaries.test.ts
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+interface IPackageJson {
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+}
+
+const REPO_ROOT: string = path.resolve(__dirname, '../../../..');
+
+function loadPackageJson(relativePath: string): IPackageJson {
+  return JSON.parse(fs.readFileSync(path.join(REPO_ROOT, relativePath), 'utf8')) as IPackageJson;
+}
+
+describe('package boundaries', () => {
+  it('keeps the reporter independent from rush-lib', () => {
+    const reporterPackageJson: IPackageJson = loadPackageJson('libraries/reporter/package.json');
+
+    for (const dependencySection of [
+      reporterPackageJson.dependencies,
+      reporterPackageJson.devDependencies,
+      reporterPackageJson.optionalDependencies,
+      reporterPackageJson.peerDependencies
+    ]) {
+      expect(dependencySection?.['@microsoft/rush-lib']).toBeUndefined();
+    }
+  });
+
+  it('wires the reporter into the Rush engine and frontend', () => {
+    const rushLibPackageJson: IPackageJson = loadPackageJson('libraries/rush-lib/package.json');
+    const rushPackageJson: IPackageJson = loadPackageJson('apps/rush/package.json');
+
+    expect(rushLibPackageJson.dependencies?.['@rushstack/rush-reporter']).toBe('workspace:*');
+    expect(rushPackageJson.dependencies?.['@rushstack/rush-reporter']).toBe('workspace:*');
+  });
+});

--- a/libraries/rush-lib/package.json
+++ b/libraries/rush-lib/package.json
@@ -53,6 +53,7 @@
     "@rushstack/rush-pnpm-kit-v10": "workspace:*",
     "@rushstack/rush-pnpm-kit-v8": "workspace:*",
     "@rushstack/rush-pnpm-kit-v9": "workspace:*",
+    "@rushstack/rush-reporter": "workspace:*",
     "@rushstack/stream-collator": "workspace:*",
     "@rushstack/terminal": "workspace:*",
     "@rushstack/ts-command-line": "workspace:*",


### PR DESCRIPTION
## Summary
- add `@rushstack/rush-reporter` as a workspace dependency of `@microsoft/rush-lib` and `@microsoft/rush`
- update the default-subspace PNPM importers and approved-package metadata through the Rush update workflow
- add a focused package-boundary test that keeps the reporter independent from `rush-lib`

## Validation
- `rush build --to @microsoft/rush --verbose`
- `rush test --only @rushstack/rush-reporter --verbose` (293 tests passed)
- `rush check`
- `rush change --verify --no-fetch`

## Non-goals
- no bootstrap-envelope encoder or protocol-major generation (owned by R1B)
- no runtime integration, reporter opt-in, or default output changes

Part of #5974