### PR TITLE
Expose scoped RushSession reporter producers

### DIFF
--- a/apps/rush/src/IRushFrontendLaunchOptions.ts
+++ b/apps/rush/src/IRushFrontendLaunchOptions.ts
@@ -1,8 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import type { ILaunchOptions } from '@microsoft/rush-lib';
-import type { IReporterEventSink } from '@rushstack/rush-reporter';
+import type { ILaunchOptions, IRushSessionReporterOptions } from '@microsoft/rush-lib';
 
 /**
  * The cross-version launch contract owned by the Rush frontend.
@@ -13,6 +12,6 @@ import type { IReporterEventSink } from '@rushstack/rush-reporter';
  * options, so an older engine can safely ignore the new property.
  */
 export interface IRushFrontendLaunchOptions extends ILaunchOptions {
-  readonly reporterEventSink: IReporterEventSink;
+  readonly reporter: IRushSessionReporterOptions;
   readonly reporterCloseAsync: () => Promise<void>;
 }

--- a/apps/rush/src/IRushFrontendLaunchOptions.ts
+++ b/apps/rush/src/IRushFrontendLaunchOptions.ts
@@ -8,8 +8,9 @@ import type { ILaunchOptions, IRushSessionReporterOptions } from '@microsoft/rus
  *
  * @remarks
  * Reporter selection remains in `@microsoft/rush`. The selected `rush-lib`
- * receives only the typed producer sink in addition to its existing launch
- * options, so an older engine can safely ignore the new property.
+ * receives a reporter channel containing the typed producer event sink and the
+ * frontend-assigned `sessionId`, in addition to its existing launch options.
+ * An older engine can safely ignore this additive reporter property.
  */
 export interface IRushFrontendLaunchOptions extends ILaunchOptions {
   readonly reporter: IRushSessionReporterOptions;

--- a/apps/rush/src/RushFrontend.ts
+++ b/apps/rush/src/RushFrontend.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+import { randomUUID } from 'node:crypto';
+
 import type { ILaunchOptions } from '@microsoft/rush-lib';
 import { DEFAULT_SIGNAL_FLUSH_TIMEOUT_MS } from '@rushstack/rush-reporter';
 
@@ -30,6 +32,7 @@ export interface IRushFrontendOptions {
     currentRushLib: typeof import('@microsoft/rush-lib'),
     launchOptions: IRushFrontendLaunchOptions
   ) => void | Promise<void>;
+  readonly createSessionId?: () => string;
   readonly processLifecycle?: IRushFrontendProcessLifecycle;
 }
 
@@ -132,6 +135,7 @@ export async function launchRushFrontendAsync(options: IRushFrontendOptions): Pr
     initializeReporterHostAsync = initializeRushReporterHostAsync,
     createVersionSelector = (version: string) => new RushVersionSelector(version),
     executeCurrentRush = RushCommandSelector.execute,
+    createSessionId = randomUUID,
     processLifecycle = createProcessLifecycle()
   } = options;
 
@@ -153,9 +157,13 @@ export async function launchRushFrontendAsync(options: IRushFrontendOptions): Pr
   }
   const reporterCloseAsync: () => Promise<void> = () =>
     reporterLifecycle?.closeAsync() ?? reporterHost.closeAsync();
+  const sessionId: string = createSessionId();
   const reporterLaunchOptions: IRushFrontendLaunchOptions = {
     ...launchOptions,
-    reporterEventSink: reporterHost.sink,
+    reporter: {
+      eventSink: reporterHost.sink,
+      sessionId
+    },
     reporterCloseAsync
   };
 

--- a/apps/rush/src/test/RushFrontend.test.ts
+++ b/apps/rush/src/test/RushFrontend.test.ts
@@ -6,6 +6,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 
 import * as rushLib from '@microsoft/rush-lib';
+import type { ILaunchOptions } from '@microsoft/rush-lib';
 import { EnvironmentConfiguration } from '@microsoft/rush-lib/lib/api/EnvironmentConfiguration';
 import { RushConfiguration } from '@microsoft/rush-lib/lib/api/RushConfiguration';
 import { RushCommandLineParser } from '@microsoft/rush-lib/lib/cli/RushCommandLineParser';
@@ -19,6 +20,7 @@ import {
 } from '@rushstack/rush-reporter';
 
 import { launchRushFrontendAsync, type IRushFrontendProcessLifecycle } from '../RushFrontend';
+import type { IRushFrontendLaunchOptions } from '../IRushFrontendLaunchOptions';
 import {
   initializeRushReporterHostAsync,
   type IInitializedRushReporterHost,
@@ -179,7 +181,7 @@ function emitCommandStarted(sink: IReporterEventSink): void {
 describe(launchRushFrontendAsync.name, () => {
   it('creates the authoritative host before invoking the bundled rush-lib and passes only its sink', async () => {
     const order: string[] = [];
-    let receivedOptions: Record<string, unknown> | undefined;
+    let receivedOptions: IRushFrontendLaunchOptions | undefined;
     const processLifecycle: ITestProcessLifecycle = createTestProcessLifecycle();
     const originalArgv: string[] = process.argv;
     process.argv = ['node', 'rush', 'build', '--reporter=legacy', '--json'];
@@ -196,7 +198,7 @@ describe(launchRushFrontendAsync.name, () => {
           void version;
           void selectedRushLib;
           order.push('engine');
-          receivedOptions = launchOptions as unknown as Record<string, unknown>;
+          receivedOptions = launchOptions;
           return launchOptions.reporterCloseAsync();
         },
         processLifecycle
@@ -204,15 +206,56 @@ describe(launchRushFrontendAsync.name, () => {
 
       expect(order).toEqual(['host', 'engine', 'close']);
       expect(process.argv).toEqual(['node', 'rush', 'build', '--json']);
-      expect(receivedOptions?.reporterEventSink).toEqual(
-        expect.objectContaining({ emit: expect.any(Function) }) as IReporterEventSink
-      );
+      expect(receivedOptions?.reporter).toEqual({
+        eventSink: expect.objectContaining({ emit: expect.any(Function) }),
+        sessionId: expect.any(String)
+      });
       expect(receivedOptions).not.toHaveProperty('selection');
       expect(receivedOptions).not.toHaveProperty('host');
       expect(receivedOptions).not.toHaveProperty('manager');
       expect(processLifecycle.beforeExitListener).toBeUndefined();
       expect(processLifecycle.signalListeners.size).toBe(0);
     } finally {
+      process.argv = originalArgv;
+    }
+  });
+
+  it('passes one typed reporter session through the real Rush launch boundary', async () => {
+    const order: string[] = [];
+    const initialized: IInitializedRushReporterHost = await createInitializedHostAsync(order);
+    const createSessionId: jest.Mock<string, []> = jest.fn(() => 'session-from-frontend');
+    let receivedOptions: ILaunchOptions | undefined;
+    const launchSpy: jest.SpyInstance = jest
+      .spyOn(rushLib.Rush, 'launch')
+      .mockImplementation((version, launchOptions) => {
+        void version;
+        receivedOptions = launchOptions;
+      });
+    const originalArgv: string[] = process.argv;
+    process.argv = ['node', 'rush', 'build'];
+
+    try {
+      await launchRushFrontendAsync({
+        currentPackageVersion: '5.178.1',
+        rushVersionToLoad: undefined,
+        configuration: undefined,
+        launchOptions: { isManaged: false },
+        currentRushLib: rushLib,
+        initializeReporterHostAsync: async () => initialized,
+        createSessionId,
+        processLifecycle: createTestProcessLifecycle()
+      });
+
+      expect(launchSpy).toHaveBeenCalledTimes(1);
+      expect(createSessionId).toHaveBeenCalledTimes(1);
+      expect(receivedOptions?.reporter).toEqual({
+        eventSink: initialized.sink,
+        sessionId: 'session-from-frontend'
+      });
+      await initialized.closeAsync();
+      expect(order).toEqual(['host', 'close']);
+    } finally {
+      launchSpy.mockRestore();
       process.argv = originalArgv;
     }
   });
@@ -630,7 +673,7 @@ describe(launchRushFrontendAsync.name, () => {
         executeCurrentRush: (version, selectedRushLib, launchOptions) => {
           void version;
           void selectedRushLib;
-          emitCommandStarted(launchOptions.reporterEventSink);
+          emitCommandStarted(launchOptions.reporter.eventSink);
           return launchOptions.reporterCloseAsync();
         },
         processLifecycle: createTestProcessLifecycle()
@@ -671,7 +714,7 @@ describe(launchRushFrontendAsync.name, () => {
         executeCurrentRush: (version, selectedRushLib, launchOptions) => {
           void version;
           void selectedRushLib;
-          emitCommandStarted(launchOptions.reporterEventSink);
+          emitCommandStarted(launchOptions.reporter.eventSink);
           process.exitCode = 1;
 
           return new Promise<void>((resolve: () => void) => {

--- a/common/changes/@microsoft/rush/copilot-reporter-r3a-session-sink_2026-08-28-02-38.json
+++ b/common/changes/@microsoft/rush/copilot-reporter-r3a-session-sink_2026-08-28-02-38.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Expose an optional scoped reporter producer API to Rush actions and plugins while preserving legacy terminal output.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "TheLarkInn@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush/reporter-session-handoff-docs_2026-09-10.json
+++ b/common/changes/@microsoft/rush/reporter-session-handoff-docs_2026-09-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Clarify that the frontend reporter handoff contains both the typed event sink and the frontend-assigned session identity.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "TheLarkInn@users.noreply.github.com"
+}

--- a/common/config/subspaces/build-tests-subspace/pnpm-lock.yaml
+++ b/common/config/subspaces/build-tests-subspace/pnpm-lock.yaml
@@ -4990,6 +4990,7 @@ snapshots:
       '@rushstack/lookup-by-path': file:../../../libraries/lookup-by-path(@types/node@20.17.19)
       '@rushstack/node-core-library': file:../../../libraries/node-core-library(@types/node@20.17.19)
       '@rushstack/package-deps-hash': file:../../../libraries/package-deps-hash(@types/node@20.17.19)
+      '@rushstack/rush-reporter': file:../../../libraries/reporter(@types/node@20.17.19)
       '@rushstack/terminal': file:../../../libraries/terminal(@types/node@20.17.19)
       tapable: 2.2.1
     transitivePeerDependencies:

--- a/common/config/subspaces/build-tests-subspace/repo-state.json
+++ b/common/config/subspaces/build-tests-subspace/repo-state.json
@@ -1,6 +1,6 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "36a63ea0a120d7f9fd7bba3e57f734059b5177e2",
+  "pnpmShrinkwrapHash": "50a1f3c8d2270f840d49426b54c028e26de05189",
   "preferredVersionsHash": "550b4cee0bef4e97db6c6aad726df5149d20e7d9",
-  "packageJsonInjectedDependenciesHash": "ee803d13f0fb0ae994024d4dc646d2def4cc1f0f"
+  "packageJsonInjectedDependenciesHash": "af9e972a5d86601391889a0ff0ae8349679a6a10"
 }

--- a/common/config/subspaces/default/pnpm-lock.yaml
+++ b/common/config/subspaces/default/pnpm-lock.yaml
@@ -4407,6 +4407,9 @@ importers:
       '@rushstack/package-deps-hash':
         specifier: workspace:*
         version: link:../package-deps-hash
+      '@rushstack/rush-reporter':
+        specifier: workspace:*
+        version: link:../reporter
       '@rushstack/terminal':
         specifier: workspace:*
         version: link:../terminal

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -13,14 +13,22 @@ import { AsyncSeriesWaterfallHook } from 'tapable';
 import type { CollatedWriter } from '@rushstack/stream-collator';
 import type { CommandLineParameter } from '@rushstack/ts-command-line';
 import { CommandLineParameterKind } from '@rushstack/ts-command-line';
+import { createRushDiagnostic } from '@rushstack/rush-reporter';
 import { CredentialCache } from '@rushstack/credential-cache';
 import { HookMap } from 'tapable';
+import { ICreateRushDiagnosticOptions } from '@rushstack/rush-reporter';
 import { ICredentialCacheEntry } from '@rushstack/credential-cache';
 import { ICredentialCacheOptions } from '@rushstack/credential-cache';
 import { IFileDiffStatus } from '@rushstack/package-deps-hash';
 import { IPackageJson } from '@rushstack/node-core-library';
 import { IPrefixMatch } from '@rushstack/lookup-by-path';
 import type { IProblemCollector } from '@rushstack/terminal';
+import { IReporterEventScope } from '@rushstack/rush-reporter';
+import { IReporterEventSink } from '@rushstack/rush-reporter';
+import { IRushDiagnostic } from '@rushstack/rush-reporter';
+import { IScopedLogger } from '@rushstack/rush-reporter';
+import { IScopedMessageOptions } from '@rushstack/rush-reporter';
+import { IScopedReporter } from '@rushstack/rush-reporter';
 import { ITerminal } from '@rushstack/terminal';
 import type { ITerminalChunk } from '@rushstack/terminal';
 import { ITerminalProvider } from '@rushstack/terminal';
@@ -28,7 +36,11 @@ import { JsonNull } from '@rushstack/node-core-library';
 import { JsonObject } from '@rushstack/node-core-library';
 import { LookupByPath } from '@rushstack/lookup-by-path';
 import { PackageNameParser } from '@rushstack/node-core-library';
+import { parseReporterExtensionEventName } from '@rushstack/rush-reporter';
 import type { PerformanceEntry as PerformanceEntry_2 } from 'node:perf_hooks';
+import { ReporterExtensionEventName } from '@rushstack/rush-reporter';
+import { ReporterJsonValue } from '@rushstack/rush-reporter';
+import { ReporterPrivacyClassification } from '@rushstack/rush-reporter';
 import type { StdioSummarizer } from '@rushstack/terminal';
 import { SyncHook } from 'tapable';
 import { SyncWaterfallHook } from 'tapable';
@@ -147,6 +159,8 @@ export class CommonVersionsConfiguration {
     save(): boolean;
     saveAsync(): Promise<boolean>;
 }
+
+export { createRushDiagnostic }
 
 export { CredentialCache }
 
@@ -439,6 +453,8 @@ export interface ICreateOperationsContext {
     readonly rushConfiguration: RushConfiguration;
 }
 
+export { ICreateRushDiagnosticOptions }
+
 export { ICredentialCacheEntry }
 
 export { ICredentialCacheOptions }
@@ -557,6 +573,8 @@ export interface ILaunchOptions {
     // @internal
     builtInPluginConfigurations?: _IBuiltInPluginConfiguration[];
     isManaged: boolean;
+    // @internal
+    reporter?: IRushSessionReporterOptions;
     terminalProvider?: ITerminalProvider;
 }
 
@@ -911,6 +929,10 @@ export type _IProjectBuildCacheOptions = _IOperationBuildCacheOptions & {
     phaseName: string;
 };
 
+export { IReporterEventScope }
+
+export { IReporterEventSink }
+
 // @beta
 export interface IRushCommand {
     readonly actionName: string;
@@ -942,6 +964,8 @@ export interface IRushCommandLineSpec {
 
 // @beta (undocumented)
 export type IRushConfigurationProjectForSnapshot = Pick<RushConfigurationProject, 'projectFolder' | 'projectRelativeFolder'>;
+
+export { IRushDiagnostic }
 
 // @alpha (undocumented)
 export interface IRushPhaseSharding {
@@ -983,9 +1007,22 @@ export interface IRushReportingConfiguration {
 export interface IRushSessionOptions {
     // (undocumented)
     getIsDebugMode: () => boolean;
+    reporter?: IRushSessionReporterOptions;
     // (undocumented)
     terminalProvider: ITerminalProvider;
 }
+
+// @beta
+export interface IRushSessionReporterOptions {
+    readonly eventSink: IReporterEventSink;
+    readonly sessionId: string;
+}
+
+export { IScopedLogger }
+
+export { IScopedMessageOptions }
+
+export { IScopedReporter }
 
 // @beta
 export interface IStopwatchResult {
@@ -1288,6 +1325,8 @@ export abstract class PackageManagerOptionsConfigurationBase implements IPackage
 // @beta
 export type Parallelism = number | IParallelismScalar;
 
+export { parseReporterExtensionEventName }
+
 // @alpha
 export class PhasedCommandHooks {
     readonly createOperationsAsync: AsyncSeriesWaterfallHook<[
@@ -1364,6 +1403,12 @@ export class ProjectChangeAnalyzer {
     // @internal
     _tryGetSnapshotProviderAsync(projectConfigurations: ReadonlyMap<RushConfigurationProject, RushProjectConfiguration>, terminal: ITerminal, projectSelection?: ReadonlySet<RushConfigurationProject>): Promise<GetInputsSnapshotAsyncFn | undefined>;
 }
+
+export { ReporterExtensionEventName }
+
+export { ReporterJsonValue }
+
+export { ReporterPrivacyClassification }
 
 // @public
 export class RepoStateFile {
@@ -1702,6 +1747,8 @@ export class RushSession {
     getCobuildLockProviderFactory(cobuildLockProviderName: string): CobuildLockProviderFactory | undefined;
     // (undocumented)
     getLogger(name: string): ILogger;
+    getReporter(scope?: IReporterEventScope): IScopedReporter | undefined;
+    getScopedLogger(scope?: IReporterEventScope): IScopedLogger | undefined;
     // (undocumented)
     readonly hooks: RushLifecycleHooks;
     // (undocumented)

--- a/libraries/rush-lib/src/api/Rush.ts
+++ b/libraries/rush-lib/src/api/Rush.ts
@@ -14,6 +14,7 @@ import { RushXCommandLine } from '../cli/RushXCommandLine';
 import { CommandLineMigrationAdvisor } from '../cli/CommandLineMigrationAdvisor';
 import { EnvironmentVariableNames } from './EnvironmentConfiguration';
 import type { IBuiltInPluginConfiguration } from '../pluginFramework/PluginLoader/BuiltInPluginLoader';
+import type { IRushSessionReporterOptions } from '../pluginFramework/RushSession';
 import { RushPnpmCommandLine } from '../cli/RushPnpmCommandLine';
 import { measureAsyncFn } from '../utilities/performance';
 
@@ -58,6 +59,17 @@ export interface ILaunchOptions {
    * @internal
    */
   builtInPluginConfigurations?: IBuiltInPluginConfiguration[];
+
+  /**
+   * Supplies the structured event sink owned by the Rush frontend.
+   *
+   * @remarks
+   * This is an internal cross-version frontend-to-engine handoff. Reporter
+   * selection and concrete reporter instances remain owned by the frontend.
+   *
+   * @internal
+   */
+  reporter?: IRushSessionReporterOptions;
 }
 
 let _rushLibPackageJsonCache: IPackageJson | undefined = undefined;
@@ -98,6 +110,7 @@ export class Rush {
     const parser: RushCommandLineParser = new RushCommandLineParser({
       alreadyReportedNodeTooNewError: options.alreadyReportedNodeTooNewError,
       builtInPluginConfigurations: options.builtInPluginConfigurations,
+      reporter: options.reporter,
       reporterCloseAsync: frontendOptions.reporterCloseAsync
     });
     // CommandLineParser.executeAsync() should never reject the promise

--- a/libraries/rush-lib/src/cli/RushCommandLineParser.ts
+++ b/libraries/rush-lib/src/cli/RushCommandLineParser.ts
@@ -57,7 +57,7 @@ import { RushGlobalFolder } from '../api/RushGlobalFolder';
 import { NodeJsCompatibility } from '../logic/NodeJsCompatibility';
 import { SetupAction } from './actions/SetupAction';
 import { type ICustomCommandLineConfigurationInfo, PluginManager } from '../pluginFramework/PluginManager';
-import { RushSession } from '../pluginFramework/RushSession';
+import { type IRushSessionReporterOptions, RushSession } from '../pluginFramework/RushSession';
 import type { IBuiltInPluginConfiguration } from '../pluginFramework/PluginLoader/BuiltInPluginLoader';
 import { InitSubspaceAction } from './actions/InitSubspaceAction';
 import { RushAlerts } from '../utilities/RushAlerts';
@@ -72,6 +72,7 @@ export interface IRushCommandLineParserOptions {
   cwd: string; // Defaults to `cwd`
   alreadyReportedNodeTooNewError: boolean;
   builtInPluginConfigurations: IBuiltInPluginConfiguration[];
+  reporter?: IRushSessionReporterOptions;
   reporterCloseAsync?: () => Promise<void>;
 }
 
@@ -131,7 +132,7 @@ export class RushCommandLineParser extends CommandLineParser {
     const terminal: Terminal = new Terminal(this.#terminalProvider);
     this.#terminal = terminal;
     this.#rushOptions = this.#normalizeOptions(options || {});
-    const { cwd, alreadyReportedNodeTooNewError, builtInPluginConfigurations } = this.#rushOptions;
+    const { cwd, alreadyReportedNodeTooNewError, builtInPluginConfigurations, reporter } = this.#rushOptions;
 
     let rushJsonFilePath: string | undefined;
     try {
@@ -159,7 +160,8 @@ export class RushCommandLineParser extends CommandLineParser {
 
     this.rushSession = new RushSession({
       getIsDebugMode: () => this.isDebug,
-      terminalProvider
+      terminalProvider,
+      reporter
     });
     this.pluginManager = new PluginManager({
       rushSession: this.rushSession,
@@ -338,6 +340,7 @@ export class RushCommandLineParser extends CommandLineParser {
       cwd: options.cwd || process.cwd(),
       alreadyReportedNodeTooNewError: options.alreadyReportedNodeTooNewError || false,
       builtInPluginConfigurations: options.builtInPluginConfigurations || [],
+      reporter: options.reporter,
       reporterCloseAsync: options.reporterCloseAsync
     };
   }

--- a/libraries/rush-lib/src/cli/actions/BaseRushAction.ts
+++ b/libraries/rush-lib/src/cli/actions/BaseRushAction.ts
@@ -6,6 +6,7 @@ import * as path from 'node:path';
 import { CommandLineAction, type ICommandLineActionOptions } from '@rushstack/ts-command-line';
 import { LockFile } from '@rushstack/node-core-library';
 import { Colorize, type ITerminal } from '@rushstack/terminal';
+import type { IScopedReporter } from '@rushstack/rush-reporter';
 
 import type { RushConfiguration } from '../../api/RushConfiguration';
 import { EventHooksManager } from '../../logic/EventHooksManager';
@@ -44,6 +45,7 @@ export abstract class BaseConfiglessRushAction extends CommandLineAction impleme
   protected readonly rushConfiguration: RushConfiguration | undefined;
   protected readonly terminal: ITerminal;
   protected readonly rushSession: RushSession;
+  protected readonly reporter: IScopedReporter | undefined;
   protected readonly rushGlobalFolder: RushGlobalFolder;
   protected readonly parser: RushCommandLineParser;
 
@@ -57,6 +59,7 @@ export abstract class BaseConfiglessRushAction extends CommandLineAction impleme
     this.rushConfiguration = rushConfiguration;
     this.terminal = terminal;
     this.rushSession = rushSession;
+    this.reporter = rushSession.getReporter({ commandName: this.actionName });
     this.rushGlobalFolder = rushGlobalFolder;
   }
 
@@ -115,7 +118,7 @@ export abstract class BaseRushAction extends BaseConfiglessRushAction {
     return this.#eventHooksManager;
   }
 
-  protected declare readonly rushConfiguration: RushConfiguration;
+  declare protected readonly rushConfiguration: RushConfiguration;
 
   protected override async onExecuteAsync(): Promise<void> {
     if (!this.rushConfiguration) {

--- a/libraries/rush-lib/src/index.ts
+++ b/libraries/rush-lib/src/index.ts
@@ -168,9 +168,25 @@ export type { ILogFilePaths } from './logic/operations/ProjectLogWritable';
 export {
   RushSession,
   type IRushSessionOptions,
+  type IRushSessionReporterOptions,
   type CloudBuildCacheProviderFactory,
   type CobuildLockProviderFactory
 } from './pluginFramework/RushSession';
+
+export {
+  createRushDiagnostic,
+  parseReporterExtensionEventName,
+  type ICreateRushDiagnosticOptions,
+  type IReporterEventScope,
+  type IReporterEventSink,
+  type IRushDiagnostic,
+  type IScopedLogger,
+  type IScopedMessageOptions,
+  type IScopedReporter,
+  type ReporterExtensionEventName,
+  type ReporterJsonValue,
+  type ReporterPrivacyClassification
+} from '@rushstack/rush-reporter';
 
 export {
   type IRushCommand,

--- a/libraries/rush-lib/src/pluginFramework/PluginLoader/PluginLoaderBase.ts
+++ b/libraries/rush-lib/src/pluginFramework/PluginLoader/PluginLoaderBase.ts
@@ -7,6 +7,8 @@ import {
   FileSystem,
   InternalError,
   JsonFile,
+  PackageJsonLookup,
+  type IPackageJson,
   type JsonObject,
   JsonSchema
 } from '@rushstack/node-core-library';
@@ -51,6 +53,7 @@ export abstract class PluginLoaderBase<
   protected readonly _terminal: ITerminal;
 
   protected _manifestCache: Readonly<IRushPluginManifest> | undefined;
+  private _packageVersionCache: string | undefined;
 
   /**
    * The folder that should be used for resolving the plugin's NPM package.
@@ -82,6 +85,20 @@ export abstract class PluginLoaderBase<
 
   public get pluginManifest(): IRushPluginManifest {
     return this.#getRushPluginManifest();
+  }
+
+  public get packageVersion(): string {
+    if (!this._packageVersionCache) {
+      const packageJson: IPackageJson = PackageJsonLookup.instance.loadPackageJson(
+        path.join(this.packageFolder, 'package.json')
+      );
+      if (!packageJson.version) {
+        throw new InternalError(`Rush plugin package "${this.packageName}" does not specify a version.`);
+      }
+      this._packageVersionCache = packageJson.version;
+    }
+
+    return this._packageVersionCache;
   }
 
   public getCommandLineConfiguration(): CommandLineConfiguration | undefined {

--- a/libraries/rush-lib/src/pluginFramework/PluginManager.ts
+++ b/libraries/rush-lib/src/pluginFramework/PluginManager.ts
@@ -9,7 +9,7 @@ import type { RushConfiguration } from '../api/RushConfiguration';
 import { BuiltInPluginLoader, type IBuiltInPluginConfiguration } from './PluginLoader/BuiltInPluginLoader';
 import type { IRushPlugin } from './IRushPlugin';
 import { AutoinstallerPluginLoader } from './PluginLoader/AutoinstallerPluginLoader';
-import type { RushSession } from './RushSession';
+import { _createRushSessionForPlugin, type RushSession } from './RushSession';
 import type { PluginLoaderBase } from './PluginLoader/PluginLoaderBase';
 import { Rush } from '../api/Rush';
 import type { RushGlobalFolder } from '../api/RushGlobalFolder';
@@ -205,7 +205,7 @@ export class PluginManager {
       const plugin: IRushPlugin | undefined = pluginLoader.load();
       this.#loadedPluginNames.add(pluginName);
       if (plugin) {
-        this.#applyPlugin(plugin, pluginName);
+        this.#applyPlugin(plugin, pluginLoader);
       }
     }
   }
@@ -227,9 +227,15 @@ export class PluginManager {
     });
   }
 
-  #applyPlugin(plugin: IRushPlugin, pluginName: string): void {
+  #applyPlugin(plugin: IRushPlugin, pluginLoader: PluginLoaderBase): void {
+    const { packageName, pluginName } = pluginLoader;
     try {
-      plugin.apply(this.#rushSession, this.#rushConfiguration);
+      const pluginSession: RushSession = _createRushSessionForPlugin(this.#rushSession, () => ({
+        packageName,
+        packageVersion: pluginLoader.packageVersion,
+        component: pluginName
+      }));
+      plugin.apply(pluginSession, this.#rushConfiguration);
     } catch (e) {
       throw new InternalError(`Error applying "${pluginName}": ${e}`);
     }

--- a/libraries/rush-lib/src/pluginFramework/RushSession.test.ts
+++ b/libraries/rush-lib/src/pluginFramework/RushSession.test.ts
@@ -1,0 +1,152 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import * as os from 'node:os';
+
+import type {
+  IReporterEmitEventInput,
+  IReporterEventSource,
+  IReporterEventSink
+} from '@rushstack/rush-reporter';
+import { StringBufferTerminalProvider } from '@rushstack/terminal';
+
+import { Rush } from '../api/Rush';
+import { RushCommandLineParser } from '../cli/RushCommandLineParser';
+import { _createRushSessionForPlugin, type IRushSessionReporterOptions, RushSession } from './RushSession';
+
+class CapturingSink implements IReporterEventSink {
+  public readonly inputs: IReporterEmitEventInput<unknown>[] = [];
+
+  public emit<TPayload>(event: IReporterEmitEventInput<TPayload>): string {
+    this.inputs.push(event);
+    return `event-${this.inputs.length}`;
+  }
+}
+
+function createSession(reporter?: IRushSessionReporterOptions): RushSession {
+  return new RushSession({
+    getIsDebugMode: () => false,
+    terminalProvider: new StringBufferTerminalProvider(),
+    reporter
+  });
+}
+
+describe(RushSession.name, () => {
+  it('preserves legacy APIs and returns undefined when no event sink is supplied', () => {
+    const session: RushSession = createSession();
+
+    expect(session.getReporter()).toBeUndefined();
+    expect(session.getScopedLogger()).toBeUndefined();
+    expect(session.getLogger('legacy')).toBeDefined();
+    expect(session.terminalProvider).toBeInstanceOf(StringBufferTerminalProvider);
+  });
+
+  it('binds session and rush-lib source identity without exposing the sink or concrete reporters', () => {
+    const sink: CapturingSink = new CapturingSink();
+    const session: RushSession = createSession({ eventSink: sink, sessionId: 'session-1' });
+    const scope = { commandName: 'build', projectName: '@scope/project' };
+    const reporter = session.getReporter(scope);
+
+    expect(reporter).toBeDefined();
+    expect(Object.keys(reporter!).sort()).toEqual(['emitDiagnostic', 'emitExtension', 'emitMessage']);
+    expect('getSink' in reporter!).toBe(false);
+    expect('reporters' in reporter!).toBe(false);
+    expect(Object.keys(session)).not.toContain('reporter');
+
+    scope.commandName = 'spoofed';
+    reporter!.emitMessage({ severity: 'info', text: 'hello' });
+
+    expect(sink.inputs).toHaveLength(1);
+    expect(sink.inputs[0]).toMatchObject({
+      sessionId: 'session-1',
+      source: {
+        packageName: '@microsoft/rush-lib',
+        packageVersion: Rush.version
+      },
+      scope: {
+        commandName: 'build',
+        projectName: '@scope/project'
+      }
+    });
+    expect(sink.inputs[0]).not.toHaveProperty('eventId');
+    expect(sink.inputs[0]).not.toHaveProperty('sequence');
+    expect(sink.inputs[0]).not.toHaveProperty('timestamp');
+    expect(sink.inputs[0]).not.toHaveProperty('required');
+  });
+
+  it('isolates plugin sources while sharing session state', () => {
+    const sink: CapturingSink = new CapturingSink();
+    const session: RushSession = createSession({ eventSink: sink, sessionId: 'session-2' });
+    const pluginSource: IReporterEventSource = {
+      packageName: '@acme/rush-plugin',
+      packageVersion: '1.2.3',
+      component: 'acme-plugin'
+    };
+    const pluginSession: RushSession = _createRushSessionForPlugin(session, () => pluginSource);
+
+    expect(pluginSession.hooks).toBe(session.hooks);
+    (pluginSource as { packageName: string }).packageName = '@acme/spoofed';
+    pluginSession.getReporter({ projectName: '@scope/a' })!.emitMessage({
+      severity: 'info',
+      text: 'plugin'
+    });
+    session.getReporter({ projectName: '@scope/b' })!.emitMessage({
+      severity: 'info',
+      text: 'rush'
+    });
+
+    expect(sink.inputs[0]).toMatchObject({
+      sessionId: 'session-2',
+      source: {
+        packageName: '@acme/rush-plugin',
+        packageVersion: '1.2.3',
+        component: 'acme-plugin'
+      },
+      scope: { projectName: '@scope/a' }
+    });
+    expect(sink.inputs[1]).toMatchObject({
+      sessionId: 'session-2',
+      source: {
+        packageName: '@microsoft/rush-lib',
+        packageVersion: Rush.version
+      },
+      scope: { projectName: '@scope/b' }
+    });
+  });
+
+  it('rejects invalid explicitly supplied reporter options', () => {
+    expect(() =>
+      createSession({
+        eventSink: {} as IReporterEventSink,
+        sessionId: 'session-3'
+      })
+    ).toThrow(/eventSink/);
+
+    expect(() => createSession({ eventSink: new CapturingSink(), sessionId: ' ' })).toThrow(/sessionId/);
+  });
+
+  it('does not resolve plugin identity when reporting is disabled', () => {
+    const session: RushSession = createSession();
+    const getSource = jest.fn((): IReporterEventSource => {
+      throw new Error('should not resolve source');
+    });
+
+    expect(_createRushSessionForPlugin(session, getSource)).toBe(session);
+    expect(getSource).not.toHaveBeenCalled();
+  });
+
+  it('binds built-in action reporters to their command name', () => {
+    const sink: CapturingSink = new CapturingSink();
+    const parser: RushCommandLineParser = new RushCommandLineParser({
+      cwd: os.tmpdir(),
+      reporter: { eventSink: sink, sessionId: 'session-4' }
+    });
+    const action = parser.actions.find(({ actionName }) => actionName === 'list') as unknown as
+      | { reporter?: ReturnType<RushSession['getReporter']> }
+      | undefined;
+
+    expect(action?.reporter).toBeDefined();
+    action!.reporter!.emitMessage({ severity: 'debug', text: 'action' });
+    expect(sink.inputs[0].scope).toEqual({ commandName: 'list' });
+  });
+});

--- a/libraries/rush-lib/src/pluginFramework/RushSession.ts
+++ b/libraries/rush-lib/src/pluginFramework/RushSession.ts
@@ -1,7 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
-import { InternalError } from '@rushstack/node-core-library';
+import { InternalError, PackageJsonLookup, type IPackageJson } from '@rushstack/node-core-library';
+import {
+  RushSessionReporting,
+  type IReporterEventScope,
+  type IReporterEventSink,
+  type IReporterEventSource,
+  type IScopedLogger,
+  type IScopedReporter
+} from '@rushstack/rush-reporter';
 import type { ITerminalProvider } from '@rushstack/terminal';
 
 import { type ILogger, type ILoggerOptions, Logger } from './logging/Logger';
@@ -12,11 +20,42 @@ import type { ICobuildJson } from '../api/CobuildConfiguration';
 import type { ICobuildLockProvider } from '../logic/cobuild/ICobuildLockProvider';
 
 /**
+ * The reporter channel supplied by the Rush frontend for a single Rush session.
+ *
+ * @remarks
+ * The frontend owns reporter selection and the concrete reporter instances. Rush
+ * only receives this presentation-free sink and binds producer identities before
+ * exposing scoped reporters to actions and plugins.
+ *
+ * @beta
+ */
+export interface IRushSessionReporterOptions {
+  /**
+   * The typed event sink owned by the Rush frontend.
+   */
+  readonly eventSink: IReporterEventSink;
+
+  /**
+   * The identifier assigned to this Rush session by the frontend.
+   */
+  readonly sessionId: string;
+}
+
+/**
  * @beta
  */
 export interface IRushSessionOptions {
   terminalProvider: ITerminalProvider;
   getIsDebugMode: () => boolean;
+
+  /**
+   * The optional structured reporter channel for this session.
+   *
+   * @remarks
+   * When omitted, scoped reporter APIs return `undefined` and legacy terminal
+   * behavior remains unchanged.
+   */
+  reporter?: IRushSessionReporterOptions;
 }
 
 /**
@@ -33,20 +72,85 @@ export type CobuildLockProviderFactory = (
   cobuildJson: ICobuildJson
 ) => ICobuildLockProvider | Promise<ICobuildLockProvider>;
 
+interface IRushSessionState {
+  readonly options: IRushSessionOptions;
+  readonly cloudBuildCacheProviderFactories: Map<string, CloudBuildCacheProviderFactory>;
+  readonly cobuildLockProviderFactories: Map<string, CobuildLockProviderFactory>;
+  readonly hooks: RushLifecycleHooks;
+  readonly reporting: RushSessionReporting | undefined;
+}
+
+let _rushLibSource: IReporterEventSource | undefined;
+const _rushSessionStates: WeakMap<RushSession, IRushSessionState> = new WeakMap();
+
+function _getRushLibSource(): IReporterEventSource {
+  if (!_rushLibSource) {
+    const packageJsonFilePath: string | undefined =
+      PackageJsonLookup.instance.tryGetPackageJsonFilePathFor(__dirname);
+    if (!packageJsonFilePath) {
+      throw new InternalError('Unable to locate the package.json file for @microsoft/rush-lib');
+    }
+
+    const packageJson: IPackageJson = PackageJsonLookup.instance.loadPackageJson(packageJsonFilePath);
+    if (!packageJson.version) {
+      throw new InternalError('The @microsoft/rush-lib package.json file does not specify a version');
+    }
+
+    _rushLibSource = {
+      packageName: '@microsoft/rush-lib',
+      packageVersion: packageJson.version
+    };
+  }
+
+  return _rushLibSource;
+}
+
+function _createReporting(
+  reporterOptions: IRushSessionReporterOptions | undefined,
+  source: IReporterEventSource
+): RushSessionReporting | undefined {
+  if (!reporterOptions) {
+    return undefined;
+  }
+
+  const { eventSink, sessionId } = reporterOptions;
+  if (!eventSink || typeof eventSink.emit !== 'function') {
+    throw new TypeError('RushSession reporter.eventSink must implement IReporterEventSink');
+  }
+  if (typeof sessionId !== 'string' || sessionId.trim().length === 0) {
+    throw new TypeError('RushSession reporter.sessionId must be a non-empty string');
+  }
+
+  return new RushSessionReporting({
+    sink: eventSink,
+    sessionId,
+    source: { ...source }
+  });
+}
+
+function _getSessionState(rushSession: RushSession): IRushSessionState {
+  const state: IRushSessionState | undefined = _rushSessionStates.get(rushSession);
+  if (!state) {
+    throw new InternalError('RushSession state was not initialized');
+  }
+  return state;
+}
+
 /**
  * @beta
  */
 export class RushSession {
-  readonly #options: IRushSessionOptions;
-  readonly #cloudBuildCacheProviderFactories: Map<string, CloudBuildCacheProviderFactory> = new Map();
-  readonly #cobuildLockProviderFactories: Map<string, CobuildLockProviderFactory> = new Map();
-
   public readonly hooks: RushLifecycleHooks;
 
   public constructor(options: IRushSessionOptions) {
-    this.#options = options;
-
     this.hooks = new RushLifecycleHooks();
+    _rushSessionStates.set(this, {
+      options,
+      cloudBuildCacheProviderFactories: new Map(),
+      cobuildLockProviderFactories: new Map(),
+      hooks: this.hooks,
+      reporting: options.reporter ? _createReporting(options.reporter, _getRushLibSource()) : undefined
+    });
   }
 
   public getLogger(name: string): ILogger {
@@ -54,51 +158,113 @@ export class RushSession {
       throw new InternalError('RushSession.getLogger(name) called without a name');
     }
 
-    const terminalProvider: ITerminalProvider = this.#options.terminalProvider;
+    const { options } = _getSessionState(this);
+    const terminalProvider: ITerminalProvider = options.terminalProvider;
     const loggerOptions: ILoggerOptions = {
       loggerName: name,
-      getShouldPrintStacks: () => this.#options.getIsDebugMode(),
+      getShouldPrintStacks: () => options.getIsDebugMode(),
       terminalProvider
     };
     return new Logger(loggerOptions);
   }
 
   public get terminalProvider(): ITerminalProvider {
-    return this.#options.terminalProvider;
+    return _getSessionState(this).options.terminalProvider;
+  }
+
+  /**
+   * Creates a structured reporter bound to this producer and the specified scope.
+   *
+   * @remarks
+   * Returns `undefined` when the frontend did not provide a reporter event sink.
+   * The returned API cannot access concrete reporters or override the session and
+   * source identity bound by Rush.
+   */
+  public getReporter(scope?: IReporterEventScope): IScopedReporter | undefined {
+    return _getSessionState(this).reporting?.createScopedReporter(scope ? { ...scope } : undefined);
+  }
+
+  /**
+   * Creates a structured logger bound to this producer and the specified scope.
+   *
+   * @remarks
+   * Returns `undefined` when the frontend did not provide a reporter event sink.
+   * This API is additive; {@link RushSession.getLogger} and terminal output remain
+   * available during the pre-major compatibility period.
+   */
+  public getScopedLogger(scope?: IReporterEventScope): IScopedLogger | undefined {
+    return _getSessionState(this).reporting?.createScopedLogger(scope ? { ...scope } : undefined);
   }
 
   public registerCloudBuildCacheProviderFactory(
     cacheProviderName: string,
     factory: CloudBuildCacheProviderFactory
   ): void {
-    if (this.#cloudBuildCacheProviderFactories.has(cacheProviderName)) {
+    const { cloudBuildCacheProviderFactories } = _getSessionState(this);
+    if (cloudBuildCacheProviderFactories.has(cacheProviderName)) {
       throw new Error(`A build cache provider factory for ${cacheProviderName} has already been registered`);
     }
 
-    this.#cloudBuildCacheProviderFactories.set(cacheProviderName, factory);
+    cloudBuildCacheProviderFactories.set(cacheProviderName, factory);
   }
 
   public getCloudBuildCacheProviderFactory(
     cacheProviderName: string
   ): CloudBuildCacheProviderFactory | undefined {
-    return this.#cloudBuildCacheProviderFactories.get(cacheProviderName);
+    return _getSessionState(this).cloudBuildCacheProviderFactories.get(cacheProviderName);
   }
 
   public registerCobuildLockProviderFactory(
     cobuildLockProviderName: string,
     factory: CobuildLockProviderFactory
   ): void {
-    if (this.#cobuildLockProviderFactories.has(cobuildLockProviderName)) {
+    const { cobuildLockProviderFactories } = _getSessionState(this);
+    if (cobuildLockProviderFactories.has(cobuildLockProviderName)) {
       throw new Error(
         `A cobuild lock provider factory for ${cobuildLockProviderName} has already been registered`
       );
     }
-    this.#cobuildLockProviderFactories.set(cobuildLockProviderName, factory);
+    cobuildLockProviderFactories.set(cobuildLockProviderName, factory);
   }
 
   public getCobuildLockProviderFactory(
     cobuildLockProviderName: string
   ): CobuildLockProviderFactory | undefined {
-    return this.#cobuildLockProviderFactories.get(cobuildLockProviderName);
+    return _getSessionState(this).cobuildLockProviderFactories.get(cobuildLockProviderName);
   }
+}
+
+/**
+ * Creates the RushSession facade passed to one plugin.
+ *
+ * @remarks
+ * This function is internal to rush-lib. PluginManager derives the source from
+ * trusted loader metadata so the plugin cannot choose another producer identity.
+ *
+ * @internal
+ */
+export function _createRushSessionForPlugin(
+  rushSession: RushSession,
+  getSource: () => IReporterEventSource
+): RushSession {
+  const state: IRushSessionState = _getSessionState(rushSession);
+  if (!state.options.reporter) {
+    return rushSession;
+  }
+
+  const pluginSession: RushSession = Object.create(RushSession.prototype) as RushSession;
+  Object.defineProperty(pluginSession, 'hooks', {
+    configurable: false,
+    enumerable: true,
+    value: state.hooks,
+    writable: false
+  });
+  _rushSessionStates.set(pluginSession, {
+    options: state.options,
+    cloudBuildCacheProviderFactories: state.cloudBuildCacheProviderFactories,
+    cobuildLockProviderFactories: state.cobuildLockProviderFactories,
+    hooks: state.hooks,
+    reporting: _createReporting(state.options.reporter, getSource())
+  });
+  return pluginSession;
 }

--- a/libraries/rush-sdk/package.json
+++ b/libraries/rush-sdk/package.json
@@ -51,6 +51,7 @@
     "@rushstack/lookup-by-path": "workspace:*",
     "@rushstack/node-core-library": "workspace:*",
     "@rushstack/package-deps-hash": "workspace:*",
+    "@rushstack/rush-reporter": "workspace:*",
     "@rushstack/terminal": "workspace:*",
     "tapable": "2.2.1"
   },

--- a/libraries/rush-sdk/src/test/__snapshots__/script.test.ts.snap
+++ b/libraries/rush-sdk/src/test/__snapshots__/script.test.ts.snap
@@ -63,7 +63,9 @@ Loaded @microsoft/rush-lib from process.env._RUSH_LIB_PATH
   '_OperationStateFile',
   '_RushGlobalFolder',
   '_RushInternals',
-  '_rushSdk_loadInternalModule'
+  '_rushSdk_loadInternalModule',
+  'createRushDiagnostic',
+  'parseReporterExtensionEventName'
 ]"
 `;
 


### PR DESCRIPTION
Part of #5976

Stack parent: #5985

## Summary
- accept an optional typed reporter sink/session identity at the frontend-to-engine launch boundary
- expose source-bound scoped reporters/loggers through `RushSession` and command-bound reporters to Rush actions
- give each plugin a RushSession facade whose package/version/plugin source is derived from trusted loader metadata
- retain legacy terminal/logger APIs and no-sink behavior unchanged
- keep rush-sdk declaration proxy compatibility for the new beta producer types

## Validation
- `rush install`
- `rush test --only @rushstack/rush-reporter --only @microsoft/rush-lib --only @rushstack/rush-sdk`
- `rush build --to @microsoft/rush-lib --to @rushstack/rush-sdk`
- `rush check`
- `rush change --verify`

## Compatibility guarantee
No reporter is created and no structured event is emitted unless the frontend explicitly supplies a sink. Existing `RushSession.getLogger()`, `RushSession.terminalProvider`, and visible terminal output remain authoritative and unchanged.

## Non-goals
- lifecycle, diagnostic, telemetry, result, or exit-status emission (R3B)
- operation stream wiring (R5)
- reporter selection/configuration or frontend controls (R2)
- terminal API removal (R9)