### PR TITLE
Harden reporter telemetry privacy projection

### DIFF
--- a/common/changes/@rushstack/rush-reporter/copilot-reporter-telemetry-privacy_2026-08-28-03-20-00.json
+++ b/common/changes/@rushstack/rush-reporter/copilot-reporter-telemetry-privacy_2026-08-28-03-20-00.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@rushstack/rush-reporter",
-      "comment": "Prevent non-public reporter events from contributing unvalidated or unbounded values to telemetry aggregates.",
+      "comment": "Prevent non-public reporter events from contributing unvalidated or unbounded values to telemetry aggregates, including producer identity and protocol metadata.",
       "type": "patch"
     }
   ],

--- a/common/changes/@rushstack/rush-reporter/copilot-reporter-telemetry-privacy_2026-08-28-03-20-00.json
+++ b/common/changes/@rushstack/rush-reporter/copilot-reporter-telemetry-privacy_2026-08-28-03-20-00.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@rushstack/rush-reporter",
-      "comment": "Prevent non-public reporter events from contributing producer identities or other non-public values to telemetry aggregates.",
+      "comment": "Prevent non-public reporter events from contributing unvalidated or unbounded values to telemetry aggregates.",
       "type": "patch"
     }
   ],

--- a/common/changes/@rushstack/rush-reporter/copilot-reporter-telemetry-privacy_2026-08-28-03-20-00.json
+++ b/common/changes/@rushstack/rush-reporter/copilot-reporter-telemetry-privacy_2026-08-28-03-20-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/rush-reporter",
+      "comment": "Prevent local-sensitive and secret reporter events from contributing producer identities or other values to telemetry aggregates.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/rush-reporter",
+  "email": "TheLarkInn@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/rush-reporter/copilot-reporter-telemetry-privacy_2026-08-28-03-20-00.json
+++ b/common/changes/@rushstack/rush-reporter/copilot-reporter-telemetry-privacy_2026-08-28-03-20-00.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@rushstack/rush-reporter",
-      "comment": "Prevent non-public reporter events from contributing unvalidated or unbounded values to telemetry aggregates, including producer identity and protocol metadata.",
+      "comment": "Prevent non-public reporter events from contributing unvalidated or unbounded values to telemetry aggregates, and protect parent-owned producer and protocol metadata.",
       "type": "patch"
     }
   ],

--- a/common/changes/@rushstack/rush-reporter/copilot-reporter-telemetry-privacy_2026-08-28-03-20-00.json
+++ b/common/changes/@rushstack/rush-reporter/copilot-reporter-telemetry-privacy_2026-08-28-03-20-00.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@rushstack/rush-reporter",
-      "comment": "Prevent local-sensitive and secret reporter events from contributing producer identities or other values to telemetry aggregates.",
+      "comment": "Prevent non-public reporter events from contributing producer identities or other non-public values to telemetry aggregates.",
       "type": "patch"
     }
   ],

--- a/common/changes/@rushstack/rush-reporter/copilot-reporter-telemetry-privacy_2026-08-28-03-20-00.json
+++ b/common/changes/@rushstack/rush-reporter/copilot-reporter-telemetry-privacy_2026-08-28-03-20-00.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@rushstack/rush-reporter",
-      "comment": "Prevent non-public reporter events from contributing unvalidated or unbounded values to telemetry aggregates, and protect parent-owned producer and protocol metadata.",
+      "comment": "Prevent non-public reporter events from contributing unvalidated or unbounded values to telemetry aggregates, protect parent-owned producer and protocol metadata, and preserve the original five-field performance budget contract.",
       "type": "patch"
     }
   ],

--- a/common/changes/@rushstack/rush-reporter/review-r4-followup_2026-09-11-19-24.json
+++ b/common/changes/@rushstack/rush-reporter/review-r4-followup_2026-09-11-19-24.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/rush-reporter",
+      "comment": "Bound individual telemetry diagnostic codes without truncation and exclude secret diagnostic codes and categories from aggregates.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/rush-reporter",
+  "email": "TheLarkInn@users.noreply.github.com"
+}

--- a/common/reviews/api/rush-reporter.api.md
+++ b/common/reviews/api/rush-reporter.api.md
@@ -854,6 +854,8 @@ export interface IReporterPerformanceBudgets {
     readonly maxInteractiveRefreshHz: number;
     readonly maxTelemetryDiagnosticCategories: number;
     readonly maxTelemetryDiagnosticCodes: number;
+    readonly maxTelemetryProducerVersionLength: number;
+    readonly maxTelemetryProducerVersions: number;
     readonly maxWallTimeRegressionPercent: number;
 }
 

--- a/common/reviews/api/rush-reporter.api.md
+++ b/common/reviews/api/rush-reporter.api.md
@@ -852,6 +852,8 @@ export interface IReporterPerformanceBudgets {
     readonly maxAiDetailedDiagnostics: number;
     readonly maxAiOutputBytes: number;
     readonly maxInteractiveRefreshHz: number;
+    readonly maxTelemetryDiagnosticCategories: number;
+    readonly maxTelemetryDiagnosticCodes: number;
     readonly maxWallTimeRegressionPercent: number;
 }
 

--- a/common/reviews/api/rush-reporter.api.md
+++ b/common/reviews/api/rush-reporter.api.md
@@ -852,10 +852,6 @@ export interface IReporterPerformanceBudgets {
     readonly maxAiDetailedDiagnostics: number;
     readonly maxAiOutputBytes: number;
     readonly maxInteractiveRefreshHz: number;
-    readonly maxTelemetryDiagnosticCategories: number;
-    readonly maxTelemetryDiagnosticCodes: number;
-    readonly maxTelemetryProducerVersionLength: number;
-    readonly maxTelemetryProducerVersions: number;
     readonly maxWallTimeRegressionPercent: number;
 }
 
@@ -903,6 +899,14 @@ export interface IReporterSelectionInput {
     readonly argv: readonly string[];
     readonly env: Record<string, string | undefined>;
     readonly isTTY: boolean;
+}
+
+// @beta
+export interface IReporterTelemetryLimits {
+    readonly maxTelemetryDiagnosticCategories: number;
+    readonly maxTelemetryDiagnosticCodes: number;
+    readonly maxTelemetryProducerVersionLength: number;
+    readonly maxTelemetryProducerVersions: number;
 }
 
 // @beta
@@ -1344,7 +1348,7 @@ export const REPORTER_MIGRATION_PHASES: readonly IReporterMigrationPhase[];
 export const REPORTER_PACKAGE_NAME: '@rushstack/rush-reporter';
 
 // @beta
-export const REPORTER_PERFORMANCE_BUDGETS: IReporterPerformanceBudgets;
+export const REPORTER_PERFORMANCE_BUDGETS: IReporterPerformanceBudgets & IReporterTelemetryLimits;
 
 // @beta
 export const REPORTER_PROTOCOL_LIMITS: IReporterProtocolLimits;

--- a/libraries/reporter/src/index.ts
+++ b/libraries/reporter/src/index.ts
@@ -327,7 +327,7 @@ export {
   parseReporterExtensionEventName
 } from './producers/ReporterExtensionEventName';
 
-export type { IReporterPerformanceBudgets } from './perf/PerformanceBudgets';
+export type { IReporterPerformanceBudgets, IReporterTelemetryLimits } from './perf/PerformanceBudgets';
 export {
   REPORTER_PERFORMANCE_BUDGETS,
   computeWallTimeRegressionPercent,

--- a/libraries/reporter/src/perf/PerformanceBudgets.ts
+++ b/libraries/reporter/src/perf/PerformanceBudgets.ts
@@ -45,6 +45,18 @@ export interface IReporterPerformanceBudgets {
    * before summarizing the remainder. Defaults to `20`.
    */
   readonly maxAiDetailedDiagnostics: number;
+
+  /**
+   * The maximum number of distinct diagnostic codes retained in a telemetry
+   * aggregate. Defaults to `20`.
+   */
+  readonly maxTelemetryDiagnosticCodes: number;
+
+  /**
+   * The maximum number of diagnostic category buckets retained in a telemetry
+   * aggregate. Defaults to `20`.
+   */
+  readonly maxTelemetryDiagnosticCategories: number;
 }
 
 /**
@@ -68,7 +80,9 @@ export const REPORTER_PERFORMANCE_BUDGETS: IReporterPerformanceBudgets = {
   maxAdditionalPeakMemoryBytes: 32 * BYTES_PER_MIB,
   maxInteractiveRefreshHz: 10,
   maxAiOutputBytes: 64 * BYTES_PER_KIB,
-  maxAiDetailedDiagnostics: 20
+  maxAiDetailedDiagnostics: 20,
+  maxTelemetryDiagnosticCodes: 20,
+  maxTelemetryDiagnosticCategories: 20
 };
 
 /**

--- a/libraries/reporter/src/perf/PerformanceBudgets.ts
+++ b/libraries/reporter/src/perf/PerformanceBudgets.ts
@@ -57,6 +57,18 @@ export interface IReporterPerformanceBudgets {
    * aggregate. Defaults to `20`.
    */
   readonly maxTelemetryDiagnosticCategories: number;
+
+  /**
+   * The maximum number of distinct producer versions retained in a telemetry
+   * aggregate. Defaults to `20`.
+   */
+  readonly maxTelemetryProducerVersions: number;
+
+  /**
+   * The maximum character length of one `packageName@packageVersion` telemetry
+   * entry. Longer entries are omitted. Defaults to `256`.
+   */
+  readonly maxTelemetryProducerVersionLength: number;
 }
 
 /**
@@ -82,7 +94,9 @@ export const REPORTER_PERFORMANCE_BUDGETS: IReporterPerformanceBudgets = {
   maxAiOutputBytes: 64 * BYTES_PER_KIB,
   maxAiDetailedDiagnostics: 20,
   maxTelemetryDiagnosticCodes: 20,
-  maxTelemetryDiagnosticCategories: 20
+  maxTelemetryDiagnosticCategories: 20,
+  maxTelemetryProducerVersions: 20,
+  maxTelemetryProducerVersionLength: 256
 };
 
 /**

--- a/libraries/reporter/src/perf/PerformanceBudgets.ts
+++ b/libraries/reporter/src/perf/PerformanceBudgets.ts
@@ -45,7 +45,15 @@ export interface IReporterPerformanceBudgets {
    * before summarizing the remainder. Defaults to `20`.
    */
   readonly maxAiDetailedDiagnostics: number;
+}
 
+/**
+ * The capacity limits applied when reporter events are projected into telemetry
+ * aggregates.
+ *
+ * @beta
+ */
+export interface IReporterTelemetryLimits {
   /**
    * The maximum number of distinct diagnostic codes retained in a telemetry
    * aggregate. Defaults to `20`.
@@ -87,7 +95,7 @@ const BYTES_PER_KIB: number = 1024;
  *
  * @beta
  */
-export const REPORTER_PERFORMANCE_BUDGETS: IReporterPerformanceBudgets = {
+export const REPORTER_PERFORMANCE_BUDGETS: IReporterPerformanceBudgets & IReporterTelemetryLimits = {
   maxWallTimeRegressionPercent: 3,
   maxAdditionalPeakMemoryBytes: 32 * BYTES_PER_MIB,
   maxInteractiveRefreshHz: 10,

--- a/libraries/reporter/src/telemetry/TelemetryAggregate.ts
+++ b/libraries/reporter/src/telemetry/TelemetryAggregate.ts
@@ -67,7 +67,7 @@ export interface ITelemetryAggregate {
   readonly protocolVersion?: IReporterProtocolVersion;
 
   /**
-   * The distinct `packageName@packageVersion` producers observed, sorted.
+   * The distinct `packageName@packageVersion` producers observed on public envelopes, sorted.
    */
   readonly producerVersions: readonly string[];
 }

--- a/libraries/reporter/src/telemetry/TelemetryAggregate.ts
+++ b/libraries/reporter/src/telemetry/TelemetryAggregate.ts
@@ -71,10 +71,10 @@ export interface ITelemetryAggregate {
    * public envelopes, sorted.
    *
    * @remarks
-   * The list is bounded by the reporter telemetry budgets. Trusted
-   * `@microsoft/` and `@rushstack/` producers are retained before other
-   * producers, remaining entries are selected lexicographically, and entries
-   * over the per-entry length budget are omitted.
+   * The list is bounded by the reporter telemetry budgets. Parent-session
+   * producers are retained before child-session producers, remaining entries
+   * are selected lexicographically, and entries over the per-entry length
+   * budget are omitted. Package namespace text does not confer priority.
    */
   readonly producerVersions: readonly string[];
 }

--- a/libraries/reporter/src/telemetry/TelemetryAggregate.ts
+++ b/libraries/reporter/src/telemetry/TelemetryAggregate.ts
@@ -67,7 +67,14 @@ export interface ITelemetryAggregate {
   readonly protocolVersion?: IReporterProtocolVersion;
 
   /**
-   * The distinct `packageName@packageVersion` producers observed on public envelopes, sorted.
+   * The distinct `packageName@packageVersion` producers observed on effectively
+   * public envelopes, sorted.
+   *
+   * @remarks
+   * The list is bounded by the reporter telemetry budgets. Trusted
+   * `@microsoft/` and `@rushstack/` producers are retained before other
+   * producers, remaining entries are selected lexicographically, and entries
+   * over the per-entry length budget are omitted.
    */
   readonly producerVersions: readonly string[];
 }

--- a/libraries/reporter/src/telemetry/TelemetryAggregate.ts
+++ b/libraries/reporter/src/telemetry/TelemetryAggregate.ts
@@ -47,12 +47,20 @@ export interface ITelemetryAggregate {
   readonly operationStatusCounts: { readonly [status: string]: number };
 
   /**
-   * The distinct diagnostic codes emitted, sorted.
+   * The distinct diagnostic codes admitted by telemetry, sorted.
+   *
+   * @remarks
+   * Codes from effectively public diagnostics and registered codes from
+   * local-sensitive envelopes are eligible. Secret envelopes contribute no
+   * values. Codes over 256 characters are omitted, not truncated, and the
+   * number retained is bounded by the reporter telemetry budgets.
    */
   readonly diagnosticCodes: readonly string[];
 
   /**
-   * The number of diagnostics emitted in each category.
+   * The number of eligible diagnostics in each category. Local-sensitive
+   * diagnostics contribute only their registered code's category; secret
+   * envelopes never contribute.
    */
   readonly diagnosticCategoryCounts: { readonly [category: string]: number };
 

--- a/libraries/reporter/src/telemetry/TelemetrySubscriber.ts
+++ b/libraries/reporter/src/telemetry/TelemetrySubscriber.ts
@@ -13,9 +13,10 @@ import type { ITelemetryAggregate, TelemetryResult } from './TelemetryAggregate'
  * @remarks
  * The subscriber runs before reporter filtering, so it observes every event. It
  * projects envelope metadata and lifecycle values only from public events. From
- * a local-sensitive diagnostic it may keep the explicitly public code and
- * category, but never parameters, remediation, or templates. It ignores secret
- * events, messages, raw external output, and command arguments entirely.
+ * a diagnostic it keeps the explicitly public code and category regardless of
+ * the envelope privacy floor, but never parameters, remediation, or templates.
+ * It ignores all other values from non-public events, messages, raw external
+ * output, and command arguments entirely.
  *
  * @beta
  */
@@ -56,20 +57,18 @@ export class TelemetrySubscriber {
     }
 
     if (event.type === 'diagnosticEmitted') {
-      if (event.privacy !== 'secret') {
-        // Code and category are public schema fields even when classified
-        // parameters make the diagnostic envelope local-sensitive.
-        const payload: { code?: string; category?: string } = event.payload as {
-          code?: string;
-          category?: string;
-        };
-        if (payload.code !== undefined) {
-          this._diagnosticCodes.add(payload.code);
-        }
-        if (payload.category !== undefined) {
-          this._diagnosticCategoryCounts[payload.category] =
-            (this._diagnosticCategoryCounts[payload.category] ?? 0) + 1;
-        }
+      // Code and category are public schema fields even when classified
+      // parameters make the diagnostic envelope non-public.
+      const payload: { code?: string; category?: string } = event.payload as {
+        code?: string;
+        category?: string;
+      };
+      if (payload.code !== undefined) {
+        this._diagnosticCodes.add(payload.code);
+      }
+      if (payload.category !== undefined) {
+        this._diagnosticCategoryCounts[payload.category] =
+          (this._diagnosticCategoryCounts[payload.category] ?? 0) + 1;
       }
       return;
     }

--- a/libraries/reporter/src/telemetry/TelemetrySubscriber.ts
+++ b/libraries/reporter/src/telemetry/TelemetrySubscriber.ts
@@ -14,7 +14,6 @@ import { REPORTER_PERFORMANCE_BUDGETS } from '../perf/PerformanceBudgets';
 import type { ITelemetryAggregate, TelemetryResult } from './TelemetryAggregate';
 
 const OTHER_DIAGNOSTIC_CATEGORY: 'other' = 'other';
-const TRUSTED_PRODUCER_PREFIXES: readonly string[] = ['@microsoft/', '@rushstack/'];
 const REGISTERED_DIAGNOSTIC_CODE_DEFINITIONS: ReadonlyMap<string, IRushDiagnosticCodeDefinition> = new Map(
   RUSH_DIAGNOSTIC_CODE_DEFINITIONS.map(
     (definition: IRushDiagnosticCodeDefinition): readonly [string, IRushDiagnosticCodeDefinition] => [
@@ -147,7 +146,11 @@ export class TelemetrySubscriber {
       if (event.parentSessionId === undefined) {
         this._protocolVersion = event.protocolVersion;
       }
-      this._recordProducerVersion(event.source.packageName, event.source.packageVersion);
+      this._recordProducerVersion(
+        event.source.packageName,
+        event.source.packageVersion,
+        event.parentSessionId === undefined
+      );
     }
 
     if (event.type === 'diagnosticEmitted') {
@@ -325,7 +328,11 @@ export class TelemetrySubscriber {
     }
   }
 
-  private _recordProducerVersion(packageName: string, packageVersion: string): void {
+  private _recordProducerVersion(
+    packageName: string,
+    packageVersion: string,
+    isParentSessionProducer: boolean
+  ): void {
     const producerVersion: string = `${packageName}@${packageVersion}`;
     if (producerVersion.length > REPORTER_PERFORMANCE_BUDGETS.maxTelemetryProducerVersionLength) {
       return;
@@ -333,7 +340,7 @@ export class TelemetrySubscriber {
     recordBoundedPrioritizedValue(
       this._producerVersions,
       producerVersion,
-      TRUSTED_PRODUCER_PREFIXES.some((prefix: string): boolean => packageName.startsWith(prefix)),
+      isParentSessionProducer,
       REPORTER_PERFORMANCE_BUDGETS.maxTelemetryProducerVersions
     );
   }

--- a/libraries/reporter/src/telemetry/TelemetrySubscriber.ts
+++ b/libraries/reporter/src/telemetry/TelemetrySubscriber.ts
@@ -5,7 +5,30 @@ import type { IReporterProtocolVersion } from '../events/ReporterProtocolVersion
 import type { IReporterEventEnvelope } from '../events/IReporterEventEnvelope';
 import type { IReporter } from '../manager/IReporter';
 import type { IOperationStatusChangedPayload } from '../lifecycle/LifecycleEvents';
+import {
+  isValidRushDiagnosticCode,
+  RUSH_DIAGNOSTIC_CODE_DEFINITIONS,
+  type IRushDiagnosticCodeDefinition
+} from '../diagnostics/RushDiagnosticCodeRegistry';
+import { REPORTER_PERFORMANCE_BUDGETS } from '../perf/PerformanceBudgets';
 import type { ITelemetryAggregate, TelemetryResult } from './TelemetryAggregate';
+
+const OTHER_DIAGNOSTIC_CATEGORY: 'other' = 'other';
+const KNOWN_DIAGNOSTIC_CATEGORIES: ReadonlySet<string> = new Set(
+  RUSH_DIAGNOSTIC_CODE_DEFINITIONS.map(
+    (definition: IRushDiagnosticCodeDefinition): string => definition.category
+  )
+);
+
+function compareDiagnosticCodeCandidates(
+  left: readonly [code: string, registered: boolean],
+  right: readonly [code: string, registered: boolean]
+): number {
+  if (left[1] !== right[1]) {
+    return left[1] ? -1 : 1;
+  }
+  return left[0] < right[0] ? -1 : left[0] > right[0] ? 1 : 0;
+}
 
 /**
  * Consumes canonical events and produces the allowlisted telemetry aggregate.
@@ -29,13 +52,13 @@ export class TelemetrySubscriber {
   private _protocolVersion: IReporterProtocolVersion | undefined;
   private readonly _operationStatuses: Map<string, IOperationStatusChangedPayload['status']>;
   private readonly _diagnosticCategoryCounts: { [category: string]: number };
-  private readonly _diagnosticCodes: Set<string>;
+  private readonly _diagnosticCodes: Map<string, boolean>;
   private readonly _producerVersions: Set<string>;
 
   public constructor() {
     this._operationStatuses = new Map();
     this._diagnosticCategoryCounts = {};
-    this._diagnosticCodes = new Set();
+    this._diagnosticCodes = new Map();
     this._producerVersions = new Set();
   }
 
@@ -63,12 +86,17 @@ export class TelemetrySubscriber {
         code?: string;
         category?: string;
       };
-      if (payload.code !== undefined) {
-        this._diagnosticCodes.add(payload.code);
+      if (typeof payload.code === 'string' && isValidRushDiagnosticCode(payload.code)) {
+        const registeredDefinition: IRushDiagnosticCodeDefinition | undefined =
+          RUSH_DIAGNOSTIC_CODE_DEFINITIONS.find(
+            (definition: IRushDiagnosticCodeDefinition): boolean => definition.code === payload.code
+          );
+        if (isPublicEnvelope || registeredDefinition !== undefined) {
+          this._recordDiagnosticCode(payload.code, registeredDefinition !== undefined);
+        }
       }
-      if (payload.category !== undefined) {
-        this._diagnosticCategoryCounts[payload.category] =
-          (this._diagnosticCategoryCounts[payload.category] ?? 0) + 1;
+      if (typeof payload.category === 'string') {
+        this._recordDiagnosticCategory(payload.category);
       }
       return;
     }
@@ -170,7 +198,7 @@ export class TelemetrySubscriber {
       producerVersions: string[];
     } = {
       operationStatusCounts,
-      diagnosticCodes: [...this._diagnosticCodes].sort(),
+      diagnosticCodes: [...this._diagnosticCodes.keys()].sort(),
       diagnosticCategoryCounts: { ...this._diagnosticCategoryCounts },
       producerVersions: [...this._producerVersions].sort()
     };
@@ -195,6 +223,48 @@ export class TelemetrySubscriber {
     }
 
     return aggregate;
+  }
+
+  private _recordDiagnosticCode(code: string, registered: boolean): void {
+    const existingRegistration: boolean | undefined = this._diagnosticCodes.get(code);
+    if (existingRegistration !== undefined) {
+      if (registered && !existingRegistration) {
+        this._diagnosticCodes.set(code, true);
+      }
+      return;
+    }
+
+    if (this._diagnosticCodes.size < REPORTER_PERFORMANCE_BUDGETS.maxTelemetryDiagnosticCodes) {
+      this._diagnosticCodes.set(code, registered);
+      return;
+    }
+
+    let worstCandidate: readonly [code: string, registered: boolean] | undefined;
+    for (const candidate of this._diagnosticCodes) {
+      if (worstCandidate === undefined || compareDiagnosticCodeCandidates(candidate, worstCandidate) > 0) {
+        worstCandidate = candidate;
+      }
+    }
+
+    const newCandidate: readonly [code: string, registered: boolean] = [code, registered];
+    if (worstCandidate !== undefined && compareDiagnosticCodeCandidates(newCandidate, worstCandidate) < 0) {
+      this._diagnosticCodes.delete(worstCandidate[0]);
+      this._diagnosticCodes.set(code, registered);
+    }
+  }
+
+  private _recordDiagnosticCategory(category: string): void {
+    let safeCategory: string = KNOWN_DIAGNOSTIC_CATEGORIES.has(category)
+      ? category
+      : OTHER_DIAGNOSTIC_CATEGORY;
+    if (
+      this._diagnosticCategoryCounts[safeCategory] === undefined &&
+      Object.keys(this._diagnosticCategoryCounts).length >=
+        REPORTER_PERFORMANCE_BUDGETS.maxTelemetryDiagnosticCategories
+    ) {
+      safeCategory = OTHER_DIAGNOSTIC_CATEGORY;
+    }
+    this._diagnosticCategoryCounts[safeCategory] = (this._diagnosticCategoryCounts[safeCategory] ?? 0) + 1;
   }
 }
 

--- a/libraries/reporter/src/telemetry/TelemetrySubscriber.ts
+++ b/libraries/reporter/src/telemetry/TelemetrySubscriber.ts
@@ -14,15 +14,47 @@ import { REPORTER_PERFORMANCE_BUDGETS } from '../perf/PerformanceBudgets';
 import type { ITelemetryAggregate, TelemetryResult } from './TelemetryAggregate';
 
 const OTHER_DIAGNOSTIC_CATEGORY: 'other' = 'other';
+const TRUSTED_PRODUCER_PREFIXES: readonly string[] = ['@microsoft/', '@rushstack/'];
+const REGISTERED_DIAGNOSTIC_CODE_DEFINITIONS: ReadonlyMap<string, IRushDiagnosticCodeDefinition> = new Map(
+  RUSH_DIAGNOSTIC_CODE_DEFINITIONS.map(
+    (definition: IRushDiagnosticCodeDefinition): readonly [string, IRushDiagnosticCodeDefinition] => [
+      definition.code,
+      definition
+    ]
+  )
+);
 const KNOWN_DIAGNOSTIC_CATEGORIES: ReadonlySet<string> = new Set(
   RUSH_DIAGNOSTIC_CODE_DEFINITIONS.map(
     (definition: IRushDiagnosticCodeDefinition): string => definition.category
   )
 );
 
-function compareDiagnosticCodeCandidates(
-  left: readonly [code: string, registered: boolean],
-  right: readonly [code: string, registered: boolean]
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isDiagnosticPayloadEffectivelyPublic(payload: unknown): boolean {
+  if (!isRecord(payload)) {
+    return false;
+  }
+  const parameters: unknown = payload.parameters;
+  if (parameters === undefined) {
+    return true;
+  }
+  if (!isRecord(parameters)) {
+    return false;
+  }
+  for (const parameter of Object.values(parameters)) {
+    if (!isRecord(parameter) || parameter.privacy !== 'public') {
+      return false;
+    }
+  }
+  return true;
+}
+
+function comparePrioritizedCandidates(
+  left: readonly [value: string, preferred: boolean],
+  right: readonly [value: string, preferred: boolean]
 ): number {
   if (left[1] !== right[1]) {
     return left[1] ? -1 : 1;
@@ -30,16 +62,51 @@ function compareDiagnosticCodeCandidates(
   return left[0] < right[0] ? -1 : left[0] > right[0] ? 1 : 0;
 }
 
+function recordBoundedPrioritizedValue(
+  values: Map<string, boolean>,
+  value: string,
+  preferred: boolean,
+  maximumCount: number
+): void {
+  const existingPriority: boolean | undefined = values.get(value);
+  if (existingPriority !== undefined) {
+    if (preferred && !existingPriority) {
+      values.set(value, true);
+    }
+    return;
+  }
+
+  if (values.size < maximumCount) {
+    values.set(value, preferred);
+    return;
+  }
+
+  let worstCandidate: readonly [value: string, preferred: boolean] | undefined;
+  for (const candidate of values) {
+    if (worstCandidate === undefined || comparePrioritizedCandidates(candidate, worstCandidate) > 0) {
+      worstCandidate = candidate;
+    }
+  }
+
+  const newCandidate: readonly [value: string, preferred: boolean] = [value, preferred];
+  if (worstCandidate !== undefined && comparePrioritizedCandidates(newCandidate, worstCandidate) < 0) {
+    values.delete(worstCandidate[0]);
+    values.set(value, preferred);
+  }
+}
+
 /**
  * Consumes canonical events and produces the allowlisted telemetry aggregate.
  *
  * @remarks
  * The subscriber runs before reporter filtering, so it observes every event. It
- * projects envelope metadata and lifecycle values only from public events. From
- * a diagnostic it keeps the explicitly public code and category regardless of
- * the envelope privacy floor, but never parameters, remediation, or templates.
- * It ignores all other values from non-public events, messages, raw external
- * output, and command arguments entirely.
+ * projects envelope metadata and lifecycle values only from effectively public
+ * events. A diagnostic containing any non-public parameter is treated as
+ * non-public even when its envelope floor is `public`. From a non-public
+ * diagnostic it keeps only a registered code and that code's registry category,
+ * never parameters, remediation, or templates. It ignores all other values from
+ * non-public events, messages, raw external output, and command arguments
+ * entirely.
  *
  * @beta
  */
@@ -53,13 +120,13 @@ export class TelemetrySubscriber {
   private readonly _operationStatuses: Map<string, IOperationStatusChangedPayload['status']>;
   private readonly _diagnosticCategoryCounts: { [category: string]: number };
   private readonly _diagnosticCodes: Map<string, boolean>;
-  private readonly _producerVersions: Set<string>;
+  private readonly _producerVersions: Map<string, boolean>;
 
   public constructor() {
     this._operationStatuses = new Map();
     this._diagnosticCategoryCounts = {};
     this._diagnosticCodes = new Map();
-    this._producerVersions = new Set();
+    this._producerVersions = new Map();
   }
 
   /**
@@ -73,35 +140,41 @@ export class TelemetrySubscriber {
    * Ingests one event, extracting only allowlisted values.
    */
   public ingest(event: IReporterEventEnvelope<unknown>): void {
-    const isPublicEnvelope: boolean = event.privacy === 'public';
-    if (isPublicEnvelope) {
-      this._protocolVersion = event.protocolVersion;
-      this._producerVersions.add(`${event.source.packageName}@${event.source.packageVersion}`);
+    const isEffectivelyPublicEnvelope: boolean =
+      event.privacy === 'public' &&
+      (event.type !== 'diagnosticEmitted' || isDiagnosticPayloadEffectivelyPublic(event.payload));
+    if (isEffectivelyPublicEnvelope) {
+      if (event.parentSessionId === undefined) {
+        this._protocolVersion = event.protocolVersion;
+      }
+      this._recordProducerVersion(event.source.packageName, event.source.packageVersion);
     }
 
     if (event.type === 'diagnosticEmitted') {
       // Code and category are public schema fields even when classified
       // parameters make the diagnostic envelope non-public.
-      const payload: { code?: string; category?: string } = event.payload as {
-        code?: string;
-        category?: string;
-      };
-      if (typeof payload.code === 'string' && isValidRushDiagnosticCode(payload.code)) {
-        const registeredDefinition: IRushDiagnosticCodeDefinition | undefined =
-          RUSH_DIAGNOSTIC_CODE_DEFINITIONS.find(
-            (definition: IRushDiagnosticCodeDefinition): boolean => definition.code === payload.code
-          );
-        if (isPublicEnvelope || registeredDefinition !== undefined) {
+      const payload: { code?: unknown; category?: unknown } = isRecord(event.payload) ? event.payload : {};
+      const registeredDefinition: IRushDiagnosticCodeDefinition | undefined =
+        typeof payload.code === 'string'
+          ? REGISTERED_DIAGNOSTIC_CODE_DEFINITIONS.get(payload.code)
+          : undefined;
+      if (isEffectivelyPublicEnvelope) {
+        if (typeof payload.code === 'string' && isValidRushDiagnosticCode(payload.code)) {
           this._recordDiagnosticCode(payload.code, registeredDefinition !== undefined);
         }
-      }
-      if (typeof payload.category === 'string') {
-        this._recordDiagnosticCategory(payload.category);
+        if (typeof payload.category === 'string') {
+          this._recordDiagnosticCategory(
+            KNOWN_DIAGNOSTIC_CATEGORIES.has(payload.category) ? payload.category : OTHER_DIAGNOSTIC_CATEGORY
+          );
+        }
+      } else if (registeredDefinition !== undefined) {
+        this._recordDiagnosticCode(registeredDefinition.code, true);
+        this._recordDiagnosticCategory(registeredDefinition.category);
       }
       return;
     }
 
-    if (!isPublicEnvelope) {
+    if (!isEffectivelyPublicEnvelope) {
       return;
     }
 
@@ -184,6 +257,10 @@ export class TelemetrySubscriber {
     for (const status of this._operationStatuses.values()) {
       operationStatusCounts[status] = (operationStatusCounts[status] ?? 0) + 1;
     }
+    const diagnosticCategoryCounts: { [category: string]: number } = {};
+    for (const category of Object.keys(this._diagnosticCategoryCounts).sort()) {
+      diagnosticCategoryCounts[category] = this._diagnosticCategoryCounts[category];
+    }
 
     const aggregate: {
       commandName?: string;
@@ -199,8 +276,8 @@ export class TelemetrySubscriber {
     } = {
       operationStatusCounts,
       diagnosticCodes: [...this._diagnosticCodes.keys()].sort(),
-      diagnosticCategoryCounts: { ...this._diagnosticCategoryCounts },
-      producerVersions: [...this._producerVersions].sort()
+      diagnosticCategoryCounts,
+      producerVersions: [...this._producerVersions.keys()].sort()
     };
 
     if (this._commandName !== undefined) {
@@ -226,45 +303,39 @@ export class TelemetrySubscriber {
   }
 
   private _recordDiagnosticCode(code: string, registered: boolean): void {
-    const existingRegistration: boolean | undefined = this._diagnosticCodes.get(code);
-    if (existingRegistration !== undefined) {
-      if (registered && !existingRegistration) {
-        this._diagnosticCodes.set(code, true);
-      }
-      return;
-    }
-
-    if (this._diagnosticCodes.size < REPORTER_PERFORMANCE_BUDGETS.maxTelemetryDiagnosticCodes) {
-      this._diagnosticCodes.set(code, registered);
-      return;
-    }
-
-    let worstCandidate: readonly [code: string, registered: boolean] | undefined;
-    for (const candidate of this._diagnosticCodes) {
-      if (worstCandidate === undefined || compareDiagnosticCodeCandidates(candidate, worstCandidate) > 0) {
-        worstCandidate = candidate;
-      }
-    }
-
-    const newCandidate: readonly [code: string, registered: boolean] = [code, registered];
-    if (worstCandidate !== undefined && compareDiagnosticCodeCandidates(newCandidate, worstCandidate) < 0) {
-      this._diagnosticCodes.delete(worstCandidate[0]);
-      this._diagnosticCodes.set(code, registered);
-    }
+    recordBoundedPrioritizedValue(
+      this._diagnosticCodes,
+      code,
+      registered,
+      REPORTER_PERFORMANCE_BUDGETS.maxTelemetryDiagnosticCodes
+    );
   }
 
   private _recordDiagnosticCategory(category: string): void {
-    let safeCategory: string = KNOWN_DIAGNOSTIC_CATEGORIES.has(category)
-      ? category
-      : OTHER_DIAGNOSTIC_CATEGORY;
-    if (
-      this._diagnosticCategoryCounts[safeCategory] === undefined &&
-      Object.keys(this._diagnosticCategoryCounts).length >=
-        REPORTER_PERFORMANCE_BUDGETS.maxTelemetryDiagnosticCategories
-    ) {
-      safeCategory = OTHER_DIAGNOSTIC_CATEGORY;
+    const existingCount: number | undefined = this._diagnosticCategoryCounts[category];
+    if (existingCount !== undefined) {
+      this._diagnosticCategoryCounts[category] = existingCount + 1;
+      return;
     }
-    this._diagnosticCategoryCounts[safeCategory] = (this._diagnosticCategoryCounts[safeCategory] ?? 0) + 1;
+    if (
+      Object.keys(this._diagnosticCategoryCounts).length <
+      REPORTER_PERFORMANCE_BUDGETS.maxTelemetryDiagnosticCategories
+    ) {
+      this._diagnosticCategoryCounts[category] = 1;
+    }
+  }
+
+  private _recordProducerVersion(packageName: string, packageVersion: string): void {
+    const producerVersion: string = `${packageName}@${packageVersion}`;
+    if (producerVersion.length > REPORTER_PERFORMANCE_BUDGETS.maxTelemetryProducerVersionLength) {
+      return;
+    }
+    recordBoundedPrioritizedValue(
+      this._producerVersions,
+      producerVersion,
+      TRUSTED_PRODUCER_PREFIXES.some((prefix: string): boolean => packageName.startsWith(prefix)),
+      REPORTER_PERFORMANCE_BUDGETS.maxTelemetryProducerVersions
+    );
   }
 }
 

--- a/libraries/reporter/src/telemetry/TelemetrySubscriber.ts
+++ b/libraries/reporter/src/telemetry/TelemetrySubscriber.ts
@@ -12,9 +12,10 @@ import type { ITelemetryAggregate, TelemetryResult } from './TelemetryAggregate'
  *
  * @remarks
  * The subscriber runs before reporter filtering, so it observes every event. It
- * extracts only allowlisted values: from a diagnostic it keeps the code and
- * category but never the parameters, remediation, or templates; it ignores
- * messages, raw external output, and command arguments entirely.
+ * projects envelope metadata and lifecycle values only from public events. From
+ * a local-sensitive diagnostic it may keep the explicitly public code and
+ * category, but never parameters, remediation, or templates. It ignores secret
+ * events, messages, raw external output, and command arguments entirely.
  *
  * @beta
  */
@@ -48,8 +49,34 @@ export class TelemetrySubscriber {
    * Ingests one event, extracting only allowlisted values.
    */
   public ingest(event: IReporterEventEnvelope<unknown>): void {
-    this._protocolVersion = event.protocolVersion;
-    this._producerVersions.add(`${event.source.packageName}@${event.source.packageVersion}`);
+    const isPublicEnvelope: boolean = event.privacy === 'public';
+    if (isPublicEnvelope) {
+      this._protocolVersion = event.protocolVersion;
+      this._producerVersions.add(`${event.source.packageName}@${event.source.packageVersion}`);
+    }
+
+    if (event.type === 'diagnosticEmitted') {
+      if (event.privacy !== 'secret') {
+        // Code and category are public schema fields even when classified
+        // parameters make the diagnostic envelope local-sensitive.
+        const payload: { code?: string; category?: string } = event.payload as {
+          code?: string;
+          category?: string;
+        };
+        if (payload.code !== undefined) {
+          this._diagnosticCodes.add(payload.code);
+        }
+        if (payload.category !== undefined) {
+          this._diagnosticCategoryCounts[payload.category] =
+            (this._diagnosticCategoryCounts[payload.category] ?? 0) + 1;
+        }
+      }
+      return;
+    }
+
+    if (!isPublicEnvelope) {
+      return;
+    }
 
     switch (event.type) {
       case 'commandStarted': {
@@ -112,21 +139,6 @@ export class TelemetrySubscriber {
         }
         const payload: IOperationStatusChangedPayload = event.payload as IOperationStatusChangedPayload;
         this._operationStatuses.set(payload.operationId, payload.status);
-        break;
-      }
-      case 'diagnosticEmitted': {
-        // Keeps only the code and category, never parameters, remediation, or templates.
-        const payload: { code?: string; category?: string } = event.payload as {
-          code?: string;
-          category?: string;
-        };
-        if (payload.code !== undefined) {
-          this._diagnosticCodes.add(payload.code);
-        }
-        if (payload.category !== undefined) {
-          this._diagnosticCategoryCounts[payload.category] =
-            (this._diagnosticCategoryCounts[payload.category] ?? 0) + 1;
-        }
         break;
       }
       default: {

--- a/libraries/reporter/src/telemetry/TelemetrySubscriber.ts
+++ b/libraries/reporter/src/telemetry/TelemetrySubscriber.ts
@@ -14,6 +14,7 @@ import { REPORTER_PERFORMANCE_BUDGETS } from '../perf/PerformanceBudgets';
 import type { ITelemetryAggregate, TelemetryResult } from './TelemetryAggregate';
 
 const OTHER_DIAGNOSTIC_CATEGORY: 'other' = 'other';
+const MAX_TELEMETRY_DIAGNOSTIC_CODE_LENGTH: number = 256;
 const REGISTERED_DIAGNOSTIC_CODE_DEFINITIONS: ReadonlyMap<string, IRushDiagnosticCodeDefinition> = new Map(
   RUSH_DIAGNOSTIC_CODE_DEFINITIONS.map(
     (definition: IRushDiagnosticCodeDefinition): readonly [string, IRushDiagnosticCodeDefinition] => [
@@ -101,11 +102,13 @@ function recordBoundedPrioritizedValue(
  * The subscriber runs before reporter filtering, so it observes every event. It
  * projects envelope metadata and lifecycle values only from effectively public
  * events. A diagnostic containing any non-public parameter is treated as
- * non-public even when its envelope floor is `public`. From a non-public
- * diagnostic it keeps only a registered code and that code's registry category,
- * never parameters, remediation, or templates. It ignores all other values from
- * non-public events, messages, raw external output, and command arguments
- * entirely.
+ * non-public even when its envelope floor is `public`. The fallback for
+ * non-public diagnostics keeps only a registered code and its registry category
+ * when the envelope is `local-sensitive`, never parameters, remediation, or
+ * templates. Secret envelopes contribute no values. Diagnostic codes over 256
+ * characters are omitted before registry lookup or syntax validation, never
+ * truncated. It ignores all other values from non-public events, messages, raw
+ * external output, and command arguments entirely.
  *
  * @beta
  */
@@ -154,23 +157,24 @@ export class TelemetrySubscriber {
     }
 
     if (event.type === 'diagnosticEmitted') {
-      // Code and category are public schema fields even when classified
-      // parameters make the diagnostic envelope non-public.
+      // Only registered schema fields are allowlisted for local-sensitive diagnostics.
       const payload: { code?: unknown; category?: unknown } = isRecord(event.payload) ? event.payload : {};
-      const registeredDefinition: IRushDiagnosticCodeDefinition | undefined =
-        typeof payload.code === 'string'
-          ? REGISTERED_DIAGNOSTIC_CODE_DEFINITIONS.get(payload.code)
+      const code: string | undefined =
+        typeof payload.code === 'string' && payload.code.length <= MAX_TELEMETRY_DIAGNOSTIC_CODE_LENGTH
+          ? payload.code
           : undefined;
+      const registeredDefinition: IRushDiagnosticCodeDefinition | undefined =
+        code === undefined ? undefined : REGISTERED_DIAGNOSTIC_CODE_DEFINITIONS.get(code);
       if (isEffectivelyPublicEnvelope) {
-        if (typeof payload.code === 'string' && isValidRushDiagnosticCode(payload.code)) {
-          this._recordDiagnosticCode(payload.code, registeredDefinition !== undefined);
+        if (code !== undefined && isValidRushDiagnosticCode(code)) {
+          this._recordDiagnosticCode(code, registeredDefinition !== undefined);
         }
         if (typeof payload.category === 'string') {
           this._recordDiagnosticCategory(
             KNOWN_DIAGNOSTIC_CATEGORIES.has(payload.category) ? payload.category : OTHER_DIAGNOSTIC_CATEGORY
           );
         }
-      } else if (registeredDefinition !== undefined) {
+      } else if (event.privacy === 'local-sensitive' && registeredDefinition !== undefined) {
         this._recordDiagnosticCode(registeredDefinition.code, true);
         this._recordDiagnosticCategory(registeredDefinition.category);
       }

--- a/libraries/reporter/src/test/Performance.test.ts
+++ b/libraries/reporter/src/test/Performance.test.ts
@@ -118,6 +118,8 @@ describe('reporter performance budgets', () => {
     expect(REPORTER_PERFORMANCE_BUDGETS.maxInteractiveRefreshHz).toBe(10);
     expect(REPORTER_PERFORMANCE_BUDGETS.maxAiOutputBytes).toBe(64 * 1024);
     expect(REPORTER_PERFORMANCE_BUDGETS.maxAiDetailedDiagnostics).toBe(20);
+    expect(REPORTER_PERFORMANCE_BUDGETS.maxTelemetryDiagnosticCodes).toBe(20);
+    expect(REPORTER_PERFORMANCE_BUDGETS.maxTelemetryDiagnosticCategories).toBe(20);
   });
 
   it('evaluates wall-time regression against the 3 percent budget', () => {

--- a/libraries/reporter/src/test/Performance.test.ts
+++ b/libraries/reporter/src/test/Performance.test.ts
@@ -120,6 +120,8 @@ describe('reporter performance budgets', () => {
     expect(REPORTER_PERFORMANCE_BUDGETS.maxAiDetailedDiagnostics).toBe(20);
     expect(REPORTER_PERFORMANCE_BUDGETS.maxTelemetryDiagnosticCodes).toBe(20);
     expect(REPORTER_PERFORMANCE_BUDGETS.maxTelemetryDiagnosticCategories).toBe(20);
+    expect(REPORTER_PERFORMANCE_BUDGETS.maxTelemetryProducerVersions).toBe(20);
+    expect(REPORTER_PERFORMANCE_BUDGETS.maxTelemetryProducerVersionLength).toBe(256);
   });
 
   it('evaluates wall-time regression against the 3 percent budget', () => {

--- a/libraries/reporter/src/test/Performance.test.ts
+++ b/libraries/reporter/src/test/Performance.test.ts
@@ -13,6 +13,7 @@ import {
   type IReporter,
   type IReporterEmitEventInput,
   type IReporterEventEnvelope,
+  type IReporterPerformanceBudgets,
   type ReporterEventType,
   type ReporterJsonValue
 } from '../index';
@@ -130,6 +131,19 @@ describe('reporter performance budgets', () => {
     expect(isWithinWallTimeBudget(1000, 1030)).toBe(true);
     expect(isWithinWallTimeBudget(1000, 1031)).toBe(false);
     expect(() => computeWallTimeRegressionPercent(0, 10)).toThrow();
+  });
+
+  it('accepts the original five-field performance budget contract', () => {
+    const legacyBudgets: IReporterPerformanceBudgets = {
+      maxWallTimeRegressionPercent: 5,
+      maxAdditionalPeakMemoryBytes: 64 * 1024 * 1024,
+      maxInteractiveRefreshHz: 10,
+      maxAiOutputBytes: 64 * 1024,
+      maxAiDetailedDiagnostics: 20
+    };
+
+    expect(isWithinWallTimeBudget(1000, 1050, legacyBudgets)).toBe(true);
+    expect(isWithinMemoryBudget(64 * 1024 * 1024, legacyBudgets)).toBe(true);
   });
 
   it('evaluates additional peak memory against the 32 MiB budget', () => {

--- a/libraries/reporter/src/test/Telemetry.test.ts
+++ b/libraries/reporter/src/test/Telemetry.test.ts
@@ -152,7 +152,7 @@ describe('TelemetrySubscriber', () => {
     }
   });
 
-  it('projects only public envelopes while aggregating public producers deterministically', async () => {
+  it('projects public envelopes while preserving allowlisted diagnostic fields deterministically', async () => {
     const PUBLIC_EXTENSION_SOURCE: IReporterEventSource = {
       packageName: '@rushstack/public-reporter-plugin',
       packageVersion: '1.2.3'
@@ -196,8 +196,11 @@ describe('TelemetrySubscriber', () => {
     });
     manager.emit({
       ...rawInput('diagnosticEmitted', {
-        code: 'PRIVATE_INTERNAL_DIAGNOSTIC',
-        category: 'private-category'
+        code: 'RUSH_DEPENDENCY_TOOL_FAILED',
+        category: 'dependency-tool',
+        parameters: {
+          token: { value: 'private-secret-value', privacy: 'secret' }
+        }
       }),
       source: PRIVATE_FIRST_PARTY_SOURCE,
       privacy: 'secret'
@@ -217,8 +220,8 @@ describe('TelemetrySubscriber', () => {
       result: 'succeeded',
       exitCode: 0,
       operationStatusCounts: { success: 1 },
-      diagnosticCodes: ['RUSH_OPERATION_FAILED'],
-      diagnosticCategoryCounts: { operation: 1 },
+      diagnosticCodes: ['RUSH_DEPENDENCY_TOOL_FAILED', 'RUSH_OPERATION_FAILED'],
+      diagnosticCategoryCounts: { operation: 1, 'dependency-tool': 1 },
       protocolVersion: { major: 1, minor: 0 },
       producerVersions: ['@microsoft/rush-lib@5.177.2', '@rushstack/public-reporter-plugin@1.2.3']
     });
@@ -227,8 +230,7 @@ describe('TelemetrySubscriber', () => {
       PRIVATE_FIRST_PARTY_SOURCE.packageName,
       PRIVATE_FIRST_PARTY_SOURCE.packageVersion,
       'private-command',
-      'PRIVATE_INTERNAL_DIAGNOSTIC',
-      'private-category',
+      'private-secret-value',
       'private-operation'
     ]) {
       expect(serialized).not.toContain(forbidden);

--- a/libraries/reporter/src/test/Telemetry.test.ts
+++ b/libraries/reporter/src/test/Telemetry.test.ts
@@ -110,6 +110,131 @@ describe('TelemetrySubscriber', () => {
     }
   });
 
+  it('does not collect producer identities from local-sensitive or secret extension events', async () => {
+    const LOCAL_PRIVATE_SOURCE: IReporterEventSource = {
+      packageName: '@private/local-reporter-plugin',
+      packageVersion: '1.2.3-private'
+    };
+    const SECRET_PRIVATE_SOURCE: IReporterEventSource = {
+      packageName: '@private/secret-reporter-plugin',
+      packageVersion: '4.5.6-secret'
+    };
+    const telemetry: TelemetrySubscriber = new TelemetrySubscriber();
+    const manager: ReporterManager = new ReporterManager();
+    manager.addReporter(createTelemetryReporter(telemetry));
+    await manager.initializeAsync();
+
+    manager.emit({
+      ...rawInput('extension', { name: 'private.local.event', privateField: 'local-private-value' }),
+      source: LOCAL_PRIVATE_SOURCE,
+      privacy: 'local-sensitive'
+    });
+    manager.emit({
+      ...rawInput('extension', { name: 'private.secret.event', secretField: 'secret-private-value' }),
+      source: SECRET_PRIVATE_SOURCE,
+      privacy: 'secret'
+    });
+    await manager.flushAsync();
+
+    const aggregate: ITelemetryAggregate = telemetry.buildAggregate();
+    const serialized: string = JSON.stringify(aggregate);
+    expect(aggregate.producerVersions).toEqual([]);
+    expect(aggregate.protocolVersion).toBeUndefined();
+    for (const forbidden of [
+      LOCAL_PRIVATE_SOURCE.packageName,
+      LOCAL_PRIVATE_SOURCE.packageVersion,
+      SECRET_PRIVATE_SOURCE.packageName,
+      SECRET_PRIVATE_SOURCE.packageVersion,
+      'local-private-value',
+      'secret-private-value'
+    ]) {
+      expect(serialized).not.toContain(forbidden);
+    }
+  });
+
+  it('projects only public envelopes while aggregating public producers deterministically', async () => {
+    const PUBLIC_EXTENSION_SOURCE: IReporterEventSource = {
+      packageName: '@rushstack/public-reporter-plugin',
+      packageVersion: '1.2.3'
+    };
+    const PRIVATE_FIRST_PARTY_SOURCE: IReporterEventSource = {
+      packageName: '@microsoft/internal-build-plugin',
+      packageVersion: '9.8.7-private'
+    };
+    const telemetry: TelemetrySubscriber = new TelemetrySubscriber();
+    const manager: ReporterManager = new ReporterManager();
+    manager.addReporter(createTelemetryReporter(telemetry));
+    await manager.initializeAsync();
+
+    manager.emit({
+      ...rawInput('commandResult', {
+        commandName: 'private-command',
+        succeeded: false,
+        exitCode: 97
+      }),
+      source: PRIVATE_FIRST_PARTY_SOURCE,
+      privacy: 'local-sensitive',
+      protocolVersion: { major: 7, minor: 0 }
+    });
+    manager.emit({
+      ...rawInput('extension', { name: 'public.plugin.event' }),
+      source: PUBLIC_EXTENSION_SOURCE
+    });
+    manager.emit(rawInput('commandResult', { commandName: 'build', succeeded: true, exitCode: 0 }));
+    manager.emit({
+      ...rawInput('extension', { name: 'public.plugin.event' }),
+      source: PUBLIC_EXTENSION_SOURCE
+    });
+    manager.emit(rawInput('diagnosticEmitted', { code: 'RUSH_OPERATION_FAILED', category: 'operation' }));
+    manager.emit({
+      ...rawInput('operationStatusChanged', {
+        operationId: 'private-operation',
+        status: 'failure'
+      }),
+      source: PRIVATE_FIRST_PARTY_SOURCE,
+      privacy: 'local-sensitive'
+    });
+    manager.emit({
+      ...rawInput('diagnosticEmitted', {
+        code: 'PRIVATE_INTERNAL_DIAGNOSTIC',
+        category: 'private-category'
+      }),
+      source: PRIVATE_FIRST_PARTY_SOURCE,
+      privacy: 'secret'
+    });
+    manager.emit(rawInput('operationStatusChanged', { operationId: 'public-operation', status: 'success' }));
+    manager.emit({
+      ...rawInput('extension', { name: 'private.secret.event' }),
+      source: PRIVATE_FIRST_PARTY_SOURCE,
+      privacy: 'secret',
+      protocolVersion: { major: 99, minor: 0 }
+    });
+    await manager.flushAsync();
+
+    const aggregate: ITelemetryAggregate = telemetry.buildAggregate();
+    expect(aggregate).toMatchObject({
+      commandName: 'build',
+      result: 'succeeded',
+      exitCode: 0,
+      operationStatusCounts: { success: 1 },
+      diagnosticCodes: ['RUSH_OPERATION_FAILED'],
+      diagnosticCategoryCounts: { operation: 1 },
+      protocolVersion: { major: 1, minor: 0 },
+      producerVersions: ['@microsoft/rush-lib@5.177.2', '@rushstack/public-reporter-plugin@1.2.3']
+    });
+    const serialized: string = JSON.stringify(aggregate);
+    for (const forbidden of [
+      PRIVATE_FIRST_PARTY_SOURCE.packageName,
+      PRIVATE_FIRST_PARTY_SOURCE.packageVersion,
+      'private-command',
+      'PRIVATE_INTERNAL_DIAGNOSTIC',
+      'private-category',
+      'private-operation'
+    ]) {
+      expect(serialized).not.toContain(forbidden);
+    }
+  });
+
   it('never leaks messages, paths, arguments, remediation, raw output, or secret values', async () => {
     const SECRET: string = 'sk-super-secret-value';
     const LOG_PATH: string = '/home/user/secret/install.log';

--- a/libraries/reporter/src/test/Telemetry.test.ts
+++ b/libraries/reporter/src/test/Telemetry.test.ts
@@ -52,23 +52,44 @@ function rawInput(type: string, payload: unknown): IReporterEmitEventInput<unkno
   };
 }
 
+interface IForeignEnvelopeOptions {
+  readonly privacy?: IReporterEventEnvelope<unknown>['privacy'];
+  readonly source?: IReporterEventSource;
+  readonly protocolVersion?: IReporterEventEnvelope<unknown>['protocolVersion'];
+  readonly parentSessionId?: string;
+}
+
+function foreignEnvelope(
+  sequence: number,
+  type: IReporterEventEnvelope<unknown>['type'],
+  payload: unknown,
+  options: IForeignEnvelopeOptions = {}
+): IReporterEventEnvelope<unknown> {
+  return {
+    protocolVersion: options.protocolVersion ?? { major: 1, minor: 0 },
+    eventId: `foreign_${sequence}`,
+    sessionId: 'foreign-session',
+    parentSessionId: options.parentSessionId,
+    sequence,
+    timestamp: '2026-08-28T00:00:00.000Z',
+    source: options.source ?? {
+      packageName: '@foreign/reporter-plugin',
+      packageVersion: '1.0.0'
+    },
+    privacy: options.privacy ?? 'public',
+    required: true,
+    type,
+    payload
+  };
+}
+
 function foreignDiagnosticEnvelope(
   sequence: number,
   privacy: IReporterEventEnvelope<unknown>['privacy'],
-  payload: unknown
+  payload: unknown,
+  options: Omit<IForeignEnvelopeOptions, 'privacy'> = {}
 ): IReporterEventEnvelope<unknown> {
-  return {
-    protocolVersion: { major: 1, minor: 0 },
-    eventId: `foreign_${sequence}`,
-    sessionId: 'foreign-session',
-    sequence,
-    timestamp: '2026-08-28T00:00:00.000Z',
-    source: { packageName: '@foreign/reporter-plugin', packageVersion: '1.0.0' },
-    privacy,
-    required: true,
-    type: 'diagnosticEmitted',
-    payload
-  };
+  return foreignEnvelope(sequence, 'diagnosticEmitted', payload, { ...options, privacy });
 }
 
 describe('TelemetrySubscriber', () => {
@@ -197,13 +218,13 @@ describe('TelemetrySubscriber', () => {
     manager.ingestForeignEnvelope(
       foreignDiagnosticEnvelope(3, 'local-sensitive', {
         code: 'RUSH_OPERATION_FAILED',
-        category: 'operation'
+        category: 'network-auth'
       })
     );
     manager.ingestForeignEnvelope(
       foreignDiagnosticEnvelope(4, 'secret', {
         code: 'RUSH_DEPENDENCY_TOOL_FAILED',
-        category: 'dependency-tool'
+        category: 'configuration'
       })
     );
     await manager.flushAsync();
@@ -211,10 +232,10 @@ describe('TelemetrySubscriber', () => {
     const aggregate: ITelemetryAggregate = telemetry.buildAggregate();
     expect(aggregate.diagnosticCodes).toEqual(['RUSH_DEPENDENCY_TOOL_FAILED', 'RUSH_OPERATION_FAILED']);
     expect(aggregate.diagnosticCategoryCounts).toEqual({
-      other: 2,
-      operation: 1,
-      'dependency-tool': 1
+      'dependency-tool': 1,
+      operation: 1
     });
+    expect(Object.keys(aggregate.diagnosticCategoryCounts)).toEqual(['dependency-tool', 'operation']);
     const serialized: string = JSON.stringify(aggregate);
     for (const forbidden of [TOKEN_CODE, TOKEN_CATEGORY, PATH_CODE, PATH_CATEGORY]) {
       expect(serialized).not.toContain(forbidden);
@@ -270,9 +291,15 @@ describe('TelemetrySubscriber', () => {
         configuration: 1,
         'dependency-tool': 1,
         operation: 1,
-        other: 2
+        other: 1
       }
     });
+    expect(Object.keys(telemetry.buildAggregate().diagnosticCategoryCounts)).toEqual([
+      'configuration',
+      'dependency-tool',
+      'operation',
+      'other'
+    ]);
   });
 
   it('bounds diagnostic dimensions deterministically under cardinality flooding', async () => {
@@ -333,11 +360,163 @@ describe('TelemetrySubscriber', () => {
     expect(forward.diagnosticCodes).toContain('RUSH_DEPENDENCY_TOOL_FAILED');
     expect(forward.diagnosticCodes).not.toContain(hostilePrivateCodes[0]);
     expect(forward.diagnosticCategoryCounts).toEqual({
-      other: publicCodes.length + hostilePrivateCodes.length,
+      other: publicCodes.length,
       operation: 1,
       'dependency-tool': 1
     });
     expect(Object.keys(forward.diagnosticCategoryCounts)).toHaveLength(3);
+  });
+
+  it('keeps protocol root-owned while attributing safe child diagnostics', async () => {
+    const CHILD_PUBLIC_SOURCE: IReporterEventSource = {
+      packageName: '@rushstack/heft',
+      packageVersion: '1.2.19'
+    };
+    const CHILD_SECRET_SOURCE: IReporterEventSource = {
+      packageName: '@private/child-plugin',
+      packageVersion: '9.9.9-secret'
+    };
+    const telemetry: TelemetrySubscriber = new TelemetrySubscriber();
+    const manager: ReporterManager = new ReporterManager();
+    manager.addReporter(createTelemetryReporter(telemetry));
+    await manager.initializeAsync();
+
+    manager.emit(rawInput('commandResult', { commandName: 'build', succeeded: true, exitCode: 0 }));
+    manager.ingestForeignEnvelope(
+      foreignDiagnosticEnvelope(
+        1,
+        'public',
+        { code: 'RUSH_OPERATION_FAILED', category: 'operation' },
+        {
+          source: CHILD_PUBLIC_SOURCE,
+          protocolVersion: { major: 99, minor: 1 },
+          parentSessionId: 'sess'
+        }
+      )
+    );
+    manager.ingestForeignEnvelope(
+      foreignDiagnosticEnvelope(
+        2,
+        'secret',
+        { code: 'RUSH_DEPENDENCY_TOOL_FAILED', category: 'configuration' },
+        {
+          source: CHILD_SECRET_SOURCE,
+          protocolVersion: { major: 100, minor: 0 },
+          parentSessionId: 'sess'
+        }
+      )
+    );
+    await manager.flushAsync();
+
+    expect(telemetry.buildAggregate()).toMatchObject({
+      protocolVersion: { major: 1, minor: 0 },
+      producerVersions: ['@microsoft/rush-lib@5.177.2', '@rushstack/heft@1.2.19'],
+      diagnosticCodes: ['RUSH_DEPENDENCY_TOOL_FAILED', 'RUSH_OPERATION_FAILED'],
+      diagnosticCategoryCounts: { 'dependency-tool': 1, operation: 1 }
+    });
+  });
+
+  it('bounds foreign producer versions by priority, order, and entry length', async () => {
+    const untrustedSources: IReporterEventSource[] = [];
+    for (
+      let index: number = 0;
+      index < REPORTER_PERFORMANCE_BUDGETS.maxTelemetryProducerVersions * 3;
+      index++
+    ) {
+      untrustedSources.push({
+        packageName: `@foreign/plugin-${String(index).padStart(3, '0')}`,
+        packageVersion: '1.0.0'
+      });
+    }
+    const trustedSources: IReporterEventSource[] = [
+      { packageName: '@microsoft/rush-lib', packageVersion: '5.177.2' },
+      { packageName: '@rushstack/heft', packageVersion: '1.2.19' }
+    ];
+    const oversizedSource: IReporterEventSource = {
+      packageName: `@microsoft/${'x'.repeat(REPORTER_PERFORMANCE_BUDGETS.maxTelemetryProducerVersionLength)}`,
+      packageVersion: '1.0.0'
+    };
+    const sources: IReporterEventSource[] = [...untrustedSources, oversizedSource, ...trustedSources];
+
+    async function aggregateSources(
+      orderedSources: readonly IReporterEventSource[]
+    ): Promise<ITelemetryAggregate> {
+      const telemetry: TelemetrySubscriber = new TelemetrySubscriber();
+      const manager: ReporterManager = new ReporterManager();
+      manager.addReporter(createTelemetryReporter(telemetry));
+      await manager.initializeAsync();
+      orderedSources.forEach((source: IReporterEventSource, index: number) => {
+        manager.ingestForeignEnvelope(
+          foreignEnvelope(
+            index + 1,
+            'extension',
+            { name: 'foreign.public.event' },
+            {
+              source,
+              parentSessionId: 'sess',
+              protocolVersion: { major: 50 + index, minor: 0 }
+            }
+          )
+        );
+      });
+      await manager.flushAsync();
+      return telemetry.buildAggregate();
+    }
+
+    const forward: ITelemetryAggregate = await aggregateSources(sources);
+    const reverse: ITelemetryAggregate = await aggregateSources([...sources].reverse());
+    expect(reverse.producerVersions).toEqual(forward.producerVersions);
+    expect(forward.producerVersions).toHaveLength(REPORTER_PERFORMANCE_BUDGETS.maxTelemetryProducerVersions);
+    expect(forward.producerVersions).toContain('@microsoft/rush-lib@5.177.2');
+    expect(forward.producerVersions).toContain('@rushstack/heft@1.2.19');
+    expect(forward.producerVersions).not.toContain(
+      `${oversizedSource.packageName}@${oversizedSource.packageVersion}`
+    );
+    for (const producerVersion of forward.producerVersions) {
+      expect(producerVersion.length).toBeLessThanOrEqual(
+        REPORTER_PERFORMANCE_BUDGETS.maxTelemetryProducerVersionLength
+      );
+    }
+    expect(forward.protocolVersion).toBeUndefined();
+  });
+
+  it('does not admit producer metadata for lifecycle diagnostics with mixed privacy', async () => {
+    const SECRET: string = 'mixed-privacy-secret';
+    const MIXED_SOURCE: IReporterEventSource = {
+      packageName: '@private/mixed-diagnostic-plugin',
+      packageVersion: '1.0.0-private'
+    };
+    const telemetry: TelemetrySubscriber = new TelemetrySubscriber();
+    const recording: RecordingReporter = new RecordingReporter();
+    const manager: ReporterManager = new ReporterManager();
+    manager.addReporter(createTelemetryReporter(telemetry));
+    manager.addReporter(recording);
+    await manager.initializeAsync();
+    const emitter: LifecycleEmitter = new LifecycleEmitter({
+      sink: manager,
+      sessionId: 'sess',
+      source: MIXED_SOURCE,
+      protocolVersion: { major: 7, minor: 0 }
+    });
+
+    emitter.emitDiagnostic(
+      createRushDiagnostic('RUSH_OPERATION_FAILED', {
+        parameters: {
+          publicValue: { value: 'safe', privacy: 'public' },
+          token: { value: SECRET, privacy: 'secret' }
+        }
+      })
+    );
+    await manager.flushAsync();
+
+    expect(recording.reported[0].privacy).toBe('public');
+    const aggregate: ITelemetryAggregate = telemetry.buildAggregate();
+    expect(aggregate.protocolVersion).toBeUndefined();
+    expect(aggregate.producerVersions).toEqual([]);
+    expect(aggregate.diagnosticCodes).toEqual(['RUSH_OPERATION_FAILED']);
+    expect(aggregate.diagnosticCategoryCounts).toEqual({ operation: 1 });
+    expect(JSON.stringify(aggregate)).not.toContain(SECRET);
+    expect(JSON.stringify(aggregate)).not.toContain(MIXED_SOURCE.packageName);
   });
 
   it('projects public envelopes while preserving allowlisted diagnostic fields deterministically', async () => {

--- a/libraries/reporter/src/test/Telemetry.test.ts
+++ b/libraries/reporter/src/test/Telemetry.test.ts
@@ -416,68 +416,113 @@ describe('TelemetrySubscriber', () => {
     });
   });
 
-  it('bounds foreign producer versions by priority, order, and entry length', async () => {
-    const untrustedSources: IReporterEventSource[] = [];
+  it('protects parent producers from root-first and root-last spoofed-prefix floods', async () => {
+    const childSources: IReporterEventSource[] = [];
     for (
       let index: number = 0;
       index < REPORTER_PERFORMANCE_BUDGETS.maxTelemetryProducerVersions * 3;
       index++
     ) {
-      untrustedSources.push({
-        packageName: `@foreign/plugin-${String(index).padStart(3, '0')}`,
+      childSources.push({
+        packageName:
+          index % 2 === 0
+            ? `@microsoft/spoof-${String(index).padStart(3, '0')}`
+            : `@rushstack/spoof-${String(index).padStart(3, '0')}`,
         packageVersion: '1.0.0'
       });
     }
-    const trustedSources: IReporterEventSource[] = [
-      { packageName: '@microsoft/rush-lib', packageVersion: '5.177.2' },
-      { packageName: '@rushstack/heft', packageVersion: '1.2.19' }
+    const parentSources: IReporterEventSource[] = [
+      { packageName: 'zz-parent-owned-a', packageVersion: '1.0.0' },
+      { packageName: 'zz-parent-owned-b', packageVersion: '2.0.0' }
     ];
-    const oversizedSource: IReporterEventSource = {
+    const oversizedChildSource: IReporterEventSource = {
       packageName: `@microsoft/${'x'.repeat(REPORTER_PERFORMANCE_BUDGETS.maxTelemetryProducerVersionLength)}`,
       packageVersion: '1.0.0'
     };
-    const sources: IReporterEventSource[] = [...untrustedSources, oversizedSource, ...trustedSources];
+    const oversizedParentSource: IReporterEventSource = {
+      packageName: 'z'.repeat(REPORTER_PERFORMANCE_BUDGETS.maxTelemetryProducerVersionLength),
+      packageVersion: '1.0.0'
+    };
 
     async function aggregateSources(
-      orderedSources: readonly IReporterEventSource[]
+      rootFirst: boolean,
+      reverseChildren: boolean
     ): Promise<ITelemetryAggregate> {
       const telemetry: TelemetrySubscriber = new TelemetrySubscriber();
       const manager: ReporterManager = new ReporterManager();
       manager.addReporter(createTelemetryReporter(telemetry));
       await manager.initializeAsync();
-      orderedSources.forEach((source: IReporterEventSource, index: number) => {
-        manager.ingestForeignEnvelope(
-          foreignEnvelope(
-            index + 1,
-            'extension',
-            { name: 'foreign.public.event' },
-            {
-              source,
-              parentSessionId: 'sess',
-              protocolVersion: { major: 50 + index, minor: 0 }
-            }
-          )
-        );
-      });
+
+      const emitParentSources = (): void => {
+        for (const source of [...parentSources, oversizedParentSource]) {
+          manager.emit({
+            ...rawInput('extension', { name: 'parent.public.event' }),
+            source
+          });
+        }
+      };
+      const emitChildSources = (): void => {
+        const orderedChildren: IReporterEventSource[] = [
+          ...(reverseChildren ? [...childSources].reverse() : childSources),
+          oversizedChildSource
+        ];
+        orderedChildren.forEach((source: IReporterEventSource, index: number) => {
+          manager.ingestForeignEnvelope(
+            foreignEnvelope(
+              index + 1,
+              'extension',
+              { name: 'foreign.public.event' },
+              {
+                source,
+                parentSessionId: 'sess',
+                protocolVersion: { major: 50 + index, minor: 0 }
+              }
+            )
+          );
+        });
+      };
+
+      if (rootFirst) {
+        emitParentSources();
+        emitChildSources();
+      } else {
+        emitChildSources();
+        emitParentSources();
+      }
       await manager.flushAsync();
       return telemetry.buildAggregate();
     }
 
-    const forward: ITelemetryAggregate = await aggregateSources(sources);
-    const reverse: ITelemetryAggregate = await aggregateSources([...sources].reverse());
-    expect(reverse.producerVersions).toEqual(forward.producerVersions);
-    expect(forward.producerVersions).toHaveLength(REPORTER_PERFORMANCE_BUDGETS.maxTelemetryProducerVersions);
-    expect(forward.producerVersions).toContain('@microsoft/rush-lib@5.177.2');
-    expect(forward.producerVersions).toContain('@rushstack/heft@1.2.19');
-    expect(forward.producerVersions).not.toContain(
-      `${oversizedSource.packageName}@${oversizedSource.packageVersion}`
+    const rootFirstForward: ITelemetryAggregate = await aggregateSources(true, false);
+    const rootFirstReverse: ITelemetryAggregate = await aggregateSources(true, true);
+    const rootLastForward: ITelemetryAggregate = await aggregateSources(false, false);
+    const rootLastReverse: ITelemetryAggregate = await aggregateSources(false, true);
+    expect(rootFirstReverse.producerVersions).toEqual(rootFirstForward.producerVersions);
+    expect(rootLastForward.producerVersions).toEqual(rootFirstForward.producerVersions);
+    expect(rootLastReverse.producerVersions).toEqual(rootFirstForward.producerVersions);
+    expect(rootFirstForward.producerVersions).toHaveLength(
+      REPORTER_PERFORMANCE_BUDGETS.maxTelemetryProducerVersions
     );
-    for (const producerVersion of forward.producerVersions) {
+    for (const source of parentSources) {
+      expect(rootFirstForward.producerVersions).toContain(`${source.packageName}@${source.packageVersion}`);
+    }
+    expect(rootFirstForward.producerVersions).not.toContain(
+      `${oversizedChildSource.packageName}@${oversizedChildSource.packageVersion}`
+    );
+    expect(rootFirstForward.producerVersions).not.toContain(
+      `${oversizedParentSource.packageName}@${oversizedParentSource.packageVersion}`
+    );
+    expect(
+      rootFirstForward.producerVersions.filter((producerVersion: string): boolean =>
+        producerVersion.startsWith('@microsoft/spoof-')
+      )
+    ).toHaveLength(REPORTER_PERFORMANCE_BUDGETS.maxTelemetryProducerVersions - parentSources.length);
+    for (const producerVersion of rootFirstForward.producerVersions) {
       expect(producerVersion.length).toBeLessThanOrEqual(
         REPORTER_PERFORMANCE_BUDGETS.maxTelemetryProducerVersionLength
       );
     }
-    expect(forward.protocolVersion).toBeUndefined();
+    expect(rootFirstForward.protocolVersion).toEqual({ major: 1, minor: 0 });
   });
 
   it('does not admit producer metadata for lifecycle diagnostics with mixed privacy', async () => {

--- a/libraries/reporter/src/test/Telemetry.test.ts
+++ b/libraries/reporter/src/test/Telemetry.test.ts
@@ -5,6 +5,7 @@ import {
   TelemetrySubscriber,
   createTelemetryReporter,
   createBeforeLogAdapter,
+  REPORTER_PERFORMANCE_BUDGETS,
   TELEMETRY_AGGREGATE_KEYS,
   LifecycleEmitter,
   ReporterManager,
@@ -47,6 +48,25 @@ function rawInput(type: string, payload: unknown): IReporterEmitEventInput<unkno
     source: SOURCE,
     privacy: 'public',
     type: type as IReporterEmitEventInput<unknown>['type'],
+    payload
+  };
+}
+
+function foreignDiagnosticEnvelope(
+  sequence: number,
+  privacy: IReporterEventEnvelope<unknown>['privacy'],
+  payload: unknown
+): IReporterEventEnvelope<unknown> {
+  return {
+    protocolVersion: { major: 1, minor: 0 },
+    eventId: `foreign_${sequence}`,
+    sessionId: 'foreign-session',
+    sequence,
+    timestamp: '2026-08-28T00:00:00.000Z',
+    source: { packageName: '@foreign/reporter-plugin', packageVersion: '1.0.0' },
+    privacy,
+    required: true,
+    type: 'diagnosticEmitted',
     payload
   };
 }
@@ -150,6 +170,174 @@ describe('TelemetrySubscriber', () => {
     ]) {
       expect(serialized).not.toContain(forbidden);
     }
+  });
+
+  it('rejects hostile non-public diagnostic fields from foreign envelopes', async () => {
+    const TOKEN_CODE: string = 'ghp_super_secret_token';
+    const TOKEN_CATEGORY: string = 'token=super-secret-value';
+    const PATH_CODE: string = '/home/user/private/.npmrc';
+    const PATH_CATEGORY: string = 'C:\\Users\\private\\rush.json';
+    const telemetry: TelemetrySubscriber = new TelemetrySubscriber();
+    const manager: ReporterManager = new ReporterManager();
+    manager.addReporter(createTelemetryReporter(telemetry));
+    await manager.initializeAsync();
+
+    manager.ingestForeignEnvelope(
+      foreignDiagnosticEnvelope(1, 'local-sensitive', {
+        code: PATH_CODE,
+        category: TOKEN_CATEGORY
+      })
+    );
+    manager.ingestForeignEnvelope(
+      foreignDiagnosticEnvelope(2, 'secret', {
+        code: TOKEN_CODE,
+        category: PATH_CATEGORY
+      })
+    );
+    manager.ingestForeignEnvelope(
+      foreignDiagnosticEnvelope(3, 'local-sensitive', {
+        code: 'RUSH_OPERATION_FAILED',
+        category: 'operation'
+      })
+    );
+    manager.ingestForeignEnvelope(
+      foreignDiagnosticEnvelope(4, 'secret', {
+        code: 'RUSH_DEPENDENCY_TOOL_FAILED',
+        category: 'dependency-tool'
+      })
+    );
+    await manager.flushAsync();
+
+    const aggregate: ITelemetryAggregate = telemetry.buildAggregate();
+    expect(aggregate.diagnosticCodes).toEqual(['RUSH_DEPENDENCY_TOOL_FAILED', 'RUSH_OPERATION_FAILED']);
+    expect(aggregate.diagnosticCategoryCounts).toEqual({
+      other: 2,
+      operation: 1,
+      'dependency-tool': 1
+    });
+    const serialized: string = JSON.stringify(aggregate);
+    for (const forbidden of [TOKEN_CODE, TOKEN_CATEGORY, PATH_CODE, PATH_CATEGORY]) {
+      expect(serialized).not.toContain(forbidden);
+    }
+  });
+
+  it('preserves allowlisted diagnostics across mixed privacy ordering', async () => {
+    const telemetry: TelemetrySubscriber = new TelemetrySubscriber();
+    const manager: ReporterManager = new ReporterManager();
+    manager.addReporter(createTelemetryReporter(telemetry));
+    await manager.initializeAsync();
+
+    manager.ingestForeignEnvelope(
+      foreignDiagnosticEnvelope(1, 'secret', {
+        code: 'RUSH_DEPENDENCY_TOOL_FAILED',
+        category: 'dependency-tool'
+      })
+    );
+    manager.ingestForeignEnvelope(
+      foreignDiagnosticEnvelope(2, 'public', {
+        code: 'RUSH_OPERATION_FAILED',
+        category: 'operation'
+      })
+    );
+    manager.ingestForeignEnvelope(
+      foreignDiagnosticEnvelope(3, 'local-sensitive', {
+        code: 'RUSH_CONFIG_INVALID_JSON',
+        category: 'configuration'
+      })
+    );
+    manager.ingestForeignEnvelope(
+      foreignDiagnosticEnvelope(4, 'secret', {
+        code: 'RUSH_NOT_REGISTERED_PRIVATE',
+        category: 'future-private-category'
+      })
+    );
+    manager.ingestForeignEnvelope(
+      foreignDiagnosticEnvelope(5, 'public', {
+        code: 'RUSH_FUTURE_PUBLIC_CODE',
+        category: 'future-public-category'
+      })
+    );
+    await manager.flushAsync();
+
+    expect(telemetry.buildAggregate()).toMatchObject({
+      diagnosticCodes: [
+        'RUSH_CONFIG_INVALID_JSON',
+        'RUSH_DEPENDENCY_TOOL_FAILED',
+        'RUSH_FUTURE_PUBLIC_CODE',
+        'RUSH_OPERATION_FAILED'
+      ],
+      diagnosticCategoryCounts: {
+        configuration: 1,
+        'dependency-tool': 1,
+        operation: 1,
+        other: 2
+      }
+    });
+  });
+
+  it('bounds diagnostic dimensions deterministically under cardinality flooding', async () => {
+    const publicCodes: string[] = [];
+    for (
+      let index: number = 0;
+      index < REPORTER_PERFORMANCE_BUDGETS.maxTelemetryDiagnosticCodes * 3;
+      index++
+    ) {
+      publicCodes.push(`RUSH_FOREIGN_CODE${String(index).padStart(3, '0')}`);
+    }
+    const hostilePrivateCodes: string[] = publicCodes.map((code: string): string => `${code}_PRIVATE`);
+    const payloads: Array<{
+      privacy: IReporterEventEnvelope<unknown>['privacy'];
+      code: string;
+      category: string;
+    }> = [
+      ...publicCodes.map((code: string, index: number) => ({
+        privacy: 'public' as const,
+        code,
+        category: `/private/category/${index}`
+      })),
+      ...hostilePrivateCodes.map((code: string, index: number) => ({
+        privacy: index % 2 === 0 ? ('local-sensitive' as const) : ('secret' as const),
+        code,
+        category: `token-${index}`
+      })),
+      { privacy: 'secret', code: 'RUSH_OPERATION_FAILED', category: 'operation' },
+      {
+        privacy: 'local-sensitive',
+        code: 'RUSH_DEPENDENCY_TOOL_FAILED',
+        category: 'dependency-tool'
+      }
+    ];
+
+    async function aggregatePayloads(orderedPayloads: typeof payloads): Promise<ITelemetryAggregate> {
+      const telemetry: TelemetrySubscriber = new TelemetrySubscriber();
+      const manager: ReporterManager = new ReporterManager();
+      manager.addReporter(createTelemetryReporter(telemetry));
+      await manager.initializeAsync();
+      orderedPayloads.forEach((payload, index: number) => {
+        manager.ingestForeignEnvelope(
+          foreignDiagnosticEnvelope(index + 1, payload.privacy, {
+            code: payload.code,
+            category: payload.category
+          })
+        );
+      });
+      await manager.flushAsync();
+      return telemetry.buildAggregate();
+    }
+
+    const forward: ITelemetryAggregate = await aggregatePayloads(payloads);
+    const reverse: ITelemetryAggregate = await aggregatePayloads([...payloads].reverse());
+    expect(reverse.diagnosticCodes).toEqual(forward.diagnosticCodes);
+    expect(forward.diagnosticCodes).toHaveLength(REPORTER_PERFORMANCE_BUDGETS.maxTelemetryDiagnosticCodes);
+    expect(forward.diagnosticCodes).toContain('RUSH_OPERATION_FAILED');
+    expect(forward.diagnosticCodes).toContain('RUSH_DEPENDENCY_TOOL_FAILED');
+    expect(forward.diagnosticCodes).not.toContain(hostilePrivateCodes[0]);
+    expect(forward.diagnosticCategoryCounts).toEqual({
+      other: publicCodes.length + hostilePrivateCodes.length,
+      operation: 1,
+      'dependency-tool': 1
+    });
+    expect(Object.keys(forward.diagnosticCategoryCounts)).toHaveLength(3);
   });
 
   it('projects public envelopes while preserving allowlisted diagnostic fields deterministically', async () => {

--- a/libraries/reporter/src/test/Telemetry.test.ts
+++ b/libraries/reporter/src/test/Telemetry.test.ts
@@ -230,17 +230,48 @@ describe('TelemetrySubscriber', () => {
     await manager.flushAsync();
 
     const aggregate: ITelemetryAggregate = telemetry.buildAggregate();
-    expect(aggregate.diagnosticCodes).toEqual(['RUSH_DEPENDENCY_TOOL_FAILED', 'RUSH_OPERATION_FAILED']);
-    expect(aggregate.diagnosticCategoryCounts).toEqual({
-      'dependency-tool': 1,
-      operation: 1
-    });
-    expect(Object.keys(aggregate.diagnosticCategoryCounts)).toEqual(['dependency-tool', 'operation']);
+    expect(aggregate.diagnosticCodes).toEqual(['RUSH_OPERATION_FAILED']);
+    expect(aggregate.diagnosticCategoryCounts).toEqual({ operation: 1 });
+    expect(Object.keys(aggregate.diagnosticCategoryCounts)).toEqual(['operation']);
     const serialized: string = JSON.stringify(aggregate);
     for (const forbidden of [TOKEN_CODE, TOKEN_CATEGORY, PATH_CODE, PATH_CATEGORY]) {
       expect(serialized).not.toContain(forbidden);
     }
   });
+
+  it.each([false, true])(
+    'does not change any aggregate field for a secret diagnostic (child: %s)',
+    async (isChild: boolean) => {
+      const telemetry: TelemetrySubscriber = new TelemetrySubscriber();
+      const recording: RecordingReporter = new RecordingReporter();
+      const manager: ReporterManager = new ReporterManager();
+      manager.addReporter(createTelemetryReporter(telemetry));
+      manager.addReporter(recording);
+      await manager.initializeAsync();
+      const before: ITelemetryAggregate = telemetry.buildAggregate();
+
+      manager.ingestForeignEnvelope(
+        foreignDiagnosticEnvelope(
+          1,
+          'secret',
+          {
+            code: 'RUSH_DEPENDENCY_TOOL_FAILED',
+            category: 'dependency-tool',
+            parameters: { token: { value: 'private-token', privacy: 'secret' } }
+          },
+          {
+            source: { packageName: '@private/secret-plugin', packageVersion: '1.0.0-private' },
+            protocolVersion: { major: 99, minor: 1 },
+            parentSessionId: isChild ? 'sess' : undefined
+          }
+        )
+      );
+      await manager.flushAsync();
+
+      expect(recording.reported).toHaveLength(1);
+      expect(telemetry.buildAggregate()).toEqual(before);
+    }
+  );
 
   it('preserves allowlisted diagnostics across mixed privacy ordering', async () => {
     const telemetry: TelemetrySubscriber = new TelemetrySubscriber();
@@ -281,35 +312,50 @@ describe('TelemetrySubscriber', () => {
     await manager.flushAsync();
 
     expect(telemetry.buildAggregate()).toMatchObject({
-      diagnosticCodes: [
-        'RUSH_CONFIG_INVALID_JSON',
-        'RUSH_DEPENDENCY_TOOL_FAILED',
-        'RUSH_FUTURE_PUBLIC_CODE',
-        'RUSH_OPERATION_FAILED'
-      ],
+      diagnosticCodes: ['RUSH_CONFIG_INVALID_JSON', 'RUSH_FUTURE_PUBLIC_CODE', 'RUSH_OPERATION_FAILED'],
       diagnosticCategoryCounts: {
         configuration: 1,
-        'dependency-tool': 1,
         operation: 1,
         other: 1
       }
     });
     expect(Object.keys(telemetry.buildAggregate().diagnosticCategoryCounts)).toEqual([
       'configuration',
-      'dependency-tool',
       'operation',
       'other'
     ]);
   });
 
+  it.each([255, 256, 257])(
+    'omits public diagnostic codes over the 256-character budget without truncation (length: %s)',
+    async (length: number) => {
+      const code: string = 'RUSH_BOUNDARY_'.padEnd(length, 'A');
+      const telemetry: TelemetrySubscriber = new TelemetrySubscriber();
+      const manager: ReporterManager = new ReporterManager();
+      manager.addReporter(createTelemetryReporter(telemetry));
+      await manager.initializeAsync();
+
+      manager.ingestForeignEnvelope(foreignDiagnosticEnvelope(1, 'public', { code, category: 'operation' }));
+      await manager.flushAsync();
+
+      const aggregate: ITelemetryAggregate = telemetry.buildAggregate();
+      expect(aggregate.diagnosticCodes).toEqual(length <= 256 ? [code] : []);
+      expect(aggregate.diagnosticCategoryCounts).toEqual({ operation: 1 });
+      expect(aggregate.producerVersions).toEqual(['@foreign/reporter-plugin@1.0.0']);
+    }
+  );
+
   it('bounds diagnostic dimensions deterministically under cardinality flooding', async () => {
+    const maximumCodeLength: number = 256;
     const publicCodes: string[] = [];
+    const oversizedPublicCodes: string[] = [];
     for (
       let index: number = 0;
       index < REPORTER_PERFORMANCE_BUDGETS.maxTelemetryDiagnosticCodes * 3;
       index++
     ) {
-      publicCodes.push(`RUSH_FOREIGN_CODE${String(index).padStart(3, '0')}`);
+      publicCodes.push(`RUSH_FOREIGN_CODE${String(index).padStart(3, '0')}`.padEnd(maximumCodeLength, 'A'));
+      oversizedPublicCodes.push(`RUSH_A_FOREIGN${index}_${'A'.repeat(8 * 1024)}`);
     }
     const hostilePrivateCodes: string[] = publicCodes.map((code: string): string => `${code}_PRIVATE`);
     const payloads: Array<{
@@ -322,12 +368,18 @@ describe('TelemetrySubscriber', () => {
         code,
         category: `/private/category/${index}`
       })),
+      ...oversizedPublicCodes.map((code: string) => ({
+        privacy: 'public' as const,
+        code,
+        category: 'future-public-category'
+      })),
       ...hostilePrivateCodes.map((code: string, index: number) => ({
         privacy: index % 2 === 0 ? ('local-sensitive' as const) : ('secret' as const),
         code,
         category: `token-${index}`
       })),
       { privacy: 'secret', code: 'RUSH_OPERATION_FAILED', category: 'operation' },
+      { privacy: 'public', code: 'RUSH_CONFIG_INVALID_JSON', category: 'configuration' },
       {
         privacy: 'local-sensitive',
         code: 'RUSH_DEPENDENCY_TOOL_FAILED',
@@ -354,17 +406,29 @@ describe('TelemetrySubscriber', () => {
 
     const forward: ITelemetryAggregate = await aggregatePayloads(payloads);
     const reverse: ITelemetryAggregate = await aggregatePayloads([...payloads].reverse());
-    expect(reverse.diagnosticCodes).toEqual(forward.diagnosticCodes);
+    expect(forward.diagnosticCodes.every((code: string): boolean => code.length <= maximumCodeLength)).toBe(
+      true
+    );
+    expect(reverse).toEqual(forward);
     expect(forward.diagnosticCodes).toHaveLength(REPORTER_PERFORMANCE_BUDGETS.maxTelemetryDiagnosticCodes);
-    expect(forward.diagnosticCodes).toContain('RUSH_OPERATION_FAILED');
-    expect(forward.diagnosticCodes).toContain('RUSH_DEPENDENCY_TOOL_FAILED');
+    expect(forward.diagnosticCodes).toEqual(
+      [
+        'RUSH_CONFIG_INVALID_JSON',
+        'RUSH_DEPENDENCY_TOOL_FAILED',
+        ...publicCodes.slice(0, REPORTER_PERFORMANCE_BUDGETS.maxTelemetryDiagnosticCodes - 2)
+      ].sort()
+    );
+    expect(forward.diagnosticCodes).not.toContain('RUSH_OPERATION_FAILED');
     expect(forward.diagnosticCodes).not.toContain(hostilePrivateCodes[0]);
     expect(forward.diagnosticCategoryCounts).toEqual({
-      other: publicCodes.length,
-      operation: 1,
+      other: publicCodes.length + oversizedPublicCodes.length,
+      configuration: 1,
       'dependency-tool': 1
     });
     expect(Object.keys(forward.diagnosticCategoryCounts)).toHaveLength(3);
+    expect(Buffer.byteLength(JSON.stringify(forward))).toBeLessThanOrEqual(
+      REPORTER_PERFORMANCE_BUDGETS.maxTelemetryDiagnosticCodes * (maximumCodeLength + 3) + 1024
+    );
   });
 
   it('keeps protocol root-owned while attributing safe child diagnostics', async () => {
@@ -411,8 +475,8 @@ describe('TelemetrySubscriber', () => {
     expect(telemetry.buildAggregate()).toMatchObject({
       protocolVersion: { major: 1, minor: 0 },
       producerVersions: ['@microsoft/rush-lib@5.177.2', '@rushstack/heft@1.2.19'],
-      diagnosticCodes: ['RUSH_DEPENDENCY_TOOL_FAILED', 'RUSH_OPERATION_FAILED'],
-      diagnosticCategoryCounts: { 'dependency-tool': 1, operation: 1 }
+      diagnosticCodes: ['RUSH_OPERATION_FAILED'],
+      diagnosticCategoryCounts: { operation: 1 }
     });
   });
 
@@ -525,44 +589,51 @@ describe('TelemetrySubscriber', () => {
     expect(rootFirstForward.protocolVersion).toEqual({ major: 1, minor: 0 });
   });
 
-  it('does not admit producer metadata for lifecycle diagnostics with mixed privacy', async () => {
-    const SECRET: string = 'mixed-privacy-secret';
-    const MIXED_SOURCE: IReporterEventSource = {
-      packageName: '@private/mixed-diagnostic-plugin',
-      packageVersion: '1.0.0-private'
-    };
-    const telemetry: TelemetrySubscriber = new TelemetrySubscriber();
-    const recording: RecordingReporter = new RecordingReporter();
-    const manager: ReporterManager = new ReporterManager();
-    manager.addReporter(createTelemetryReporter(telemetry));
-    manager.addReporter(recording);
-    await manager.initializeAsync();
-    const emitter: LifecycleEmitter = new LifecycleEmitter({
-      sink: manager,
-      sessionId: 'sess',
-      source: MIXED_SOURCE,
-      protocolVersion: { major: 7, minor: 0 }
-    });
+  it.each(['public', 'local-sensitive', 'secret'] as const)(
+    'restricts mixed-privacy lifecycle diagnostics to the local-sensitive allowlist (floor: %s)',
+    async (privacy: IReporterEventEnvelope<unknown>['privacy']) => {
+      const SECRET: string = 'mixed-privacy-secret';
+      const MIXED_SOURCE: IReporterEventSource = {
+        packageName: '@private/mixed-diagnostic-plugin',
+        packageVersion: '1.0.0-private'
+      };
+      const telemetry: TelemetrySubscriber = new TelemetrySubscriber();
+      const recording: RecordingReporter = new RecordingReporter();
+      const manager: ReporterManager = new ReporterManager();
+      manager.addReporter(createTelemetryReporter(telemetry));
+      manager.addReporter(recording);
+      await manager.initializeAsync();
+      const emitter: LifecycleEmitter = new LifecycleEmitter({
+        sink: manager,
+        sessionId: 'sess',
+        source: MIXED_SOURCE,
+        protocolVersion: { major: 7, minor: 0 }
+      });
 
-    emitter.emitDiagnostic(
-      createRushDiagnostic('RUSH_OPERATION_FAILED', {
-        parameters: {
-          publicValue: { value: 'safe', privacy: 'public' },
-          token: { value: SECRET, privacy: 'secret' }
-        }
-      })
-    );
-    await manager.flushAsync();
+      emitter.emitDiagnostic(
+        createRushDiagnostic('RUSH_OPERATION_FAILED', {
+          parameters: {
+            floorValue: { value: 'safe', privacy },
+            token: { value: SECRET, privacy: 'secret' }
+          }
+        })
+      );
+      await manager.flushAsync();
 
-    expect(recording.reported[0].privacy).toBe('public');
-    const aggregate: ITelemetryAggregate = telemetry.buildAggregate();
-    expect(aggregate.protocolVersion).toBeUndefined();
-    expect(aggregate.producerVersions).toEqual([]);
-    expect(aggregate.diagnosticCodes).toEqual(['RUSH_OPERATION_FAILED']);
-    expect(aggregate.diagnosticCategoryCounts).toEqual({ operation: 1 });
-    expect(JSON.stringify(aggregate)).not.toContain(SECRET);
-    expect(JSON.stringify(aggregate)).not.toContain(MIXED_SOURCE.packageName);
-  });
+      expect(recording.reported[0].privacy).toBe(privacy);
+      const aggregate: ITelemetryAggregate = telemetry.buildAggregate();
+      expect(aggregate.protocolVersion).toBeUndefined();
+      expect(aggregate.producerVersions).toEqual([]);
+      expect(aggregate.diagnosticCodes).toEqual(
+        privacy === 'local-sensitive' ? ['RUSH_OPERATION_FAILED'] : []
+      );
+      expect(aggregate.diagnosticCategoryCounts).toEqual(
+        privacy === 'local-sensitive' ? { operation: 1 } : {}
+      );
+      expect(JSON.stringify(aggregate)).not.toContain(SECRET);
+      expect(JSON.stringify(aggregate)).not.toContain(MIXED_SOURCE.packageName);
+    }
+  );
 
   it('projects public envelopes while preserving allowlisted diagnostic fields deterministically', async () => {
     const PUBLIC_EXTENSION_SOURCE: IReporterEventSource = {
@@ -632,8 +703,8 @@ describe('TelemetrySubscriber', () => {
       result: 'succeeded',
       exitCode: 0,
       operationStatusCounts: { success: 1 },
-      diagnosticCodes: ['RUSH_DEPENDENCY_TOOL_FAILED', 'RUSH_OPERATION_FAILED'],
-      diagnosticCategoryCounts: { operation: 1, 'dependency-tool': 1 },
+      diagnosticCodes: ['RUSH_OPERATION_FAILED'],
+      diagnosticCategoryCounts: { operation: 1 },
       protocolVersion: { major: 1, minor: 0 },
       producerVersions: ['@microsoft/rush-lib@5.177.2', '@rushstack/public-reporter-plugin@1.2.3']
     });


### PR DESCRIPTION
## Summary

- collect producer package identities and protocol metadata only from `public` envelopes
- project lifecycle values only from `public` envelopes while preserving explicitly allowlisted diagnostic codes/categories from `local-sensitive` diagnostics
- ignore `secret` diagnostics and add mixed-order regression coverage for public, local-sensitive, and secret first-party/extension events

## Review context

Follow-up to https://github.com/microsoft/rushstack/pull/5867#discussion_r3866455319.

## Threat model

`TelemetrySubscriber` observes canonical events before reporter filtering. A private extension or internal plugin can therefore place a private package name/version in envelope source metadata even when the event is classified `local-sensitive` or `secret`. This change treats source/protocol metadata and lifecycle payload fields as telemetry-safe only for `public` envelopes. Extension payloads remain outside the projection, `secret` events contribute no values, and the existing field-level allowlist for public diagnostic code/category data remains intact.

## Validation

- `rushx _phase:build`
- ESLint on the changed telemetry and test files
- `rushx _phase:test` (293 tests passed)
- `rush change --verify`

## Non-goals

- wiring reporter aggregates into the live `rush-lib` upload stack
- changing local reporter redaction or storage behavior
- broadening reporter privacy classification semantics outside this telemetry projection

Part of #5977
