### PR TITLE
Add feature-flagged operation event adapter

### DIFF
--- a/apps/rush/src/RushFrontend.ts
+++ b/apps/rush/src/RushFrontend.ts
@@ -161,7 +161,8 @@ export async function launchRushFrontendAsync(options: IRushFrontendOptions): Pr
     ...launchOptions,
     reporter: {
       eventSink: reporterHost.sink,
-      sessionId
+      sessionId,
+      operationStreamEnabled: reporterHost.selection.enabled
     },
     reporterCloseAsync
   };

--- a/apps/rush/src/RushReporterHost.ts
+++ b/apps/rush/src/RushReporterHost.ts
@@ -122,6 +122,7 @@ class LogLevelReporter implements IReporter {
 
 /**
  * Keeps operation presentation on the legacy collator until R5B transfers terminal ownership.
+ * Output without an operation scope remains owned by the primary reporter.
  */
 class DeferredOperationPresentationReporter implements IReporter {
   public readonly name: string;
@@ -138,7 +139,10 @@ class DeferredOperationPresentationReporter implements IReporter {
   }
 
   public report(event: IReporterEventEnvelope<unknown>): void {
-    if (!DEFERRED_OPERATION_EVENT_TYPES.has(event.type)) {
+    if (
+      !DEFERRED_OPERATION_EVENT_TYPES.has(event.type) ||
+      (event.type === 'externalOutput' && event.scope?.operationId === undefined)
+    ) {
       this._reporter.report(event);
     }
   }

--- a/apps/rush/src/RushReporterHost.ts
+++ b/apps/rush/src/RushReporterHost.ts
@@ -23,6 +23,7 @@ import {
   type IReporterEventEnvelope,
   type IReporterEventSink,
   type IReporterOutputTarget,
+  type ReporterEventType,
   type ReporterLogLevel,
   type ReporterName
 } from '@rushstack/rush-reporter';
@@ -71,6 +72,13 @@ export interface IInitializedRushReporterHost {
 const REPORTER_VALUE_FLAGS: ReadonlySet<string> = new Set(['--reporter', '--output', '--log-level']);
 const ALL_REPORTER_VALUE_FLAGS: readonly string[] = ['--reporter', '--output', '--log-level'];
 const REPORTER_SELECTION_FLAG: readonly string[] = ['--reporter'];
+const DEFERRED_OPERATION_EVENT_TYPES: ReadonlySet<ReporterEventType> = new Set([
+  'operationRegistered',
+  'operationStatusChanged',
+  'operationStreamClosed',
+  'operationCompleted',
+  'externalOutput'
+]);
 
 interface IParsedReporterControls {
   readonly reporters: readonly string[];
@@ -99,6 +107,38 @@ class LogLevelReporter implements IReporter {
 
   public report(event: IReporterEventEnvelope<unknown>): void {
     if (shouldRenderAtLogLevel(this._logLevel, event)) {
+      this._reporter.report(event);
+    }
+  }
+
+  public flushAsync(): Promise<void> {
+    return this._reporter.flushAsync();
+  }
+
+  public closeAsync(): Promise<void> {
+    return this._reporter.closeAsync();
+  }
+}
+
+/**
+ * Keeps operation presentation on the legacy collator until R5B transfers terminal ownership.
+ */
+class DeferredOperationPresentationReporter implements IReporter {
+  public readonly name: string;
+
+  private readonly _reporter: IReporter;
+
+  public constructor(reporter: IReporter) {
+    this._reporter = reporter;
+    this.name = reporter.name;
+  }
+
+  public initializeAsync(context: IReporterContext): Promise<void> {
+    return this._reporter.initializeAsync(context);
+  }
+
+  public report(event: IReporterEventEnvelope<unknown>): void {
+    if (!DEFERRED_OPERATION_EVENT_TYPES.has(event.type)) {
       this._reporter.report(event);
     }
   }
@@ -630,7 +670,11 @@ export async function initializeRushReporterHostAsync(
   if (selection.enabled) {
     const primaryReporter: IReporter | undefined = createPrimaryReporter(selection, stdout, env);
     if (primaryReporter) {
-      host.manager.addReporter(new LogLevelReporter(primaryReporter, selection.logLevel), {
+      const presentationReporter: IReporter =
+        selection.reporter === 'file'
+          ? primaryReporter
+          : new DeferredOperationPresentationReporter(primaryReporter);
+      host.manager.addReporter(new LogLevelReporter(presentationReporter, selection.logLevel), {
         destination: selection.reporter === 'file' ? 'file:auto' : 'stdout'
       });
     }

--- a/apps/rush/src/test/RushFrontend.test.ts
+++ b/apps/rush/src/test/RushFrontend.test.ts
@@ -179,7 +179,7 @@ function emitCommandStarted(sink: IReporterEventSink): void {
 }
 
 describe(launchRushFrontendAsync.name, () => {
-  it('creates the authoritative host before invoking the bundled rush-lib and passes only its sink', async () => {
+  it('creates the authoritative host before invoking the bundled rush-lib and passes only its channel', async () => {
     const order: string[] = [];
     let receivedOptions: IRushFrontendLaunchOptions | undefined;
     const processLifecycle: ITestProcessLifecycle = createTestProcessLifecycle();
@@ -208,7 +208,8 @@ describe(launchRushFrontendAsync.name, () => {
       expect(process.argv).toEqual(['node', 'rush', 'build', '--json']);
       expect(receivedOptions?.reporter).toEqual({
         eventSink: expect.objectContaining({ emit: expect.any(Function) }),
-        sessionId: expect.any(String)
+        sessionId: expect.any(String),
+        operationStreamEnabled: false
       });
       expect(receivedOptions).not.toHaveProperty('selection');
       expect(receivedOptions).not.toHaveProperty('host');
@@ -250,7 +251,8 @@ describe(launchRushFrontendAsync.name, () => {
       expect(createSessionId).toHaveBeenCalledTimes(1);
       expect(receivedOptions?.reporter).toEqual({
         eventSink: initialized.sink,
-        sessionId: 'session-from-frontend'
+        sessionId: 'session-from-frontend',
+        operationStreamEnabled: false
       });
       await initialized.closeAsync();
       expect(order).toEqual(['host', 'close']);

--- a/apps/rush/src/test/RushReporterHost.test.ts
+++ b/apps/rush/src/test/RushReporterHost.test.ts
@@ -44,6 +44,45 @@ function emitCommandStarted(sink: IReporterEventSink): void {
   });
 }
 
+function emitOperationEvents(sink: IReporterEventSink): void {
+  const base = {
+    protocolVersion: { major: 1, minor: 1 },
+    sessionId: 'session',
+    source: { packageName: '@microsoft/rush-lib', packageVersion: '5.178.1' },
+    scope: { commandName: 'build', operationId: 'project#phase' }
+  } as const;
+  sink.emit({
+    ...base,
+    privacy: 'public',
+    type: 'operationRegistered',
+    payload: { operationId: 'project#phase', projectName: 'project', phaseName: 'phase' }
+  });
+  sink.emit({
+    ...base,
+    privacy: 'public',
+    type: 'operationStatusChanged',
+    payload: { operationId: 'project#phase', previousStatus: 'queued', status: 'executing' }
+  });
+  sink.emit({
+    ...base,
+    privacy: 'local-sensitive',
+    type: 'externalOutput',
+    payload: { stream: 'stdout', text: 'raw operation output\n' }
+  });
+  sink.emit({
+    ...base,
+    privacy: 'public',
+    type: 'operationStreamClosed',
+    payload: { operationId: 'project#phase' }
+  });
+  sink.emit({
+    ...base,
+    privacy: 'public',
+    type: 'operationCompleted',
+    payload: { operationId: 'project#phase', status: 'success' }
+  });
+}
+
 describe(resolveRushReporterSelection.name, () => {
   it('preserves the legacy path without an explicit opt-in in TTY, non-TTY, CI, and agent environments', () => {
     for (const testCase of [
@@ -578,7 +617,12 @@ describe(initializeRushReporterHostAsync.name, () => {
     let stdoutText: string = '';
     try {
       const initialized = await initializeRushReporterHostAsync({
-        argv: ['build', '--reporter=json', `--output=json://${outputPath}`],
+        argv: [
+          'build',
+          '--reporter=json',
+          '--log-level=debug',
+          `--output=json://${outputPath}?logLevel=debug`
+        ],
         env: {},
         stdout: {
           isTTY: false,
@@ -590,12 +634,28 @@ describe(initializeRushReporterHostAsync.name, () => {
       });
 
       emitCommandStarted(initialized.sink);
+      emitOperationEvents(initialized.sink);
       const firstClose: Promise<void> = initialized.closeAsync();
       expect(initialized.closeAsync()).toBe(firstClose);
       await firstClose;
 
-      expect(JSON.parse(stdoutText).type).toBe('commandStarted');
-      expect(JSON.parse(await fs.promises.readFile(outputPath, 'utf8')).type).toBe('commandStarted');
+      const stdoutEvents: Record<string, unknown>[] = stdoutText
+        .trim()
+        .split('\n')
+        .map((line: string) => JSON.parse(line) as Record<string, unknown>);
+      const fileEvents: Record<string, unknown>[] = (await fs.promises.readFile(outputPath, 'utf8'))
+        .trim()
+        .split('\n')
+        .map((line: string) => JSON.parse(line) as Record<string, unknown>);
+      expect(stdoutEvents.map(({ type }) => type)).toEqual(['commandStarted']);
+      expect(fileEvents.map(({ type }) => type)).toEqual([
+        'commandStarted',
+        'operationRegistered',
+        'operationStatusChanged',
+        'externalOutput',
+        'operationStreamClosed',
+        'operationCompleted'
+      ]);
     } finally {
       await fs.promises.rm(directory, { recursive: true, force: true });
     }

--- a/apps/rush/src/test/RushReporterHost.test.ts
+++ b/apps/rush/src/test/RushReporterHost.test.ts
@@ -5,7 +5,11 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
-import type { IReporterEventSink } from '@rushstack/rush-reporter';
+import {
+  OldEngineOutputAdapter,
+  type IReporterEventEnvelope,
+  type IReporterEventSink
+} from '@rushstack/rush-reporter';
 
 import {
   initializeRushReporterHostAsync,
@@ -660,4 +664,60 @@ describe(initializeRushReporterHostAsync.name, () => {
       await fs.promises.rm(directory, { recursive: true, force: true });
     }
   });
+
+  it.each(['json', 'plaintext'])(
+    'preserves unscoped and command-scoped output while deferring collated operations: %s',
+    async (reporter) => {
+      let output: string = '';
+      const initialized = await initializeRushReporterHostAsync({
+        argv: ['build', `--reporter=${reporter}`, '--log-level=debug'],
+        env: { CI: 'true' },
+        stdout: { isTTY: false, write: (text: string) => (output += text) },
+        includeDefaultFileReporter: false
+      });
+      const adapter: OldEngineOutputAdapter = new OldEngineOutputAdapter({
+        sink: initialized.sink,
+        sessionId: 'session',
+        source: { packageName: '@microsoft/rush-lib', packageVersion: '5.178.1' }
+      });
+      try {
+        emitCommandStarted(initialized.sink);
+        adapter.capture('stdout', 'bootstrap stdout\n');
+        emitOperationEvents(initialized.sink);
+        adapter.capture('stderr', 'bootstrap stderr\n');
+        initialized.sink.emit({
+          protocolVersion: { major: 1, minor: 1 },
+          sessionId: 'session',
+          source: { packageName: '@microsoft/rush-lib', packageVersion: '5.178.1' },
+          scope: { commandName: 'build' },
+          privacy: 'local-sensitive',
+          type: 'externalOutput',
+          payload: { stream: 'stdout', text: 'command output\n' }
+        });
+        await initialized.closeAsync();
+
+        if (reporter === 'json') {
+          const events: IReporterEventEnvelope<{ stream?: string; text?: string }>[] = output
+            .trim()
+            .split('\n')
+            .map((line) => JSON.parse(line));
+          expect(events.map((event) => event.type)).toEqual([
+            'commandStarted',
+            'externalOutput',
+            'externalOutput',
+            'externalOutput'
+          ]);
+          expect(events.slice(1).map((event) => event.payload)).toEqual([
+            { stream: 'stdout', text: 'bootstrap stdout\n' },
+            { stream: 'stderr', text: 'bootstrap stderr\n' },
+            { stream: 'stdout', text: 'command output\n' }
+          ]);
+        } else {
+          expect(output).toBe('Starting "rush build"\nbootstrap stdout\nbootstrap stderr\ncommand output\n');
+        }
+      } finally {
+        await initialized.closeAsync();
+      }
+    }
+  );
 });

--- a/common/changes/@microsoft/rush/copilot-reporter-r5a-operation-adapter_2026-08-28-06-35.json
+++ b/common/changes/@microsoft/rush/copilot-reporter-r5a-operation-adapter_2026-08-28-06-35.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Emit feature-flagged phase-aware operation registration, status, raw output, stream-close, and completion events while preserving the legacy StreamCollator output path.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "TheLarkInn@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush/reporter-unscoped-output_2026-09-10.json
+++ b/common/changes/@microsoft/rush/reporter-unscoped-output_2026-09-10.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Preserve unscoped and command-scoped external output in the primary reporter while operation output remains owned by the legacy collator.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@rushstack/rush-daemon/reporter-operation-forwarding_2026-09-07.json
+++ b/common/changes/@rushstack/rush-daemon/reporter-operation-forwarding_2026-09-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/rush-daemon",
+      "comment": "Forward reporter operation completion and iteration identity through phased request event multiplexing.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/rush-daemon",
+  "email": "223556219+Copilot@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/rush-reporter/copilot-reporter-r5a-operation-adapter_2026-08-28-06-35.json
+++ b/common/changes/@rushstack/rush-reporter/copilot-reporter-r5a-operation-adapter_2026-08-28-06-35.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/rush-reporter",
+      "comment": "Extend OperationStreamEmitter with silent registration metadata, previous status, stream-close, and operation-completion events.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/rush-reporter",
+  "email": "TheLarkInn@users.noreply.github.com"
+}

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -683,11 +683,12 @@ export interface IOperationGraphContext extends ICreateOperationsContext {
 // @internal
 export interface _IOperationGraphEventSink {
     onActivity?(text: string, options?: _IOperationActivityOptions): void;
-    onOperationChunk?(operationId: string, chunk: ITerminalChunk): void;
+    onOperationChunk?(operationId: string, chunk: ITerminalChunk, result?: IOperationExecutionResult): void;
+    onOperationCompleted?(result: IOperationExecutionResult): void;
     onOperationHeader?(operationId: string, completedOperations: number, totalOperations: number): void;
     onOperationRegistered?(operationId: string, silent: boolean, result?: IOperationExecutionResult): void;
     onOperationStatusChanged?(result: IOperationExecutionResult, previousStatus: OperationStatus): void;
-    onOperationStreamClosed?(operationId: string): void;
+    onOperationStreamClosed?(operationId: string, result?: IOperationExecutionResult): void;
 }
 
 // @alpha
@@ -1016,6 +1017,8 @@ export interface IRushSessionOptions {
 // @beta
 export interface IRushSessionReporterOptions {
     readonly eventSink: IReporterEventSink;
+    // @internal
+    readonly operationStreamEnabled?: boolean;
     readonly sessionId: string;
 }
 

--- a/common/reviews/api/rush-reporter.api.md
+++ b/common/reviews/api/rush-reporter.api.md
@@ -605,17 +605,31 @@ export interface IOldEngineOutputAdapterOptions {
 }
 
 // @beta
+export interface IOperationCompletedPayload {
+    readonly durationMs?: number;
+    readonly operationId: string;
+    readonly status: OperationStatus;
+}
+
+// @beta
 export interface IOperationRegisteredPayload {
     readonly operationId: string;
     readonly phaseName?: string;
     readonly projectName?: string;
+    readonly silent?: boolean;
 }
 
 // @beta
 export interface IOperationStatusChangedPayload {
     readonly durationMs?: number;
     readonly operationId: string;
+    readonly previousStatus?: OperationStatus;
     readonly status: OperationStatus;
+}
+
+// @beta
+export interface IOperationStreamClosedPayload {
+    readonly operationId: string;
 }
 
 // @beta
@@ -805,6 +819,7 @@ export interface IReporterHostOptions {
     readonly manager?: ReporterManager;
     readonly nowMs?: () => number;
     readonly retentionMs?: number;
+    readonly supportedProtocolVersion?: IReporterProtocolVersion;
 }
 
 // @beta
@@ -1251,11 +1266,13 @@ export type OperationStatus = 'ready' | 'waiting' | 'queued' | 'executing' | 'su
 // @beta
 export class OperationStreamEmitter {
     constructor(options: IOperationStreamEmitterOptions);
-    changeStatus(operationId: string, status: OperationStatus, durationMs?: number): string;
+    changeStatus(operationId: string, status: OperationStatus, durationMs?: number, previousStatus?: OperationStatus): string;
+    closeOperationStream(operationId: string): string;
     completeCommand(commandName: string, succeeded: boolean, exitCode: number, operationCounts?: {
         readonly [status: string]: number;
     }): string;
-    registerOperation(operationId: string, projectName?: string, phaseName?: string): string;
+    completeOperation(operationId: string, status: OperationStatus, durationMs?: number): string;
+    registerOperation(operationId: string, projectName?: string, phaseName?: string, silent?: boolean): string;
     writeOutput(operationId: string, stream: 'stdout' | 'stderr', text: string): string[];
 }
 
@@ -1328,7 +1345,7 @@ export function renderActiveProjectsRow(projects: readonly string[], width: numb
 export function renderLiveRegion(state: ILiveRegionState, options: IRenderLiveRegionOptions): string[];
 
 // @beta
-export const REPORTER_EVENT_TYPES: readonly ["sessionStarted", "sessionCompleted", "commandStarted", "commandCompleted", "operationRegistered", "operationStatusChanged", "activityChanged", "watchCycleCompleted", "diagnosticEmitted", "messageEmitted", "externalProcessStarted", "externalOutput", "externalProcessCompleted", "artifactAvailable", "commandResult", "extension"];
+export const REPORTER_EVENT_TYPES: readonly ["sessionStarted", "sessionCompleted", "commandStarted", "commandCompleted", "operationRegistered", "operationStatusChanged", "activityChanged", "watchCycleCompleted", "diagnosticEmitted", "messageEmitted", "externalProcessStarted", "externalOutput", "externalProcessCompleted", "artifactAvailable", "commandResult", "extension", "operationStreamClosed", "operationCompleted"];
 
 // @beta
 export const REPORTER_KNOWN_CAPABILITIES: readonly [];

--- a/libraries/reporter/src/bootstrap/BootstrapEventBuffer.ts
+++ b/libraries/reporter/src/bootstrap/BootstrapEventBuffer.ts
@@ -7,7 +7,7 @@ import {
   BOOTSTRAP_BUFFER_TRUNCATED_EXTENSION_NAME,
   encodeBootstrapEnvelope
 } from './BootstrapProtocol';
-import type { ReporterEventType } from '../events/ReporterEventType';
+import { isReporterEventRequired, type ReporterEventType } from '../events/ReporterEventType';
 import { chunkUtf8Text } from '../utilities/chunkUtf8Text';
 
 const TRUNCATION_NOTICE_RESERVE_BYTES: number = 512;
@@ -191,7 +191,7 @@ export class BootstrapEventBuffer {
    */
   public emit(input: IBootstrapEventInput): string {
     const eventId: string = `boot_${this._nextEventId++}`;
-    const required: boolean = input.type !== 'activityChanged';
+    const required: boolean = isReporterEventRequired(input.type);
     const line: string = encodeBootstrapEnvelope({
       eventId,
       sessionId: this._sessionId,

--- a/libraries/reporter/src/config/LogLevelFilter.ts
+++ b/libraries/reporter/src/config/LogLevelFilter.ts
@@ -59,6 +59,7 @@ export function getEventMinimumLogLevel(event: IReporterEventEnvelope<unknown>):
     case 'sessionStarted':
     case 'commandStarted':
     case 'operationStatusChanged':
+    case 'operationCompleted':
     case 'watchCycleCompleted':
     case 'artifactAvailable':
       return 'normal';
@@ -79,6 +80,7 @@ export function getEventMinimumLogLevel(event: IReporterEventEnvelope<unknown>):
     case 'externalProcessCompleted':
       return 'verbose';
     case 'externalOutput':
+    case 'operationStreamClosed':
       return 'debug';
     case 'extension':
       return 'normal';

--- a/libraries/reporter/src/events/IReporterEventEnvelope.ts
+++ b/libraries/reporter/src/events/IReporterEventEnvelope.ts
@@ -132,7 +132,8 @@ export interface IReporterEventEnvelope<TPayload = unknown> {
   readonly privacy: ReporterPrivacyClassification;
 
   /**
-   * Whether this event is correctness-critical and must never be dropped.
+   * Whether an older same-major consumer must reject the stream if it does not
+   * recognize this event. Event types added in a minor version are optional.
    */
   readonly required: boolean;
 

--- a/libraries/reporter/src/events/ReporterEventType.ts
+++ b/libraries/reporter/src/events/ReporterEventType.ts
@@ -12,7 +12,7 @@
  * Per-type policy (the contract the manager, log-level filters, and reporters
  * implement):
  *
- * | type | never dropped | minimum log level |
+ * | type | required on wire | minimum log level |
  * | --- | --- | --- |
  * | `sessionStarted` | yes | `normal` |
  * | `sessionCompleted` | yes | `quiet` |
@@ -30,6 +30,8 @@
  * | `artifactAvailable` | yes | `normal` |
  * | `commandResult` | yes | `quiet` |
  * | `extension` | yes | `normal` |
+ * | `operationStreamClosed` | additive optional | `debug` |
+ * | `operationCompleted` | additive optional | `normal` |
  *
  * Coalescing a replaceable `activityChanged` event under queue pressure leaves
  * gaps in the delivered `sequence` values; gaps are legal and are not a
@@ -57,7 +59,9 @@ export const REPORTER_EVENT_TYPES = [
   'externalProcessCompleted',
   'artifactAvailable',
   'commandResult',
-  'extension'
+  'extension',
+  'operationStreamClosed',
+  'operationCompleted'
 ] as const;
 
 /**
@@ -68,19 +72,38 @@ export const REPORTER_EVENT_TYPES = [
  */
 export type ReporterEventType = (typeof REPORTER_EVENT_TYPES)[number];
 
+const REQUIRED_REPORTER_EVENT_TYPES: ReadonlySet<ReporterEventType> = new Set([
+  'sessionStarted',
+  'sessionCompleted',
+  'commandStarted',
+  'commandCompleted',
+  'operationRegistered',
+  'operationStatusChanged',
+  'watchCycleCompleted',
+  'diagnosticEmitted',
+  'messageEmitted',
+  'externalProcessStarted',
+  'externalOutput',
+  'externalProcessCompleted',
+  'artifactAvailable',
+  'commandResult',
+  'extension'
+]);
+
 /**
  * Returns `true` if events of this type are correctness-critical and must
  * never be dropped or coalesced.
  *
  * @remarks
  * The manager derives the envelope `required` flag from this policy;
- * producers never set it. Only `activityChanged` is replaceable — every other
- * type, including `extension`, must be delivered.
+ * producers never set it. The required set is frozen to the protocol 1.0 event
+ * types so a same-major older peer can skip event types introduced by a newer
+ * minor version without discarding the stream.
  *
  * @param type - the event type to check
  *
  * @beta
  */
 export function isReporterEventRequired(type: ReporterEventType): boolean {
-  return type !== 'activityChanged';
+  return REQUIRED_REPORTER_EVENT_TYPES.has(type);
 }

--- a/libraries/reporter/src/frontend/ReporterHost.ts
+++ b/libraries/reporter/src/frontend/ReporterHost.ts
@@ -11,10 +11,7 @@ import type { ReporterEventType } from '../events/ReporterEventType';
 import type { IReporterEventSink } from '../producers/IReporterEventSink';
 import { REPORTER_EVENT_TYPES } from '../events/ReporterEventType';
 import { ReporterManager } from '../manager/ReporterManager';
-import {
-  REPORTER_PROTOCOL_VERSION,
-  isReporterProtocolCompatible
-} from '../protocol/ReporterProtocol';
+import { REPORTER_PROTOCOL_VERSION, isReporterProtocolCompatible } from '../protocol/ReporterProtocol';
 import {
   RUSH_REPORTER_BOOTSTRAP_HANDOFF_ENV_VAR,
   RUSH_REPORTER_BOOTSTRAP_NONCE_ENV_VAR
@@ -64,6 +61,11 @@ export interface IReporterHostOptions {
    * Returns the current time in milliseconds. Injectable for testing.
    */
   readonly nowMs?: () => number;
+
+  /**
+   * The protocol version supported by this host. Defaults to the current version.
+   */
+  readonly supportedProtocolVersion?: IReporterProtocolVersion;
 }
 
 /**
@@ -101,7 +103,12 @@ export interface IBootstrapReplayResult {
    * The reason no events were replayed, when a handoff path was present.
    * `nonce-mismatch` means the file failed authentication and was rejected.
    */
-  readonly skipReason?: 'unreadable' | 'invalid-path' | 'nonce-mismatch' | 'invalid-event' | 'incompatible-protocol';
+  readonly skipReason?:
+    | 'unreadable'
+    | 'invalid-path'
+    | 'nonce-mismatch'
+    | 'invalid-event'
+    | 'incompatible-protocol';
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -161,6 +168,7 @@ export class ReporterHost {
   private readonly _handoffDirectory: string;
   private readonly _retentionMs: number;
   private readonly _nowMs: () => number;
+  private readonly _supportedProtocolVersion: IReporterProtocolVersion;
 
   public constructor(options: IReporterHostOptions = {}) {
     this._manager = options.manager ?? new ReporterManager();
@@ -168,6 +176,7 @@ export class ReporterHost {
     this._handoffDirectory = options.handoffDirectory ?? os.tmpdir();
     this._retentionMs = options.retentionMs ?? DEFAULT_HANDOFF_RETENTION_MS;
     this._nowMs = options.nowMs ?? (() => Date.now());
+    this._supportedProtocolVersion = options.supportedProtocolVersion ?? REPORTER_PROTOCOL_VERSION;
   }
 
   /**
@@ -247,10 +256,7 @@ export class ReporterHost {
     let skippedEventCount: number = discardedRecordCount;
     for (const event of events) {
       const protocolVersion: IReporterProtocolVersion | undefined = getProtocolVersion(event);
-      if (
-        protocolVersion &&
-        !isReporterProtocolCompatible(REPORTER_PROTOCOL_VERSION, protocolVersion)
-      ) {
+      if (protocolVersion && !isReporterProtocolCompatible(this._supportedProtocolVersion, protocolVersion)) {
         await deleteBootstrapHandoffFileAsync(handoffPath);
         return {
           direct: false,

--- a/libraries/reporter/src/index.ts
+++ b/libraries/reporter/src/index.ts
@@ -177,6 +177,8 @@ export type {
   ICommandCompletedPayload,
   IOperationRegisteredPayload,
   IOperationStatusChangedPayload,
+  IOperationStreamClosedPayload,
+  IOperationCompletedPayload,
   ICommandResultPayload,
   IWatchCycleCompletedPayload
 } from './lifecycle/LifecycleEvents';

--- a/libraries/reporter/src/lifecycle/LifecycleEvents.ts
+++ b/libraries/reporter/src/lifecycle/LifecycleEvents.ts
@@ -113,6 +113,11 @@ export interface IOperationRegisteredPayload {
    * The phase the operation belongs to.
    */
   readonly phaseName?: string;
+
+  /**
+   * Whether the operation is architectural and normally omitted from visible summaries.
+   */
+  readonly silent?: boolean;
 }
 
 /**
@@ -132,7 +137,46 @@ export interface IOperationStatusChangedPayload {
   readonly status: OperationStatus;
 
   /**
+   * The status immediately preceding this transition.
+   */
+  readonly previousStatus?: OperationStatus;
+
+  /**
    * The operation duration in milliseconds when known.
+   */
+  readonly durationMs?: number;
+}
+
+/**
+ * The payload of an `operationStreamClosed` event.
+ *
+ * @beta
+ */
+export interface IOperationStreamClosedPayload {
+  /**
+   * The operation whose output stream has closed.
+   */
+  readonly operationId: string;
+}
+
+/**
+ * The payload of an `operationCompleted` event.
+ *
+ * @beta
+ */
+export interface IOperationCompletedPayload {
+  /**
+   * The completed operation.
+   */
+  readonly operationId: string;
+
+  /**
+   * The terminal operation status.
+   */
+  readonly status: OperationStatus;
+
+  /**
+   * The final operation duration in milliseconds when known.
    */
   readonly durationMs?: number;
 }

--- a/libraries/reporter/src/protocol/ReporterProtocol.ts
+++ b/libraries/reporter/src/protocol/ReporterProtocol.ts
@@ -15,7 +15,7 @@ import type { IReporterProtocolVersion } from '../events/ReporterProtocolVersion
  */
 export const REPORTER_PROTOCOL_VERSION: IReporterProtocolVersion = {
   major: 1,
-  minor: 0
+  minor: 1
 };
 
 /**

--- a/libraries/reporter/src/scheduler/OperationStreamEmitter.ts
+++ b/libraries/reporter/src/scheduler/OperationStreamEmitter.ts
@@ -49,11 +49,11 @@ export interface IOperationStreamEmitterOptions {
  *
  * @remarks
  * The operation scheduler uses this to publish operation registration, status
- * transitions, raw output chunks, and the aggregate command result. Output
- * chunks are emitted immediately in call order and are never collated, so the
- * concise reporter can derive activity without buffering, the detailed and file
- * reporters can own grouping, and problem matchers can consume the same
- * uncollated source stream.
+ * transitions, raw output chunks, stream close, operation completion, and the
+ * aggregate command result. Output chunks are emitted immediately in call order
+ * and are never collated, so the concise reporter can derive activity without
+ * buffering, the detailed and file reporters can own grouping, and problem
+ * matchers can consume the same uncollated source stream.
  *
  * @beta
  */
@@ -71,8 +71,7 @@ export class OperationStreamEmitter {
     this._source = options.source;
     this._scope = options.scope;
     this._protocolVersion = options.protocolVersion ?? REPORTER_PROTOCOL_VERSION;
-    const maxChunkBytes: number =
-      options.maxChunkBytes ?? REPORTER_PROTOCOL_LIMITS.externalOutputChunkBytes;
+    const maxChunkBytes: number = options.maxChunkBytes ?? REPORTER_PROTOCOL_LIMITS.externalOutputChunkBytes;
     if (
       !Number.isInteger(maxChunkBytes) ||
       maxChunkBytes < 4 ||
@@ -88,10 +87,20 @@ export class OperationStreamEmitter {
   /**
    * Emits an operation registration event.
    */
-  public registerOperation(operationId: string, projectName?: string, phaseName?: string): string {
+  public registerOperation(
+    operationId: string,
+    projectName?: string,
+    phaseName?: string,
+    silent?: boolean
+  ): string {
     return this._emit(
       'operationRegistered',
-      { operationId, projectName, phaseName },
+      {
+        operationId,
+        projectName,
+        phaseName,
+        ...(silent === undefined ? {} : { silent })
+      },
       { operationId, projectName, phaseName },
       'public'
     );
@@ -100,10 +109,20 @@ export class OperationStreamEmitter {
   /**
    * Emits an operation status transition.
    */
-  public changeStatus(operationId: string, status: OperationStatus, durationMs?: number): string {
+  public changeStatus(
+    operationId: string,
+    status: OperationStatus,
+    durationMs?: number,
+    previousStatus?: OperationStatus
+  ): string {
     return this._emit(
       'operationStatusChanged',
-      { operationId, status, durationMs },
+      {
+        operationId,
+        status,
+        ...(previousStatus === undefined ? {} : { previousStatus }),
+        ...(durationMs === undefined ? {} : { durationMs })
+      },
       { operationId },
       'public'
     );
@@ -147,6 +166,25 @@ export class OperationStreamEmitter {
   }
 
   /**
+   * Emits the authoritative signal that no more output will be emitted for an operation.
+   */
+  public closeOperationStream(operationId: string): string {
+    return this._emit('operationStreamClosed', { operationId }, { operationId }, 'public');
+  }
+
+  /**
+   * Emits the final outcome of an operation.
+   */
+  public completeOperation(operationId: string, status: OperationStatus, durationMs?: number): string {
+    return this._emit(
+      'operationCompleted',
+      { operationId, status, ...(durationMs === undefined ? {} : { durationMs }) },
+      { operationId },
+      'public'
+    );
+  }
+
+  /**
    * Emits the aggregate command result.
    */
   public completeCommand(
@@ -164,7 +202,13 @@ export class OperationStreamEmitter {
   }
 
   private _emit(
-    type: 'operationRegistered' | 'operationStatusChanged' | 'externalOutput' | 'commandResult',
+    type:
+      | 'operationRegistered'
+      | 'operationStatusChanged'
+      | 'operationStreamClosed'
+      | 'operationCompleted'
+      | 'externalOutput'
+      | 'commandResult',
     payload: unknown,
     scopeOverride: IReporterEventScope,
     privacy: 'public' | 'local-sensitive' | 'secret'

--- a/libraries/reporter/src/test/HeftIntegration.test.ts
+++ b/libraries/reporter/src/test/HeftIntegration.test.ts
@@ -269,6 +269,57 @@ describe('HeftDescriptorHost new descriptor path', () => {
     expect(result.diagnostic?.code).toBe('RUSH_PROTOCOL_UPDATE_REQUIRED');
   });
 
+  it('lets a 1.0 consumer skip an unknown optional 1.1 event and continue the stream', () => {
+    const forwarded: IReporterEventEnvelope<unknown>[] = [];
+    const host: HeftDescriptorHost = new HeftDescriptorHost({
+      parentSessionId: 'parent-sess',
+      supportedProtocolVersion: { major: 1, minor: 0 },
+      forwardEnvelope: (envelope: IReporterEventEnvelope<unknown>) => forwarded.push(envelope)
+    });
+
+    expect(
+      host.processChildRecord({
+        kind: 'hello',
+        protocolVersion: { major: 1, minor: 1 },
+        producerVersion: '@rushstack/heft 1.2.19',
+        capabilities: [],
+        requiredFeatures: []
+      })
+    ).toBe(true);
+    expect(
+      host.processChildRecord({
+        protocolVersion: { major: 1, minor: 1 },
+        eventId: 'future_optional',
+        sessionId: 'child-sess',
+        sequence: 1,
+        timestamp: '2026-01-01T00:00:00.000Z',
+        source: SOURCE,
+        privacy: 'public',
+        required: false,
+        type: 'futureMinorEvent',
+        payload: {}
+      })
+    ).toBe(true);
+    expect(
+      host.processChildRecord({
+        protocolVersion: { major: 1, minor: 1 },
+        eventId: 'known_after_future',
+        sessionId: 'child-sess',
+        sequence: 2,
+        timestamp: '2026-01-01T00:00:00.001Z',
+        source: SOURCE,
+        privacy: 'public',
+        required: true,
+        type: 'commandCompleted',
+        payload: { commandName: 'build', exitCode: 0 }
+      })
+    ).toBe(true);
+
+    const result: IHeftChildResult = host.processChildRecords([]);
+    expect(result).toMatchObject({ accepted: true, eventCount: 1 });
+    expect(forwarded.map(({ eventId }) => eventId)).toEqual(['known_after_future']);
+  });
+
   it('rejects malformed records without throwing from the streaming drain', () => {
     const negotiationResults: boolean[] = [];
     const host: HeftDescriptorHost = new HeftDescriptorHost({

--- a/libraries/reporter/src/test/IReporterEventEnvelope.test.ts
+++ b/libraries/reporter/src/test/IReporterEventEnvelope.test.ts
@@ -27,7 +27,9 @@ describe('ReporterEventType', () => {
       'externalProcessCompleted',
       'artifactAvailable',
       'commandResult',
-      'extension'
+      'extension',
+      'operationStreamClosed',
+      'operationCompleted'
     ]);
   });
 

--- a/libraries/reporter/src/test/LogLevelFilter.test.ts
+++ b/libraries/reporter/src/test/LogLevelFilter.test.ts
@@ -40,6 +40,7 @@ describe('getEventMinimumLogLevel', () => {
   it('classifies standard lifecycle and non-required warnings as normal', () => {
     expect(getEventMinimumLogLevel(ev('commandStarted', { commandName: 'build' }))).toBe('normal');
     expect(getEventMinimumLogLevel(ev('operationStatusChanged', { status: 'success' }))).toBe('normal');
+    expect(getEventMinimumLogLevel(ev('operationCompleted', { status: 'success' }))).toBe('normal');
     expect(getEventMinimumLogLevel(ev('diagnosticEmitted', { severity: 'warning' }, false))).toBe('normal');
   });
 
@@ -47,6 +48,7 @@ describe('getEventMinimumLogLevel', () => {
     expect(getEventMinimumLogLevel(ev('operationRegistered', {}))).toBe('normal');
     expect(getEventMinimumLogLevel(ev('externalProcessStarted', {}))).toBe('verbose');
     expect(getEventMinimumLogLevel(ev('externalOutput', { stream: 'stdout', text: 'x' }))).toBe('debug');
+    expect(getEventMinimumLogLevel(ev('operationStreamClosed', {}))).toBe('debug');
     expect(getEventMinimumLogLevel(ev('messageEmitted', { severity: 'debug', text: 'd' }))).toBe('debug');
     expect(getEventMinimumLogLevel(ev('extension', { name: 'a.b' }, false))).toBe('normal');
   });

--- a/libraries/reporter/src/test/Manager.test.ts
+++ b/libraries/reporter/src/test/Manager.test.ts
@@ -117,12 +117,16 @@ describe('ReporterManager ordering and assignment', () => {
     manager.emit(makeInput('activityChanged'));
     manager.emit(makeInput('messageEmitted'));
     manager.emit(makeInput('commandStarted'));
+    manager.emit(makeInput('operationStreamClosed'));
+    manager.emit(makeInput('operationCompleted'));
     await manager.flushAsync();
 
     expect(reporter.reported.map((e: IReporterEventEnvelope<unknown>) => e.required)).toEqual([
       false,
       true,
-      true
+      true,
+      false,
+      false
     ]);
   });
 
@@ -152,9 +156,10 @@ describe('ReporterManager ordering and assignment', () => {
     manager.ingestForeignEnvelope(foreign);
     await manager.flushAsync();
 
-    const byIdentity: [string, string][] = reporter.reported.map(
-      (e: IReporterEventEnvelope<unknown>) => [e.sessionId, e.eventId]
-    );
+    const byIdentity: [string, string][] = reporter.reported.map((e: IReporterEventEnvelope<unknown>) => [
+      e.sessionId,
+      e.eventId
+    ]);
     expect(byIdentity).toEqual([
       ['sess', 'evt_1'],
       ['child', 'evt_1']

--- a/libraries/reporter/src/test/OperationStreamEmitter.test.ts
+++ b/libraries/reporter/src/test/OperationStreamEmitter.test.ts
@@ -61,10 +61,12 @@ describe('OperationStreamEmitter', () => {
   it('emits registration, status, output, and result with operation scope', () => {
     const sink: CapturingSink = new CapturingSink();
     const emitter: OperationStreamEmitter = makeEmitter(sink);
-    emitter.registerOperation('op1', 'project-a', 'build');
-    emitter.changeStatus('op1', 'executing');
+    emitter.registerOperation('op1', 'project-a', 'build', false);
+    emitter.changeStatus('op1', 'executing', 0, 'queued');
     emitter.writeOutput('op1', 'stdout', 'hello\n');
-    emitter.changeStatus('op1', 'success', 100);
+    emitter.changeStatus('op1', 'success', 100, 'executing');
+    emitter.closeOperationStream('op1');
+    emitter.completeOperation('op1', 'success', 100);
     emitter.completeCommand('build', true, 0, { success: 1 });
 
     expect(sink.inputs.map((i) => i.type)).toEqual([
@@ -72,13 +74,45 @@ describe('OperationStreamEmitter', () => {
       'operationStatusChanged',
       'externalOutput',
       'operationStatusChanged',
+      'operationStreamClosed',
+      'operationCompleted',
       'commandResult'
     ]);
     expect(sink.inputs[2].scope).toEqual({ commandName: 'build', operationId: 'op1' });
     expect(sink.inputs[2].privacy).toBe('local-sensitive');
-    expect(sink.inputs[3].payload).toMatchObject({ operationId: 'op1', status: 'success', durationMs: 100 });
+    expect(sink.inputs[0].payload).toMatchObject({ operationId: 'op1', silent: false });
+    expect(sink.inputs[3].payload).toMatchObject({
+      operationId: 'op1',
+      previousStatus: 'executing',
+      status: 'success',
+      durationMs: 100
+    });
     // externalOutput is protected (never coalesced/dropped); the manager derives `required`.
     expect(isReporterEventRequired('externalOutput')).toBe(true);
+    expect(isReporterEventRequired('operationStreamClosed')).toBe(false);
+    expect(isReporterEventRequired('operationCompleted')).toBe(false);
+  });
+
+  it('records silent metadata and orders close before completion', () => {
+    const sink: CapturingSink = new CapturingSink();
+    const emitter: OperationStreamEmitter = makeEmitter(sink);
+    emitter.registerOperation('silent-op', 'project-a', '_phase:synthetic', true);
+    emitter.changeStatus('silent-op', 'noOp', 0, 'ready');
+    emitter.closeOperationStream('silent-op');
+    emitter.completeOperation('silent-op', 'noOp', 0);
+
+    expect(sink.inputs.map(({ type }) => type)).toEqual([
+      'operationRegistered',
+      'operationStatusChanged',
+      'operationStreamClosed',
+      'operationCompleted'
+    ]);
+    expect(sink.inputs[0].payload).toEqual({
+      operationId: 'silent-op',
+      projectName: 'project-a',
+      phaseName: '_phase:synthetic',
+      silent: true
+    });
   });
 
   it('splits raw output into uncollated chunks', () => {

--- a/libraries/reporter/src/test/Protocol.test.ts
+++ b/libraries/reporter/src/test/Protocol.test.ts
@@ -5,6 +5,7 @@ import {
   REPORTER_PROTOCOL_VERSION,
   REPORTER_PROTOCOL_LIMITS,
   isReporterProtocolCompatible,
+  isReporterEventRequired,
   encodeNdjsonRecord,
   NdjsonDecoder,
   NdjsonInvalidRecordError,
@@ -18,6 +19,7 @@ import {
 describe('ReporterProtocol', () => {
   it('advertises protocol major 1 and the specified byte limits', () => {
     expect(REPORTER_PROTOCOL_VERSION.major).toBe(1);
+    expect(REPORTER_PROTOCOL_VERSION.minor).toBe(1);
     expect(REPORTER_PROTOCOL_LIMITS.bootstrapBufferBytes).toBe(1024 * 1024);
     expect(REPORTER_PROTOCOL_LIMITS.ndjsonRecordBytes).toBe(1024 * 1024);
     expect(REPORTER_PROTOCOL_LIMITS.externalOutputChunkBytes).toBe(64 * 1024);
@@ -26,6 +28,12 @@ describe('ReporterProtocol', () => {
   it('treats an equal major as compatible regardless of minor', () => {
     expect(isReporterProtocolCompatible({ major: 1, minor: 0 }, { major: 1, minor: 9 })).toBe(true);
     expect(isReporterProtocolCompatible({ major: 1, minor: 0 }, { major: 2, minor: 0 })).toBe(false);
+  });
+
+  it('marks event types added in protocol 1.1 as optional for protocol 1.0 consumers', () => {
+    expect(isReporterEventRequired('operationStreamClosed')).toBe(false);
+    expect(isReporterEventRequired('operationCompleted')).toBe(false);
+    expect(isReporterEventRequired('commandResult')).toBe(true);
   });
 });
 
@@ -175,10 +183,7 @@ describe('negotiateReporterHello', () => {
 
   it('rejects a malformed wire hello with a predictable validation error', () => {
     expect(() =>
-      negotiateReporterHello(
-        { kind: 'hello' },
-        { supportedProtocolVersion: { major: 1, minor: 0 } }
-      )
+      negotiateReporterHello({ kind: 'hello' }, { supportedProtocolVersion: { major: 1, minor: 0 } })
     ).toThrow(InvalidReporterHelloError);
     expect(() =>
       negotiateReporterHello(

--- a/libraries/reporter/src/test/ReporterHost.test.ts
+++ b/libraries/reporter/src/test/ReporterHost.test.ts
@@ -234,7 +234,7 @@ describe('ReporterHost handoff replay', () => {
     });
   });
 
-  it('skips an unknown additive event and replays known events', async () => {
+  it('lets a 1.0 consumer skip an unknown optional 1.1 event and replay the remaining stream', async () => {
     await withTempDir(async (directory: string) => {
       const buffer: BootstrapEventBuffer = makeBuffer();
       buffer.emit({ type: 'sessionStarted', payload: {} });
@@ -251,12 +251,15 @@ describe('ReporterHost handoff replay', () => {
       lines.splice(2, 0, JSON.stringify(unknownEvent));
       await fs.promises.writeFile(handoffPath, `${lines.join('\n')}\n`);
 
-      const manager: ReporterManager = new ReporterManager();
+      const manager: ReporterManager = new ReporterManager({
+        protocolVersion: { major: 1, minor: 0 }
+      });
       const reporter: RecordingReporter = new RecordingReporter();
       manager.addReporter(reporter);
       await manager.initializeAsync();
       const host: ReporterHost = new ReporterHost({
         manager,
+        supportedProtocolVersion: { major: 1, minor: 0 },
         env: {
           [RUSH_REPORTER_BOOTSTRAP_HANDOFF_ENV_VAR]: handoffPath,
           [RUSH_REPORTER_BOOTSTRAP_NONCE_ENV_VAR]: nonce
@@ -267,10 +270,7 @@ describe('ReporterHost handoff replay', () => {
       const result: IBootstrapReplayResult = await host.replayBootstrapHandoffAsync();
       await manager.flushAsync();
       expect(result).toMatchObject({ replayed: true, eventCount: 2, skippedEventCount: 1 });
-      expect(reporter.reported.map((event) => event.type)).toEqual([
-        'sessionStarted',
-        'diagnosticEmitted'
-      ]);
+      expect(reporter.reported.map((event) => event.type)).toEqual(['sessionStarted', 'diagnosticEmitted']);
     });
   });
 

--- a/libraries/reporter/src/test/Telemetry.test.ts
+++ b/libraries/reporter/src/test/Telemetry.test.ts
@@ -85,7 +85,7 @@ describe('TelemetrySubscriber', () => {
     expect(aggregate.diagnosticCodes).toEqual(['RUSH_OPERATION_FAILED']);
     expect(aggregate.diagnosticCategoryCounts).toEqual({ operation: 1 });
     expect(aggregate.reporterMode).toBe('default');
-    expect(aggregate.protocolVersion).toEqual({ major: 1, minor: 0 });
+    expect(aggregate.protocolVersion).toEqual({ major: 1, minor: 1 });
     expect(aggregate.producerVersions).toEqual(['@microsoft/rush-lib@5.177.2']);
 
     // The subscriber runs alongside a rendering reporter and does not consume events from it.

--- a/libraries/reporter/src/test/__snapshots__/Goldens.test.ts.snap
+++ b/libraries/reporter/src/test/__snapshots__/Goldens.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`compatibility goldens advertises the current protocol version as the negotiation baseline 1`] = `
 Object {
   "major": 1,
-  "minor": 0,
+  "minor": 1,
 }
 `;
 

--- a/libraries/rush-daemon/src/PhasedRequestEventMultiplexer.ts
+++ b/libraries/rush-daemon/src/PhasedRequestEventMultiplexer.ts
@@ -39,17 +39,18 @@ export class PhasedRequestEventMultiplexer implements _IOperationGraphEventSink 
     }
   }
 
-  public onOperationRegistered(operationId: string, silent: boolean): void {
-    this.#workspaceSink?.onOperationRegistered?.(operationId, silent);
+  public onOperationRegistered(
+    operationId: string,
+    silent: boolean,
+    result?: IOperationExecutionResult
+  ): void {
+    this.#workspaceSink?.onOperationRegistered?.(operationId, silent, result);
     for (const requestSink of this.#requestSinks) {
-      requestSink.onOperationRegistered?.(operationId, silent);
+      requestSink.onOperationRegistered?.(operationId, silent, result);
     }
   }
 
-  public onOperationStatusChanged(
-    result: IOperationExecutionResult,
-    previousStatus: OperationStatus
-  ): void {
+  public onOperationStatusChanged(result: IOperationExecutionResult, previousStatus: OperationStatus): void {
     this.#workspaceSink?.onOperationStatusChanged?.(result, previousStatus);
     for (const requestSink of this.#requestSinks) {
       requestSink.onOperationStatusChanged?.(result, previousStatus);
@@ -63,17 +64,28 @@ export class PhasedRequestEventMultiplexer implements _IOperationGraphEventSink 
     }
   }
 
-  public onOperationChunk(operationId: string, chunk: ITerminalChunk): void {
-    this.#workspaceSink?.onOperationChunk?.(operationId, chunk);
+  public onOperationChunk(
+    operationId: string,
+    chunk: ITerminalChunk,
+    result?: IOperationExecutionResult
+  ): void {
+    this.#workspaceSink?.onOperationChunk?.(operationId, chunk, result);
     for (const requestSink of this.#requestSinks) {
-      requestSink.onOperationChunk?.(operationId, chunk);
+      requestSink.onOperationChunk?.(operationId, chunk, result);
     }
   }
 
-  public onOperationStreamClosed(operationId: string): void {
-    this.#workspaceSink?.onOperationStreamClosed?.(operationId);
+  public onOperationStreamClosed(operationId: string, result?: IOperationExecutionResult): void {
+    this.#workspaceSink?.onOperationStreamClosed?.(operationId, result);
     for (const requestSink of this.#requestSinks) {
-      requestSink.onOperationStreamClosed?.(operationId);
+      requestSink.onOperationStreamClosed?.(operationId, result);
+    }
+  }
+
+  public onOperationCompleted(result: IOperationExecutionResult): void {
+    this.#workspaceSink?.onOperationCompleted?.(result);
+    for (const requestSink of this.#requestSinks) {
+      requestSink.onOperationCompleted?.(result);
     }
   }
 

--- a/libraries/rush-daemon/src/test/PhasedRequestEventMultiplexer.test.ts
+++ b/libraries/rush-daemon/src/test/PhasedRequestEventMultiplexer.test.ts
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import type { IOperationExecutionResult, _IOperationGraphEventSink } from '@microsoft/rush-lib';
+
+import { PhasedRequestEventMultiplexer } from '../PhasedRequestEventMultiplexer';
+
+describe(PhasedRequestEventMultiplexer.name, () => {
+  it('forwards execution identity, stream closure, and completion to every sink', () => {
+    const events: string[] = [];
+    const result: IOperationExecutionResult = {} as IOperationExecutionResult;
+    const workspaceSink: _IOperationGraphEventSink = {
+      onOperationRegistered: (operationId, silent, forwardedResult) => {
+        expect(operationId).toBe('operation');
+        expect(silent).toBe(false);
+        expect(forwardedResult).toBe(result);
+        events.push('workspace-registered');
+      },
+      onOperationStreamClosed: () => events.push('workspace-closed'),
+      onOperationCompleted: () => events.push('workspace-completed')
+    };
+    const requestSink: _IOperationGraphEventSink & {
+      onIterationScheduled(records: Iterable<IOperationExecutionResult>): void;
+    } = {
+      onIterationScheduled: () => {},
+      onOperationRegistered: (operationId, silent, forwardedResult) => {
+        expect(operationId).toBe('operation');
+        expect(silent).toBe(false);
+        expect(forwardedResult).toBe(result);
+        events.push('request-registered');
+      },
+      onOperationStreamClosed: () => events.push('request-closed'),
+      onOperationCompleted: () => events.push('request-completed')
+    };
+    const multiplexer: PhasedRequestEventMultiplexer = new PhasedRequestEventMultiplexer(workspaceSink);
+    multiplexer.subscribe(requestSink);
+
+    multiplexer.onOperationRegistered('operation', false, result);
+    multiplexer.onOperationStreamClosed('operation', result);
+    multiplexer.onOperationCompleted(result);
+
+    expect(events).toEqual([
+      'workspace-registered',
+      'request-registered',
+      'workspace-closed',
+      'request-closed',
+      'workspace-completed',
+      'request-completed'
+    ]);
+  });
+});

--- a/libraries/rush-lib/src/logic/operations/CacheableOperationPlugin.ts
+++ b/libraries/rush-lib/src/logic/operations/CacheableOperationPlugin.ts
@@ -762,15 +762,17 @@ export class CacheableOperationPlugin implements IPhasedCommandPlugin {
       cacheConsoleWritable = collatedWriter;
     }
 
-    let cacheCollatedTerminal: CollatedTerminal;
+    let cacheDestination: TerminalWritable;
     if (cacheProjectLogWritable) {
-      const cacheSplitterTransform: SplitterTransform = new SplitterTransform({
+      cacheDestination = new SplitterTransform({
         destinations: [cacheConsoleWritable, cacheProjectLogWritable]
       });
-      cacheCollatedTerminal = new CollatedTerminal(cacheSplitterTransform);
     } else {
-      cacheCollatedTerminal = new CollatedTerminal(cacheConsoleWritable);
+      cacheDestination = cacheConsoleWritable;
     }
+    const cacheCollatedTerminal: CollatedTerminal = new CollatedTerminal(
+      record.addOperationChunkTap(cacheDestination)
+    );
 
     const buildCacheTerminalProvider: CollatedTerminalProvider = new CollatedTerminalProvider(
       cacheCollatedTerminal,

--- a/libraries/rush-lib/src/logic/operations/OperationEventSink.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationEventSink.ts
@@ -57,17 +57,21 @@ export interface IOperationGraphEventSink {
 
   /**
    * Invoked for each chunk of an operation's raw output, upstream of any
-   * quiet-mode filtering. Concatenated chunks for one operation exactly match
-   * what the collated sink receives for that operation.
+   * newline normalization or quiet-mode filtering.
    */
-  onOperationChunk?(operationId: string, chunk: ITerminalChunk): void;
+  onOperationChunk?(operationId: string, chunk: ITerminalChunk, result?: IOperationExecutionResult): void;
 
   /**
    * Invoked when an operation's collated output stream is closed at the end of
    * its execution, after all status lines and output have been written. This
    * is the authoritative "no more output for this operation" signal.
    */
-  onOperationStreamClosed?(operationId: string): void;
+  onOperationStreamClosed?(operationId: string, result?: IOperationExecutionResult): void;
+
+  /**
+   * Invoked after the operation stream is closed and the final outcome is authoritative.
+   */
+  onOperationCompleted?(result: IOperationExecutionResult): void;
 
   /**
    * Invoked for each human-oriented status line written to the terminal,

--- a/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
@@ -173,6 +173,8 @@ export class OperationExecutionRecord implements IOperationRunnerContext, IOpera
   #status: OperationStatus;
   #stateHash: string | undefined;
   #stateHashComponents: IOperationStateHashComponents | undefined;
+  #operationStreamClosed: boolean = false;
+  #operationCompleted: boolean = false;
 
   public constructor(operation: Operation, context: IOperationExecutionRecordContext) {
     const { runner, associatedPhase, associatedProject, enabled } = operation;
@@ -281,6 +283,63 @@ export class OperationExecutionRecord implements IOperationRunnerContext, IOpera
 
   public get silent(): boolean {
     return !this.enabled || this.runner.silent;
+  }
+
+  /**
+   * Notifies observers that this iteration cannot emit more output for the operation.
+   *
+   * @internal
+   */
+  public closeOperationStream(): void {
+    if (!this.#operationStreamClosed) {
+      this.#operationStreamClosed = true;
+      this.#context.eventSink?.onOperationStreamClosed?.(this.name, this);
+    }
+  }
+
+  /**
+   * Emits the ordered terminal stream events exactly once.
+   *
+   * @internal
+   */
+  public finalizeOperation(): void {
+    this.closeOperationStream();
+    if (!this.#operationCompleted) {
+      this.#operationCompleted = true;
+      this.#context.eventSink?.onOperationCompleted?.(this);
+    }
+  }
+
+  /**
+   * Whether this record has emitted its terminal completion event.
+   *
+   * @internal
+   */
+  public get isOperationCompleted(): boolean {
+    return this.#operationCompleted;
+  }
+
+  /**
+   * Adds the reporter's lossless operation-output tap ahead of any legacy presentation transforms.
+   *
+   * @internal
+   */
+  public addOperationChunkTap(destination: TerminalWritable): TerminalWritable {
+    const eventSink: IOperationGraphEventSink | undefined = this.#context.eventSink;
+    if (!eventSink?.onOperationChunk) {
+      return destination;
+    }
+
+    return new SplitterTransform({
+      destinations: [
+        destination,
+        new OperationChunkTap(this.name, (operationId, chunk) => {
+          if (operationId === this.name) {
+            eventSink.onOperationChunk?.(operationId, chunk, this);
+          }
+        })
+      ]
+    });
   }
 
   public getStateHash(): string {
@@ -396,25 +455,12 @@ export class OperationExecutionRecord implements IOperationRunnerContext, IOpera
         newlineKind: NewlineKind.Lf // for StdioSummarizer
       });
 
-      const chunkTapDestinations: TerminalWritable[] = [];
-      const eventSink: IOperationGraphEventSink | undefined = this.#context.eventSink;
-      if (eventSink?.onOperationChunk) {
-        // Tap the stream upstream of the quiet-mode discard so the sink observes
-        // the exact bytes the collated writer would receive, regardless of verbosity.
-        chunkTapDestinations.push(
-          new OperationChunkTap(this.name, (operationId, chunk) =>
-            eventSink.onOperationChunk?.(operationId, chunk)
-          )
-        );
-      }
-
       const splitterTransform1: SplitterTransform = new SplitterTransform({
         destinations: [
           this.quietMode
             ? new DiscardStdoutTransform({ destination: this.collatedWriter })
             : this.collatedWriter,
-          stderrLineTransform,
-          ...chunkTapDestinations
+          stderrLineTransform
         ]
       });
 
@@ -424,7 +470,9 @@ export class OperationExecutionRecord implements IOperationRunnerContext, IOpera
         ensureNewlineAtEnd: true
       });
 
-      const collatedTerminal: CollatedTerminal = new CollatedTerminal(normalizeNewlineTransform);
+      const collatedTerminal: CollatedTerminal = new CollatedTerminal(
+        this.addOperationChunkTap(normalizeNewlineTransform)
+      );
       const terminalProvider: CollatedTerminalProvider = new CollatedTerminalProvider(collatedTerminal, {
         debugEnabled: this.debugMode
       });
@@ -486,9 +534,7 @@ export class OperationExecutionRecord implements IOperationRunnerContext, IOpera
     } finally {
       if (this.isTerminal) {
         this.#collatedWriter?.close();
-        if (this.#collatedWriter) {
-          this.#context.eventSink?.onOperationStreamClosed?.(this.name);
-        }
+        this.finalizeOperation();
         this.stdioSummarizer.close();
         this.problemCollector.close();
       }

--- a/libraries/rush-lib/src/logic/operations/OperationGraph.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationGraph.ts
@@ -677,9 +677,7 @@ export class OperationGraph implements IOperationGraph {
         operation,
         iterationContext
       );
-
       executionRecords.set(operation, executionRecord);
-      eventSink?.onOperationRegistered?.(executionRecord.name, executionRecord.silent, executionRecord);
     }
 
     for (const [operation, record] of executionRecords) {
@@ -715,6 +713,13 @@ export class OperationGraph implements IOperationGraph {
     }
 
     if (iterationContext.totalOperations === 0) {
+      registerOperations();
+      for (const executionRecord of executionRecords.values()) {
+        executionRecord.status = OperationStatus.NoOp;
+        executionRecord.finalizeOperation();
+        executionRecord.stdioSummarizer.close();
+        executionRecord.problemCollector.close();
+      }
       return;
     }
 
@@ -729,12 +734,19 @@ export class OperationGraph implements IOperationGraph {
       terminal.writeStderrLine(Colorize.red(errorMessage));
       throw e;
     }
+    registerOperations();
     if (!this.#currentIteration) {
       this.#setIdleTimeout();
     } else if (!this.pauseNextIteration) {
       void this.abortCurrentIterationAsync();
     }
     return iterationContext;
+
+    function registerOperations(): void {
+      for (const executionRecord of executionRecords.values()) {
+        eventSink?.onOperationRegistered?.(executionRecord.name, executionRecord.silent, executionRecord);
+      }
+    }
 
     function onWriterActive(writer: CollatedWriter | undefined): void {
       if (writer) {
@@ -799,6 +811,7 @@ export class OperationGraph implements IOperationGraph {
     this.#setStatus(OperationStatus.Executing);
 
     const { hooks } = this;
+    const graph: OperationGraph = this;
 
     const { abortController, records: executionRecords, terminal, totalOperations } = iterationContext;
 
@@ -876,12 +889,28 @@ export class OperationGraph implements IOperationGraph {
     terminal.writeStdoutLine(parallelismLine);
     eventSink?.onActivity?.(parallelismLine);
 
-    const bailStatus: OperationStatus | undefined | void = abortSignal.aborted
-      ? OperationStatus.Aborted
-      : await measureAsyncFn(
-          `${PERF_PREFIX}:beforeExecuteIterationAsync`,
-          async () => await hooks.beforeExecuteIterationAsync.promise(executionRecords, iterationOptions)
-        );
+    let bailStatus: OperationStatus | undefined | void;
+    try {
+      bailStatus = abortSignal.aborted
+        ? OperationStatus.Aborted
+        : await measureAsyncFn(
+            `${PERF_PREFIX}:beforeExecuteIterationAsync`,
+            async () => await hooks.beforeExecuteIterationAsync.promise(executionRecords, iterationOptions)
+          );
+    } catch (error) {
+      await closeRunnersAndReportFailuresAsync(
+        [...executionRecords.values()].filter((record) => !record.shouldRunnerPersist)
+      );
+      for (const record of executionRecords.values()) {
+        if (!record.isTerminal) {
+          record.status = OperationStatus.Aborted;
+        }
+        record.finalizeOperation();
+        record.stdioSummarizer.close();
+        record.problemCollector.close();
+      }
+      throw error;
+    }
 
     if (bailStatus) {
       // A tap short-circuited the iteration. If it bailed with a successful status (e.g. the
@@ -929,21 +958,20 @@ export class OperationGraph implements IOperationGraph {
       });
     }
 
-    const recordsToClose: OperationExecutionRecord[] = [];
-    for (const record of executionRecords.values()) {
-      if (!record.shouldRunnerPersist) {
-        recordsToClose.push(record);
-      }
-    }
     function reportRunnerCleanupFailure(record: OperationExecutionRecord, error: Error): void {
       record.error = error;
       record.status = OperationStatus.Failure;
       _reportOperationErrorIfAny(record);
       state.hasAnyFailures = true;
     }
-    if (recordsToClose.length > 0) {
+    async function closeRunnersAndReportFailuresAsync(
+      recordsToClose: readonly OperationExecutionRecord[]
+    ): Promise<void> {
+      if (recordsToClose.length === 0) {
+        return;
+      }
       try {
-        await this.closeRunnersAsync(recordsToClose.map((record) => record.operation));
+        await graph.closeRunnersAsync(recordsToClose.map((record) => record.operation));
       } catch (e) {
         if (e instanceof AggregateError) {
           for (const error of e.errors) {
@@ -961,7 +989,17 @@ export class OperationGraph implements IOperationGraph {
         }
       }
     }
+    const incompleteRecordsToClose: OperationExecutionRecord[] = [];
     for (const record of executionRecords.values()) {
+      if (!record.shouldRunnerPersist && !record.isOperationCompleted) {
+        incompleteRecordsToClose.push(record);
+      }
+    }
+    await closeRunnersAndReportFailuresAsync(incompleteRecordsToClose);
+    for (const record of executionRecords.values()) {
+      if (!record.isOperationCompleted) {
+        record.finalizeOperation();
+      }
       record.stdioSummarizer.close();
       record.problemCollector.close();
     }
@@ -1119,6 +1157,9 @@ export class OperationGraph implements IOperationGraph {
           _reportOperationErrorIfAny(record);
           record.error = e;
           record.status = OperationStatus.Failure;
+        }
+        if (!record.shouldRunnerPersist) {
+          await closeRunnersAndReportFailuresAsync([record]);
         }
         _onOperationComplete(record, state);
       }

--- a/libraries/rush-lib/src/logic/operations/ReporterOperationEventSink.ts
+++ b/libraries/rush-lib/src/logic/operations/ReporterOperationEventSink.ts
@@ -5,14 +5,16 @@ import {
   createRushDiagnostic,
   type IRushDiagnostic,
   type LifecycleEmitter,
+  type OperationStreamEmitter,
   type OperationStatus as ReporterOperationStatus
 } from '@rushstack/rush-reporter';
-import type { ITerminalChunk } from '@rushstack/terminal';
+import { TerminalChunkKind, type ITerminalChunk } from '@rushstack/terminal';
 
 import type { RushSession } from '../../pluginFramework/RushSession';
 import {
   _correlateRushSessionError,
-  _getRushSessionLifecycleEmitter
+  _getRushSessionLifecycleEmitter,
+  _getRushSessionOperationStreamEmitter
 } from '../../pluginFramework/RushSession';
 import type { IOperationExecutionResult } from './IOperationExecutionResult';
 import type { IOperationGraphEventSink, IOperationActivityOptions } from './OperationEventSink';
@@ -26,18 +28,30 @@ interface IReporterOperation {
   readonly operationId: string;
   readonly phaseName: string;
   readonly projectName: string;
+  readonly streamEmitter: OperationStreamEmitter | undefined;
   registrationCycle: IReporterOperationCycle | undefined;
 }
 
 interface IReporterOperationCycle {
   readonly registeredOperationIds: Set<string>;
   readonly statuses: Map<string, OperationStatus>;
+  readonly closedOperationIds: Set<string>;
+  readonly completedResults: Map<string, IOperationExecutionResult>;
   diagnosed: boolean;
   lastEmittedStatus: ReporterOperationStatus | undefined;
   silent: boolean;
+  streamClosed: boolean;
 }
 
 class ReporterOperationEventSink implements IOperationGraphEventSink {
+  public readonly onOperationChunk:
+    | ((operationId: string, chunk: ITerminalChunk, result?: IOperationExecutionResult) => void)
+    | undefined;
+  public readonly onOperationStreamClosed:
+    | ((operationId: string, result?: IOperationExecutionResult) => void)
+    | undefined;
+  public readonly onOperationCompleted: ((result: IOperationExecutionResult) => void) | undefined;
+
   private readonly _operationsByLegacyId: Map<string, IReporterOperation> = new Map();
   private readonly _cyclesByResult: WeakMap<IOperationExecutionResult, IReporterOperationCycle> =
     new WeakMap();
@@ -62,18 +76,40 @@ class ReporterOperationEventSink implements IOperationGraphEventSink {
         if (!emitter) {
           continue;
         }
+        const streamEmitter: OperationStreamEmitter | undefined = _getRushSessionOperationStreamEmitter(
+          rushSession,
+          {
+            commandName,
+            operationId,
+            projectName,
+            phaseName
+          }
+        );
         reporterOperation = {
           emitter,
           legacyOperationIds: new Set(),
           operationId,
           phaseName,
           projectName,
+          streamEmitter,
           registrationCycle: undefined
         };
         operationsByReporterId.set(operationId, reporterOperation);
       }
       reporterOperation.legacyOperationIds.add(operation.name);
       this._operationsByLegacyId.set(operation.name, reporterOperation);
+    }
+
+    if (Array.from(this._operationsByLegacyId.values()).some(({ streamEmitter }) => !!streamEmitter)) {
+      this.onOperationChunk = (operationId, chunk, result) =>
+        this._onOperationChunk(operationId, chunk, result);
+      this.onOperationStreamClosed = (operationId, result) =>
+        this._onOperationStreamClosed(operationId, result);
+      this.onOperationCompleted = (result) => this._onOperationCompleted(result);
+    } else {
+      this.onOperationChunk = undefined;
+      this.onOperationStreamClosed = undefined;
+      this.onOperationCompleted = undefined;
     }
   }
 
@@ -96,9 +132,12 @@ class ReporterOperationEventSink implements IOperationGraphEventSink {
       cycle = {
         registeredOperationIds: new Set(),
         statuses: new Map(),
+        closedOperationIds: new Set(),
+        completedResults: new Map(),
         diagnosed: false,
         lastEmittedStatus: undefined,
-        silent: true
+        silent: true,
+        streamClosed: false
       };
       operation.registrationCycle = cycle;
     }
@@ -106,18 +145,27 @@ class ReporterOperationEventSink implements IOperationGraphEventSink {
     this._cyclesByResult.set(result, cycle);
     cycle.registeredOperationIds.add(operationId);
     cycle.silent &&= silent;
-    if (cycle.registeredOperationIds.size !== operation.legacyOperationIds.size || cycle.silent) {
+    if (cycle.registeredOperationIds.size !== operation.legacyOperationIds.size) {
       return;
     }
 
-    operation.emitter.emitOperationRegistered({
-      operationId: operation.operationId,
-      projectName: operation.projectName,
-      phaseName: operation.phaseName
-    });
+    if (operation.streamEmitter) {
+      operation.streamEmitter.registerOperation(
+        operation.operationId,
+        operation.projectName,
+        operation.phaseName,
+        cycle.silent
+      );
+    } else if (!cycle.silent) {
+      operation.emitter.emitOperationRegistered({
+        operationId: operation.operationId,
+        projectName: operation.projectName,
+        phaseName: operation.phaseName
+      });
+    }
   }
 
-  public onOperationStatusChanged(result: IOperationExecutionResult): void {
+  public onOperationStatusChanged(result: IOperationExecutionResult, previousStatus: OperationStatus): void {
     const operation: IReporterOperation | undefined = this._operationsByLegacyId.get(result.operation.name);
     if (!operation) {
       return;
@@ -152,12 +200,22 @@ class ReporterOperationEventSink implements IOperationGraphEventSink {
     if (status === undefined || status === cycle.lastEmittedStatus) {
       return;
     }
+    const aggregatePreviousStatus: ReporterOperationStatus | undefined =
+      cycle.lastEmittedStatus ??
+      (operation.legacyOperationIds.size === 1 ? _toReporterStatus(previousStatus) : undefined);
     cycle.lastEmittedStatus = status;
-    if (!cycle.silent) {
-      const durationMs: number | undefined =
-        operation.legacyOperationIds.size === 1 && result.stopwatch.startTime !== undefined
-          ? result.stopwatch.duration * 1000
-          : undefined;
+    const durationMs: number | undefined =
+      operation.legacyOperationIds.size === 1 && result.stopwatch.startTime !== undefined
+        ? result.stopwatch.duration * 1000
+        : undefined;
+    if (operation.streamEmitter) {
+      operation.streamEmitter.changeStatus(
+        operation.operationId,
+        status,
+        durationMs,
+        aggregatePreviousStatus
+      );
+    } else if (!cycle.silent) {
       operation.emitter.emitOperationStatusChanged({
         operationId: operation.operationId,
         status,
@@ -165,11 +223,67 @@ class ReporterOperationEventSink implements IOperationGraphEventSink {
       });
     }
   }
+
+  private _onOperationChunk(
+    operationId: string,
+    chunk: ITerminalChunk,
+    result?: IOperationExecutionResult
+  ): void {
+    const operation: IReporterOperation | undefined = this._operationsByLegacyId.get(operationId);
+    if (!operation?.streamEmitter || !result || !this._cyclesByResult.has(result)) {
+      return;
+    }
+
+    if (chunk.kind === TerminalChunkKind.Stdout) {
+      operation.streamEmitter.writeOutput(operation.operationId, 'stdout', chunk.text);
+    } else if (chunk.kind === TerminalChunkKind.Stderr) {
+      operation.streamEmitter.writeOutput(operation.operationId, 'stderr', chunk.text);
+    }
+  }
+
+  private _onOperationStreamClosed(operationId: string, result?: IOperationExecutionResult): void {
+    const operation: IReporterOperation | undefined = this._operationsByLegacyId.get(operationId);
+    const cycle: IReporterOperationCycle | undefined = result ? this._cyclesByResult.get(result) : undefined;
+    if (!operation?.streamEmitter || !cycle || cycle.streamClosed) {
+      return;
+    }
+    cycle.closedOperationIds.add(operationId);
+    if (cycle.closedOperationIds.size === operation.legacyOperationIds.size) {
+      cycle.streamClosed = true;
+      operation.streamEmitter.closeOperationStream(operation.operationId);
+    }
+  }
+
+  private _onOperationCompleted(result: IOperationExecutionResult): void {
+    const operation: IReporterOperation | undefined = this._operationsByLegacyId.get(result.operation.name);
+    if (!operation?.streamEmitter) {
+      return;
+    }
+    const cycle: IReporterOperationCycle | undefined = this._cyclesByResult.get(result);
+    if (!cycle) {
+      return;
+    }
+
+    cycle.completedResults.set(result.operation.name, result);
+    if (cycle.completedResults.size !== operation.legacyOperationIds.size) {
+      return;
+    }
+    const status: ReporterOperationStatus = _getAggregateTerminalStatus(
+      Array.from(cycle.completedResults.values(), ({ status: resultStatus }) => resultStatus)
+    );
+    const durationMs: number | undefined = _getAggregateDurationMs(cycle.completedResults);
+    operation.streamEmitter.completeOperation(operation.operationId, status, durationMs);
+  }
 }
 
 class CompositeOperationGraphEventSink implements IOperationGraphEventSink {
-  public readonly onOperationChunk: ((operationId: string, chunk: ITerminalChunk) => void) | undefined;
-  public readonly onOperationStreamClosed: ((operationId: string) => void) | undefined;
+  public readonly onOperationChunk:
+    | ((operationId: string, chunk: ITerminalChunk, result?: IOperationExecutionResult) => void)
+    | undefined;
+  public readonly onOperationStreamClosed:
+    | ((operationId: string, result?: IOperationExecutionResult) => void)
+    | undefined;
+  public readonly onOperationCompleted: ((result: IOperationExecutionResult) => void) | undefined;
 
   private readonly _first: IOperationGraphEventSink;
   private readonly _second: IOperationGraphEventSink;
@@ -179,16 +293,23 @@ class CompositeOperationGraphEventSink implements IOperationGraphEventSink {
     this._second = second;
     this.onOperationChunk =
       first.onOperationChunk || second.onOperationChunk
-        ? (operationId, chunk) => {
-            first.onOperationChunk?.(operationId, chunk);
-            second.onOperationChunk?.(operationId, chunk);
+        ? (operationId, chunk, result) => {
+            first.onOperationChunk?.(operationId, chunk, result);
+            second.onOperationChunk?.(operationId, chunk, result);
           }
         : undefined;
     this.onOperationStreamClosed =
       first.onOperationStreamClosed || second.onOperationStreamClosed
-        ? (operationId) => {
-            first.onOperationStreamClosed?.(operationId);
-            second.onOperationStreamClosed?.(operationId);
+        ? (operationId, result) => {
+            first.onOperationStreamClosed?.(operationId, result);
+            second.onOperationStreamClosed?.(operationId, result);
+          }
+        : undefined;
+    this.onOperationCompleted =
+      first.onOperationCompleted || second.onOperationCompleted
+        ? (result) => {
+            first.onOperationCompleted?.(result);
+            second.onOperationCompleted?.(result);
           }
         : undefined;
   }
@@ -219,7 +340,7 @@ class CompositeOperationGraphEventSink implements IOperationGraphEventSink {
 }
 
 /**
- * Adds status-only reporter emission without changing the graph's visible output or raw chunk routing.
+ * Adds reporter emission without changing the graph's visible output or collator routing.
  *
  * @internal
  */
@@ -333,4 +454,31 @@ function _isTerminalStatus(status: OperationStatus): boolean {
     default:
       return false;
   }
+}
+
+function _getAggregateDurationMs(
+  results: ReadonlyMap<string, IOperationExecutionResult>
+): number | undefined {
+  let startTime: number | undefined;
+  let endTime: number | undefined;
+  for (const result of results.values()) {
+    if (result.stopwatch.startTime !== undefined) {
+      startTime =
+        startTime === undefined
+          ? result.stopwatch.startTime
+          : Math.min(startTime, result.stopwatch.startTime);
+    }
+    if (result.stopwatch.endTime !== undefined) {
+      endTime =
+        endTime === undefined ? result.stopwatch.endTime : Math.max(endTime, result.stopwatch.endTime);
+    }
+  }
+  if (startTime !== undefined && endTime !== undefined) {
+    return Math.max(0, endTime - startTime);
+  }
+  if (results.size === 1) {
+    const result: IOperationExecutionResult | undefined = results.values().next().value;
+    return result?.stopwatch.startTime === undefined ? undefined : result.stopwatch.duration * 1000;
+  }
+  return undefined;
 }

--- a/libraries/rush-lib/src/logic/operations/test/OperationGraphEventSink.test.ts
+++ b/libraries/rush-lib/src/logic/operations/test/OperationGraphEventSink.test.ts
@@ -35,7 +35,12 @@ jest.mock('../ProjectLogWritable', () => {
 });
 
 import type { IReporterEmitEventInput, IReporterEventSink } from '@rushstack/rush-reporter';
-import { MockWritable, StringBufferTerminalProvider, type ITerminalChunk } from '@rushstack/terminal';
+import {
+  MockWritable,
+  StringBufferTerminalProvider,
+  TerminalProviderSeverity,
+  type ITerminalChunk
+} from '@rushstack/terminal';
 import type { CollatedTerminal } from '@rushstack/stream-collator';
 
 import type { IPhase } from '../../../api/CommandLineConfiguration';
@@ -85,6 +90,8 @@ class RecordingSink implements IOperationGraphEventSink {
   public readonly headers: [string, number, number][] = [];
   public readonly activities: string[] = [];
   public readonly chunks: Map<string, string[]> = new Map();
+  public readonly closed: string[] = [];
+  public readonly completed: [string, string][] = [];
 
   public onOperationRegistered(operationId: string, silent: boolean): void {
     this.registered.push([operationId, silent]);
@@ -105,6 +112,12 @@ class RecordingSink implements IOperationGraphEventSink {
       this.chunks.set(operationId, chunks);
     }
     chunks.push(chunk.text);
+  }
+  public onOperationStreamClosed(operationId: string): void {
+    this.closed.push(operationId);
+  }
+  public onOperationCompleted(result: IOperationExecutionResult): void {
+    this.completed.push([result.operation.name, result.status]);
   }
 }
 
@@ -167,6 +180,11 @@ describe('OperationGraph event sink (dual-emit)', () => {
     expect(sink.activities.some((line: string) => line.includes('"alpha" completed successfully'))).toBe(
       true
     );
+    expect([...sink.closed].sort()).toEqual(['alpha', 'beta']);
+    expect([...sink.completed].sort()).toEqual([
+      ['alpha', OperationStatus.Success],
+      ['beta', OperationStatus.Success]
+    ]);
   });
 
   it('emits raw per-operation chunks even in quiet mode, matching the collated stream', async () => {
@@ -206,6 +224,73 @@ describe('OperationGraph event sink (dual-emit)', () => {
     expect(mockWritable.getAllOutput()).not.toContain('quiet-hidden-stdout');
   });
 
+  it('emits terminal events before a dependent operation starts', async () => {
+    const sink: RecordingSink = new RecordingSink();
+    const first: Operation = createOperation(
+      'first',
+      new MockOperationRunner('first', async () => OperationStatus.Success)
+    );
+    let firstWasFinalized: boolean = false;
+    const second: Operation = createOperation(
+      'second',
+      new MockOperationRunner('second', async () => {
+        firstWasFinalized =
+          sink.closed.filter((name) => name === 'first').length === 1 &&
+          sink.completed.filter(([name]) => name === 'first').length === 1;
+        return OperationStatus.Success;
+      })
+    );
+    second.addDependency(first);
+    const graph: OperationGraph = new OperationGraph(
+      new Set([first, second]),
+      createGraphOptions(mockWritable, false)
+    );
+    graph.eventSink = sink;
+
+    await graph.executeAsync({});
+
+    expect(firstWasFinalized).toBe(true);
+    expect(sink.closed).toEqual(['first', 'second']);
+    expect(sink.completed).toEqual([
+      ['first', OperationStatus.Success],
+      ['second', OperationStatus.Success]
+    ]);
+  });
+
+  it('emits the runner cleanup failure as the single authoritative completion', async () => {
+    const sink: RecordingSink = new RecordingSink();
+    const runner: IOperationRunner = {
+      name: 'cleanup failure',
+      reportTiming: true,
+      silent: false,
+      cacheable: false,
+      warningsAreAllowed: false,
+      isNoOp: false,
+      executeAsync: async () => OperationStatus.Success,
+      closeAsync: async () => {
+        throw new Error('cleanup failed');
+      },
+      getConfigHash: () => 'cleanup-failure'
+    };
+    const operation: Operation = createOperation('cleanup failure', runner);
+    const graph: OperationGraph = new OperationGraph(
+      new Set([operation]),
+      createGraphOptions(mockWritable, false)
+    );
+    graph.eventSink = sink;
+    graph.hooks.configureIteration.tap('test', (records) => {
+      for (const record of records.values()) {
+        record.shouldRunnerPersist = false;
+      }
+    });
+
+    const result = await graph.executeAsync({});
+
+    expect(result.status).toBe(OperationStatus.Failure);
+    expect(sink.closed).toEqual(['cleanup failure']);
+    expect(sink.completed).toEqual([['cleanup failure', OperationStatus.Failure]]);
+  });
+
   it('leaves terminal output byte-identical whether or not a sink is attached', async () => {
     const makeRunner: () => MockOperationRunner = () =>
       new MockOperationRunner('echo', async (terminal: CollatedTerminal) => {
@@ -235,7 +320,11 @@ describe('OperationGraph event sink (dual-emit)', () => {
     const rushSession: RushSession = new RushSession({
       terminalProvider: new StringBufferTerminalProvider(),
       getIsDebugMode: () => false,
-      reporter: { eventSink: reporterSink, sessionId: 'operation-shadow' }
+      reporter: {
+        eventSink: reporterSink,
+        sessionId: 'operation-shadow',
+        operationStreamEnabled: false
+      }
     });
     const createFailingOperation = (): Operation =>
       createOperation(
@@ -277,6 +366,251 @@ describe('OperationGraph event sink (dual-emit)', () => {
     );
     expect(reporterSink.inputs.some(({ type }) => type === 'externalOutput')).toBe(false);
     expect(mockWritable.getAllOutput()).toEqual(plainWritable.getAllOutput());
+  });
+
+  it('emits the opted-in canonical stream without duplicating or losing operation chunks', async () => {
+    const stdoutText: string = `${'a'.repeat(64 * 1024 + 7)}\rprogress`;
+    const stderrText: string = 'stderr detail\r';
+    const createOutputRunner = (): IOperationRunner => ({
+      name: '@scope/project (_phase:build)',
+      reportTiming: true,
+      silent: false,
+      cacheable: false,
+      warningsAreAllowed: true,
+      isNoOp: false,
+      executeAsync: async (context: IOperationRunnerContext) =>
+        await context.runWithTerminalAsync(
+          async (terminal, terminalProvider) => {
+            void terminal;
+            terminalProvider.write(stdoutText, TerminalProviderSeverity.log);
+            terminalProvider.write(stderrText, TerminalProviderSeverity.error);
+            return OperationStatus.SuccessWithWarning;
+          },
+          { createLogFile: false, logFileSuffix: '' }
+        ),
+      getConfigHash: () => 'mock'
+    });
+
+    const plainWritable: MockWritable = new MockWritable();
+    await new OperationGraph(
+      new Set([createOperation('@scope/project', createOutputRunner(), mockPhase, '@scope/project')]),
+      createGraphOptions(plainWritable, false)
+    ).executeAsync({});
+
+    const reporterSink: CapturingReporterSink = new CapturingReporterSink();
+    const rushSession: RushSession = new RushSession({
+      terminalProvider: new StringBufferTerminalProvider(),
+      getIsDebugMode: () => false,
+      reporter: {
+        eventSink: reporterSink,
+        sessionId: 'operation-stream',
+        operationStreamEnabled: true
+      }
+    });
+    const streamedWritable: MockWritable = new MockWritable();
+    const graph: OperationGraph = new OperationGraph(
+      new Set([createOperation('@scope/project', createOutputRunner(), mockPhase, '@scope/project')]),
+      createGraphOptions(streamedWritable, false)
+    );
+
+    attachReporterOperationEventSink(graph, rushSession, 'build');
+    await graph.executeAsync({});
+
+    expect(streamedWritable.getAllOutput()).toEqual(plainWritable.getAllOutput());
+
+    const operationEvents: IReporterEmitEventInput<unknown>[] = reporterSink.inputs.filter(
+      ({ scope }) => scope?.operationId === '@scope/project#phase'
+    );
+    expect(operationEvents[0]).toMatchObject({
+      type: 'operationRegistered',
+      payload: {
+        operationId: '@scope/project#phase',
+        projectName: '@scope/project',
+        phaseName: 'phase',
+        silent: false
+      }
+    });
+
+    const statusEvents: IReporterEmitEventInput<unknown>[] = operationEvents.filter(
+      ({ type }) => type === 'operationStatusChanged'
+    );
+    expect(statusEvents.map(({ payload }) => payload)).toEqual([
+      expect.objectContaining({ previousStatus: 'ready', status: 'queued' }),
+      expect.objectContaining({ previousStatus: 'queued', status: 'executing' }),
+      expect.objectContaining({ previousStatus: 'executing', status: 'successWithWarnings' })
+    ]);
+
+    const outputEvents: IReporterEmitEventInput<unknown>[] = operationEvents.filter(
+      ({ type }) => type === 'externalOutput'
+    );
+    expect(
+      outputEvents.every(
+        ({ payload }) => Buffer.byteLength((payload as { text: string }).text, 'utf8') <= 64 * 1024
+      )
+    ).toBe(true);
+    const stdoutChunks: string = outputEvents
+      .filter(({ payload }) => (payload as { stream: string }).stream === 'stdout')
+      .map(({ payload }) => (payload as { text: string }).text)
+      .join('');
+    const stderrChunks: string = outputEvents
+      .filter(({ payload }) => (payload as { stream: string }).stream === 'stderr')
+      .map(({ payload }) => (payload as { text: string }).text)
+      .join('');
+    expect(stdoutChunks).toBe(stdoutText);
+    expect(stderrChunks).toBe(stderrText);
+
+    const closedIndex: number = operationEvents.findIndex(({ type }) => type === 'operationStreamClosed');
+    const completedIndex: number = operationEvents.findIndex(({ type }) => type === 'operationCompleted');
+    expect(closedIndex).toBeGreaterThan(operationEvents.lastIndexOf(outputEvents.at(-1)!));
+    expect(completedIndex).toBeGreaterThan(closedIndex);
+    expect(operationEvents[completedIndex].payload).toMatchObject({
+      operationId: '@scope/project#phase',
+      status: 'successWithWarnings'
+    });
+  });
+
+  it('does not register operations when scheduling hooks reject the iteration', async () => {
+    const sink: RecordingSink = new RecordingSink();
+    const graph: OperationGraph = new OperationGraph(
+      new Set([createOperation('hook failure', new MockOperationRunner('hook failure'))]),
+      createGraphOptions(mockWritable, false)
+    );
+    graph.eventSink = sink;
+    graph.hooks.onIterationScheduled.tap('test', () => {
+      throw new Error('schedule rejected');
+    });
+
+    await expect(graph.executeAsync({})).rejects.toThrow('schedule rejected');
+    expect(sink.registered).toEqual([]);
+    expect(sink.closed).toEqual([]);
+    expect(sink.completed).toEqual([]);
+  });
+
+  it('finalizes registered operations when the pre-execution hook rejects', async () => {
+    const sink: RecordingSink = new RecordingSink();
+    const graph: OperationGraph = new OperationGraph(
+      new Set([createOperation('hook failure', new MockOperationRunner('hook failure'))]),
+      createGraphOptions(mockWritable, false)
+    );
+    graph.eventSink = sink;
+    graph.hooks.beforeExecuteIterationAsync.tapPromise('test', async () => {
+      throw new Error('pre-execution rejected');
+    });
+
+    await expect(graph.executeAsync({})).rejects.toThrow('pre-execution rejected');
+    expect(sink.registered).toEqual([['hook failure', false]]);
+    expect(sink.closed).toEqual(['hook failure']);
+    expect(sink.completed).toEqual([['hook failure', OperationStatus.Aborted]]);
+  });
+
+  it('reports silent operation metadata and outcomes on the opted-in stream', async () => {
+    const silentRunner: IOperationRunner = {
+      name: 'silent synthetic',
+      reportTiming: false,
+      silent: true,
+      cacheable: false,
+      warningsAreAllowed: false,
+      isNoOp: false,
+      executeAsync: async () => OperationStatus.Success,
+      getConfigHash: () => 'silent'
+    };
+    const reporterSink: CapturingReporterSink = new CapturingReporterSink();
+    const rushSession: RushSession = new RushSession({
+      terminalProvider: new StringBufferTerminalProvider(),
+      getIsDebugMode: () => false,
+      reporter: {
+        eventSink: reporterSink,
+        sessionId: 'silent-operation',
+        operationStreamEnabled: true
+      }
+    });
+    const graph: OperationGraph = new OperationGraph(
+      new Set([
+        createOperation('visible', new MockOperationRunner('visible'), mockPhase, '@scope/visible'),
+        createOperation('silent synthetic', silentRunner, mockPhase, '@scope/project')
+      ]),
+      createGraphOptions(mockWritable, false)
+    );
+
+    attachReporterOperationEventSink(graph, rushSession, 'build');
+    await graph.executeAsync({});
+
+    expect(reporterSink.inputs).toContainEqual(
+      expect.objectContaining({
+        type: 'operationRegistered',
+        payload: expect.objectContaining({
+          operationId: '@scope/project#phase',
+          silent: true
+        })
+      })
+    );
+    expect(reporterSink.inputs).toContainEqual(
+      expect.objectContaining({
+        type: 'operationCompleted',
+        payload: expect.objectContaining({
+          operationId: '@scope/project#phase',
+          status: 'success'
+        })
+      })
+    );
+  });
+
+  it('finalizes every registered operation for an all-silent iteration', async () => {
+    const silentRunner: IOperationRunner = {
+      name: 'silent only',
+      reportTiming: false,
+      silent: true,
+      cacheable: false,
+      warningsAreAllowed: false,
+      isNoOp: false,
+      executeAsync: async () => OperationStatus.Success,
+      getConfigHash: () => 'silent-only'
+    };
+    const reporterSink: CapturingReporterSink = new CapturingReporterSink();
+    const rushSession: RushSession = new RushSession({
+      terminalProvider: new StringBufferTerminalProvider(),
+      getIsDebugMode: () => false,
+      reporter: {
+        eventSink: reporterSink,
+        sessionId: 'silent-only',
+        operationStreamEnabled: true
+      }
+    });
+    const graph: OperationGraph = new OperationGraph(
+      new Set([createOperation('silent only', silentRunner, mockPhase, '@scope/silent')]),
+      createGraphOptions(mockWritable, false)
+    );
+    attachReporterOperationEventSink(graph, rushSession, 'build');
+
+    await graph.executeAsync({});
+    await graph.executeAsync({});
+
+    const operationEvents: IReporterEmitEventInput<unknown>[] = reporterSink.inputs.filter(
+      ({ scope }) => scope?.operationId === '@scope/silent#phase'
+    );
+    expect(operationEvents.filter(({ type }) => type === 'operationRegistered')).toHaveLength(2);
+    expect(operationEvents.filter(({ type }) => type === 'operationStreamClosed')).toHaveLength(2);
+    expect(operationEvents.filter(({ type }) => type === 'operationCompleted')).toHaveLength(2);
+    expect(
+      operationEvents
+        .filter(({ type }) => type === 'operationCompleted')
+        .map(({ payload }) => (payload as { status: string }).status)
+    ).toEqual(['noOp', 'noOp']);
+  });
+
+  it('does not attach an operation adapter when the session has no reporter sink', () => {
+    const rushSession: RushSession = new RushSession({
+      terminalProvider: new StringBufferTerminalProvider(),
+      getIsDebugMode: () => false
+    });
+    const graph: OperationGraph = new OperationGraph(
+      new Set([createOperation('no sink', new MockOperationRunner('no sink'))]),
+      createGraphOptions(mockWritable, false)
+    );
+
+    attachReporterOperationEventSink(graph, rushSession, 'build');
+
+    expect(graph.eventSink).toBeUndefined();
   });
 
   it('aggregates sharded records across mixed outcomes and repeated watch-style iterations', async () => {
@@ -486,7 +820,11 @@ describe('OperationGraph event sink (dual-emit)', () => {
     const rushSession: RushSession = new RushSession({
       terminalProvider: new StringBufferTerminalProvider(),
       getIsDebugMode: () => false,
-      reporter: { eventSink: reporterSink, sessionId: 'operation-retries' }
+      reporter: {
+        eventSink: reporterSink,
+        sessionId: 'operation-retries',
+        operationStreamEnabled: true
+      }
     });
     const compilePhase: IPhase = {
       ...mockPhase,
@@ -530,6 +868,17 @@ describe('OperationGraph event sink (dual-emit)', () => {
       '@scope/project#_phase:compile',
       '@scope/project#_phase:test'
     ]);
+    expect(
+      reporterSink.inputs
+        .filter(({ type }) => type === 'operationCompleted')
+        .map(({ scope }) => scope?.operationId)
+        .sort()
+    ).toEqual([
+      '@scope/project#_phase:compile',
+      '@scope/project#_phase:compile',
+      '@scope/project#_phase:test',
+      '@scope/project#_phase:test'
+    ]);
     for (const event of reporterSink.inputs.filter(({ type }) => type === 'operationStatusChanged')) {
       expect(event.scope?.operationId).toBe(`@scope/project#${event.scope?.phaseName}`);
       expect((event.payload as { operationId: string }).operationId).toBe(event.scope?.operationId);
@@ -554,7 +903,11 @@ describe('OperationGraph event sink (dual-emit)', () => {
     const rushSession: RushSession = new RushSession({
       terminalProvider: new StringBufferTerminalProvider(),
       getIsDebugMode: () => false,
-      reporter: { eventSink: reporterSink, sessionId: 'output-parity' }
+      reporter: {
+        eventSink: reporterSink,
+        sessionId: 'output-parity',
+        operationStreamEnabled: false
+      }
     });
     const shadowWritable: MockWritable = new MockWritable();
     const shadowGraph: OperationGraph = new OperationGraph(
@@ -562,6 +915,7 @@ describe('OperationGraph event sink (dual-emit)', () => {
       createGraphOptions(shadowWritable, false)
     );
     attachReporterOperationEventSink(shadowGraph, rushSession, 'build');
+    expect(shadowGraph.eventSink?.onOperationChunk).toBeUndefined();
     await shadowGraph.executeAsync({});
     expect(shadowWritable.getAllOutput()).toEqual(plainWritable.getAllOutput());
     expect(reporterSink.inputs.some(({ type }) => type === 'externalOutput')).toBe(false);

--- a/libraries/rush-lib/src/pluginFramework/RushSession.ts
+++ b/libraries/rush-lib/src/pluginFramework/RushSession.ts
@@ -5,6 +5,7 @@ import { InternalError, PackageJsonLookup, type IPackageJson } from '@rushstack/
 import {
   LifecycleEmitter,
   LegacyErrorBridge,
+  OperationStreamEmitter,
   RushSessionReporting,
   TelemetrySubscriber,
   isReporterEventRequired,
@@ -49,6 +50,17 @@ export interface IRushSessionReporterOptions {
    * The identifier assigned to this Rush session by the frontend.
    */
   readonly sessionId: string;
+
+  /**
+   * Enables raw semantic operation events for the pre-major reporter opt-in path.
+   *
+   * @remarks
+   * When false or omitted, Rush retains the shadow lifecycle-only behavior and
+   * does not tap operation output.
+   *
+   * @internal
+   */
+  readonly operationStreamEnabled?: boolean;
 }
 
 /**
@@ -293,6 +305,22 @@ function _createLifecycleEmitter(
   });
 }
 
+function _createOperationStreamEmitter(
+  state: IRushSessionReportingState | undefined,
+  scope?: IReporterEventScope
+): OperationStreamEmitter | undefined {
+  if (!state) {
+    return undefined;
+  }
+
+  return new OperationStreamEmitter({
+    sink: state.eventSink,
+    sessionId: state.sessionId,
+    source: state.source,
+    scope: scope ? { ...scope } : undefined
+  });
+}
+
 function _getSessionState(rushSession: RushSession): IRushSessionState {
   const state: IRushSessionState | undefined = _rushSessionStates.get(rushSession);
   if (!state) {
@@ -449,6 +477,21 @@ export function _getRushSessionLifecycleEmitter(
   scope?: IReporterEventScope
 ): LifecycleEmitter | undefined {
   return _createLifecycleEmitter(_getSessionState(rushSession).reporting, scope);
+}
+
+/**
+ * Creates the raw operation stream emitter only for the pre-major opt-in path.
+ *
+ * @internal
+ */
+export function _getRushSessionOperationStreamEmitter(
+  rushSession: RushSession,
+  scope?: IReporterEventScope
+): OperationStreamEmitter | undefined {
+  const state: IRushSessionState = _getSessionState(rushSession);
+  return state.options.reporter?.operationStreamEnabled
+    ? _createOperationStreamEmitter(state.reporting, scope)
+    : undefined;
 }
 
 /**


### PR DESCRIPTION
Part of #5978

## Stack

Parent: #5992 (`copilot/reporter-r3c-shadow-parity`)

```text
#5985 -> #5986 -> #5987 -> #5989 -> #5988 -> #5991 -> #5992 -> this PR
```

R6 #5993 remains a parallel fork from #5989 and is not included here. Keep auto-merge disabled while stack ancestors are open.

## Architecture

- pass the frontend-owned reporter sink, session identity, and operation-stream opt-in to the selected Rush engine without exposing reporter instances or selection state
- adapt the existing phase-aware `OperationGraph.eventSink` and `OperationExecutionRecord` hooks into the existing `OperationStreamEmitter`; scheduling and operation identity remain project x phase
- emit registration (including silent metadata), previous/current status transitions, bounded ordered stdout/stderr chunks, authoritative stream close, and final operation outcome
- retain the existing parser-owned aggregate `commandResult` hook instead of emitting a competing result path
- bump the additive reporter protocol minor and update the beta API reviews/changefiles

## Flag-off and presentation guarantee

When the reporter opt-in is disabled, the adapter does not expose a raw chunk callback, so `OperationChunkTap` is not installed. The existing `StreamCollator`, problem-matcher, stdout, and stderr pipeline remains byte-identical and authoritative.

When opted in, raw events flow to the manager, full-log file reporter, and explicit output sinks. The primary terminal reporter temporarily filters operation registration/status/output/close/completion events, so this slice cannot duplicate or suppress operation output while legacy collation still owns presentation.

## Validation

- `rush test --only @rushstack/rush-reporter --only @microsoft/rush-lib --only @microsoft/rush --verbose` (6 operations; reporter 295 tests, rush-lib 766 tests, apps/rush 19 tests)
- `rush build --to @rushstack/rush-reporter --to @microsoft/rush-lib --to @microsoft/rush --verbose` (8 operations)
- `rush check`
- `rush change --verify --no-fetch`

Focused coverage includes event ordering, stdout/stderr separation, 64 KiB chunk boundaries, no duplicated/lost chunks, previous/current status and outcome mapping, phase-aware identity, repeated watch iteration identity, silent operations, no-sink behavior, disabled-tap behavior, and byte-identical flag-off output.

## R5B non-goals

- no compact spinner/activity/result UI
- no plaintext/AI/legacy rendering parity ownership
- no full-log demo fixture or documentation
- no disabling of the legacy terminal destination
- no removal of `StreamCollator` or duplicate-output cutover
