### PR TITLE
Emit shadow Rush lifecycle events

### DIFF
--- a/common/changes/@microsoft/rush/copilot-reporter-r3b-shadow-events_2026-08-28-04-20.json
+++ b/common/changes/@microsoft/rush/copilot-reporter-r3b-shadow-events_2026-08-28-04-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Emit shadow Rush lifecycle, phase-aware operation, diagnostic, telemetry, and command-result events without changing legacy terminal output.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "TheLarkInn@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush/copilot-review-lifecycle_2026-09-10.json
+++ b/common/changes/@microsoft/rush/copilot-review-lifecycle_2026-09-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Preserve immutable errors, diagnose pre-execution parser failures once, and register shadow operations after final watch iteration configuration.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "TheLarkInn@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush/reporter-foundation-lifecycle_2026-09-09.json
+++ b/common/changes/@microsoft/rush/reporter-foundation-lifecycle_2026-09-09.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Report early initialization failures and defer successful reporter completion until telemetry finalization preserves the command's native outcome.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "TheLarkInn@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/rush-reporter/copilot-reporter-r3b-shadow-events_2026-08-28-04-20.json
+++ b/common/changes/@rushstack/rush-reporter/copilot-reporter-r3b-shadow-events_2026-08-28-04-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/rush-reporter",
+      "comment": "Add a stable structured diagnostic code for Rush command failures.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/rush-reporter",
+  "email": "TheLarkInn@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/rush-reporter/copilot-review-lifecycle_2026-09-10.json
+++ b/common/changes/@rushstack/rush-reporter/copilot-review-lifecycle_2026-09-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/rush-reporter",
+      "comment": "Correlate diagnostics using weak metadata instead of mutating potentially frozen or non-extensible errors.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/rush-reporter",
+  "email": "TheLarkInn@users.noreply.github.com"
+}

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -29,6 +29,7 @@ import { IRushDiagnostic } from '@rushstack/rush-reporter';
 import { IScopedLogger } from '@rushstack/rush-reporter';
 import { IScopedMessageOptions } from '@rushstack/rush-reporter';
 import { IScopedReporter } from '@rushstack/rush-reporter';
+import type { ITelemetryAggregate } from '@rushstack/rush-reporter';
 import { ITerminal } from '@rushstack/terminal';
 import type { ITerminalChunk } from '@rushstack/terminal';
 import { ITerminalProvider } from '@rushstack/terminal';
@@ -684,7 +685,7 @@ export interface _IOperationGraphEventSink {
     onActivity?(text: string, options?: _IOperationActivityOptions): void;
     onOperationChunk?(operationId: string, chunk: ITerminalChunk): void;
     onOperationHeader?(operationId: string, completedOperations: number, totalOperations: number): void;
-    onOperationRegistered?(operationId: string, silent: boolean): void;
+    onOperationRegistered?(operationId: string, silent: boolean, result?: IOperationExecutionResult): void;
     onOperationStatusChanged?(result: IOperationExecutionResult, previousStatus: OperationStatus): void;
     onOperationStreamClosed?(operationId: string): void;
 }
@@ -1044,6 +1045,7 @@ export interface ITelemetryData {
     readonly operationResults?: Record<string, ITelemetryOperationResult>;
     readonly performanceEntries?: readonly PerformanceEntry_2[];
     readonly platform?: string;
+    readonly reporterData?: ITelemetryAggregate;
     readonly result: 'Succeeded' | 'Failed';
     readonly rushVersion?: string;
     readonly timestampMs?: number;

--- a/common/reviews/api/rush-reporter.api.md
+++ b/common/reviews/api/rush-reporter.api.md
@@ -1506,6 +1506,12 @@ export const RUSH_DIAGNOSTIC_CODE_DEFINITIONS: readonly [{
     readonly defaultSeverity: "error";
     readonly summaryKey: "diagnostic.RUSH_EXTERNAL_TOOL_PROBLEM.summary";
     readonly detailKey: undefined;
+}, {
+    readonly code: "RUSH_COMMAND_FAILED";
+    readonly category: "operation";
+    readonly defaultSeverity: "error";
+    readonly summaryKey: "diagnostic.RUSH_COMMAND_FAILED.summary";
+    readonly detailKey: undefined;
 }];
 
 // @beta

--- a/libraries/reporter/README.md
+++ b/libraries/reporter/README.md
@@ -4,6 +4,16 @@ Canonical event protocol, reporter manager, and built-in reporters for Rush.
 
 This package is released as a public beta. Exported contracts may change before the stable release.
 
+## Shadow lifecycle compatibility
+
+Error correlation uses external weak metadata, so frozen and non-extensible errors retain their original
+identity, cause, and properties. Correlation remains visible across bridge instances without keeping errors alive.
+
+Rush command-line parse failures emit one session-scoped `RUSH_COMMAND_FAILED` diagnostic before completion.
+The original parser message is retained in the diagnostic's local-sensitive `message` parameter; native error
+rendering and exit codes remain unchanged. Operation registration observes the final iteration configuration,
+so unchanged watch operations do not produce visible shadow registration or status events.
+
 ## Links
 
 - [CHANGELOG.md](https://github.com/microsoft/rushstack/blob/main/libraries/reporter/CHANGELOG.md) - Find out

--- a/libraries/reporter/src/compat/LegacyErrorBridge.ts
+++ b/libraries/reporter/src/compat/LegacyErrorBridge.ts
@@ -11,7 +11,7 @@ import { RushError } from '../diagnostics/RushError';
  */
 export const ALREADY_REPORTED_ERROR_NAME: 'AlreadyReportedError' = 'AlreadyReportedError';
 
-const CORRELATION_KEY: unique symbol = Symbol('rush-reporter-correlated-diagnostic-id');
+const correlatedDiagnosticIds: WeakMap<object, string> = new WeakMap();
 
 /**
  * The criteria that must be met before the legacy error bridge is removed.
@@ -94,11 +94,11 @@ export class LegacyErrorBridge {
   }
 
   /**
-   * Correlates a legacy sentinel error with the diagnostic id it corresponds to.
+   * Correlates an error with its diagnostic id without modifying the supplied object.
    */
   public correlate(error: unknown, diagnosticId: string): void {
     if (typeof error === 'object' && error !== null) {
-      (error as { [CORRELATION_KEY]?: string })[CORRELATION_KEY] = diagnosticId;
+      correlatedDiagnosticIds.set(error, diagnosticId);
     }
   }
 
@@ -107,7 +107,7 @@ export class LegacyErrorBridge {
    */
   public getCorrelatedDiagnosticId(error: unknown): string | undefined {
     if (typeof error === 'object' && error !== null) {
-      return (error as { [CORRELATION_KEY]?: string })[CORRELATION_KEY];
+      return correlatedDiagnosticIds.get(error);
     }
     return undefined;
   }

--- a/libraries/reporter/src/diagnostics/RushDiagnosticCodeRegistry.ts
+++ b/libraries/reporter/src/diagnostics/RushDiagnosticCodeRegistry.ts
@@ -111,16 +111,13 @@ type AreValidRushDiagnosticCodeSegments<
     ? IsValidRushDiagnosticCodeSegment<TSegments>
     : false;
 
-type ValidateRushDiagnosticCode<TCode extends string> =
-  TCode extends `RUSH_${infer Segments}`
-    ? AreValidRushDiagnosticCodeSegments<Segments> extends true
-      ? TCode
-      : never
-    : never;
+type ValidateRushDiagnosticCode<TCode extends string> = TCode extends `RUSH_${infer Segments}`
+  ? AreValidRushDiagnosticCodeSegments<Segments> extends true
+    ? TCode
+    : never
+  : never;
 
-type ValidatedRushDiagnosticCodeDefinitions<
-  TDefinitions extends readonly IRushDiagnosticCodeDefinition[]
-> = {
+type ValidatedRushDiagnosticCodeDefinitions<TDefinitions extends readonly IRushDiagnosticCodeDefinition[]> = {
   readonly [K in keyof TDefinitions]: TDefinitions[K] extends IRushDiagnosticCodeDefinition
     ? TDefinitions[K] & {
         readonly code: ValidateRushDiagnosticCode<TDefinitions[K]['code']>;
@@ -130,9 +127,7 @@ type ValidatedRushDiagnosticCodeDefinitions<
 
 function defineRushDiagnosticCodeDefinitions<
   const TDefinitions extends readonly IRushDiagnosticCodeDefinition[]
->(
-  definitions: TDefinitions & ValidatedRushDiagnosticCodeDefinitions<TDefinitions>
-): TDefinitions {
+>(definitions: TDefinitions & ValidatedRushDiagnosticCodeDefinitions<TDefinitions>): TDefinitions {
   return definitions;
 }
 
@@ -233,6 +228,13 @@ export const RUSH_DIAGNOSTIC_CODE_DEFINITIONS = defineRushDiagnosticCodeDefiniti
     defaultSeverity: 'error',
     summaryKey: 'diagnostic.RUSH_EXTERNAL_TOOL_PROBLEM.summary',
     detailKey: undefined
+  },
+  {
+    code: 'RUSH_COMMAND_FAILED',
+    category: 'operation',
+    defaultSeverity: 'error',
+    summaryKey: 'diagnostic.RUSH_COMMAND_FAILED.summary',
+    detailKey: undefined
   }
 ]);
 
@@ -257,12 +259,11 @@ export type RushDiagnosticTemplateKey = NonNullable<
  *
  * @beta
  */
-export const RUSH_DIAGNOSTIC_CODES: ReadonlyMap<RushDiagnosticCode, IRushDiagnosticCodeDefinition> =
-  new Map(
-    RUSH_DIAGNOSTIC_CODE_DEFINITIONS.map(
-      (definition: IRushDiagnosticCodeDefinition) => [definition.code, definition] as const
-    )
-  );
+export const RUSH_DIAGNOSTIC_CODES: ReadonlyMap<RushDiagnosticCode, IRushDiagnosticCodeDefinition> = new Map(
+  RUSH_DIAGNOSTIC_CODE_DEFINITIONS.map(
+    (definition: IRushDiagnosticCodeDefinition) => [definition.code, definition] as const
+  )
+);
 
 export { isValidRushDiagnosticCode } from './RushDiagnosticCode';
 export { RUSH_DIAGNOSTIC_TEMPLATES } from './templates';

--- a/libraries/reporter/src/diagnostics/templates/operation.ts
+++ b/libraries/reporter/src/diagnostics/templates/operation.ts
@@ -11,5 +11,6 @@
 // eslint-disable-next-line @typescript-eslint/typedef -- literal keys are required for the Record<RushDiagnosticTemplateKey, string> aggregate check
 export const OPERATION_DIAGNOSTIC_TEMPLATES = {
   'diagnostic.RUSH_OPERATION_FAILED.summary': 'The operation for {projectName} failed.',
-  'diagnostic.RUSH_EXTERNAL_TOOL_PROBLEM.summary': '{tool} reported {code}: {message}'
+  'diagnostic.RUSH_EXTERNAL_TOOL_PROBLEM.summary': '{tool} reported {code}: {message}',
+  'diagnostic.RUSH_COMMAND_FAILED.summary': 'The Rush command {commandName} failed.'
 } as const;

--- a/libraries/reporter/src/test/LegacyErrorBridge.test.ts
+++ b/libraries/reporter/src/test/LegacyErrorBridge.test.ts
@@ -86,4 +86,26 @@ describe('LegacyErrorBridge', () => {
     bridge.recordEmittedDiagnostic('diag_2');
     expect(bridge.shouldSuppressRendering(sentinel)).toBe(true);
   });
+
+  it.each([Object.freeze, Object.seal, Object.preventExtensions])(
+    'correlates an immutable error without modifying its identity, cause, or properties (%p)',
+    (restrict) => {
+      const cause: Error = new Error('original cause');
+      const error: Error = new Error('original failure', { cause });
+      restrict(error);
+      const descriptors: PropertyDescriptorMap = Object.getOwnPropertyDescriptors(error);
+      const bridge: LegacyErrorBridge = new LegacyErrorBridge();
+      const otherBridge: LegacyErrorBridge = new LegacyErrorBridge();
+
+      bridge.correlate(error, 'immutable-error');
+
+      expect(Object.getOwnPropertyDescriptors(error)).toEqual(descriptors);
+      expect(error.cause).toBe(cause);
+      expect(otherBridge.getCorrelatedDiagnosticId(error)).toBe('immutable-error');
+      expect(otherBridge.shouldSuppressRendering(error)).toBe(false);
+      otherBridge.recordEmittedDiagnostic('immutable-error');
+      expect(otherBridge.shouldSuppressRendering(error)).toBe(true);
+      expect(otherBridge.shouldSuppressRendering(new Error(error.message, { cause }))).toBe(false);
+    }
+  );
 });

--- a/libraries/rush-lib/src/cli/RushCommandLineParser.ts
+++ b/libraries/rush-lib/src/cli/RushCommandLineParser.ts
@@ -302,6 +302,16 @@ export class RushCommandLineParser extends CommandLineParser {
     }
   }
 
+  public override async executeWithoutErrorHandlingAsync(args?: string[]): Promise<void> {
+    try {
+      await super.executeWithoutErrorHandlingAsync(args);
+    } catch (error) {
+      // Capture the original parse error before the base executeAsync renders it and returns false.
+      this._emitReporterFailureDiagnostic(error as Error, !this.#commandLifecycleEmitter);
+      throw error;
+    }
+  }
+
   protected override async onExecuteAsync(): Promise<void> {
     // Defensively set the exit code to 1 so if Rush crashes for whatever reason, we'll have a nonzero exit code.
     // For example, Node.js currently has the inexcusable design of terminating with zero exit code when
@@ -592,7 +602,7 @@ export class RushCommandLineParser extends CommandLineParser {
     }
   }
 
-  private _emitReporterFailureDiagnostic(error: Error): void {
+  private _emitReporterFailureDiagnostic(error: Error, includeMessage: boolean = false): void {
     this._startReporterSession();
     const emitter: LifecycleEmitter | undefined =
       this.#commandLifecycleEmitter ?? this.#sessionLifecycleEmitter;
@@ -603,7 +613,15 @@ export class RushCommandLineParser extends CommandLineParser {
           commandName: {
             value: this.selectedAction?.actionName ?? 'unknown',
             privacy: 'public'
-          }
+          },
+          ...(includeMessage
+            ? {
+                message: {
+                  value: error instanceof Error ? error.message : String(error),
+                  privacy: 'local-sensitive' as const
+                }
+              }
+            : {})
         }
       });
       emitter.emitDiagnostic(diagnostic);

--- a/libraries/rush-lib/src/cli/RushCommandLineParser.ts
+++ b/libraries/rush-lib/src/cli/RushCommandLineParser.ts
@@ -16,6 +16,7 @@ import {
   Colorize,
   type ITerminal
 } from '@rushstack/terminal';
+import { createRushDiagnostic, type IRushDiagnostic, type LifecycleEmitter } from '@rushstack/rush-reporter';
 
 import { RushConfiguration } from '../api/RushConfiguration';
 import { RushConstants } from '../logic/RushConstants';
@@ -64,6 +65,13 @@ import { RushAlerts } from '../utilities/RushAlerts';
 import { initializeDotEnv } from '../logic/dotenv';
 import { measureAsyncFn } from '../utilities/performance';
 import { EnvironmentVariableNames } from '../api/EnvironmentConfiguration';
+import {
+  _correlateRushSessionError,
+  _getRushSessionDerivedExitStatus,
+  _getRushSessionLifecycleEmitter,
+  _getRushSessionReporterSourceVersion,
+  _isRushSessionErrorRepresented
+} from '../pluginFramework/RushSession';
 
 /**
  * Options for `RushCommandLineParser`.
@@ -91,6 +99,11 @@ export class RushCommandLineParser extends CommandLineParser {
   readonly #terminal: Terminal;
   readonly #autocreateBuildCommand: boolean;
   #initializationFailed: boolean = false;
+  #sessionLifecycleEmitter: LifecycleEmitter | undefined;
+  #commandLifecycleEmitter: LifecycleEmitter | undefined;
+  #sessionStartTimeMs: number | undefined;
+  #commandStartTimeMs: number | undefined;
+  #reporterCompletionEmitted: boolean = false;
   #reporterClosePromise: Promise<void> | undefined;
 
   /**
@@ -134,6 +147,13 @@ export class RushCommandLineParser extends CommandLineParser {
     this.#rushOptions = this.#normalizeOptions(options || {});
     const { cwd, alreadyReportedNodeTooNewError, builtInPluginConfigurations, reporter } = this.#rushOptions;
 
+    this.rushSession = new RushSession({
+      getIsDebugMode: () => this.isDebug,
+      terminalProvider,
+      reporter
+    });
+    this.#sessionLifecycleEmitter = _getRushSessionLifecycleEmitter(this.rushSession);
+
     let rushJsonFilePath: string | undefined;
     try {
       rushJsonFilePath = RushConfiguration.tryFindRushJsonLocation({
@@ -158,11 +178,6 @@ export class RushCommandLineParser extends CommandLineParser {
 
     this.rushGlobalFolder = new RushGlobalFolder();
 
-    this.rushSession = new RushSession({
-      getIsDebugMode: () => this.isDebug,
-      terminalProvider,
-      reporter
-    });
     this.pluginManager = new PluginManager({
       rushSession: this.rushSession,
       rushConfiguration: this.rushConfiguration,
@@ -264,12 +279,24 @@ export class RushCommandLineParser extends CommandLineParser {
     this.#terminalProvider.verboseEnabled = this.#terminalProvider.debugEnabled =
       rushArgv.includes('--debug') || rushArgv.includes('-d');
 
+    this._startReporterSession();
+
     try {
       await measureAsyncFn('rush:initializeUnassociatedPlugins', () =>
         this.pluginManager.tryInitializeUnassociatedPluginsAsync()
       );
 
-      return await super.executeAsync(args);
+      const succeeded: boolean = await super.executeAsync(args);
+      if (!this.#reporterCompletionEmitted) {
+        this._emitReporterCompletion(succeeded ? 0 : _getNumericProcessExitCode(1));
+      }
+      return succeeded;
+    } catch (error) {
+      if (!process.exitCode) {
+        process.exitCode = 1;
+      }
+      this._reportErrorAndSetExitCode(error as Error);
+      return false;
     } finally {
       await this._closeReporterAsync();
     }
@@ -285,6 +312,17 @@ export class RushCommandLineParser extends CommandLineParser {
 
     if (this.#debugParameter.value) {
       InternalError.breakInDebugger = true;
+    }
+
+    const commandName: string | undefined = this.selectedAction?.actionName;
+    if (commandName) {
+      this.#commandLifecycleEmitter = _getRushSessionLifecycleEmitter(this.rushSession, {
+        commandName
+      });
+      if (this.#commandLifecycleEmitter) {
+        this.#commandStartTimeMs = performance.now();
+        this.#commandLifecycleEmitter.emitCommandStarted({ commandName });
+      }
     }
 
     try {
@@ -332,7 +370,12 @@ export class RushCommandLineParser extends CommandLineParser {
     }
 
     // This only gets hit if the wrapped execution completes successfully
-    await this.telemetry?.ensureFlushedAsync();
+    try {
+      await this.telemetry?.ensureFlushedAsync();
+    } catch (error) {
+      this._emitReporterFailureDiagnostic(error as Error);
+      throw error;
+    }
   }
 
   #normalizeOptions(options: Partial<IRushCommandLineParserOptions>): IRushCommandLineParserOptions {
@@ -540,7 +583,37 @@ export class RushCommandLineParser extends CommandLineParser {
     );
   }
 
+  private _startReporterSession(): void {
+    if (this.#sessionLifecycleEmitter && this.#sessionStartTimeMs === undefined) {
+      this.#sessionStartTimeMs = performance.now();
+      this.#sessionLifecycleEmitter.emitSessionStarted({
+        rushVersion: _getRushSessionReporterSourceVersion(this.rushSession)!
+      });
+    }
+  }
+
+  private _emitReporterFailureDiagnostic(error: Error): void {
+    this._startReporterSession();
+    const emitter: LifecycleEmitter | undefined =
+      this.#commandLifecycleEmitter ?? this.#sessionLifecycleEmitter;
+    const rushSession: RushSession | undefined = this.rushSession;
+    if (emitter && rushSession && !_isRushSessionErrorRepresented(rushSession, error)) {
+      const diagnostic: IRushDiagnostic = createRushDiagnostic('RUSH_COMMAND_FAILED', {
+        parameters: {
+          commandName: {
+            value: this.selectedAction?.actionName ?? 'unknown',
+            privacy: 'public'
+          }
+        }
+      });
+      emitter.emitDiagnostic(diagnostic);
+      _correlateRushSessionError(rushSession, error, diagnostic.diagnosticId);
+    }
+  }
+
   private _reportErrorAndSetExitCode(error: Error): void {
+    this._emitReporterFailureDiagnostic(error);
+
     if (!(error instanceof AlreadyReportedError)) {
       const prefix: string = 'ERROR: ';
 
@@ -561,8 +634,6 @@ export class RushCommandLineParser extends CommandLineParser {
       console.error(`\n${error.stack}`);
     }
 
-    this.flushTelemetry();
-
     const configuredExitCode: string | number | undefined = process.exitCode;
     const numericExitCode: number = Number(configuredExitCode);
     const exitCode: number =
@@ -570,6 +641,9 @@ export class RushCommandLineParser extends CommandLineParser {
         ? numericExitCode
         : 1;
     process.exitCode = exitCode;
+    this._emitReporterCompletion(exitCode);
+    this.flushTelemetry();
+
     const handleExit = (): never => {
       // Ideally we want to eliminate all calls to process.exit() from our code, and replace them
       // with normal control flow that properly cleans up its data structures.
@@ -617,4 +691,54 @@ export class RushCommandLineParser extends CommandLineParser {
     }
     return this.#reporterClosePromise;
   }
+
+  private _emitReporterCompletion(exitCode: number): void {
+    if (!this.#sessionLifecycleEmitter || this.#reporterCompletionEmitted) {
+      return;
+    }
+    this.#reporterCompletionEmitted = true;
+
+    const commandName: string | undefined = this.selectedAction?.actionName;
+    if (commandName && this.#commandLifecycleEmitter) {
+      const durationMs: number | undefined =
+        this.#commandStartTimeMs === undefined ? undefined : performance.now() - this.#commandStartTimeMs;
+      this.#commandLifecycleEmitter.emitCommandResult({
+        commandName,
+        succeeded: exitCode === 0,
+        exitCode
+      });
+      this.#commandLifecycleEmitter.emitCommandCompleted({
+        commandName,
+        exitCode,
+        ...(durationMs === undefined ? {} : { durationMs })
+      });
+    }
+
+    if (this.#sessionLifecycleEmitter) {
+      const durationMs: number | undefined =
+        this.#sessionStartTimeMs === undefined ? undefined : performance.now() - this.#sessionStartTimeMs;
+      this.#sessionLifecycleEmitter.emitSessionCompleted({
+        exitCode,
+        ...(durationMs === undefined ? {} : { durationMs })
+      });
+    }
+
+    // Shadow derivation is deliberately observational. process.exitCode remains authoritative.
+    const rushSession: RushSession | undefined = this.rushSession;
+    if (rushSession) {
+      _getRushSessionDerivedExitStatus(rushSession);
+    }
+  }
+}
+
+function _getNumericProcessExitCode(fallback: number): number {
+  const { exitCode } = process;
+  if (typeof exitCode === 'number') {
+    return exitCode;
+  }
+  if (typeof exitCode === 'string') {
+    const parsed: number = Number(exitCode);
+    return Number.isFinite(parsed) ? parsed : fallback;
+  }
+  return fallback;
 }

--- a/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
+++ b/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
@@ -62,6 +62,7 @@ import { IgnoredParametersPlugin } from '../../logic/operations/IgnoredParameter
 import { TrimRushEnvironmentVariablesPlugin } from '../../logic/operations/TrimRushEnvironmentVariablesPlugin';
 import { DebugHashesPlugin } from '../../logic/operations/DebugHashesPlugin';
 import { measureAsyncFn, measureFn } from '../../utilities/performance';
+import { attachReporterOperationEventSink } from '../../logic/operations/ReporterOperationEventSink';
 
 const PERF_PREFIX: 'rush:phasedScriptAction' = 'rush:phasedScriptAction';
 
@@ -678,6 +679,7 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> i
       await measureAsyncFn(`${PERF_PREFIX}:executionManager`, async () => {
         await hooks.onGraphCreatedAsync.promise(graph, graphContext);
       });
+      attachReporterOperationEventSink(graph, this.rushSession, this.actionName);
 
       const executeOptions: IExecuteOperationsOptions = {
         graph,

--- a/libraries/rush-lib/src/cli/test/RushCommandLineParser.test.ts
+++ b/libraries/rush-lib/src/cli/test/RushCommandLineParser.test.ts
@@ -31,6 +31,7 @@ import './mockRushCommandLineParser';
 import type { SpawnOptions } from 'node:child_process';
 import { FileSystem, JsonFile, Path } from '@rushstack/node-core-library';
 import type { IDetailedRepoState } from '@rushstack/package-deps-hash';
+import type { IReporterEmitEventInput, IReporterEventSink } from '@rushstack/rush-reporter';
 import { Autoinstaller } from '../../logic/Autoinstaller';
 import type { ITelemetryData } from '../../logic/Telemetry';
 import {
@@ -46,6 +47,15 @@ import { IS_WINDOWS } from '../../utilities/executionUtilities';
 // the exact structure of these arguments differs between Windows and non-Windows platforms, so
 // we only reference the one that is common.
 const SPAWN_ARG_OPTIONS: number = 2;
+
+class CapturingReporterSink implements IReporterEventSink {
+  public readonly inputs: IReporterEmitEventInput<unknown>[] = [];
+
+  public emit<TPayload>(event: IReporterEmitEventInput<TPayload>): string {
+    this.inputs.push(event);
+    return `event-${this.inputs.length}`;
+  }
+}
 
 function spawnOptionEquals<TOption extends keyof SpawnOptions, TExepcted>(
   spawnCall: SpawnMockCall,
@@ -93,7 +103,11 @@ describe('RushCommandLineParser', () => {
       describe("'build' action", () => {
         it(`executes the package's 'build' script`, async () => {
           const repoName: string = 'basicAndRunBuildActionRepo';
-          const { parser, spawnMock, repoPath } = await getCommandLineParserInstanceAsync(repoName, 'build');
+          const reporterSink: CapturingReporterSink = new CapturingReporterSink();
+          const { parser, spawnMock, repoPath } = await getCommandLineParserInstanceAsync(repoName, 'build', {
+            eventSink: reporterSink,
+            sessionId: 'parser-shadow'
+          });
 
           await expect(parser.executeAsync()).resolves.toEqual(true);
 
@@ -111,6 +125,23 @@ describe('RushCommandLineParser', () => {
           const secondSpawn: SpawnMockArgs = spawnMock.mock.calls[1];
           expectSpawnToMatchRegexp(secondSpawn, expectedBuildTaskRegexp);
           cwdOptionEquals(secondSpawn, `${repoPath}/b`);
+
+          const eventTypes: string[] = reporterSink.inputs.map(({ type }) => type);
+          expect(eventTypes[0]).toBe('sessionStarted');
+          expect(eventTypes[1]).toBe('commandStarted');
+          expect(eventTypes).toContain('operationRegistered');
+          expect(eventTypes).toContain('operationStatusChanged');
+          expect(eventTypes.slice(-3)).toEqual(['commandResult', 'commandCompleted', 'sessionCompleted']);
+          expect(reporterSink.inputs.at(-3)?.payload).toMatchObject({
+            commandName: 'build',
+            succeeded: true,
+            exitCode: 0
+          });
+          for (const event of reporterSink.inputs.filter(({ type }) => type === 'operationRegistered')) {
+            const scope = event.scope!;
+            expect(scope.operationId).toBe(`${scope.projectName}#${scope.phaseName}`);
+          }
+          expect(reporterSink.inputs.some(({ type }) => type === 'externalOutput')).toBe(false);
         });
       });
 

--- a/libraries/rush-lib/src/cli/test/RushCommandLineParserReporterClose.test.ts
+++ b/libraries/rush-lib/src/cli/test/RushCommandLineParserReporterClose.test.ts
@@ -5,6 +5,16 @@ import { RushCommandLineParser } from '../RushCommandLineParser';
 import { EnvironmentConfiguration } from '../../api/EnvironmentConfiguration';
 import { RushConfiguration } from '../../api/RushConfiguration';
 import { ConsoleTerminalProvider } from '@rushstack/terminal';
+import type { IReporterEmitEventInput, IReporterEventSink } from '@rushstack/rush-reporter';
+
+class CapturingReporterSink implements IReporterEventSink {
+  public readonly events: IReporterEmitEventInput<unknown>[] = [];
+
+  public emit<TPayload>(event: IReporterEmitEventInput<TPayload>): string {
+    this.events.push(event);
+    return `event-${this.events.length}`;
+  }
+}
 
 describe('RushCommandLineParser reporter close', () => {
   let originalExitCode: string | number | undefined;
@@ -74,6 +84,7 @@ describe('RushCommandLineParser reporter close', () => {
           resolveClose = resolve;
         })
     );
+    const sink: CapturingReporterSink = new CapturingReporterSink();
     const exitSpy: jest.SpyInstance<never, [code?: string | number | null | undefined]> = jest
       .spyOn(process, 'exit')
       .mockImplementation(() => undefined as never);
@@ -84,11 +95,13 @@ describe('RushCommandLineParser reporter close', () => {
     });
     const parser: RushCommandLineParser = new RushCommandLineParser({
       cwd: `${__dirname}/repo`,
+      reporter: { eventSink: sink, sessionId: 'parser-exit-close' },
       reporterCloseAsync: closeAsync
     });
     const execution: Promise<boolean> = parser.executeAsync();
 
     expect(closeAsync).toHaveBeenCalledTimes(1);
+    expect(sink.events.at(-1)).toMatchObject({ type: 'sessionCompleted', payload: { exitCode: 1 } });
     expect(exitSpy).not.toHaveBeenCalled();
     process.exitCode = 0;
 
@@ -143,5 +156,35 @@ describe('RushCommandLineParser reporter close', () => {
 
     expect(process.exitCode).toBe(1);
     expect(errorSpy).toHaveBeenCalledWith('[reporter] Unable to finalize reporters: close failed\n');
+  });
+
+  it('shares one reporter close operation across failure and finalization paths', async () => {
+    let resolveClose: (() => void) | undefined;
+    const closeAsync: jest.Mock<Promise<void>, []> = jest.fn(
+      () =>
+        new Promise<void>((resolve: () => void) => {
+          resolveClose = resolve;
+        })
+    );
+    jest.spyOn(RushConfiguration, 'tryFindRushJsonLocation').mockImplementation(() => {
+      throw new Error('configuration failed');
+    });
+    const exitSpy: jest.SpyInstance = jest
+      .spyOn(process, 'exit')
+      .mockImplementation(() => undefined as never);
+    jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    const parser: RushCommandLineParser = new RushCommandLineParser({
+      cwd: `${__dirname}/repo`,
+      reporterCloseAsync: closeAsync
+    });
+    const firstClose: Promise<boolean> = parser.executeAsync();
+    const secondClose: Promise<boolean> = parser.executeAsync();
+
+    expect(closeAsync).toHaveBeenCalledTimes(1);
+    resolveClose!();
+    await expect(Promise.all([firstClose, secondClose])).resolves.toEqual([false, false]);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(closeAsync).toHaveBeenCalledTimes(1);
+    expect(exitSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/libraries/rush-lib/src/cli/test/RushCommandLineParserReporterLifecycle.test.ts
+++ b/libraries/rush-lib/src/cli/test/RushCommandLineParserReporterLifecycle.test.ts
@@ -6,7 +6,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 
 import { JsonFile } from '@rushstack/node-core-library';
-import type { IReporterEmitEventInput, IReporterEventSink } from '@rushstack/rush-reporter';
+import type { IReporterEmitEventInput, IReporterEventSink, IRushDiagnostic } from '@rushstack/rush-reporter';
 
 import { EnvironmentConfiguration } from '../../api/EnvironmentConfiguration';
 import type { IRushConfigurationJson } from '../../api/RushConfiguration';
@@ -136,7 +136,7 @@ describe('RushCommandLineParser reporter lifecycle', () => {
     expect(visibleOutput[1]).toEqual(visibleOutput[0]);
   });
 
-  it('emits and correlates a session diagnostic when plugin initialization fails before action selection', async () => {
+  it.each([false, true])('correlates a plugin initialization failure (frozen: %s)', async (frozen) => {
     const repoPath: string = await copyRepositoryAsync();
     const sink: CapturingReporterSink = new CapturingReporterSink();
     const closeAsync: jest.Mock<Promise<void>, []> = jest.fn(async () => undefined);
@@ -149,6 +149,9 @@ describe('RushCommandLineParser reporter lifecycle', () => {
       reporterCloseAsync: closeAsync
     });
     const error: Error = new Error('plugin initialization failed');
+    if (frozen) {
+      Object.freeze(error);
+    }
     jest.spyOn(parser.pluginManager, 'tryInitializeUnassociatedPluginsAsync').mockRejectedValue(error);
 
     await expect(parser.executeAsync(['custom-output'])).resolves.toBe(false);
@@ -165,6 +168,80 @@ describe('RushCommandLineParser reporter lifecycle', () => {
     expect(closeAsync).toHaveBeenCalledTimes(1);
     expect(exitSpy).toHaveBeenCalledTimes(1);
     expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(stderrSpy.mock.calls.flat().join('\n')).toContain(error.message);
+    expect(stderrSpy.mock.calls.flat().join('\n')).not.toContain('TypeError');
+  });
+
+  it.each([
+    { args: ['not-a-rush-command'], message: 'not-a-rush-command' },
+    { args: ['list', '--not-a-rush-option'], message: '--not-a-rush-option' }
+  ])('reports one real pre-execution parse diagnostic for $args', async ({ args, message }) => {
+    const repoPath: string = await copyRepositoryAsync();
+    const visibleOutput: unknown[] = [];
+    const stdoutWriteSpy: jest.SpyInstance = jest.spyOn(process.stdout, 'write').mockReturnValue(true);
+    const stderrWriteSpy: jest.SpyInstance = jest.spyOn(process.stderr, 'write').mockReturnValue(true);
+    for (const reporting of [false, true]) {
+      process.exitCode = undefined;
+      EnvironmentConfiguration.reset();
+      jest.clearAllMocks();
+      const sink: CapturingReporterSink = new CapturingReporterSink();
+      const closeAsync: jest.Mock<Promise<void>, []> = jest.fn(async () => undefined);
+      const exitSpy: jest.SpyInstance = jest
+        .spyOn(process, 'exit')
+        .mockImplementation(() => undefined as never);
+      const parser: RushCommandLineParser = new RushCommandLineParser({
+        cwd: repoPath,
+        reporter: reporting ? { eventSink: sink, sessionId: 'parse-failure' } : undefined,
+        reporterCloseAsync: closeAsync
+      });
+
+      await expect(parser.executeAsync(args)).resolves.toBe(false);
+
+      expect(process.exitCode).toBe(2);
+      expect(exitSpy).not.toHaveBeenCalled();
+      expect(closeAsync).toHaveBeenCalledTimes(1);
+      const stderr: string = stderrSpy.mock.calls.flat().join('\n');
+      expect(stderr).toContain(message);
+      expect(sink.events.map(({ type }) => type)).toEqual(
+        reporting ? ['sessionStarted', 'diagnosticEmitted', 'sessionCompleted'] : []
+      );
+      if (reporting) {
+        const diagnosticEvent: IReporterEmitEventInput<unknown> = sink.events[1];
+        const diagnostic: IRushDiagnostic = diagnosticEvent.payload as IRushDiagnostic;
+        expect(diagnostic.code).toBe('RUSH_COMMAND_FAILED');
+        expect(diagnosticEvent.scope?.commandName).toBeUndefined();
+        expect(diagnostic.parameters?.message).toEqual({
+          value: expect.stringContaining(message),
+          privacy: 'local-sensitive'
+        });
+        expect(stderr).toContain(diagnostic.parameters?.message.value);
+        expect(_getRushSessionDerivedExitStatus(parser.rushSession)).toEqual({
+          exitCode: 1,
+          outcome: 'failed'
+        });
+      }
+      visibleOutput.push({
+        stdout: stdoutSpy.mock.calls.map((call) => [...call]),
+        stderr: stderrSpy.mock.calls.map((call) => [...call]),
+        stdoutWrites: stdoutWriteSpy.mock.calls.map(([chunk]) => chunk),
+        stderrWrites: stderrWriteSpy.mock.calls.map(([chunk]) => chunk)
+      });
+      exitSpy.mockRestore();
+    }
+    expect(visibleOutput[1]).toEqual(visibleOutput[0]);
+  });
+
+  it('does not diagnose a successful help request as a parse failure', async () => {
+    jest.spyOn(process.stdout, 'write').mockReturnValue(true);
+    const sink: CapturingReporterSink = new CapturingReporterSink();
+    const parser: RushCommandLineParser = new RushCommandLineParser({
+      cwd: await copyRepositoryAsync(),
+      reporter: { eventSink: sink, sessionId: 'help' }
+    });
+
+    await expect(parser.executeAsync(['--help'])).resolves.toBe(true);
+    expect(sink.events.filter(({ type }) => type === 'diagnosticEmitted')).toEqual([]);
+    expect(sink.events.at(-1)?.payload).toMatchObject({ exitCode: 0 });
   });
 
   it.each([false, true])('awaits a real delayed public telemetry hook (reject: %s)', async (reject) => {

--- a/libraries/rush-lib/src/cli/test/RushCommandLineParserReporterLifecycle.test.ts
+++ b/libraries/rush-lib/src/cli/test/RushCommandLineParserReporterLifecycle.test.ts
@@ -1,0 +1,249 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { JsonFile } from '@rushstack/node-core-library';
+import type { IReporterEmitEventInput, IReporterEventSink } from '@rushstack/rush-reporter';
+
+import { EnvironmentConfiguration } from '../../api/EnvironmentConfiguration';
+import type { IRushConfigurationJson } from '../../api/RushConfiguration';
+import {
+  _getRushSessionDerivedExitStatus,
+  _isRushSessionErrorRepresented
+} from '../../pluginFramework/RushSession';
+import { RushCommandLineParser } from '../RushCommandLineParser';
+
+class CapturingReporterSink implements IReporterEventSink {
+  public readonly events: IReporterEmitEventInput<unknown>[] = [];
+
+  public emit<TPayload>(event: IReporterEmitEventInput<TPayload>): string {
+    this.events.push(event);
+    return `event-${this.events.length}`;
+  }
+}
+
+function isCompletion(event: IReporterEmitEventInput<unknown>): boolean {
+  return (
+    event.type === 'commandResult' || event.type === 'commandCompleted' || event.type === 'sessionCompleted'
+  );
+}
+
+describe('RushCommandLineParser reporter lifecycle', () => {
+  const temporaryFolders: string[] = [];
+  let originalExitCode: string | number | undefined;
+  let originalArgv: string[];
+  let stdoutSpy: jest.SpyInstance;
+  let stderrSpy: jest.SpyInstance;
+
+  async function copyRepositoryAsync(): Promise<string> {
+    const directory: string = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'rush-reporter-lifecycle-'));
+    temporaryFolders.push(directory);
+    const repoPath: string = path.join(directory, 'repo');
+    await fs.promises.cp(path.join(__dirname, 'basicAndRunBuildActionRepo'), repoPath, { recursive: true });
+    return repoPath;
+  }
+
+  beforeEach(() => {
+    originalExitCode = process.exitCode;
+    originalArgv = process.argv;
+    process.exitCode = undefined;
+    process.argv = ['node', 'rush', 'custom-output'];
+    EnvironmentConfiguration.reset();
+    stdoutSpy = jest.spyOn(console, 'log').mockImplementation(() => undefined);
+    stderrSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(async () => {
+    await Promise.all(
+      temporaryFolders
+        .splice(0)
+        .map((directory) => fs.promises.rm(directory, { recursive: true, force: true }))
+    );
+    process.exitCode = originalExitCode;
+    process.argv = originalArgv;
+    EnvironmentConfiguration.reset();
+    jest.restoreAllMocks();
+  });
+
+  it.each([
+    { file: 'rush.json', withClose: false },
+    { file: 'rush.json', withClose: true },
+    { file: 'common/config/rush/command-line.json', withClose: false },
+    { file: 'common/config/rush/command-line.json', withClose: true }
+  ])('reports invalid $file before fatal exit (close callback: $withClose)', async ({ file, withClose }) => {
+    const repoPath: string = await copyRepositoryAsync();
+    await fs.promises.writeFile(path.join(repoPath, file), '{');
+    const visibleOutput: unknown[] = [];
+
+    for (const reporting of [false, true]) {
+      process.exitCode = undefined;
+      EnvironmentConfiguration.reset();
+      jest.clearAllMocks();
+      const sink: CapturingReporterSink = new CapturingReporterSink();
+      let eventsAtExit: readonly IReporterEmitEventInput<unknown>[] = [];
+      let eventsAtClose: readonly IReporterEmitEventInput<unknown>[] = [];
+      const exitSpy: jest.SpyInstance = jest.spyOn(process, 'exit').mockImplementation(() => {
+        eventsAtExit = [...sink.events];
+        return undefined as never;
+      });
+      const closeAsync: jest.Mock<Promise<void>, []> = jest.fn(async () => {
+        eventsAtClose = [...sink.events];
+      });
+      const parser: RushCommandLineParser = new RushCommandLineParser({
+        cwd: repoPath,
+        reporter: reporting ? { eventSink: sink, sessionId: 'initialization-failure' } : undefined,
+        reporterCloseAsync: withClose ? closeAsync : undefined
+      });
+
+      if (!withClose) {
+        expect(exitSpy).toHaveBeenCalledWith(1);
+      }
+      await expect(parser.executeAsync(['custom-output'])).resolves.toBe(false);
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      expect(process.exitCode).toBe(1);
+      expect(exitSpy).toHaveBeenCalledTimes(1);
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      expect(closeAsync).toHaveBeenCalledTimes(withClose ? 1 : 0);
+      expect(sink.events.map(({ type }) => type)).toEqual(
+        reporting ? ['sessionStarted', 'diagnosticEmitted', 'sessionCompleted'] : []
+      );
+      expect(eventsAtExit).toEqual(sink.events);
+      if (withClose) {
+        expect(eventsAtClose).toEqual(sink.events);
+      }
+      if (reporting) {
+        expect(sink.events[1].payload).toMatchObject({
+          code: 'RUSH_COMMAND_FAILED',
+          diagnosticId: expect.any(String)
+        });
+        expect(sink.events[2].payload).toMatchObject({ exitCode: 1 });
+        expect(_getRushSessionDerivedExitStatus(parser.rushSession)).toEqual({
+          exitCode: 1,
+          outcome: 'failed'
+        });
+      }
+      visibleOutput.push({
+        stdout: stdoutSpy.mock.calls.map((args) => [...args]),
+        stderr: stderrSpy.mock.calls.map((args) => [...args])
+      });
+      exitSpy.mockRestore();
+    }
+
+    expect(visibleOutput[1]).toEqual(visibleOutput[0]);
+  });
+
+  it('emits and correlates a session diagnostic when plugin initialization fails before action selection', async () => {
+    const repoPath: string = await copyRepositoryAsync();
+    const sink: CapturingReporterSink = new CapturingReporterSink();
+    const closeAsync: jest.Mock<Promise<void>, []> = jest.fn(async () => undefined);
+    const exitSpy: jest.SpyInstance = jest
+      .spyOn(process, 'exit')
+      .mockImplementation(() => undefined as never);
+    const parser: RushCommandLineParser = new RushCommandLineParser({
+      cwd: repoPath,
+      reporter: { eventSink: sink, sessionId: 'plugin-initialization-failure' },
+      reporterCloseAsync: closeAsync
+    });
+    const error: Error = new Error('plugin initialization failed');
+    jest.spyOn(parser.pluginManager, 'tryInitializeUnassociatedPluginsAsync').mockRejectedValue(error);
+
+    await expect(parser.executeAsync(['custom-output'])).resolves.toBe(false);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(sink.events.map(({ type }) => type)).toEqual([
+      'sessionStarted',
+      'diagnosticEmitted',
+      'sessionCompleted'
+    ]);
+    expect(sink.events[1].scope?.commandName).toBeUndefined();
+    expect(_isRushSessionErrorRepresented(parser.rushSession, error)).toBe(true);
+    expect(sink.events[2].payload).toMatchObject({ exitCode: 1 });
+    expect(closeAsync).toHaveBeenCalledTimes(1);
+    expect(exitSpy).toHaveBeenCalledTimes(1);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it.each([false, true])('awaits a real delayed public telemetry hook (reject: %s)', async (reject) => {
+    const visibleErrors: unknown[] = [];
+    for (const reporting of [false, true]) {
+      process.exitCode = undefined;
+      EnvironmentConfiguration.reset();
+      jest.clearAllMocks();
+      const repoPath: string = await copyRepositoryAsync();
+      const rushJsonPath: string = path.join(repoPath, 'rush.json');
+      const rushJson: IRushConfigurationJson = JsonFile.load(rushJsonPath);
+      rushJson.telemetryEnabled = true;
+      JsonFile.save(rushJson, rushJsonPath);
+      const sink: CapturingReporterSink = new CapturingReporterSink();
+      const closeAsync: jest.Mock<Promise<void>, []> = jest.fn(async () => undefined);
+      const exitSpy: jest.SpyInstance = jest
+        .spyOn(process, 'exit')
+        .mockImplementation(() => undefined as never);
+      const parser: RushCommandLineParser = new RushCommandLineParser({
+        cwd: repoPath,
+        reporter: reporting ? { eventSink: sink, sessionId: 'telemetry-finalization' } : undefined,
+        reporterCloseAsync: reporting ? closeAsync : undefined
+      });
+      let markHookStarted: (() => void) | undefined;
+      const hookStarted: Promise<void> = new Promise((resolve) => {
+        markHookStarted = resolve;
+      });
+      let releaseHook: (() => void) | undefined;
+      const hookReleased: Promise<void> = new Promise((resolve) => {
+        releaseHook = resolve;
+      });
+      const failure: Error = new Error('delayed telemetry flush failed');
+      const flushTelemetry: jest.Mock<Promise<void>, []> = jest.fn(async () => {
+        markHookStarted!();
+        await hookReleased;
+        if (reject) {
+          throw failure;
+        }
+      });
+      parser.rushSession.hooks.flushTelemetry.tapPromise('DelayedTelemetry', flushTelemetry);
+
+      const execution: Promise<boolean> = parser.executeAsync(['custom-output', '--reporter=junit']);
+      await hookStarted;
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      const prematureCompletions: IReporterEmitEventInput<unknown>[] = sink.events.filter(isCompletion);
+      releaseHook!();
+      const succeeded: boolean = await execution;
+
+      expect(JsonFile.load(path.join(repoPath, 'custom-output-args.json'))).toEqual(['--reporter', 'junit']);
+      expect(prematureCompletions).toEqual([]);
+      expect(succeeded).toBe(!reject);
+      expect(process.exitCode).toBe(reject ? 1 : 0);
+      expect(exitSpy).not.toHaveBeenCalled();
+      expect(flushTelemetry).toHaveBeenCalledTimes(1);
+      expect(closeAsync).toHaveBeenCalledTimes(reporting ? 1 : 0);
+      if (reporting) {
+        const completions: IReporterEmitEventInput<unknown>[] = sink.events.filter(isCompletion);
+        expect(completions.map(({ type }) => type)).toEqual([
+          'commandResult',
+          'commandCompleted',
+          'sessionCompleted'
+        ]);
+        for (const event of completions) {
+          expect(event.payload).toMatchObject({ exitCode: reject ? 1 : 0 });
+        }
+        expect(completions[0].payload).toMatchObject({ succeeded: !reject });
+        expect(_getRushSessionDerivedExitStatus(parser.rushSession)).toEqual({
+          exitCode: reject ? 1 : 0,
+          outcome: reject ? 'failed' : 'succeeded'
+        });
+        expect(_isRushSessionErrorRepresented(parser.rushSession, failure)).toBe(reject);
+        expect(sink.events.filter(({ type }) => type === 'diagnosticEmitted')).toHaveLength(reject ? 1 : 0);
+      } else {
+        expect(sink.events).toEqual([]);
+      }
+      visibleErrors.push(stderrSpy.mock.calls.map((args) => [...args]));
+      exitSpy.mockRestore();
+    }
+
+    expect(visibleErrors[1]).toEqual(visibleErrors[0]);
+  });
+});

--- a/libraries/rush-lib/src/cli/test/TestUtils.ts
+++ b/libraries/rush-lib/src/cli/test/TestUtils.ts
@@ -4,6 +4,7 @@
 import { AlreadyExistsBehavior, FileSystem, PackageJsonLookup } from '@rushstack/node-core-library';
 
 import type { RushCommandLineParser as RushCommandLineParserType } from '../RushCommandLineParser';
+import type { IRushSessionReporterOptions } from '../../pluginFramework/RushSession';
 import { FlagFile } from '../../api/FlagFile';
 import { RushConstants } from '../../logic/RushConstants';
 import { EnvironmentConfiguration } from '../../api/EnvironmentConfiguration';
@@ -76,7 +77,8 @@ export const TEST_REPO_FOLDER_PATH: string = `${PROJECT_ROOT}/temp/test/unit-tes
  */
 export async function getCommandLineParserInstanceAsync(
   repoName: string,
-  taskName: string
+  taskName: string,
+  reporter?: IRushSessionReporterOptions
 ): Promise<IParserTestInstance> {
   // Copy the test repo to a sandbox folder
   const repoPath: string = `${TEST_REPO_FOLDER_PATH}/${repoName}-${performance.now()}`;
@@ -100,7 +102,7 @@ export async function getCommandLineParserInstanceAsync(
   // to exit and clear the Rush file lock. So running multiple `it` or `describe` test blocks over the same test
   // repo will fail due to contention over the same lock which is kept until the test runner process
   // ends.
-  const parser: RushCommandLineParserType = new RushCommandLineParser({ cwd: repoPath });
+  const parser: RushCommandLineParserType = new RushCommandLineParser({ cwd: repoPath, reporter });
 
   // Bulk tasks are hard-coded to expect install to have been completed. So, ensure the last-link.flag
   // file exists and is valid

--- a/libraries/rush-lib/src/logic/Telemetry.ts
+++ b/libraries/rush-lib/src/logic/Telemetry.ts
@@ -6,10 +6,12 @@ import * as path from 'node:path';
 import type { PerformanceEntry } from 'node:perf_hooks';
 
 import { FileSystem, type FileSystemStats, JsonFile } from '@rushstack/node-core-library';
+import type { ITelemetryAggregate } from '@rushstack/rush-reporter';
 
 import type { RushConfiguration } from '../api/RushConfiguration';
 import { Rush } from '../api/Rush';
 import type { RushSession } from '../pluginFramework/RushSession';
+import { _getRushSessionTelemetryAggregate } from '../pluginFramework/RushSession';
 import { collectPerformanceEntries } from '../utilities/performance';
 
 /**
@@ -138,6 +140,16 @@ export interface ITelemetryData {
    * This is an array of `PerformanceEntry` objects, which can include marks, measures, and function timings.
    */
   readonly performanceEntries?: readonly PerformanceEntry[];
+
+  /**
+   * The allowlisted projection derived from shadow reporter events.
+   *
+   * @remarks
+   * This is present only when the Rush frontend supplied a reporter event sink.
+   * It never contains messages, paths, arguments, raw output, remediation
+   * parameters, stack traces, or non-public envelope metadata.
+   */
+  readonly reporterData?: ITelemetryAggregate;
 }
 
 const MAX_FILE_COUNT: number = 100;
@@ -166,9 +178,30 @@ export class Telemetry {
     if (!this.#enabled) {
       return;
     }
+    const reporterAggregate: ITelemetryAggregate | undefined = _getRushSessionTelemetryAggregate(
+      this.#rushSession
+    );
+    const processExitCode: number =
+      typeof process.exitCode === 'number' ? process.exitCode : Number(process.exitCode);
     const cpus: os.CpuInfo[] = os.cpus();
     const data: ITelemetryData = {
       ...telemetryData,
+      reporterData: reporterAggregate
+        ? {
+            ...reporterAggregate,
+            commandName: reporterAggregate.commandName ?? telemetryData.name,
+            result:
+              reporterAggregate.result ?? (telemetryData.result === 'Succeeded' ? 'succeeded' : 'failed'),
+            exitCode:
+              reporterAggregate.exitCode ??
+              (telemetryData.result === 'Succeeded'
+                ? 0
+                : Number.isFinite(processExitCode)
+                  ? processExitCode
+                  : 1),
+            durationMs: reporterAggregate.durationMs ?? telemetryData.durationInSeconds * 1000
+          }
+        : telemetryData.reporterData,
       performanceEntries:
         telemetryData.performanceEntries || collectPerformanceEntries(this.#telemetryStartTime),
       machineInfo: telemetryData.machineInfo || {

--- a/libraries/rush-lib/src/logic/operations/OperationEventSink.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationEventSink.ts
@@ -40,16 +40,13 @@ export interface IOperationGraphEventSink {
   /**
    * Invoked when an operation is prepared for an iteration.
    */
-  onOperationRegistered?(operationId: string, silent: boolean): void;
+  onOperationRegistered?(operationId: string, silent: boolean, result?: IOperationExecutionResult): void;
 
   /**
    * Invoked synchronously on every operation status transition. The result's
    * `status`, `error`, and `stopwatch` reflect the new state.
    */
-  onOperationStatusChanged?(
-    result: IOperationExecutionResult,
-    previousStatus: OperationStatus
-  ): void;
+  onOperationStatusChanged?(result: IOperationExecutionResult, previousStatus: OperationStatus): void;
 
   /**
    * Invoked when an operation's collated output is about to be displayed,

--- a/libraries/rush-lib/src/logic/operations/OperationGraph.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationGraph.ts
@@ -679,7 +679,7 @@ export class OperationGraph implements IOperationGraph {
       );
 
       executionRecords.set(operation, executionRecord);
-      eventSink?.onOperationRegistered?.(executionRecord.name, executionRecord.silent);
+      eventSink?.onOperationRegistered?.(executionRecord.name, executionRecord.silent, executionRecord);
     }
 
     for (const [operation, record] of executionRecords) {
@@ -1296,10 +1296,9 @@ function _handleOperationNoOp(record: OperationExecutionRecord, context: IStatef
 function _handleOperationSuccess(record: OperationExecutionRecord, context: IStatefulExecutionContext): void {
   const stopwatch: IStopwatchResult = _getOperationStopwatch(record);
   if (!record.silent) {
-    record.eventSink?.onActivity?.(
-      `"${record.name}" completed successfully in ${stopwatch.toString()}.`,
-      { operationId: record.name }
-    );
+    record.eventSink?.onActivity?.(`"${record.name}" completed successfully in ${stopwatch.toString()}.`, {
+      operationId: record.name
+    });
     record.collatedWriter.terminal.writeStdoutLine(
       Colorize.green(`"${record.name}" completed successfully in ${stopwatch.toString()}.`)
     );
@@ -1316,10 +1315,10 @@ function _handleOperationSuccessWithWarning(
 ): void {
   const stopwatch: IStopwatchResult = _getOperationStopwatch(record);
   if (!record.silent) {
-    record.eventSink?.onActivity?.(
-      `"${record.name}" completed with warnings in ${stopwatch.toString()}.`,
-      { operationId: record.name, stderr: true }
-    );
+    record.eventSink?.onActivity?.(`"${record.name}" completed with warnings in ${stopwatch.toString()}.`, {
+      operationId: record.name,
+      stderr: true
+    });
     record.collatedWriter.terminal.writeStderrLine(
       Colorize.yellow(`"${record.name}" completed with warnings in ${stopwatch.toString()}.`)
     );

--- a/libraries/rush-lib/src/logic/operations/OperationGraph.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationGraph.ts
@@ -679,7 +679,6 @@ export class OperationGraph implements IOperationGraph {
       );
 
       executionRecords.set(operation, executionRecord);
-      eventSink?.onOperationRegistered?.(executionRecord.name, executionRecord.silent, executionRecord);
     }
 
     for (const [operation, record] of executionRecords) {
@@ -708,6 +707,7 @@ export class OperationGraph implements IOperationGraph {
     });
 
     for (const executionRecord of executionRecords.values()) {
+      eventSink?.onOperationRegistered?.(executionRecord.name, executionRecord.silent, executionRecord);
       if (!executionRecord.silent) {
         // Only count non-silent operations
         iterationContext.totalOperations++;

--- a/libraries/rush-lib/src/logic/operations/ReporterOperationEventSink.ts
+++ b/libraries/rush-lib/src/logic/operations/ReporterOperationEventSink.ts
@@ -1,0 +1,336 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import {
+  createRushDiagnostic,
+  type IRushDiagnostic,
+  type LifecycleEmitter,
+  type OperationStatus as ReporterOperationStatus
+} from '@rushstack/rush-reporter';
+import type { ITerminalChunk } from '@rushstack/terminal';
+
+import type { RushSession } from '../../pluginFramework/RushSession';
+import {
+  _correlateRushSessionError,
+  _getRushSessionLifecycleEmitter
+} from '../../pluginFramework/RushSession';
+import type { IOperationExecutionResult } from './IOperationExecutionResult';
+import type { IOperationGraphEventSink, IOperationActivityOptions } from './OperationEventSink';
+import type { Operation } from './Operation';
+import { OperationStatus } from './OperationStatus';
+import type { OperationGraph } from './OperationGraph';
+
+interface IReporterOperation {
+  readonly emitter: LifecycleEmitter;
+  readonly legacyOperationIds: Set<string>;
+  readonly operationId: string;
+  readonly phaseName: string;
+  readonly projectName: string;
+  registrationCycle: IReporterOperationCycle | undefined;
+}
+
+interface IReporterOperationCycle {
+  readonly registeredOperationIds: Set<string>;
+  readonly statuses: Map<string, OperationStatus>;
+  diagnosed: boolean;
+  lastEmittedStatus: ReporterOperationStatus | undefined;
+  silent: boolean;
+}
+
+class ReporterOperationEventSink implements IOperationGraphEventSink {
+  private readonly _operationsByLegacyId: Map<string, IReporterOperation> = new Map();
+  private readonly _cyclesByResult: WeakMap<IOperationExecutionResult, IReporterOperationCycle> =
+    new WeakMap();
+  private readonly _rushSession: RushSession;
+
+  public constructor(rushSession: RushSession, commandName: string, operations: Iterable<Operation>) {
+    this._rushSession = rushSession;
+    const operationsByReporterId: Map<string, IReporterOperation> = new Map();
+
+    for (const operation of operations) {
+      const projectName: string = operation.associatedProject.packageName;
+      const phaseName: string = operation.associatedPhase.name;
+      const operationId: string = `${projectName}#${phaseName}`;
+      let reporterOperation: IReporterOperation | undefined = operationsByReporterId.get(operationId);
+      if (!reporterOperation) {
+        const emitter: LifecycleEmitter | undefined = _getRushSessionLifecycleEmitter(rushSession, {
+          commandName,
+          operationId,
+          projectName,
+          phaseName
+        });
+        if (!emitter) {
+          continue;
+        }
+        reporterOperation = {
+          emitter,
+          legacyOperationIds: new Set(),
+          operationId,
+          phaseName,
+          projectName,
+          registrationCycle: undefined
+        };
+        operationsByReporterId.set(operationId, reporterOperation);
+      }
+      reporterOperation.legacyOperationIds.add(operation.name);
+      this._operationsByLegacyId.set(operation.name, reporterOperation);
+    }
+  }
+
+  public get isEnabled(): boolean {
+    return this._operationsByLegacyId.size > 0;
+  }
+
+  public onOperationRegistered(
+    operationId: string,
+    silent: boolean,
+    result?: IOperationExecutionResult
+  ): void {
+    const operation: IReporterOperation | undefined = this._operationsByLegacyId.get(operationId);
+    if (!operation || !result) {
+      return;
+    }
+
+    let cycle: IReporterOperationCycle | undefined = operation.registrationCycle;
+    if (!cycle || cycle.registeredOperationIds.size === operation.legacyOperationIds.size) {
+      cycle = {
+        registeredOperationIds: new Set(),
+        statuses: new Map(),
+        diagnosed: false,
+        lastEmittedStatus: undefined,
+        silent: true
+      };
+      operation.registrationCycle = cycle;
+    }
+
+    this._cyclesByResult.set(result, cycle);
+    cycle.registeredOperationIds.add(operationId);
+    cycle.silent &&= silent;
+    if (cycle.registeredOperationIds.size !== operation.legacyOperationIds.size || cycle.silent) {
+      return;
+    }
+
+    operation.emitter.emitOperationRegistered({
+      operationId: operation.operationId,
+      projectName: operation.projectName,
+      phaseName: operation.phaseName
+    });
+  }
+
+  public onOperationStatusChanged(result: IOperationExecutionResult): void {
+    const operation: IReporterOperation | undefined = this._operationsByLegacyId.get(result.operation.name);
+    if (!operation) {
+      return;
+    }
+    const cycle: IReporterOperationCycle | undefined = this._cyclesByResult.get(result);
+    if (!cycle) {
+      return;
+    }
+
+    if (
+      result.status === OperationStatus.Ready &&
+      cycle.registeredOperationIds.size === operation.legacyOperationIds.size
+    ) {
+      return;
+    }
+
+    cycle.statuses.set(result.operation.name, result.status);
+    if (result.status === OperationStatus.Failure && !cycle.diagnosed) {
+      cycle.diagnosed = true;
+      const diagnostic: IRushDiagnostic = createRushDiagnostic('RUSH_OPERATION_FAILED', {
+        parameters: {
+          projectName: { value: operation.projectName, privacy: 'public' }
+        }
+      });
+      operation.emitter.emitDiagnostic(diagnostic);
+      if (result.error) {
+        _correlateRushSessionError(this._rushSession, result.error, diagnostic.diagnosticId);
+      }
+    }
+
+    const status: ReporterOperationStatus | undefined = _getAggregateStatus(operation, cycle);
+    if (status === undefined || status === cycle.lastEmittedStatus) {
+      return;
+    }
+    cycle.lastEmittedStatus = status;
+    if (!cycle.silent) {
+      const durationMs: number | undefined =
+        operation.legacyOperationIds.size === 1 && result.stopwatch.startTime !== undefined
+          ? result.stopwatch.duration * 1000
+          : undefined;
+      operation.emitter.emitOperationStatusChanged({
+        operationId: operation.operationId,
+        status,
+        ...(durationMs === undefined ? {} : { durationMs })
+      });
+    }
+  }
+}
+
+class CompositeOperationGraphEventSink implements IOperationGraphEventSink {
+  public readonly onOperationChunk: ((operationId: string, chunk: ITerminalChunk) => void) | undefined;
+  public readonly onOperationStreamClosed: ((operationId: string) => void) | undefined;
+
+  private readonly _first: IOperationGraphEventSink;
+  private readonly _second: IOperationGraphEventSink;
+
+  public constructor(first: IOperationGraphEventSink, second: IOperationGraphEventSink) {
+    this._first = first;
+    this._second = second;
+    this.onOperationChunk =
+      first.onOperationChunk || second.onOperationChunk
+        ? (operationId, chunk) => {
+            first.onOperationChunk?.(operationId, chunk);
+            second.onOperationChunk?.(operationId, chunk);
+          }
+        : undefined;
+    this.onOperationStreamClosed =
+      first.onOperationStreamClosed || second.onOperationStreamClosed
+        ? (operationId) => {
+            first.onOperationStreamClosed?.(operationId);
+            second.onOperationStreamClosed?.(operationId);
+          }
+        : undefined;
+  }
+
+  public onOperationRegistered(
+    operationId: string,
+    silent: boolean,
+    result?: IOperationExecutionResult
+  ): void {
+    this._first.onOperationRegistered?.(operationId, silent, result);
+    this._second.onOperationRegistered?.(operationId, silent, result);
+  }
+
+  public onOperationStatusChanged(result: IOperationExecutionResult, previousStatus: OperationStatus): void {
+    this._first.onOperationStatusChanged?.(result, previousStatus);
+    this._second.onOperationStatusChanged?.(result, previousStatus);
+  }
+
+  public onOperationHeader(operationId: string, completedOperations: number, totalOperations: number): void {
+    this._first.onOperationHeader?.(operationId, completedOperations, totalOperations);
+    this._second.onOperationHeader?.(operationId, completedOperations, totalOperations);
+  }
+
+  public onActivity(text: string, options?: IOperationActivityOptions): void {
+    this._first.onActivity?.(text, options);
+    this._second.onActivity?.(text, options);
+  }
+}
+
+/**
+ * Adds status-only reporter emission without changing the graph's visible output or raw chunk routing.
+ *
+ * @internal
+ */
+export function attachReporterOperationEventSink(
+  graph: OperationGraph,
+  rushSession: RushSession,
+  commandName: string
+): void {
+  const reporterSink: ReporterOperationEventSink = new ReporterOperationEventSink(
+    rushSession,
+    commandName,
+    graph.operations
+  );
+  if (!reporterSink.isEnabled) {
+    return;
+  }
+
+  graph.eventSink = graph.eventSink
+    ? new CompositeOperationGraphEventSink(graph.eventSink, reporterSink)
+    : reporterSink;
+}
+
+function _toReporterStatus(status: OperationStatus): ReporterOperationStatus {
+  switch (status) {
+    case OperationStatus.Ready:
+      return 'ready';
+    case OperationStatus.Waiting:
+      return 'waiting';
+    case OperationStatus.Queued:
+      return 'queued';
+    case OperationStatus.Executing:
+      return 'executing';
+    case OperationStatus.Success:
+      return 'success';
+    case OperationStatus.SuccessWithWarning:
+      return 'successWithWarnings';
+    case OperationStatus.Failure:
+      return 'failure';
+    case OperationStatus.Blocked:
+      return 'blocked';
+    case OperationStatus.Skipped:
+      return 'skipped';
+    case OperationStatus.FromCache:
+      return 'fromCache';
+    case OperationStatus.NoOp:
+      return 'noOp';
+    case OperationStatus.Aborted:
+      return 'aborted';
+  }
+}
+
+function _getAggregateStatus(
+  operation: IReporterOperation,
+  cycle: IReporterOperationCycle
+): ReporterOperationStatus | undefined {
+  const statuses: readonly OperationStatus[] = [...cycle.statuses.values()];
+  if (
+    statuses.some((status) => status === OperationStatus.Executing) ||
+    cycle.lastEmittedStatus === 'executing'
+  ) {
+    if (
+      cycle.statuses.size !== operation.legacyOperationIds.size ||
+      statuses.some((status) => !_isTerminalStatus(status))
+    ) {
+      return 'executing';
+    }
+  }
+  if (
+    cycle.statuses.size === operation.legacyOperationIds.size &&
+    statuses.every((status) => _isTerminalStatus(status))
+  ) {
+    return _getAggregateTerminalStatus(statuses);
+  }
+  if (statuses.some((status) => status === OperationStatus.Queued)) {
+    return 'queued';
+  }
+  if (statuses.some((status) => status === OperationStatus.Ready)) {
+    return 'ready';
+  }
+  if (statuses.some((status) => status === OperationStatus.Waiting)) {
+    return 'waiting';
+  }
+  return operation.legacyOperationIds.size === 1
+    ? _toReporterStatus(statuses[0] ?? OperationStatus.Ready)
+    : undefined;
+}
+
+function _getAggregateTerminalStatus(operationStatuses: Iterable<OperationStatus>): ReporterOperationStatus {
+  const statuses: Set<OperationStatus> = new Set(operationStatuses);
+  if (statuses.has(OperationStatus.Failure)) return 'failure';
+  if (statuses.has(OperationStatus.Aborted)) return 'aborted';
+  if (statuses.has(OperationStatus.Blocked)) return 'blocked';
+  if (statuses.has(OperationStatus.SuccessWithWarning)) return 'successWithWarnings';
+  if (statuses.has(OperationStatus.Success)) return 'success';
+  if (statuses.has(OperationStatus.FromCache)) return 'fromCache';
+  if (statuses.has(OperationStatus.Skipped)) return 'skipped';
+  return 'noOp';
+}
+
+function _isTerminalStatus(status: OperationStatus): boolean {
+  switch (status) {
+    case OperationStatus.Success:
+    case OperationStatus.SuccessWithWarning:
+    case OperationStatus.Failure:
+    case OperationStatus.Blocked:
+    case OperationStatus.Skipped:
+    case OperationStatus.FromCache:
+    case OperationStatus.NoOp:
+    case OperationStatus.Aborted:
+      return true;
+    default:
+      return false;
+  }
+}

--- a/libraries/rush-lib/src/logic/operations/test/OperationGraphEventSink.test.ts
+++ b/libraries/rush-lib/src/logic/operations/test/OperationGraphEventSink.test.ts
@@ -34,7 +34,8 @@ jest.mock('../ProjectLogWritable', () => {
   };
 });
 
-import { MockWritable, type ITerminalChunk } from '@rushstack/terminal';
+import type { IReporterEmitEventInput, IReporterEventSink } from '@rushstack/rush-reporter';
+import { MockWritable, StringBufferTerminalProvider, type ITerminalChunk } from '@rushstack/terminal';
 import type { CollatedTerminal } from '@rushstack/stream-collator';
 
 import type { IPhase } from '../../../api/CommandLineConfiguration';
@@ -46,6 +47,13 @@ import { OperationStatus } from '../OperationStatus';
 import { Operation } from '../Operation';
 import type { IOperationRunner, IOperationRunnerContext } from '../IOperationRunner';
 import { MockOperationRunner } from './MockOperationRunner';
+import {
+  _getRushSessionDerivedExitStatus,
+  _getRushSessionLifecycleEmitter,
+  _getRushSessionTelemetryAggregate,
+  RushSession
+} from '../../../pluginFramework/RushSession';
+import { attachReporterOperationEventSink } from '../ReporterOperationEventSink';
 
 const mockPhase: IPhase = {
   name: 'phase',
@@ -57,12 +65,17 @@ const mockPhase: IPhase = {
   missingScriptBehavior: 'silent'
 };
 
-function createOperation(name: string, runner: IOperationRunner): Operation {
+function createOperation(
+  name: string,
+  runner: IOperationRunner,
+  phase: IPhase = mockPhase,
+  projectName: string = name
+): Operation {
   return new Operation({
     runner,
     logFilenameIdentifier: name,
-    phase: mockPhase,
-    project: { packageName: name } as unknown as RushConfigurationProject
+    phase,
+    project: { packageName: projectName } as unknown as RushConfigurationProject
   });
 }
 
@@ -92,6 +105,15 @@ class RecordingSink implements IOperationGraphEventSink {
       this.chunks.set(operationId, chunks);
     }
     chunks.push(chunk.text);
+  }
+}
+
+class CapturingReporterSink implements IReporterEventSink {
+  public readonly inputs: IReporterEmitEventInput<unknown>[] = [];
+
+  public emit<TPayload>(event: IReporterEmitEventInput<TPayload>): string {
+    this.inputs.push(event);
+    return `event-${this.inputs.length}`;
   }
 }
 
@@ -206,5 +228,256 @@ describe('OperationGraph event sink (dual-emit)', () => {
     await tappedGraph.executeAsync({});
 
     expect(tappedWritable.getAllOutput()).toEqual(plainWritable.getAllOutput());
+  });
+
+  it('emits phase-aware status and diagnostic events without routing operation chunks', async () => {
+    const reporterSink: CapturingReporterSink = new CapturingReporterSink();
+    const rushSession: RushSession = new RushSession({
+      terminalProvider: new StringBufferTerminalProvider(),
+      getIsDebugMode: () => false,
+      reporter: { eventSink: reporterSink, sessionId: 'operation-shadow' }
+    });
+    const createFailingOperation = (): Operation =>
+      createOperation(
+        '@scope/project',
+        new MockOperationRunner('@scope/project (phase)', async () => OperationStatus.Failure)
+      );
+    const plainWritable: MockWritable = new MockWritable();
+    await new OperationGraph(
+      new Set([createFailingOperation()]),
+      createGraphOptions(plainWritable, false)
+    ).executeAsync({});
+
+    const operation: Operation = createFailingOperation();
+    const graph: OperationGraph = new OperationGraph(
+      new Set([operation]),
+      createGraphOptions(mockWritable, false)
+    );
+
+    attachReporterOperationEventSink(graph, rushSession, 'build');
+    await graph.executeAsync({});
+
+    const operationEvents: IReporterEmitEventInput<unknown>[] = reporterSink.inputs.filter(
+      ({ type }) => type === 'operationRegistered' || type === 'operationStatusChanged'
+    );
+    expect(operationEvents.length).toBeGreaterThan(1);
+    for (const event of operationEvents) {
+      expect(event.scope).toMatchObject({
+        commandName: 'build',
+        operationId: '@scope/project#phase',
+        projectName: '@scope/project',
+        phaseName: 'phase'
+      });
+    }
+    expect(reporterSink.inputs).toContainEqual(
+      expect.objectContaining({
+        type: 'diagnosticEmitted',
+        payload: expect.objectContaining({ code: 'RUSH_OPERATION_FAILED' })
+      })
+    );
+    expect(reporterSink.inputs.some(({ type }) => type === 'externalOutput')).toBe(false);
+    expect(mockWritable.getAllOutput()).toEqual(plainWritable.getAllOutput());
+  });
+
+  it('aggregates sharded records across mixed outcomes and repeated watch-style iterations', async () => {
+    const reporterSink: CapturingReporterSink = new CapturingReporterSink();
+    const rushSession: RushSession = new RushSession({
+      terminalProvider: new StringBufferTerminalProvider(),
+      getIsDebugMode: () => false,
+      reporter: { eventSink: reporterSink, sessionId: 'sharded-operation-shadow' }
+    });
+    const projectName: string = '@scope/sharded';
+    const preShardRunner: IOperationRunner = {
+      name: `${projectName} (phase) - pre-shard`,
+      reportTiming: false,
+      silent: true,
+      cacheable: false,
+      warningsAreAllowed: false,
+      isNoOp: true,
+      executeAsync: async () => OperationStatus.NoOp,
+      getConfigHash: () => 'pre-shard'
+    };
+    const shardOneRunner: MockOperationRunner = new MockOperationRunner(
+      `${projectName} (phase) - shard 1/2`,
+      async () => OperationStatus.Success
+    );
+    let shardTwoOutcome: OperationStatus = OperationStatus.Failure;
+    const shardTwoRunner: MockOperationRunner = new MockOperationRunner(
+      `${projectName} (phase) - shard 2/2`,
+      async () => shardTwoOutcome
+    );
+    const collatorRunner: MockOperationRunner = new MockOperationRunner(
+      `${projectName} (phase) - collate`,
+      async () => OperationStatus.Success
+    );
+    const preShard: Operation = createOperation('pre-shard', preShardRunner, mockPhase, projectName);
+    const shardOne: Operation = createOperation('shard-one', shardOneRunner, mockPhase, projectName);
+    const shardTwo: Operation = createOperation('shard-two', shardTwoRunner, mockPhase, projectName);
+    const collator: Operation = createOperation('collator', collatorRunner, mockPhase, projectName);
+    shardOne.addDependency(preShard);
+    shardTwo.addDependency(preShard);
+    collator.addDependency(shardOne);
+    collator.addDependency(shardTwo);
+    const graph: OperationGraph = new OperationGraph(
+      new Set([collator, preShard, shardOne, shardTwo]),
+      createGraphOptions(mockWritable, false)
+    );
+
+    attachReporterOperationEventSink(graph, rushSession, 'build');
+    await graph.executeAsync({});
+
+    const reporterOperationId: string = `${projectName}#phase`;
+    const operationEvents = (): IReporterEmitEventInput<unknown>[] =>
+      reporterSink.inputs.filter(({ scope }) => scope?.operationId === reporterOperationId);
+    expect(operationEvents().filter(({ type }) => type === 'operationRegistered')).toHaveLength(1);
+    expect(
+      operationEvents()
+        .filter(({ type }) => type === 'operationStatusChanged')
+        .at(-1)?.payload
+    ).toMatchObject({ operationId: reporterOperationId, status: 'failure' });
+    expect(
+      operationEvents().filter(
+        ({ type, payload }) =>
+          type === 'diagnosticEmitted' && (payload as { code?: string }).code === 'RUSH_OPERATION_FAILED'
+      )
+    ).toHaveLength(1);
+    expect(_getRushSessionTelemetryAggregate(rushSession)?.operationStatusCounts).toEqual({
+      failure: 1
+    });
+    expect(_getRushSessionDerivedExitStatus(rushSession)).toEqual({
+      exitCode: 1,
+      outcome: 'failed'
+    });
+
+    shardTwoOutcome = OperationStatus.Success;
+    graph.invalidateOperations(undefined, 'watch iteration');
+    await graph.executeAsync({});
+
+    expect(
+      operationEvents()
+        .filter(({ type }) => type === 'operationRegistered')
+        .map(({ scope }) => scope?.operationId)
+    ).toEqual([reporterOperationId, reporterOperationId]);
+    expect(
+      operationEvents()
+        .filter(({ type }) => type === 'operationStatusChanged')
+        .at(-1)?.payload
+    ).toMatchObject({ operationId: reporterOperationId, status: 'success' });
+    expect(
+      operationEvents().filter(
+        ({ type, payload }) =>
+          type === 'diagnosticEmitted' && (payload as { code?: string }).code === 'RUSH_OPERATION_FAILED'
+      )
+    ).toHaveLength(1);
+    expect(_getRushSessionTelemetryAggregate(rushSession)?.operationStatusCounts).toEqual({
+      success: 1
+    });
+    expect(_getRushSessionDerivedExitStatus(rushSession)).toEqual({
+      exitCode: 0,
+      outcome: 'succeeded'
+    });
+
+    const lifecycleEmitter = _getRushSessionLifecycleEmitter(rushSession, { commandName: 'build' })!;
+    lifecycleEmitter.emitCommandResult({ commandName: 'build', succeeded: true, exitCode: 0 });
+    lifecycleEmitter.emitCommandCompleted({ commandName: 'build', exitCode: 0 });
+    lifecycleEmitter.emitSessionCompleted({ exitCode: 0 });
+    expect(_getRushSessionDerivedExitStatus(rushSession)).toEqual({
+      exitCode: 0,
+      outcome: 'succeeded'
+    });
+    expect(reporterSink.inputs.some(({ type }) => type === 'externalOutput')).toBe(false);
+  });
+
+  it('isolates diagnostics when the next watch iteration registers before abort completes', async () => {
+    const reporterSink: CapturingReporterSink = new CapturingReporterSink();
+    const rushSession: RushSession = new RushSession({
+      terminalProvider: new StringBufferTerminalProvider(),
+      getIsDebugMode: () => false,
+      reporter: { eventSink: reporterSink, sessionId: 'overlapping-operation-shadow' }
+    });
+    let runCount: number = 0;
+    let resolveFirstRun: ((status: OperationStatus) => void) | undefined;
+    let markFirstRunStarted: (() => void) | undefined;
+    const firstRunStarted: Promise<void> = new Promise<void>((resolve: () => void) => {
+      markFirstRunStarted = resolve;
+    });
+    const runner: MockOperationRunner = new MockOperationRunner('@scope/overlap (phase)', async () => {
+      runCount++;
+      if (runCount === 1) {
+        markFirstRunStarted!();
+        return await new Promise<OperationStatus>((resolve: (status: OperationStatus) => void) => {
+          resolveFirstRun = resolve;
+        });
+      }
+      return OperationStatus.Failure;
+    });
+    const graph: OperationGraph = new OperationGraph(
+      new Set([createOperation('overlap', runner, mockPhase, '@scope/overlap')]),
+      { ...createGraphOptions(mockWritable, false), pauseNextIteration: true }
+    );
+    attachReporterOperationEventSink(graph, rushSession, 'build');
+
+    await graph.scheduleIterationAsync({});
+    const firstExecution: Promise<boolean> = graph.executeScheduledIterationAsync();
+    await firstRunStarted;
+    await graph.scheduleIterationAsync({});
+    const abortPromise: Promise<void> = graph.abortCurrentIterationAsync();
+    resolveFirstRun!(OperationStatus.Failure);
+    await Promise.all([firstExecution, abortPromise]);
+    await graph.executeScheduledIterationAsync();
+
+    expect(
+      reporterSink.inputs.filter(
+        ({ type, payload }) =>
+          type === 'diagnosticEmitted' && (payload as { code?: string }).code === 'RUSH_OPERATION_FAILED'
+      )
+    ).toHaveLength(2);
+  });
+
+  it('recomputes grouped silence for each watch-style iteration', async () => {
+    const reporterSink: CapturingReporterSink = new CapturingReporterSink();
+    const rushSession: RushSession = new RushSession({
+      terminalProvider: new StringBufferTerminalProvider(),
+      getIsDebugMode: () => false,
+      reporter: { eventSink: reporterSink, sessionId: 'grouped-silence-shadow' }
+    });
+    const projectName: string = '@scope/silence';
+    const first: Operation = createOperation(
+      'first',
+      new MockOperationRunner(`${projectName} (phase) - first`),
+      mockPhase,
+      projectName
+    );
+    const second: Operation = createOperation(
+      'second',
+      new MockOperationRunner(`${projectName} (phase) - second`),
+      mockPhase,
+      projectName
+    );
+    const graph: OperationGraph = new OperationGraph(
+      new Set([first, second]),
+      createGraphOptions(mockWritable, false)
+    );
+
+    attachReporterOperationEventSink(graph, rushSession, 'build');
+    await graph.executeAsync({});
+
+    const operationId: string = `${projectName}#phase`;
+    const countEvents = (type: IReporterEmitEventInput<unknown>['type']): number =>
+      reporterSink.inputs.filter(
+        ({ type: eventType, scope }) => eventType === type && scope?.operationId === operationId
+      ).length;
+    const registrationCount: number = countEvents('operationRegistered');
+    const statusCount: number = countEvents('operationStatusChanged');
+    expect(registrationCount).toBe(1);
+    expect(statusCount).toBeGreaterThan(0);
+
+    first.enabled = false;
+    second.enabled = false;
+    graph.invalidateOperations(undefined, 'disable group');
+    await graph.executeAsync({});
+
+    expect(countEvents('operationRegistered')).toBe(registrationCount);
+    expect(countEvents('operationStatusChanged')).toBe(statusCount);
   });
 });

--- a/libraries/rush-lib/src/logic/operations/test/OperationGraphEventSink.test.ts
+++ b/libraries/rush-lib/src/logic/operations/test/OperationGraphEventSink.test.ts
@@ -54,6 +54,9 @@ import {
   RushSession
 } from '../../../pluginFramework/RushSession';
 import { attachReporterOperationEventSink } from '../ReporterOperationEventSink';
+import { PhasedOperationPlugin } from '../PhasedOperationPlugin';
+import { PhasedCommandHooks, type IOperationGraphContext } from '../../../pluginFramework/PhasedCommandHooks';
+import type { IInputsSnapshot } from '../../incremental/InputsSnapshot';
 
 const mockPhase: IPhase = {
   name: 'phase',
@@ -432,6 +435,55 @@ describe('OperationGraph event sink (dual-emit)', () => {
           type === 'diagnosticEmitted' && (payload as { code?: string }).code === 'RUSH_OPERATION_FAILED'
       )
     ).toHaveLength(2);
+  });
+
+  it('registers final silence after the standard plugin disables unchanged watch operations', async () => {
+    const reporterSink: CapturingReporterSink = new CapturingReporterSink();
+    const rushSession: RushSession = new RushSession({
+      terminalProvider: new StringBufferTerminalProvider(),
+      getIsDebugMode: () => false,
+      reporter: { eventSink: reporterSink, sessionId: 'unchanged-watch' }
+    });
+    const execute: jest.Mock<Promise<OperationStatus>, []> = jest.fn(async () => OperationStatus.Success);
+    const operations: Set<Operation> = new Set(
+      ['first', 'second'].map((name) =>
+        createOperation(name, new MockOperationRunner(name, execute), mockPhase, '@scope/unchanged')
+      )
+    );
+    const graph: OperationGraph = new OperationGraph(operations, createGraphOptions(mockWritable, false));
+    const hooks: PhasedCommandHooks = new PhasedCommandHooks();
+    new PhasedOperationPlugin().apply(hooks);
+    // This plugin's graph-configuration callback does not consume the command context.
+    await hooks.onGraphCreatedAsync.promise(graph, {} as IOperationGraphContext);
+    const registrationSink: RecordingSink = new RecordingSink();
+    graph.eventSink = registrationSink;
+    attachReporterOperationEventSink(graph, rushSession, 'build');
+    const inputsSnapshot: IInputsSnapshot = {
+      hashes: new Map(),
+      rootDirectory: '/repo',
+      hasUncommittedChanges: false,
+      getTrackedFileHashesForOperation: () => new Map(),
+      getOperationOwnStateHash: () => 'unchanged'
+    };
+
+    await graph.executeAsync({ inputsSnapshot });
+    const eventsAfterFirstRun: IReporterEmitEventInput<unknown>[] = [...reporterSink.inputs];
+    expect(execute).toHaveBeenCalledTimes(2);
+    expect(eventsAfterFirstRun.some(({ type }) => type === 'operationRegistered')).toBe(true);
+    expect(registrationSink.registered).toEqual([
+      ['first', false],
+      ['second', false]
+    ]);
+
+    await graph.executeAsync({ inputsSnapshot });
+
+    expect(execute).toHaveBeenCalledTimes(2);
+    expect([...operations].every((operation) => operation.enabled)).toBe(true);
+    expect(registrationSink.registered.slice(2)).toEqual([
+      ['first', true],
+      ['second', true]
+    ]);
+    expect(reporterSink.inputs).toEqual(eventsAfterFirstRun);
   });
 
   it('recomputes grouped silence for each watch-style iteration', async () => {

--- a/libraries/rush-lib/src/logic/test/Telemetry.test.ts
+++ b/libraries/rush-lib/src/logic/test/Telemetry.test.ts
@@ -2,12 +2,22 @@
 // See LICENSE in the project root for license information.
 
 import { JsonFile } from '@rushstack/node-core-library';
+import type { IReporterEmitEventInput, IReporterEventSink } from '@rushstack/rush-reporter';
 import { ConsoleTerminalProvider } from '@rushstack/terminal';
 
 import { RushConfiguration } from '../../api/RushConfiguration';
 import { Rush } from '../../api/Rush';
 import { Telemetry, type ITelemetryData, type ITelemetryMachineInfo } from '../Telemetry';
-import { RushSession } from '../../pluginFramework/RushSession';
+import { _getRushSessionLifecycleEmitter, RushSession } from '../../pluginFramework/RushSession';
+
+class CapturingSink implements IReporterEventSink {
+  public readonly inputs: IReporterEmitEventInput<unknown>[] = [];
+
+  public emit<TPayload>(event: IReporterEmitEventInput<TPayload>): string {
+    this.inputs.push(event);
+    return `event-${this.inputs.length}`;
+  }
+}
 
 interface ITelemetryPrivateMembers extends Omit<Telemetry, '_flushAsyncTasks'> {
   _flushAsyncTasks: Set<Promise<void>>;
@@ -134,6 +144,38 @@ describe(Telemetry.name, () => {
     expect(result.platform).toEqual(process.platform);
     expect(result.rushVersion).toEqual(Rush.version);
     expect(result.timestampMs).toBeDefined();
+  });
+
+  it('projects public shadow events into legacy telemetry without exposing command arguments', () => {
+    const filename: string = `${__dirname}/telemetry/telemetryEnabled.json`;
+    const rushConfig: RushConfiguration = RushConfiguration.loadFromConfigurationFile(filename);
+    const sink: CapturingSink = new CapturingSink();
+    const rushSession: RushSession = new RushSession({
+      terminalProvider: new ConsoleTerminalProvider(),
+      getIsDebugMode: () => false,
+      reporter: { eventSink: sink, sessionId: 'telemetry-shadow' }
+    });
+    const emitter = _getRushSessionLifecycleEmitter(rushSession, { commandName: 'build' })!;
+    emitter.emitCommandStarted({ commandName: 'build', argv: ['--auth-token=secret'] });
+    emitter.emitOperationStatusChanged({ operationId: '@scope/project#_phase:build', status: 'success' });
+
+    const telemetry: Telemetry = new Telemetry(rushConfig, rushSession);
+    telemetry.log({
+      name: 'build',
+      durationInSeconds: 2,
+      result: 'Succeeded',
+      machineInfo: {} as ITelemetryMachineInfo,
+      performanceEntries: []
+    });
+
+    expect(telemetry.store[0].reporterData).toMatchObject({
+      commandName: 'build',
+      result: 'succeeded',
+      exitCode: 0,
+      durationMs: 2000,
+      operationStatusCounts: { success: 1 }
+    });
+    expect(JSON.stringify(telemetry.store[0].reporterData)).not.toContain('--auth-token=secret');
   });
 
   it('calls custom flush telemetry', async () => {

--- a/libraries/rush-lib/src/pluginFramework/RushSession.test.ts
+++ b/libraries/rush-lib/src/pluginFramework/RushSession.test.ts
@@ -3,16 +3,27 @@
 
 import * as os from 'node:os';
 
+import { AlreadyReportedError } from '@rushstack/node-core-library';
 import type {
   IReporterEmitEventInput,
   IReporterEventSource,
   IReporterEventSink
 } from '@rushstack/rush-reporter';
+import { createRushDiagnostic } from '@rushstack/rush-reporter';
 import { StringBufferTerminalProvider } from '@rushstack/terminal';
 
 import { Rush } from '../api/Rush';
 import { RushCommandLineParser } from '../cli/RushCommandLineParser';
-import { _createRushSessionForPlugin, type IRushSessionReporterOptions, RushSession } from './RushSession';
+import {
+  _correlateRushSessionError,
+  _createRushSessionForPlugin,
+  _getRushSessionDerivedExitStatus,
+  _getRushSessionLifecycleEmitter,
+  _getRushSessionTelemetryAggregate,
+  _isRushSessionErrorRepresented,
+  type IRushSessionReporterOptions,
+  RushSession
+} from './RushSession';
 
 class CapturingSink implements IReporterEventSink {
   public readonly inputs: IReporterEmitEventInput<unknown>[] = [];
@@ -148,5 +159,87 @@ describe(RushSession.name, () => {
     expect(action?.reporter).toBeDefined();
     action!.reporter!.emitMessage({ severity: 'debug', text: 'action' });
     expect(sink.inputs[0].scope).toEqual({ commandName: 'list' });
+  });
+
+  it('observes shadow lifecycle, diagnostics, telemetry, and legacy correlation without terminal output', () => {
+    const sink: CapturingSink = new CapturingSink();
+    const terminalProvider: StringBufferTerminalProvider = new StringBufferTerminalProvider();
+    const session: RushSession = new RushSession({
+      getIsDebugMode: () => false,
+      terminalProvider,
+      reporter: { eventSink: sink, sessionId: 'session-shadow' }
+    });
+    const emitter = _getRushSessionLifecycleEmitter(session, { commandName: 'build' })!;
+    const error: AlreadyReportedError = new AlreadyReportedError();
+
+    emitter.emitSessionStarted({ rushVersion: Rush.version });
+    emitter.emitCommandStarted({ commandName: 'build' });
+    emitter.emitOperationRegistered({
+      operationId: '@scope/project#_phase:test',
+      projectName: '@scope/project',
+      phaseName: '_phase:test'
+    });
+    emitter.emitOperationStatusChanged({
+      operationId: '@scope/project#_phase:test',
+      status: 'failure'
+    });
+    const diagnostic = createRushDiagnostic('RUSH_OPERATION_FAILED', {
+      parameters: {
+        projectName: { value: '@scope/project', privacy: 'public' }
+      }
+    });
+    emitter.emitDiagnostic(diagnostic);
+    _correlateRushSessionError(session, error, diagnostic.diagnosticId);
+    emitter.emitCommandResult({ commandName: 'build', succeeded: false, exitCode: 1 });
+    emitter.emitCommandCompleted({ commandName: 'build', exitCode: 1, durationMs: 25 });
+    emitter.emitSessionCompleted({ exitCode: 1, durationMs: 30 });
+
+    expect(sink.inputs.map(({ type }) => type)).toEqual([
+      'sessionStarted',
+      'commandStarted',
+      'operationRegistered',
+      'operationStatusChanged',
+      'diagnosticEmitted',
+      'commandResult',
+      'commandCompleted',
+      'sessionCompleted'
+    ]);
+    expect(_isRushSessionErrorRepresented(session, error)).toBe(true);
+    expect(_getRushSessionDerivedExitStatus(session)).toEqual({ exitCode: 1, outcome: 'failed' });
+    expect(_getRushSessionTelemetryAggregate(session)).toMatchObject({
+      commandName: 'build',
+      result: 'failed',
+      exitCode: 1,
+      operationStatusCounts: { failure: 1 },
+      diagnosticCodes: ['RUSH_OPERATION_FAILED'],
+      diagnosticCategoryCounts: { operation: 1 }
+    });
+    expect(terminalProvider.getAllOutput(false)).toEqual({
+      log: '',
+      warning: '',
+      error: '',
+      verbose: '',
+      debug: ''
+    });
+  });
+
+  it('excludes non-public plugin envelopes from the shadow telemetry projection', () => {
+    const sink: CapturingSink = new CapturingSink();
+    const session: RushSession = createSession({ eventSink: sink, sessionId: 'session-private' });
+    const pluginSession: RushSession = _createRushSessionForPlugin(session, () => ({
+      packageName: '@private/plugin',
+      packageVersion: '1.0.0'
+    }));
+
+    pluginSession.getReporter()!.emitMessage({
+      severity: 'info',
+      text: '/local/private/path'
+    });
+    _getRushSessionLifecycleEmitter(session)!.emitSessionStarted({ rushVersion: Rush.version });
+
+    const aggregate = _getRushSessionTelemetryAggregate(session)!;
+    expect(JSON.stringify(aggregate)).not.toContain('@private/plugin');
+    expect(JSON.stringify(aggregate)).not.toContain('/local/private/path');
+    expect(aggregate.producerVersions).toEqual([`@microsoft/rush-lib@${Rush.version}`]);
   });
 });

--- a/libraries/rush-lib/src/pluginFramework/RushSession.ts
+++ b/libraries/rush-lib/src/pluginFramework/RushSession.ts
@@ -3,10 +3,19 @@
 
 import { InternalError, PackageJsonLookup, type IPackageJson } from '@rushstack/node-core-library';
 import {
+  LifecycleEmitter,
+  LegacyErrorBridge,
   RushSessionReporting,
+  TelemetrySubscriber,
+  isReporterEventRequired,
+  resolveExitStatus,
+  type IReporterEmitEventInput,
+  type IReporterEventEnvelope,
   type IReporterEventScope,
   type IReporterEventSink,
   type IReporterEventSource,
+  type IRushExitStatus,
+  type ITelemetryAggregate,
   type IScopedLogger,
   type IScopedReporter
 } from '@rushstack/rush-reporter';
@@ -77,7 +86,23 @@ interface IRushSessionState {
   readonly cloudBuildCacheProviderFactories: Map<string, CloudBuildCacheProviderFactory>;
   readonly cobuildLockProviderFactories: Map<string, CobuildLockProviderFactory>;
   readonly hooks: RushLifecycleHooks;
-  readonly reporting: RushSessionReporting | undefined;
+  readonly reporting: IRushSessionReportingState | undefined;
+}
+
+interface IRushSessionReportingState {
+  readonly eventSink: IReporterEventSink;
+  readonly sessionId: string;
+  readonly source: IReporterEventSource;
+  readonly sessionReporting: RushSessionReporting;
+  readonly observer: IRushSessionShadowEventObserver;
+}
+
+interface IRushSessionShadowEventObserver {
+  ingest<TPayload>(event: IReporterEmitEventInput<TPayload>, eventId: string): void;
+  buildTelemetryAggregate(): ITelemetryAggregate;
+  resolveExitStatus(): IRushExitStatus;
+  correlateError(error: unknown, diagnosticId: string): void;
+  isErrorRepresented(error: unknown): boolean;
 }
 
 let _rushLibSource: IReporterEventSource | undefined;
@@ -107,8 +132,9 @@ function _getRushLibSource(): IReporterEventSource {
 
 function _createReporting(
   reporterOptions: IRushSessionReporterOptions | undefined,
-  source: IReporterEventSource
-): RushSessionReporting | undefined {
+  source: IReporterEventSource,
+  observer?: IRushSessionShadowEventObserver
+): IRushSessionReportingState | undefined {
   if (!reporterOptions) {
     return undefined;
   }
@@ -121,10 +147,148 @@ function _createReporting(
     throw new TypeError('RushSession reporter.sessionId must be a non-empty string');
   }
 
-  return new RushSessionReporting({
-    sink: eventSink,
+  const shadowObserver: IRushSessionShadowEventObserver = observer ?? _createRushSessionShadowEventObserver();
+  const observedEventSink: IReporterEventSink = {
+    emit<TPayload>(event: IReporterEmitEventInput<TPayload>): string {
+      const eventId: string = eventSink.emit(event);
+      shadowObserver.ingest(event, eventId);
+      return eventId;
+    }
+  };
+  const boundSource: IReporterEventSource = { ...source };
+
+  return {
+    eventSink: observedEventSink,
     sessionId,
-    source: { ...source }
+    source: boundSource,
+    observer: shadowObserver,
+    sessionReporting: new RushSessionReporting({
+      sink: observedEventSink,
+      sessionId,
+      source: boundSource
+    })
+  };
+}
+
+function _createRushSessionShadowEventObserver(): IRushSessionShadowEventObserver {
+  const legacyErrorBridge: LegacyErrorBridge = new LegacyErrorBridge();
+  const telemetrySubscriber: TelemetrySubscriber = new TelemetrySubscriber();
+  const operationStatuses: Map<string, string> = new Map();
+  let sequence: number = 0;
+  let derivedExitStatus: IRushExitStatus = { exitCode: 0, outcome: 'succeeded' };
+  let hasUnscopedFailure: boolean = false;
+
+  const updateDerivedOperationStatus = (): void => {
+    const hasOperationFailure: boolean = [...operationStatuses.values()].some(
+      (status) => status === 'failure' || status === 'aborted'
+    );
+    derivedExitStatus = resolveExitStatus({
+      hasFailures: hasUnscopedFailure || hasOperationFailure
+    });
+  };
+
+  return {
+    ingest<TPayload>(event: IReporterEmitEventInput<TPayload>, eventId: string): void {
+      const envelope: IReporterEventEnvelope<TPayload> = {
+        ...event,
+        eventId,
+        sequence: ++sequence,
+        timestamp: new Date().toISOString(),
+        required: isReporterEventRequired(event.type)
+      };
+      legacyErrorBridge.ingest(envelope);
+
+      if (envelope.parentSessionId === undefined) {
+        switch (envelope.type) {
+          case 'commandStarted': {
+            operationStatuses.clear();
+            hasUnscopedFailure = false;
+            derivedExitStatus = { exitCode: 0, outcome: 'succeeded' };
+            break;
+          }
+          case 'operationRegistered': {
+            const { operationId } = envelope.payload as { operationId: string };
+            operationStatuses.set(operationId, 'ready');
+            updateDerivedOperationStatus();
+            break;
+          }
+          case 'operationStatusChanged': {
+            const { operationId, status } = envelope.payload as {
+              operationId: string;
+              status: string;
+            };
+            operationStatuses.set(operationId, status);
+            updateDerivedOperationStatus();
+            break;
+          }
+          case 'diagnosticEmitted': {
+            const { severity } = envelope.payload as { severity?: string };
+            if (severity === 'error' && envelope.scope?.operationId === undefined) {
+              hasUnscopedFailure = true;
+              updateDerivedOperationStatus();
+            }
+            break;
+          }
+          case 'commandResult': {
+            const { succeeded, exitCode } = envelope.payload as {
+              succeeded: boolean;
+              exitCode: number;
+            };
+            derivedExitStatus = resolveExitStatus({
+              hasFailures: !succeeded || exitCode !== 0
+            });
+            break;
+          }
+          case 'commandCompleted':
+          case 'sessionCompleted': {
+            const { exitCode } = envelope.payload as { exitCode: number };
+            derivedExitStatus = resolveExitStatus({ hasFailures: exitCode !== 0 });
+            break;
+          }
+          default:
+            break;
+        }
+      }
+
+      // Match the privacy behavior from #5990 without duplicating its reporter-package changes:
+      // only public envelopes contribute source, protocol, lifecycle, or diagnostic telemetry.
+      // Remove this outer gate after #5990 reaches shared main and the hardened subscriber is in this ancestry.
+      if (envelope.privacy === 'public') {
+        telemetrySubscriber.ingest(envelope);
+      }
+    },
+
+    buildTelemetryAggregate(): ITelemetryAggregate {
+      return telemetrySubscriber.buildAggregate();
+    },
+
+    resolveExitStatus(): IRushExitStatus {
+      return derivedExitStatus;
+    },
+
+    correlateError(error: unknown, diagnosticId: string): void {
+      legacyErrorBridge.correlate(error, diagnosticId);
+    },
+
+    isErrorRepresented(error: unknown): boolean {
+      return legacyErrorBridge.shouldSuppressRendering(error);
+    }
+  };
+}
+
+function _createLifecycleEmitter(
+  state: IRushSessionReportingState | undefined,
+  scope?: IReporterEventScope
+): LifecycleEmitter | undefined {
+  if (!state) {
+    return undefined;
+  }
+
+  return new LifecycleEmitter({
+    sink: state.eventSink,
+    sessionId: state.sessionId,
+    source: state.source,
+    scope: scope ? { ...scope } : undefined
   });
 }
 
@@ -181,7 +345,9 @@ export class RushSession {
    * source identity bound by Rush.
    */
   public getReporter(scope?: IReporterEventScope): IScopedReporter | undefined {
-    return _getSessionState(this).reporting?.createScopedReporter(scope ? { ...scope } : undefined);
+    return _getSessionState(this).reporting?.sessionReporting.createScopedReporter(
+      scope ? { ...scope } : undefined
+    );
   }
 
   /**
@@ -193,7 +359,9 @@ export class RushSession {
    * available during the pre-major compatibility period.
    */
   public getScopedLogger(scope?: IReporterEventScope): IScopedLogger | undefined {
-    return _getSessionState(this).reporting?.createScopedLogger(scope ? { ...scope } : undefined);
+    return _getSessionState(this).reporting?.sessionReporting.createScopedLogger(
+      scope ? { ...scope } : undefined
+    );
   }
 
   public registerCloudBuildCacheProviderFactory(
@@ -248,7 +416,8 @@ export function _createRushSessionForPlugin(
   getSource: () => IReporterEventSource
 ): RushSession {
   const state: IRushSessionState = _getSessionState(rushSession);
-  if (!state.options.reporter) {
+  const reporting: IRushSessionReportingState | undefined = state.reporting;
+  if (!state.options.reporter || !reporting) {
     return rushSession;
   }
 
@@ -264,7 +433,68 @@ export function _createRushSessionForPlugin(
     cloudBuildCacheProviderFactories: state.cloudBuildCacheProviderFactories,
     cobuildLockProviderFactories: state.cobuildLockProviderFactories,
     hooks: state.hooks,
-    reporting: _createReporting(state.options.reporter, getSource())
+    reporting: _createReporting(state.options.reporter, getSource(), reporting.observer)
   });
   return pluginSession;
+}
+
+/**
+ * Creates a Rush-owned lifecycle emitter for internal command and operation paths.
+ *
+ * @internal
+ */
+export function _getRushSessionLifecycleEmitter(
+  rushSession: RushSession,
+  scope?: IReporterEventScope
+): LifecycleEmitter | undefined {
+  return _createLifecycleEmitter(_getSessionState(rushSession).reporting, scope);
+}
+
+/**
+ * Returns the current allowlisted reporter telemetry projection.
+ *
+ * @internal
+ */
+export function _getRushSessionTelemetryAggregate(rushSession: RushSession): ITelemetryAggregate | undefined {
+  return _getSessionState(rushSession).reporting?.observer.buildTelemetryAggregate();
+}
+
+/**
+ * Derives the shadow exit status without changing the authoritative process exit code.
+ *
+ * @internal
+ */
+export function _getRushSessionDerivedExitStatus(rushSession: RushSession): IRushExitStatus | undefined {
+  return _getSessionState(rushSession).reporting?.observer.resolveExitStatus();
+}
+
+/**
+ * Returns the Rush version bound to structured events for this session.
+ *
+ * @internal
+ */
+export function _getRushSessionReporterSourceVersion(rushSession: RushSession): string | undefined {
+  return _getSessionState(rushSession).reporting?.source.packageVersion;
+}
+
+/**
+ * Correlates a legacy failure sentinel with an emitted structured diagnostic.
+ *
+ * @internal
+ */
+export function _correlateRushSessionError(
+  rushSession: RushSession,
+  error: unknown,
+  diagnosticId: string
+): void {
+  _getSessionState(rushSession).reporting?.observer.correlateError(error, diagnosticId);
+}
+
+/**
+ * Returns whether a failure is already represented by an emitted diagnostic or legacy sentinel.
+ *
+ * @internal
+ */
+export function _isRushSessionErrorRepresented(rushSession: RushSession, error: unknown): boolean {
+  return _getSessionState(rushSession).reporting?.observer.isErrorRepresented(error) ?? false;
 }

--- a/specs/2026-07-12-rush-reporter-overhaul.md
+++ b/specs/2026-07-12-rush-reporter-overhaul.md
@@ -335,6 +335,12 @@ required parent/wire reporter is fatal. Failure to create the full-detail file
 at both repository and OS-temp paths is nonfatal but emits an emergency warning
 and marks the artifact unavailable.
 
+The engine's root reporting context is available before fallible repository
+initialization. Failures before command selection emit a session-scoped
+diagnostic and failure completion before reporter close. Successful command
+completion is published only after command finalization, including the public
+telemetry flush hooks, so reporter results retain the native exit outcome.
+
 ### 5.5 Bootstrap and Wire Protocol
 
 `install-run-rush` performs a minimal prelude:


### PR DESCRIPTION
Part of #5976

Stack parent: #5988

## Summary
- emit root session and command start/completion/result events through the scoped R3A sink boundary
- adapt phased operation registration/status into stable project x phase identities and emit registered `RUSH_OPERATION_FAILED` diagnostics without routing raw chunks
- correlate legacy `AlreadyReportedError` failures so catch boundaries do not emit duplicate structured diagnostics
- feed a privacy-gated `TelemetrySubscriber` projection into existing Rush telemetry while leaving process exit behavior authoritative
- add the registered `RUSH_COMMAND_FAILED` diagnostic for representative uncorrelated command failures

## Validation
- `rush install`
- `rush build --to @microsoft/rush`
- `rush test --only @rushstack/rush-reporter --only @microsoft/rush-lib --only @microsoft/rush`
- `rush check`
- `rush change --verify`

## No-output guarantee
Legacy terminal rendering and `StreamCollator` remain the only visible stdout/stderr owners. The shadow sink emits no terminal text, operation chunks are not routed to reporters, and focused tests compare legacy graph output with and without the reporter adapter.

## Non-goals
- reporter selection, defaults, CLI controls, or automatic activation
- replacing `StreamCollator` or emitting the R5 raw operation/output stream
- removing legacy terminal/logger APIs
- exhaustive parity, watch/retry, and integration matrices reserved for R3C
- retargeting or merging this child stack before parent branches advance