### PR TITLE
[rush reporter][R1B] Generate install-run-rush bootstrap protocol

### DIFF
--- a/common/changes/@microsoft/rush/copilot-reporter-bootstrap-generation_2026-08-28-01-58.json
+++ b/common/changes/@microsoft/rush/copilot-reporter-bootstrap-generation_2026-08-28-01-58.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Embed the generated zero-dependency Rush reporter bootstrap protocol in the install-run-rush bundle.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "223556219+Copilot@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/rush-reporter/copilot-reporter-bootstrap-generation_2026-08-28-01-58.json
+++ b/common/changes/@rushstack/rush-reporter/copilot-reporter-bootstrap-generation_2026-08-28-01-58.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/rush-reporter",
+      "comment": "Add the source-of-truth frozen bootstrap envelope encoder and deterministic generation check for install-run-rush.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/rush-reporter",
+  "email": "223556219+Copilot@users.noreply.github.com"
+}

--- a/common/config/subspaces/default/pnpm-lock.yaml
+++ b/common/config/subspaces/default/pnpm-lock.yaml
@@ -4070,6 +4070,9 @@ importers:
       local-node-rig:
         specifier: workspace:*
         version: link:../../rigs/local-node-rig
+      typescript:
+        specifier: ~5.8.2
+        version: 5.8.2
 
   ../../../libraries/rig-package:
     dependencies:

--- a/libraries/reporter/config/heft.json
+++ b/libraries/reporter/config/heft.json
@@ -1,0 +1,24 @@
+/**
+ * Defines configuration used by core Heft.
+ */
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/heft/v0/heft.schema.json",
+
+  "extends": "local-node-rig/profiles/default/config/heft.json",
+
+  "phasesByName": {
+    "build": {
+      "tasksByName": {
+        "check-bootstrap-protocol": {
+          "taskPlugin": {
+            "pluginPackage": "@rushstack/heft",
+            "pluginName": "run-script-plugin",
+            "options": {
+              "scriptPath": "./scripts/generateBootstrapProtocol.js"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/libraries/reporter/package.json
+++ b/libraries/reporter/package.json
@@ -52,7 +52,8 @@
     "@rushstack/heft": "workspace:*",
     "eslint": "~9.37.0",
     "local-node-rig": "workspace:*",
-    "@types/semver": "7.7.1"
+    "@types/semver": "7.7.1",
+    "typescript": "~5.8.2"
   },
   "peerDependencies": {
     "@types/node": "*"

--- a/libraries/reporter/package.json
+++ b/libraries/reporter/package.json
@@ -43,6 +43,8 @@
   },
   "scripts": {
     "build": "heft build --clean",
+    "generate-bootstrap-protocol": "node scripts/generateBootstrapProtocol.js --write",
+    "check-bootstrap-protocol": "node scripts/generateBootstrapProtocol.js --check",
     "_phase:build": "heft run --only build -- --clean",
     "_phase:test": "heft run --only test -- --clean"
   },

--- a/libraries/reporter/scripts/generateBootstrapProtocol.d.ts
+++ b/libraries/reporter/scripts/generateBootstrapProtocol.d.ts
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+export declare function assertSelfContainedBootstrapSource(source: string): void;

--- a/libraries/reporter/scripts/generateBootstrapProtocol.js
+++ b/libraries/reporter/scripts/generateBootstrapProtocol.js
@@ -57,7 +57,7 @@ function checkGeneratedFile() {
   const expected = renderGeneratedFile();
   let actual;
   try {
-    actual = fs.readFileSync(TARGET_PATH, 'utf8');
+    actual = fs.readFileSync(TARGET_PATH, 'utf8').replace(/\r\n/g, '\n');
   } catch (error) {
     if (error && error.code === 'ENOENT') {
       throw new Error(

--- a/libraries/reporter/scripts/generateBootstrapProtocol.js
+++ b/libraries/reporter/scripts/generateBootstrapProtocol.js
@@ -1,0 +1,104 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const SOURCE_START_MARKER = '// BEGIN GENERATED BOOTSTRAP PROTOCOL';
+const SOURCE_END_MARKER = '// END GENERATED BOOTSTRAP PROTOCOL';
+const SOURCE_PATH = path.resolve(__dirname, '../src/bootstrap/BootstrapProtocol.ts');
+const PROTOCOL_SOURCE_PATH = path.resolve(__dirname, '../src/protocol/ReporterProtocol.ts');
+const TARGET_PATH = path.resolve(__dirname, '../../rush-lib/src/scripts/generated/BootstrapProtocol.ts');
+
+function renderGeneratedFile() {
+  const source = fs.readFileSync(SOURCE_PATH, 'utf8').replace(/\r\n/g, '\n');
+  const protocolSource = fs.readFileSync(PROTOCOL_SOURCE_PATH, 'utf8').replace(/\r\n/g, '\n');
+  const startIndex = source.indexOf(SOURCE_START_MARKER);
+  const endIndex = source.indexOf(SOURCE_END_MARKER);
+  if (startIndex < 0 || endIndex < 0 || endIndex <= startIndex) {
+    throw new Error(`Unable to find the generated bootstrap protocol markers in ${SOURCE_PATH}.`);
+  }
+
+  const generatedSource = source.slice(startIndex + SOURCE_START_MARKER.length, endIndex).trim();
+  if (/^\s*import\b/m.test(generatedSource) || /\brequire\s*\(/.test(generatedSource)) {
+    throw new Error('The generated bootstrap protocol must not contain imports or require() calls.');
+  }
+
+  const bootstrapMajorMatch = generatedSource.match(/export const BOOTSTRAP_PROTOCOL_MAJOR: number = (\d+);/);
+  const reporterMajorMatch = protocolSource.match(/REPORTER_PROTOCOL_VERSION:[^=]+=\s*\{\s*major:\s*(\d+),/);
+  if (!bootstrapMajorMatch || !reporterMajorMatch) {
+    throw new Error('Unable to read the bootstrap and reporter protocol-major constants.');
+  }
+  if (bootstrapMajorMatch[1] !== reporterMajorMatch[1]) {
+    throw new Error(
+      `BOOTSTRAP_PROTOCOL_MAJOR (${bootstrapMajorMatch[1]}) must match ` +
+        `REPORTER_PROTOCOL_VERSION.major (${reporterMajorMatch[1]}).`
+    );
+  }
+
+  return [
+    '// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.',
+    '// See LICENSE in the project root for license information.',
+    '',
+    '// THIS FILE IS GENERATED. Run "rushx generate-bootstrap-protocol" in libraries/reporter to update it.',
+    '// Sources: libraries/reporter/src/bootstrap/BootstrapProtocol.ts',
+    '//          libraries/reporter/src/protocol/ReporterProtocol.ts',
+    '',
+    generatedSource,
+    ''
+  ].join('\n');
+}
+
+function writeGeneratedFile() {
+  fs.mkdirSync(path.dirname(TARGET_PATH), { recursive: true });
+  fs.writeFileSync(TARGET_PATH, renderGeneratedFile(), 'utf8');
+}
+
+function checkGeneratedFile() {
+  const expected = renderGeneratedFile();
+  let actual;
+  try {
+    actual = fs.readFileSync(TARGET_PATH, 'utf8');
+  } catch (error) {
+    if (error && error.code === 'ENOENT') {
+      throw new Error(
+        `The generated bootstrap protocol is missing at ${TARGET_PATH}. ` +
+          'Run "rushx generate-bootstrap-protocol" in libraries/reporter.'
+      );
+    }
+    throw error;
+  }
+
+  if (actual !== expected) {
+    throw new Error(
+      `The generated bootstrap protocol is stale at ${TARGET_PATH}. ` +
+        'Run "rushx generate-bootstrap-protocol" in libraries/reporter.'
+    );
+  }
+}
+
+module.exports = {
+  runAsync: async ({
+    heftTaskSession: {
+      logger: { terminal }
+    }
+  }) => {
+    checkGeneratedFile();
+    terminal.writeVerboseLine('The generated install-run-rush bootstrap protocol is up to date.');
+  }
+};
+
+if (require.main === module) {
+  try {
+    const mode = process.argv[2];
+    if (mode === '--write') {
+      writeGeneratedFile();
+    } else if (mode === '--check') {
+      checkGeneratedFile();
+    } else {
+      throw new Error('Specify either --write or --check.');
+    }
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  }
+}

--- a/libraries/reporter/scripts/generateBootstrapProtocol.js
+++ b/libraries/reporter/scripts/generateBootstrapProtocol.js
@@ -10,6 +10,35 @@ const SOURCE_PATH = path.resolve(__dirname, '../src/bootstrap/BootstrapProtocol.
 const PROTOCOL_SOURCE_PATH = path.resolve(__dirname, '../src/protocol/ReporterProtocol.ts');
 const TARGET_PATH = path.resolve(__dirname, '../../rush-lib/src/scripts/generated/BootstrapProtocol.ts');
 
+function unwrapExpression(expression) {
+  let current = expression;
+  while (
+    ts.isParenthesizedExpression(current) ||
+    ts.isAsExpression(current) ||
+    ts.isTypeAssertionExpression(current) ||
+    ts.isNonNullExpression(current) ||
+    ts.isSatisfiesExpression(current)
+  ) {
+    current = current.expression;
+  }
+  return current;
+}
+
+function isRequireRootedExpression(expression) {
+  let current = expression;
+  for (;;) {
+    current = unwrapExpression(current);
+    if (ts.isIdentifier(current)) {
+      return current.text === 'require';
+    }
+    if (ts.isPropertyAccessExpression(current) || ts.isElementAccessExpression(current)) {
+      current = current.expression;
+      continue;
+    }
+    return false;
+  }
+}
+
 function getModuleEdgeKind(node) {
   if (ts.isImportDeclaration(node)) {
     return 'an import declaration';
@@ -30,15 +59,8 @@ function getModuleEdgeKind(node) {
     if (node.expression.kind === ts.SyntaxKind.ImportKeyword) {
       return 'a dynamic import';
     }
-    if (ts.isIdentifier(node.expression) && node.expression.text === 'require') {
-      return 'a require() call';
-    }
-    if (
-      ts.isPropertyAccessExpression(node.expression) &&
-      ts.isIdentifier(node.expression.expression) &&
-      node.expression.expression.text === 'require'
-    ) {
-      return 'a require property call';
+    if (isRequireRootedExpression(node.expression)) {
+      return 'a require-rooted call';
     }
   }
 

--- a/libraries/reporter/scripts/generateBootstrapProtocol.js
+++ b/libraries/reporter/scripts/generateBootstrapProtocol.js
@@ -28,6 +28,10 @@ function isRequireRootedExpression(expression) {
   let current = expression;
   for (;;) {
     current = unwrapExpression(current);
+    if (ts.isBinaryExpression(current) && current.operatorToken.kind === ts.SyntaxKind.CommaToken) {
+      current = current.right;
+      continue;
+    }
     if (ts.isIdentifier(current)) {
       return current.text === 'require';
     }
@@ -62,6 +66,9 @@ function getModuleEdgeKind(node) {
     if (isRequireRootedExpression(node.expression)) {
       return 'a require-rooted call';
     }
+  }
+  if (ts.isNewExpression(node) && isRequireRootedExpression(node.expression)) {
+    return 'a require-rooted constructor';
   }
 
   return undefined;

--- a/libraries/reporter/scripts/generateBootstrapProtocol.js
+++ b/libraries/reporter/scripts/generateBootstrapProtocol.js
@@ -2,12 +2,72 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
+const ts = require('typescript');
 
 const SOURCE_START_MARKER = '// BEGIN GENERATED BOOTSTRAP PROTOCOL';
 const SOURCE_END_MARKER = '// END GENERATED BOOTSTRAP PROTOCOL';
 const SOURCE_PATH = path.resolve(__dirname, '../src/bootstrap/BootstrapProtocol.ts');
 const PROTOCOL_SOURCE_PATH = path.resolve(__dirname, '../src/protocol/ReporterProtocol.ts');
 const TARGET_PATH = path.resolve(__dirname, '../../rush-lib/src/scripts/generated/BootstrapProtocol.ts');
+
+function getModuleEdgeKind(node) {
+  if (ts.isImportDeclaration(node)) {
+    return 'an import declaration';
+  }
+  if (ts.isImportEqualsDeclaration(node)) {
+    return 'an import-equals declaration';
+  }
+  if (ts.isImportTypeNode(node)) {
+    return 'an import type';
+  }
+  if (ts.isExportDeclaration(node) && node.moduleSpecifier) {
+    return 'an export-from declaration';
+  }
+  if (ts.isMetaProperty(node) && node.keywordToken === ts.SyntaxKind.ImportKeyword) {
+    return 'an import.meta expression';
+  }
+  if (ts.isCallExpression(node)) {
+    if (node.expression.kind === ts.SyntaxKind.ImportKeyword) {
+      return 'a dynamic import';
+    }
+    if (ts.isIdentifier(node.expression) && node.expression.text === 'require') {
+      return 'a require() call';
+    }
+    if (
+      ts.isPropertyAccessExpression(node.expression) &&
+      ts.isIdentifier(node.expression.expression) &&
+      node.expression.expression.text === 'require'
+    ) {
+      return 'a require property call';
+    }
+  }
+
+  return undefined;
+}
+
+function assertSelfContainedBootstrapSource(source) {
+  const sourceFile = ts.createSourceFile(
+    'BootstrapProtocol.generated.ts',
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS
+  );
+
+  function visit(node) {
+    const moduleEdgeKind = getModuleEdgeKind(node);
+    if (moduleEdgeKind) {
+      const location = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
+      throw new Error(
+        `The generated bootstrap protocol must be self-contained; found ${moduleEdgeKind} at ` +
+          `line ${location.line + 1}, column ${location.character + 1}.`
+      );
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+}
 
 function renderGeneratedFile() {
   const source = fs.readFileSync(SOURCE_PATH, 'utf8').replace(/\r\n/g, '\n');
@@ -19,9 +79,7 @@ function renderGeneratedFile() {
   }
 
   const generatedSource = source.slice(startIndex + SOURCE_START_MARKER.length, endIndex).trim();
-  if (/^\s*import\b/m.test(generatedSource) || /\brequire\s*\(/.test(generatedSource)) {
-    throw new Error('The generated bootstrap protocol must not contain imports or require() calls.');
-  }
+  assertSelfContainedBootstrapSource(generatedSource);
 
   const bootstrapMajorMatch = generatedSource.match(/export const BOOTSTRAP_PROTOCOL_MAJOR: number = (\d+);/);
   const reporterMajorMatch = protocolSource.match(/REPORTER_PROTOCOL_VERSION:[^=]+=\s*\{\s*major:\s*(\d+),/);
@@ -77,6 +135,7 @@ function checkGeneratedFile() {
 }
 
 module.exports = {
+  assertSelfContainedBootstrapSource,
   runAsync: async ({
     heftTaskSession: {
       logger: { terminal }

--- a/libraries/reporter/src/bootstrap/BootstrapEventBuffer.ts
+++ b/libraries/reporter/src/bootstrap/BootstrapEventBuffer.ts
@@ -2,10 +2,10 @@
 // See LICENSE in the project root for license information.
 
 import {
-  BOOTSTRAP_PROTOCOL_MAJOR,
   BOOTSTRAP_BUFFER_MAX_BYTES,
   BOOTSTRAP_EXTERNAL_CHUNK_MAX_BYTES,
-  BOOTSTRAP_BUFFER_TRUNCATED_EXTENSION_NAME
+  BOOTSTRAP_BUFFER_TRUNCATED_EXTENSION_NAME,
+  encodeBootstrapEnvelope
 } from './BootstrapProtocol';
 import type { ReporterEventType } from '../events/ReporterEventType';
 import { chunkUtf8Text } from '../utilities/chunkUtf8Text';
@@ -192,8 +192,7 @@ export class BootstrapEventBuffer {
   public emit(input: IBootstrapEventInput): string {
     const eventId: string = `boot_${this._nextEventId++}`;
     const required: boolean = input.type !== 'activityChanged';
-    const envelope: Record<string, unknown> = {
-      protocolVersion: { major: BOOTSTRAP_PROTOCOL_MAJOR, minor: 0 },
+    const line: string = encodeBootstrapEnvelope({
       eventId,
       sessionId: this._sessionId,
       sequence: this._nextSequence++,
@@ -203,8 +202,7 @@ export class BootstrapEventBuffer {
       required,
       type: input.type,
       payload: input.payload === undefined ? {} : input.payload
-    };
-    const line: string = JSON.stringify(envelope);
+    });
     const bytes: number = Buffer.byteLength(line, 'utf8') + 1;
     const mustPreserve: boolean = required;
     const replaceable: boolean = input.type === 'activityChanged';
@@ -257,8 +255,7 @@ export class BootstrapEventBuffer {
   public serialize(): string {
     const lines: string[] = this._entries.map((entry: IBufferEntry) => entry.line);
     if (this._truncated) {
-      const notice: Record<string, unknown> = {
-        protocolVersion: { major: BOOTSTRAP_PROTOCOL_MAJOR, minor: 0 },
+      const noticeLine: string = encodeBootstrapEnvelope({
         eventId: 'boot_bufferTruncated',
         sessionId: this._sessionId,
         sequence: this._nextSequence++,
@@ -274,8 +271,7 @@ export class BootstrapEventBuffer {
           droppedRequired: this._droppedRequired,
           failed: this._failed
         }
-      };
-      const noticeLine: string = JSON.stringify(notice);
+      });
       const noticeBytes: number = Buffer.byteLength(noticeLine, 'utf8') + 1;
       if (noticeBytes > TRUNCATION_NOTICE_RESERVE_BYTES) {
         throw new Error('The bootstrap truncation notice exceeded its reserved capacity.');

--- a/libraries/reporter/src/bootstrap/BootstrapProtocol.ts
+++ b/libraries/reporter/src/bootstrap/BootstrapProtocol.ts
@@ -70,7 +70,7 @@ export function encodeBootstrapEnvelope(input: IBootstrapEnvelopeInput): string 
     privacy: input.privacy,
     required: input.required,
     type: input.type,
-    payload: input.payload
+    payload: input.payload === undefined ? {} : input.payload
   });
 }
 

--- a/libraries/reporter/src/test/Bootstrap.test.ts
+++ b/libraries/reporter/src/test/Bootstrap.test.ts
@@ -49,7 +49,10 @@ describe('bootstrap protocol generation', () => {
     { description: 'export-all declarations', source: "export * from 'pkg';" },
     { description: 'import.meta expressions', source: 'const url = import.meta.url;' },
     { description: 'require calls', source: "const value = require('pkg');" },
-    { description: 'require property calls', source: "const path = require.resolve('pkg');" }
+    { description: 'require property calls', source: "const path = require.resolve('pkg');" },
+    { description: 'parenthesized require calls', source: "const value = (require)('pkg');" },
+    { description: 'require element-access calls', source: "const path = require['resolve']('pkg');" },
+    { description: 'nested require property calls', source: "const paths = require.resolve.paths('pkg');" }
   ])('rejects $description', ({ source }: { source: string }) => {
     expect(() => assertSelfContainedBootstrapSource(source)).toThrow(
       'The generated bootstrap protocol must be self-contained'

--- a/libraries/reporter/src/test/Bootstrap.test.ts
+++ b/libraries/reporter/src/test/Bootstrap.test.ts
@@ -5,6 +5,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
+import { assertSelfContainedBootstrapSource } from '../../scripts/generateBootstrapProtocol';
 import {
   parseEarlyReporterControls,
   BootstrapEventBuffer,
@@ -37,6 +38,34 @@ function makeBuffer(overrides?: Partial<IBootstrapEventBufferOptions>): Bootstra
     ...overrides
   });
 }
+
+describe('bootstrap protocol generation', () => {
+  it.each([
+    { description: 'static imports', source: "import { value } from 'pkg';" },
+    { description: 'import-equals declarations', source: "import value = require('pkg');" },
+    { description: 'import types', source: "type Value = import('pkg').Value;" },
+    { description: 'dynamic imports', source: "const value = import('pkg');" },
+    { description: 'export-from declarations', source: "export { value } from 'pkg';" },
+    { description: 'export-all declarations', source: "export * from 'pkg';" },
+    { description: 'import.meta expressions', source: 'const url = import.meta.url;' },
+    { description: 'require calls', source: "const value = require('pkg');" },
+    { description: 'require property calls', source: "const path = require.resolve('pkg');" }
+  ])('rejects $description', ({ source }: { source: string }) => {
+    expect(() => assertSelfContainedBootstrapSource(source)).toThrow(
+      'The generated bootstrap protocol must be self-contained'
+    );
+  });
+
+  it('allows import-like text without module edges', () => {
+    const source: string = [
+      "/* import { value } from 'pkg'; */",
+      `const message: string = "import('pkg')";`,
+      'export const value: string = message;'
+    ].join('\n');
+
+    expect(() => assertSelfContainedBootstrapSource(source)).not.toThrow();
+  });
+});
 
 describe('parseEarlyReporterControls', () => {
   it('reads the reporter and log level from flags', () => {

--- a/libraries/reporter/src/test/Bootstrap.test.ts
+++ b/libraries/reporter/src/test/Bootstrap.test.ts
@@ -19,6 +19,7 @@ import {
   type IBootstrapEventBufferOptions,
   type IEarlyReporterControls
 } from '../index';
+import { encodeBootstrapEnvelope } from '../bootstrap/BootstrapProtocol';
 
 function decode(ndjson: string): Record<string, unknown>[] {
   return ndjson
@@ -72,6 +73,27 @@ describe('parseEarlyReporterControls', () => {
 describe('BootstrapEventBuffer', () => {
   it('freezes a protocol major that matches the source of truth', () => {
     expect(BOOTSTRAP_PROTOCOL_MAJOR).toBe(REPORTER_PROTOCOL_VERSION.major);
+  });
+
+  it('encodes the frozen bootstrap envelope deterministically', () => {
+    expect(
+      encodeBootstrapEnvelope({
+        eventId: 'boot_1',
+        sessionId: 'sess_boot',
+        sequence: 1,
+        timestamp: '2026-01-01T00:00:00.000Z',
+        source: { packageName: 'install-run-rush', packageVersion: '0.0.0' },
+        privacy: 'public',
+        required: true,
+        type: 'sessionStarted',
+        payload: { argv: ['build'] }
+      })
+    ).toBe(
+      '{"protocolVersion":{"major":1,"minor":0},"eventId":"boot_1","sessionId":"sess_boot",' +
+        '"sequence":1,"timestamp":"2026-01-01T00:00:00.000Z","source":{"packageName":' +
+        '"install-run-rush","packageVersion":"0.0.0"},"privacy":"public","required":true,' +
+        '"type":"sessionStarted","payload":{"argv":["build"]}}'
+    );
   });
 
   it('encodes events with assigned ids, sequence, timestamp, and protocol version', () => {

--- a/libraries/reporter/src/test/Bootstrap.test.ts
+++ b/libraries/reporter/src/test/Bootstrap.test.ts
@@ -52,7 +52,10 @@ describe('bootstrap protocol generation', () => {
     { description: 'require property calls', source: "const path = require.resolve('pkg');" },
     { description: 'parenthesized require calls', source: "const value = (require)('pkg');" },
     { description: 'require element-access calls', source: "const path = require['resolve']('pkg');" },
-    { description: 'nested require property calls', source: "const paths = require.resolve.paths('pkg');" }
+    { description: 'nested require property calls', source: "const paths = require.resolve.paths('pkg');" },
+    { description: 'require constructors', source: "const value = new require('pkg');" },
+    { description: 'parenthesized require constructors', source: "const value = new (require)('pkg');" },
+    { description: 'comma-expression require calls', source: "const value = (0, require)('pkg');" }
   ])('rejects $description', ({ source }: { source: string }) => {
     expect(() => assertSelfContainedBootstrapSource(source)).toThrow(
       'The generated bootstrap protocol must be self-contained'
@@ -126,6 +129,25 @@ describe('BootstrapEventBuffer', () => {
         '"install-run-rush","packageVersion":"0.0.0"},"privacy":"public","required":true,' +
         '"type":"sessionStarted","payload":{"argv":["build"]}}'
     );
+  });
+
+  it('preserves the payload field when the input payload is undefined', () => {
+    const envelope: Record<string, unknown> = JSON.parse(
+      encodeBootstrapEnvelope({
+        eventId: 'boot_1',
+        sessionId: 'sess_boot',
+        sequence: 1,
+        timestamp: '2026-01-01T00:00:00.000Z',
+        source: { packageName: 'install-run-rush', packageVersion: '0.0.0' },
+        privacy: 'public',
+        required: true,
+        type: 'sessionStarted',
+        payload: undefined
+      })
+    ) as Record<string, unknown>;
+
+    expect(Object.hasOwn(envelope, 'payload')).toBe(true);
+    expect(envelope.payload).toEqual({});
   });
 
   it('encodes events with assigned ids, sequence, timestamp, and protocol version', () => {

--- a/libraries/rush-lib/config/heft.json
+++ b/libraries/rush-lib/config/heft.json
@@ -12,6 +12,16 @@
       "cleanFiles": [{ "includeGlobs": ["lib-intermediate-commonjs", "lib-intermediate-esm"] }],
 
       "tasksByName": {
+        "check-bootstrap-protocol": {
+          "taskPlugin": {
+            "pluginPackage": "@rushstack/heft",
+            "pluginName": "run-script-plugin",
+            "options": {
+              "scriptPath": "../reporter/scripts/generateBootstrapProtocol.js"
+            }
+          }
+        },
+
         "copy-mock-flush-telemetry-plugin": {
           "taskDependencies": ["typescript"],
           "taskPlugin": {

--- a/libraries/rush-lib/src/scripts/generated/BootstrapProtocol.ts
+++ b/libraries/rush-lib/src/scripts/generated/BootstrapProtocol.ts
@@ -1,12 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-// This module is intentionally self-contained. It imports no runtime values
-// from the rest of the package so that a frozen copy can be embedded into the
-// zero-dependency `install-run-rush` bundle, which must not import
-// `@rushstack/rush-reporter` at runtime.
-
-// BEGIN GENERATED BOOTSTRAP PROTOCOL
+// THIS FILE IS GENERATED. Run "rushx generate-bootstrap-protocol" in libraries/reporter to update it.
+// Sources: libraries/reporter/src/bootstrap/BootstrapProtocol.ts
+//          libraries/reporter/src/protocol/ReporterProtocol.ts
 
 /**
  * The protocol major version frozen into the bootstrap encoder.
@@ -73,50 +70,3 @@ export function encodeBootstrapEnvelope(input: IBootstrapEnvelopeInput): string 
     payload: input.payload
   });
 }
-
-// END GENERATED BOOTSTRAP PROTOCOL
-
-/**
- * The maximum size of the buffered bootstrap event stream, in bytes (1 MiB).
- *
- * @beta
- */
-export const BOOTSTRAP_BUFFER_MAX_BYTES: number = 1024 * 1024;
-
-/**
- * The maximum size of a single raw external-output chunk, in bytes (64 KiB).
- *
- * @beta
- */
-export const BOOTSTRAP_EXTERNAL_CHUNK_MAX_BYTES: number = 64 * 1024;
-
-/**
- * The private environment variable used to hand the bootstrap NDJSON file path
- * to the installed frontend.
- *
- * @beta
- */
-export const RUSH_REPORTER_BOOTSTRAP_HANDOFF_ENV_VAR: '_RUSH_REPORTER_BOOTSTRAP_HANDOFF' =
-  '_RUSH_REPORTER_BOOTSTRAP_HANDOFF';
-
-/**
- * The private environment variable carrying the one-time nonce that must match
- * the handoff file's header line.
- *
- * @remarks
- * The nonce proves the handoff file was written by the same bootstrap process
- * that set the environment variable: a stale or foreign handoff file (same
- * temp directory, different invocation) is rejected rather than replayed.
- *
- * @beta
- */
-export const RUSH_REPORTER_BOOTSTRAP_NONCE_ENV_VAR: '_RUSH_REPORTER_BOOTSTRAP_NONCE' =
-  '_RUSH_REPORTER_BOOTSTRAP_NONCE';
-
-/**
- * The namespaced extension event name that describes bootstrap buffer truncation.
- *
- * @beta
- */
-export const BOOTSTRAP_BUFFER_TRUNCATED_EXTENSION_NAME: 'rush.reporter.buffer-truncated' =
-  'rush.reporter.buffer-truncated';

--- a/libraries/rush-lib/src/scripts/generated/BootstrapProtocol.ts
+++ b/libraries/rush-lib/src/scripts/generated/BootstrapProtocol.ts
@@ -67,6 +67,6 @@ export function encodeBootstrapEnvelope(input: IBootstrapEnvelopeInput): string 
     privacy: input.privacy,
     required: input.required,
     type: input.type,
-    payload: input.payload
+    payload: input.payload === undefined ? {} : input.payload
   });
 }

--- a/libraries/rush-lib/src/scripts/install-run-rush.ts
+++ b/libraries/rush-lib/src/scripts/install-run-rush.ts
@@ -6,19 +6,27 @@
 import * as path from 'node:path';
 import * as fs from 'node:fs';
 
+import type { ILogger } from '../utilities/npmrcUtilities';
+import { BOOTSTRAP_PROTOCOL_MAJOR, encodeBootstrapEnvelope } from './generated/BootstrapProtocol';
+
 const {
   installAndRun,
   findRushJsonFolder,
   RUSH_JSON_FILENAME,
   runWithErrorAndStatusCode
 }: typeof import('./install-run') = __non_webpack_require__('./install-run');
-import type { ILogger } from '../utilities/npmrcUtilities';
 
 const PACKAGE_NAME: string = '@microsoft/rush';
 const RUSH_PREVIEW_VERSION: string = 'RUSH_PREVIEW_VERSION';
 const RUSH_QUIET_MODE: string = 'RUSH_QUIET_MODE';
 const INSTALL_RUN_RUSH_LOCKFILE_PATH_VARIABLE: 'INSTALL_RUN_RUSH_LOCKFILE_PATH' =
   'INSTALL_RUN_RUSH_LOCKFILE_PATH';
+
+function _validateBundledBootstrapProtocol(): void {
+  if (BOOTSTRAP_PROTOCOL_MAJOR < 1 || typeof encodeBootstrapEnvelope !== 'function') {
+    throw new Error('The bundled Rush reporter bootstrap protocol is invalid.');
+  }
+}
 
 function _getRushVersion(logger: ILogger): string {
   const rushPreviewVersion: string | undefined = process.env[RUSH_PREVIEW_VERSION];
@@ -58,6 +66,8 @@ function _getBin(scriptName: string): string {
 }
 
 function _run(): void {
+  _validateBundledBootstrapProtocol();
+
   const [
     nodePath /* Ex: /bin/node */,
     scriptPath /* /repo/common/scripts/install-run-rush.js */,


### PR DESCRIPTION
## Summary

- generate the reporter's self-contained bootstrap envelope encoder and protocol-major constant into a committed rush-lib module
- validate the extracted TypeScript syntax tree against static, dynamic, type, export-from, import.meta, and require-rooted module edges
- preserve the required payload field when callers provide an undefined payload
- run deterministic generated-artifact checks from both the reporter source build and the rush-lib artifact-owner build
- embed the generated module in the existing install-run-rush webpack entry without importing @rushstack/rush-reporter at runtime

## Stack

- parent: #5985 (copilot/reporter-r1a-package-wiring)

This is the R1B child of #5985. Auto-merge stays disabled while #5985 is open. After #5985 merges, retarget this PR to main, verify its slice and full CI, then merge it before #5987.

## Generation and boundary guarantees

libraries/reporter/scripts/generateBootstrapProtocol.js extracts only the marked protocol region, parses it with TypeScript, verifies its major matches REPORTER_PROTOCOL_VERSION.major, rejects module-loading edges, and writes the committed artifact. Check mode compares the artifact deterministically after normalizing checkout line endings.

The rush-lib build owns validation of the committed generated artifact. The reporter build also validates source changes early. The generated module contains only the frozen major, envelope DTO types, and JSON encoder. The built install-run-rush.js contains the encoder and contains no @rushstack/rush-reporter runtime reference.

## Validation

- reporter build and full test suite
- rush-lib build and full test suite
- generated protocol write and check round trip
- stale generated artifact rejection through the rush-lib build
- syntax-tree rejection matrix for import and require module edges
- undefined payload envelope preservation
- frozen Rush install against the committed lockfile
- rush check and rush change --verify --no-fetch
- gh pr diff 5986 contains only the 13-file R1B bootstrap-generation slice

## Non-goals

This slice does not implement the bootstrap handoff prelude, reporter selection, or the Rush 6 default change. Those remain separate workstreams.

Part of #5974