### PR TITLE
Add direct Rush reporter demo path

### DIFF
--- a/apps/rush/src/MinimalRushConfiguration.ts
+++ b/apps/rush/src/MinimalRushConfiguration.ts
@@ -3,10 +3,14 @@
 
 import * as path from 'node:path';
 
-import { FileSystem, JsonFile } from '@rushstack/node-core-library';
+import { FileSystem, JsonFile, PackageJsonLookup } from '@rushstack/node-core-library';
 import { RushConfiguration } from '@microsoft/rush-lib';
+import { EnvironmentConfiguration } from '@microsoft/rush-lib/lib/api/EnvironmentConfiguration';
 import { RushConstants } from '@microsoft/rush-lib/lib/logic/RushConstants';
 import { RushCommandLineParser } from '@microsoft/rush-lib/lib/cli/RushCommandLineParser';
+import { isSupportedReporterName, type ReporterName } from '@rushstack/rush-reporter';
+
+import { getRushPreviewVersion } from './RushPreviewVersion';
 
 interface IMinimalRushConfigurationJson {
   rushMinimumVersion: string;
@@ -52,14 +56,37 @@ export class MinimalRushConfiguration {
   }
 
   public static loadFromDefaultLocation(): MinimalRushConfiguration | undefined {
+    const showVerbose: boolean = !RushCommandLineParser.shouldRestrictConsoleOutput();
     const rushJsonLocation: string | undefined = RushConfiguration.tryFindRushJsonLocation({
-      showVerbose: !RushCommandLineParser.shouldRestrictConsoleOutput()
+      showVerbose: false
     });
     if (rushJsonLocation) {
       const minimalRushConfigurationJson: IMinimalRushConfigurationJson | undefined =
         _loadConfigurationJson(rushJsonLocation);
       if (minimalRushConfigurationJson) {
-        return new MinimalRushConfiguration(minimalRushConfigurationJson, rushJsonLocation);
+        const configuration: MinimalRushConfiguration = new MinimalRushConfiguration(
+          minimalRushConfigurationJson,
+          rushJsonLocation
+        );
+        const explicitReporter: ReporterName | undefined = _getExplicitReporter(process.argv.slice(2));
+        const currentPackageVersion: string = PackageJsonLookup.loadOwnPackageJson(__dirname).version;
+        const effectiveRushVersion: string = getRushPreviewVersion() ?? configuration.rushVersion;
+        const legacyFallbackRequested: boolean =
+          explicitReporter === 'legacy' ||
+          process.env.RUSH_REPORTER?.trim().toLowerCase() === 'legacy' ||
+          _hasHelpControl(process.argv.slice(2)) ||
+          effectiveRushVersion !== currentPackageVersion;
+        if (
+          showVerbose &&
+          (legacyFallbackRequested ||
+            (!configuration.useRushReporter &&
+              (explicitReporter === undefined || explicitReporter === 'legacy')))
+        ) {
+          // Preserve the legacy discovery message exactly when the reporter path is not taking ownership.
+          console.log('Found configuration in ' + rushJsonLocation);
+          console.log('');
+        }
+        return configuration;
       }
       return undefined;
     } else {
@@ -94,6 +121,53 @@ export class MinimalRushConfiguration {
   public get useRushReporter(): boolean {
     return this.#useRushReporter;
   }
+
+  /**
+   * The repository's common temp folder, used for invocation-scoped reporter logs.
+   */
+  public get commonTempFolder(): string {
+    return (
+      EnvironmentConfiguration._getRushTempFolderOverride(process.env) ??
+      path.resolve(this.#commonRushConfigFolder, '..', '..', 'temp')
+    );
+  }
+}
+
+function _getExplicitReporter(argv: readonly string[]): ReporterName | undefined {
+  for (let index: number = 0; index < argv.length; index++) {
+    const argument: string = argv[index];
+    if (argument === '--') {
+      break;
+    }
+    let value: string | undefined;
+    if (argument === '--reporter') {
+      const nextArgument: string | undefined = argv[index + 1];
+      if (!nextArgument || nextArgument.startsWith('-')) {
+        continue;
+      }
+      value = nextArgument;
+      index++;
+    } else if (argument.startsWith('--reporter=')) {
+      value = argument.slice('--reporter='.length);
+    }
+    if (value !== undefined) {
+      const normalizedValue: string = value.trim().toLowerCase();
+      return isSupportedReporterName(normalizedValue) ? normalizedValue : undefined;
+    }
+  }
+  return undefined;
+}
+
+function _hasHelpControl(argv: readonly string[]): boolean {
+  for (const argument of argv) {
+    if (argument === '--') {
+      return false;
+    }
+    if (argument === '--help' || argument === '-h') {
+      return true;
+    }
+  }
+  return false;
 }
 
 function _loadConfigurationJson(rushJsonFilename: string): IMinimalRushConfigurationJson | undefined {

--- a/apps/rush/src/MinimalRushConfiguration.ts
+++ b/apps/rush/src/MinimalRushConfiguration.ts
@@ -63,32 +63,28 @@ export class MinimalRushConfiguration {
     if (rushJsonLocation) {
       const minimalRushConfigurationJson: IMinimalRushConfigurationJson | undefined =
         _loadConfigurationJson(rushJsonLocation);
+      const explicitReporter: ReporterName | undefined = _getExplicitReporter(process.argv.slice(2));
+      const legacyFallbackRequested: boolean =
+        explicitReporter === 'legacy' ||
+        process.env.RUSH_REPORTER?.trim().toLowerCase() === 'legacy' ||
+        _hasHelpControl(process.argv.slice(2));
+      let configuration: MinimalRushConfiguration | undefined;
+      let legacyPresentation: boolean = legacyFallbackRequested || explicitReporter === undefined;
       if (minimalRushConfigurationJson) {
-        const configuration: MinimalRushConfiguration = new MinimalRushConfiguration(
-          minimalRushConfigurationJson,
-          rushJsonLocation
-        );
-        const explicitReporter: ReporterName | undefined = _getExplicitReporter(process.argv.slice(2));
+        configuration = new MinimalRushConfiguration(minimalRushConfigurationJson, rushJsonLocation);
         const currentPackageVersion: string = PackageJsonLookup.loadOwnPackageJson(__dirname).version;
         const effectiveRushVersion: string = getRushPreviewVersion() ?? configuration.rushVersion;
-        const legacyFallbackRequested: boolean =
-          explicitReporter === 'legacy' ||
-          process.env.RUSH_REPORTER?.trim().toLowerCase() === 'legacy' ||
-          _hasHelpControl(process.argv.slice(2)) ||
-          effectiveRushVersion !== currentPackageVersion;
-        if (
-          showVerbose &&
-          (legacyFallbackRequested ||
-            (!configuration.useRushReporter &&
-              (explicitReporter === undefined || explicitReporter === 'legacy')))
-        ) {
-          // Preserve the legacy discovery message exactly when the reporter path is not taking ownership.
-          console.log('Found configuration in ' + rushJsonLocation);
-          console.log('');
-        }
-        return configuration;
+        legacyPresentation =
+          legacyFallbackRequested ||
+          effectiveRushVersion !== currentPackageVersion ||
+          (!configuration.useRushReporter && explicitReporter === undefined);
       }
-      return undefined;
+      if (showVerbose && legacyPresentation) {
+        // Preserve discovery even when the full engine must report a configuration load error.
+        console.log('Found configuration in ' + rushJsonLocation);
+        console.log('');
+      }
+      return configuration;
     } else {
       return undefined;
     }

--- a/apps/rush/src/RushFrontend.ts
+++ b/apps/rush/src/RushFrontend.ts
@@ -4,7 +4,7 @@
 import { randomUUID } from 'node:crypto';
 
 import type { ILaunchOptions } from '@microsoft/rush-lib';
-import { DEFAULT_SIGNAL_FLUSH_TIMEOUT_MS } from '@rushstack/rush-reporter';
+import { DEFAULT_SIGNAL_FLUSH_TIMEOUT_MS, REPORTER_PROTOCOL_VERSION } from '@rushstack/rush-reporter';
 
 import {
   initializeRushReporterHostAsync,
@@ -139,10 +139,14 @@ export async function launchRushFrontendAsync(options: IRushFrontendOptions): Pr
     processLifecycle = createProcessLifecycle()
   } = options;
 
+  const engineArgv: string[] = stripReporterValueControls(process.argv.slice(2));
+  const actionName: string | undefined = engineArgv.find((argument: string) => !argument.startsWith('-'));
   const reporterHost: IInitializedRushReporterHost = await initializeReporterHostAsync({
     repositoryOptIn: configuration?.useRushReporter,
     forceLegacy: rushVersionToLoad !== undefined && rushVersionToLoad !== currentPackageVersion,
-    selectedRushVersion: rushVersionToLoad
+    selectedRushVersion: rushVersionToLoad,
+    commonTempFolder: actionName === 'purge' ? undefined : configuration?.commonTempFolder,
+    actionName
   });
   const reporterLifecycle: RushFrontendReporterLifecycle | undefined = reporterHost.selection.enabled
     ? new RushFrontendReporterLifecycle(reporterHost, processLifecycle)
@@ -153,10 +157,27 @@ export async function launchRushFrontendAsync(options: IRushFrontendOptions): Pr
       process.argv,
       new Set(reporterHost.selection.reporterValueFlagsToStrip)
     );
+    delete process.env.RUSH_REPORTER;
+    delete process.env.RUSH_LOG_LEVEL;
   }
   const reporterCloseAsync: () => Promise<void> = () =>
     reporterLifecycle?.closeAsync() ?? reporterHost.closeAsync();
   const sessionId: string = createSessionId();
+  if (reporterHost.selection.enabled && reporterHost.logArtifact?.path) {
+    reporterHost.sink.emit({
+      protocolVersion: REPORTER_PROTOCOL_VERSION,
+      sessionId,
+      source: { packageName: '@microsoft/rush', packageVersion: currentPackageVersion },
+      privacy: 'local-sensitive',
+      type: 'artifactAvailable',
+      payload: {
+        role: 'log',
+        path: reporterHost.logArtifact.path,
+        format: 'plaintext',
+        complete: false
+      }
+    });
+  }
   const reporterLaunchOptions: IRushFrontendLaunchOptions = {
     ...launchOptions,
     reporter: {

--- a/apps/rush/src/RushPreviewVersion.ts
+++ b/apps/rush/src/RushPreviewVersion.ts
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { EnvironmentVariableNames } from '@microsoft/rush-lib/lib/api/EnvironmentConfiguration';
+
+export function getRushPreviewVersion(
+  env: Record<string, string | undefined> = process.env
+): string | undefined {
+  return env[EnvironmentVariableNames.RUSH_PREVIEW_VERSION] || undefined;
+}

--- a/apps/rush/src/RushReporterHost.ts
+++ b/apps/rush/src/RushReporterHost.ts
@@ -475,9 +475,10 @@ function hasHelpControl(argv: readonly string[]): boolean {
 
 function getImplicitHelpValueFlagsToStrip(
   argv: readonly string[],
-  ownership: IReporterCommandLineOwnership
+  ownership: IReporterCommandLineOwnership,
+  actionName: string | undefined
 ): readonly string[] {
-  if (!ownership.known) {
+  if (actionName !== undefined && !ownership.known) {
     return [];
   }
   const commandOwnedFlags: ReadonlySet<string> = ownership.parameters;
@@ -656,6 +657,10 @@ export function resolveRushReporterSelection(options: IRushReporterHostOptions =
 
   const cwd: string = options.cwd ?? process.cwd();
   const commandJson: boolean = separateJsonControls(argv).commandJson;
+  const separator: number = argv.indexOf('--');
+  const actionName: string | undefined = stripReporterValueControls(
+    separator < 0 ? argv : argv.slice(0, separator)
+  ).find((argument) => !argument.startsWith('-'));
   let commandOwnership: IReporterCommandLineOwnership | undefined;
 
   const reporterProbe: IParsedReporterControls = parseReporterControls(argv, false, true);
@@ -728,7 +733,7 @@ export function resolveRushReporterSelection(options: IRushReporterHostOptions =
           ? REPORTER_SELECTION_FLAG
           : ALL_REPORTER_VALUE_FLAGS
         : options.repositoryOptIn
-          ? getImplicitHelpValueFlagsToStrip(argv, getCommandOwnership())
+          ? getImplicitHelpValueFlagsToStrip(argv, getCommandOwnership(), actionName)
           : [];
     const reporterFlagsToStrip: readonly string[] = (
       requestedReporter === undefined ? options.repositoryOptIn === true : requestedReporter !== 'legacy'
@@ -764,10 +769,6 @@ export function resolveRushReporterSelection(options: IRushReporterHostOptions =
 
   function getCommandOwnership(): IReporterCommandLineOwnership {
     if (!commandOwnership) {
-      const separator: number = argv.indexOf('--');
-      const actionName: string | undefined = stripReporterValueControls(
-        separator < 0 ? argv : argv.slice(0, separator)
-      ).find((argument) => !argument.startsWith('-'));
       commandOwnership = getReporterCommandLineOwnership(actionName, cwd);
     }
     return commandOwnership;
@@ -929,12 +930,7 @@ export async function initializeRushReporterHostAsync(
         commonTempFolder: options.commonTempFolder,
         actionName: options.actionName
       });
-      host.manager.addReporter(
-        selection.reporter === 'file'
-          ? new LogLevelReporter(fullDetailReporter, selection.logLevel, true)
-          : fullDetailReporter,
-        { destination: 'file:auto' }
-      );
+      host.manager.addReporter(fullDetailReporter, { destination: 'file:auto' });
     }
 
     if (primaryReporter) {

--- a/apps/rush/src/RushReporterHost.ts
+++ b/apps/rush/src/RushReporterHost.ts
@@ -20,12 +20,15 @@ import {
   shouldRenderAtLogLevel,
   type IReporter,
   type IReporterContext,
+  type IReporterEmitEventInput,
   type IReporterEventEnvelope,
   type IReporterEventSink,
+  type IFileReporterArtifact,
   type IReporterOutputTarget,
   type ReporterEventType,
   type ReporterLogLevel,
-  type ReporterName
+  type ReporterName,
+  type ReporterManager
 } from '@rushstack/rush-reporter';
 
 export interface IRushReporterOutputStream {
@@ -40,11 +43,14 @@ export interface IRushReporterHostOptions {
   readonly cwd?: string;
   readonly stdout?: IRushReporterOutputStream;
   readonly stderr?: IRushReporterOutputStream;
+  readonly commonTempFolder?: string;
+  readonly actionName?: string;
   readonly includeDefaultFileReporter?: boolean;
   readonly commandName?: 'rush' | 'rush-pnpm' | 'rushx';
   readonly repositoryOptIn?: boolean;
   readonly forceLegacy?: boolean;
   readonly selectedRushVersion?: string;
+  readonly manager?: ReporterManager;
 }
 
 export interface IRushReporterSelection {
@@ -66,13 +72,15 @@ export interface IInitializedRushReporterHost {
   readonly host: ReporterHost;
   readonly sink: IReporterEventSink;
   readonly selection: IRushReporterSelection;
+  readonly logArtifact: IFileReporterArtifact | undefined;
   closeAsync(timeoutMs?: number): Promise<void>;
 }
 
 const REPORTER_VALUE_FLAGS: ReadonlySet<string> = new Set(['--reporter', '--output', '--log-level']);
 const ALL_REPORTER_VALUE_FLAGS: readonly string[] = ['--reporter', '--output', '--log-level'];
 const REPORTER_SELECTION_FLAG: readonly string[] = ['--reporter'];
-const DEFERRED_OPERATION_EVENT_TYPES: ReadonlySet<ReporterEventType> = new Set([
+const REPORTER_OUTPUT_VALUE_FLAGS: readonly string[] = ['--output', '--log-level'];
+const GROUPED_OPERATION_EVENT_TYPES: ReadonlySet<ReporterEventType> = new Set([
   'operationRegistered',
   'operationStatusChanged',
   'operationStreamClosed',
@@ -94,10 +102,16 @@ class LogLevelReporter implements IReporter {
 
   private readonly _reporter: IReporter;
   private readonly _logLevel: ReporterLogLevel;
+  private readonly _preserveOperationStream: boolean;
 
-  public constructor(reporter: IReporter, logLevel: ReporterLogLevel) {
+  public constructor(
+    reporter: IReporter,
+    logLevel: ReporterLogLevel,
+    preserveOperationStream: boolean = false
+  ) {
     this._reporter = reporter;
     this._logLevel = logLevel;
+    this._preserveOperationStream = preserveOperationStream;
     this.name = reporter.name;
   }
 
@@ -106,39 +120,13 @@ class LogLevelReporter implements IReporter {
   }
 
   public report(event: IReporterEventEnvelope<unknown>): void {
-    if (shouldRenderAtLogLevel(this._logLevel, event)) {
-      this._reporter.report(event);
-    }
-  }
-
-  public flushAsync(): Promise<void> {
-    return this._reporter.flushAsync();
-  }
-
-  public closeAsync(): Promise<void> {
-    return this._reporter.closeAsync();
-  }
-}
-
-/**
- * Keeps operation presentation on the legacy collator until R5B transfers terminal ownership.
- */
-class DeferredOperationPresentationReporter implements IReporter {
-  public readonly name: string;
-
-  private readonly _reporter: IReporter;
-
-  public constructor(reporter: IReporter) {
-    this._reporter = reporter;
-    this.name = reporter.name;
-  }
-
-  public initializeAsync(context: IReporterContext): Promise<void> {
-    return this._reporter.initializeAsync(context);
-  }
-
-  public report(event: IReporterEventEnvelope<unknown>): void {
-    if (!DEFERRED_OPERATION_EVENT_TYPES.has(event.type)) {
+    if (
+      shouldRenderAtLogLevel(this._logLevel, event) ||
+      event.type === 'artifactAvailable' ||
+      (this._preserveOperationStream &&
+        GROUPED_OPERATION_EVENT_TYPES.has(event.type) &&
+        !(this._logLevel === 'quiet' && event.type === 'externalOutput'))
+    ) {
       this._reporter.report(event);
     }
   }
@@ -213,6 +201,112 @@ class ExplicitOutputReporter implements IReporter {
         this._fileDescriptor = undefined;
       }
     }
+  }
+}
+
+class FilePathReporter implements IReporter {
+  public readonly name: string = 'file-path';
+
+  private readonly _write: (text: string) => unknown;
+  private _path: string | undefined;
+  private _written: boolean = false;
+
+  public constructor(write: (text: string) => unknown) {
+    this._write = write;
+  }
+
+  public async initializeAsync(): Promise<void> {
+    /* no-op */
+  }
+
+  public report(event: IReporterEventEnvelope<unknown>): void {
+    if (event.type === 'artifactAvailable') {
+      const payload: { role?: string; path?: string } = event.payload as {
+        role?: string;
+        path?: string;
+      };
+      if (payload.role === 'log') {
+        this._path = payload.path;
+      }
+    } else if ((event.type === 'commandResult' || event.type === 'sessionCompleted') && this._path) {
+      this._writePathOnce();
+    }
+  }
+
+  public async flushAsync(): Promise<void> {
+    /* no-op */
+  }
+
+  public async closeAsync(): Promise<void> {
+    this._writePathOnce();
+  }
+
+  private _writePathOnce(): void {
+    if (!this._written && this._path) {
+      this._written = true;
+      this._write(`Rush full log: ${this._path}\n`);
+    }
+  }
+}
+
+class ArtifactCompletionReporterSink implements IReporterEventSink {
+  private readonly _host: ReporterHost;
+  private readonly _fullDetailReporter: FileReporter;
+  private _lastComplete: boolean | undefined;
+  private _artifactContext: IReporterEmitEventInput<unknown> | undefined;
+
+  public constructor(host: ReporterHost, fullDetailReporter: FileReporter) {
+    this._host = host;
+    this._fullDetailReporter = fullDetailReporter;
+  }
+
+  public emit<TPayload>(event: IReporterEmitEventInput<TPayload>): string {
+    if (event.type === 'artifactAvailable') {
+      const payload: { role?: string; path?: string; complete?: boolean } = event.payload as {
+        role?: string;
+        path?: string;
+        complete?: boolean;
+      };
+      if (payload.role === 'log' && typeof payload.complete === 'boolean') {
+        this._lastComplete = payload.complete;
+        this._artifactContext = event;
+      }
+    }
+    return this._host.manager.emit(event);
+  }
+
+  public publishIfChanged(
+    context: IReporterEmitEventInput<unknown> | undefined = this._artifactContext
+  ): void {
+    if (!context) {
+      return;
+    }
+    const artifact: IFileReporterArtifact = this._fullDetailReporter.getArtifact();
+    if (!artifact.path || artifact.complete === this._lastComplete) {
+      return;
+    }
+    const complete: boolean = artifact.complete;
+    const payload: Readonly<{
+      role: 'log';
+      path: string;
+      format: 'plaintext';
+      complete: boolean;
+    }> = Object.freeze({
+      role: 'log' as const,
+      path: artifact.path,
+      format: 'plaintext' as const,
+      complete
+    });
+    this._host.manager.emit({
+      protocolVersion: context.protocolVersion,
+      sessionId: context.sessionId,
+      source: context.source,
+      scope: context.scope,
+      privacy: 'local-sensitive',
+      type: 'artifactAvailable',
+      payload
+    });
+    this._lastComplete = complete;
   }
 }
 
@@ -361,6 +455,34 @@ function hasReporterOutputControl(argv: readonly string[]): boolean {
   return false;
 }
 
+function hasReporterLogLevelControl(argv: readonly string[]): boolean {
+  for (let index: number = 0; index < argv.length; index++) {
+    const argument: string = argv[index];
+    if (argument === '--') {
+      break;
+    }
+    if (argument.startsWith('--log-level=') && argument.length > '--log-level='.length) {
+      return true;
+    }
+    if (argument === '--log-level' && argv[index + 1] !== undefined && !argv[index + 1].startsWith('-')) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function hasHelpControl(argv: readonly string[]): boolean {
+  for (const argument of argv) {
+    if (argument === '--') {
+      return false;
+    }
+    if (argument === '--help' || argument === '-h') {
+      return true;
+    }
+  }
+  return false;
+}
+
 function resolveLogLevel(
   controls: IParsedReporterControls,
   env: Record<string, string | undefined>,
@@ -411,6 +533,19 @@ function resolveLogLevel(
   }
 
   const environmentLogLevel: string | undefined = includeEnvironment ? env.RUSH_LOG_LEVEL : undefined;
+  const environmentQuiet: boolean =
+    includeEnvironment && (env.RUSH_QUIET_MODE === '1' || env.RUSH_QUIET_MODE?.toLowerCase() === 'true');
+  if (environmentQuiet && environmentLogLevel) {
+    const normalizedLogLevel: string = environmentLogLevel.trim().toLowerCase();
+    if (normalizedLogLevel !== 'quiet') {
+      throw new Error(
+        'RUSH_QUIET_MODE contradicts RUSH_LOG_LEVEL. Remove one of these environment controls.'
+      );
+    }
+  }
+  if (environmentQuiet) {
+    return 'quiet';
+  }
   if (environmentLogLevel) {
     const normalizedLogLevel: string = environmentLogLevel.trim().toLowerCase();
     if (!isSupportedLogLevel(normalizedLogLevel)) {
@@ -498,7 +633,7 @@ export function resolveRushReporterSelection(options: IRushReporterHostOptions =
       outputs: [],
       commandJson,
       enabled: false,
-      reporterControlsOwnedByFrontend: reporterValueFlagsToStrip.length > 0,
+      reporterControlsOwnedByFrontend: true,
       reporterValueFlagsToStrip,
       reason: 'RUSH_REPORTER=legacy'
     };
@@ -546,6 +681,19 @@ export function resolveRushReporterSelection(options: IRushReporterHostOptions =
     };
   }
 
+  if (hasHelpControl(argv)) {
+    return {
+      reporter: 'legacy',
+      logLevel: 'normal',
+      outputs: [],
+      commandJson,
+      enabled: false,
+      reporterControlsOwnedByFrontend: requestedReporter !== undefined,
+      reporterValueFlagsToStrip: requestedReporter === undefined ? [] : REPORTER_SELECTION_FLAG,
+      reason: requestedReporter === undefined ? 'pre-major legacy default' : 'explicit --reporter'
+    };
+  }
+
   function getCommandName(): 'rush' | 'rush-pnpm' | 'rushx' {
     const executableName: string = path.basename(process.argv[1] ?? '').toLowerCase();
     if (executableName === 'rush-pnpm') {
@@ -567,14 +715,53 @@ export function resolveRushReporterSelection(options: IRushReporterHostOptions =
     }
     if (options.repositoryOptIn) {
       const stdout: IRushReporterOutputStream = options.stdout ?? process.stdout;
+      const ownsOutputControls: boolean = hasReporterOutputControl(argv);
+      const ownsLogLevelControls: boolean = hasReporterLogLevelControl(argv);
+      const candidateValueControls: IParsedReporterControls =
+        ownsOutputControls || ownsLogLevelControls ? parseReporterControls(argv, true) : selectionControls;
+      const ownsLogLevelControl: boolean =
+        ownsLogLevelControls &&
+        !ownsOutputControls &&
+        candidateValueControls.logLevels.length > 0 &&
+        candidateValueControls.logLevels.every((logLevel: string) => isSupportedLogLevel(logLevel));
+      const ownsValueControls: boolean = ownsOutputControls || ownsLogLevelControl;
+      const ownsEnvironmentControls: boolean = env.RUSH_LOG_LEVEL !== undefined;
+      const parsedValueControls: IParsedReporterControls = ownsValueControls
+        ? candidateValueControls
+        : selectionControls;
+      const outputControlsAreUnambiguous: boolean =
+        !parsedValueControls.logLevels.some((logLevel: string) => !isSupportedLogLevel(logLevel)) &&
+        parsedValueControls.outputs.every((outputValue: string) => {
+          try {
+            const output: IReporterOutputTarget = parseOutputControl(outputValue);
+            return output.reporter === 'file' || output.reporter === 'json';
+          } catch {
+            return false;
+          }
+        });
+      const implicitControls: IParsedReporterControls =
+        ownsOutputControls && !outputControlsAreUnambiguous
+          ? {
+              ...parsedValueControls,
+              logLevels: [],
+              outputs: []
+            }
+          : parsedValueControls;
+      validateReporterControlMultiplicity(implicitControls, ownsValueControls);
       return {
-        reporter: isCiDetected(env) || !stdout.isTTY ? 'plaintext' : 'default',
-        logLevel: resolveLogLevel(selectionControls, env, true, true),
-        outputs: [],
+        reporter: commandJson ? 'file' : isCiDetected(env) || !stdout.isTTY ? 'plaintext' : 'default',
+        logLevel: resolveLogLevel(implicitControls, env, true, true),
+        outputs: resolveOutputs(implicitControls.outputs, cwd),
         commandJson,
         enabled: true,
-        reporterControlsOwnedByFrontend: false,
-        reporterValueFlagsToStrip: [],
+        reporterControlsOwnedByFrontend:
+          ownsLogLevelControl || ownsEnvironmentControls || implicitControls.outputs.length > 0,
+        reporterValueFlagsToStrip:
+          implicitControls.outputs.length > 0
+            ? REPORTER_OUTPUT_VALUE_FLAGS
+            : ownsLogLevelControl
+              ? ['--log-level']
+              : [],
         reason: 'repository experiment'
       };
     }
@@ -601,6 +788,13 @@ export function resolveRushReporterSelection(options: IRushReporterHostOptions =
       reporterValueFlagsToStrip: REPORTER_SELECTION_FLAG,
       reason: 'explicit --reporter'
     };
+  }
+
+  if (commandJson && requestedReporter !== 'file') {
+    throw new Error(
+      `The command-specific --json output owns stdout and cannot be combined with --reporter=${requestedReporter}. ` +
+        'Use --reporter=file or omit --reporter.'
+    );
   }
 
   const controls: IParsedReporterControls = parseReporterControls(argv, true);
@@ -633,8 +827,12 @@ function createPrimaryReporter(
     case 'default':
       return new DefaultInteractiveReporter({
         terminal: {
-          columns: stdout.columns ?? 80,
-          isTTY: stdout.isTTY === true,
+          get columns() {
+            return stdout.columns && stdout.columns > 0 ? stdout.columns : 80;
+          },
+          get isTTY() {
+            return stdout.isTTY === true;
+          },
           write: (text: string) => {
             stdout.write(text);
           }
@@ -648,11 +846,12 @@ function createPrimaryReporter(
     case 'plaintext':
       return new PlaintextReporter({
         write: (text: string) => stdout.write(text),
-        variant: isCiDetected(env) ? 'detailed' : 'concise',
-        color: false
+        variant: selection.reason === 'explicit --reporter' || isCiDetected(env) ? 'detailed' : 'concise',
+        color: false,
+        logLevel: selection.logLevel
       });
     case 'file':
-      return new FileReporter();
+      return undefined;
     case 'legacy':
       return undefined;
   }
@@ -665,29 +864,35 @@ export async function initializeRushReporterHostAsync(
   const stdout: IRushReporterOutputStream = options.stdout ?? process.stdout;
   const stderr: IRushReporterOutputStream = options.stderr ?? process.stderr;
   const selection: IRushReporterSelection = resolveRushReporterSelection({ ...options, env, stdout });
-  const host: ReporterHost = new ReporterHost({ env });
+  const host: ReporterHost = new ReporterHost({ env, manager: options.manager });
+  let fullDetailReporter: FileReporter | undefined;
 
   if (selection.enabled) {
     const primaryReporter: IReporter | undefined = createPrimaryReporter(selection, stdout, env);
-    if (primaryReporter) {
-      const presentationReporter: IReporter =
-        selection.reporter === 'file'
-          ? primaryReporter
-          : new DeferredOperationPresentationReporter(primaryReporter);
-      host.manager.addReporter(new LogLevelReporter(presentationReporter, selection.logLevel), {
-        destination: selection.reporter === 'file' ? 'file:auto' : 'stdout'
+
+    if (options.includeDefaultFileReporter !== false || selection.reporter === 'file') {
+      fullDetailReporter = new FileReporter({
+        commonTempFolder: options.commonTempFolder,
+        actionName: options.actionName
+      });
+      host.manager.addReporter(fullDetailReporter, {
+        destination: 'file:auto'
       });
     }
 
-    const hasExplicitFileOutput: boolean = selection.outputs.some(
-      (output: IReporterOutputTarget) => output.reporter === 'file'
-    );
-    if (
-      options.includeDefaultFileReporter !== false &&
-      selection.reporter !== 'file' &&
-      !hasExplicitFileOutput
-    ) {
-      host.manager.addReporter(new FileReporter(), { destination: 'file:auto' });
+    if (primaryReporter) {
+      host.manager.addReporter(
+        new LogLevelReporter(primaryReporter, selection.logLevel, selection.reporter === 'plaintext'),
+        {
+          destination: 'stdout'
+        }
+      );
+    }
+
+    if (selection.reporter === 'file') {
+      host.manager.addReporter(new FilePathReporter((text: string) => stderr.write(text)), {
+        destination: 'stderr'
+      });
     }
 
     for (const output of selection.outputs) {
@@ -710,13 +915,24 @@ export async function initializeRushReporterHostAsync(
   }
 
   await host.manager.initializeAsync();
+  const artifactCompletionSink: ArtifactCompletionReporterSink | undefined = fullDetailReporter
+    ? new ArtifactCompletionReporterSink(host, fullDetailReporter)
+    : undefined;
   let closePromise: Promise<void> | undefined;
   return {
     host,
-    sink: host.getSink(),
+    sink: artifactCompletionSink ?? host.getSink(),
     selection,
+    logArtifact: fullDetailReporter?.getArtifact(),
     closeAsync: (timeoutMs?: number) => {
-      closePromise ??= host.manager.closeAsync(timeoutMs);
+      closePromise ??= (async () => {
+        const fullyFlushed: boolean = await host.manager._flushAndConfirmAsync(timeoutMs);
+        if (fullyFlushed) {
+          await fullDetailReporter?.closeAsync();
+          artifactCompletionSink?.publishIfChanged();
+        }
+        await host.manager.closeAsync(timeoutMs);
+      })();
       return closePromise;
     }
   };

--- a/apps/rush/src/RushReporterHost.ts
+++ b/apps/rush/src/RushReporterHost.ts
@@ -352,7 +352,7 @@ export function stripReporterValueControls(
       result.push(argument);
       continue;
     }
-    if (equalsIndex < 0 && index + 1 < argv.length && argv[index + 1] !== '--') {
+    if (equalsIndex < 0 && index + 1 < argv.length && !argv[index + 1].startsWith('-')) {
       index++;
     }
   }
@@ -481,6 +481,42 @@ function hasHelpControl(argv: readonly string[]): boolean {
     }
   }
   return false;
+}
+
+function getImplicitHelpValueFlagsToStrip(argv: readonly string[]): readonly string[] {
+  const outputs: (string | undefined)[] = [];
+  const logLevels: (string | undefined)[] = [];
+  for (let index: number = 0; index < argv.length; index++) {
+    const argument: string = argv[index];
+    if (argument === '--') {
+      break;
+    }
+    const equalsIndex: number = argument.indexOf('=');
+    const flag: string = equalsIndex < 0 ? argument : argument.slice(0, equalsIndex);
+    const values: (string | undefined)[] | undefined =
+      flag === '--output' ? outputs : flag === '--log-level' ? logLevels : undefined;
+    if (values) {
+      const nextArgument: string | undefined = argv[index + 1];
+      values.push(
+        equalsIndex >= 0
+          ? argument.slice(equalsIndex + 1)
+          : nextArgument && !nextArgument.startsWith('-')
+            ? argv[++index]
+            : undefined
+      );
+    }
+  }
+
+  // Help must tolerate command-owned flags without parsing their values as reporter controls.
+  const logLevelsAreOwned: boolean = logLevels.every(
+    (value: string | undefined) => value !== undefined && isSupportedLogLevel(value)
+  );
+  const isReporterOutput = (value: string | undefined): boolean =>
+    value !== undefined && /^(?:file|json):\/\//.test(value);
+  if (outputs.some(isReporterOutput)) {
+    return outputs.every(isReporterOutput) && logLevelsAreOwned ? REPORTER_OUTPUT_VALUE_FLAGS : [];
+  }
+  return logLevels.length > 0 && logLevelsAreOwned ? ['--log-level'] : [];
 }
 
 function resolveLogLevel(
@@ -682,14 +718,24 @@ export function resolveRushReporterSelection(options: IRushReporterHostOptions =
   }
 
   if (hasHelpControl(argv)) {
+    const reporterValueFlagsToStrip: readonly string[] =
+      requestedReporter !== undefined
+        ? requestedReporter === 'legacy'
+          ? REPORTER_SELECTION_FLAG
+          : ALL_REPORTER_VALUE_FLAGS
+        : options.repositoryOptIn
+          ? getImplicitHelpValueFlagsToStrip(argv)
+          : [];
     return {
       reporter: 'legacy',
       logLevel: 'normal',
       outputs: [],
       commandJson,
       enabled: false,
-      reporterControlsOwnedByFrontend: requestedReporter !== undefined,
-      reporterValueFlagsToStrip: requestedReporter === undefined ? [] : REPORTER_SELECTION_FLAG,
+      reporterControlsOwnedByFrontend:
+        reporterValueFlagsToStrip.length > 0 ||
+        (options.repositoryOptIn === true && env.RUSH_LOG_LEVEL !== undefined),
+      reporterValueFlagsToStrip,
       reason: requestedReporter === undefined ? 'pre-major legacy default' : 'explicit --reporter'
     };
   }

--- a/apps/rush/src/RushReporterHost.ts
+++ b/apps/rush/src/RushReporterHost.ts
@@ -4,6 +4,8 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
+import { CommandLineConfiguration, type Command } from '@microsoft/rush-lib/lib/api/CommandLineConfiguration';
+import { RushConfiguration } from '@microsoft/rush-lib/lib/api/RushConfiguration';
 import {
   AiReporter,
   DefaultInteractiveReporter,
@@ -483,7 +485,36 @@ function hasHelpControl(argv: readonly string[]): boolean {
   return false;
 }
 
-function getImplicitHelpValueFlagsToStrip(argv: readonly string[]): readonly string[] {
+function getImplicitHelpValueFlagsToStrip(argv: readonly string[], cwd: string): readonly string[] {
+  let commandName: string | undefined;
+  for (const argument of stripReporterValueControls(argv)) {
+    if (argument === '--') {
+      break;
+    }
+    if (!argument.startsWith('-')) {
+      commandName = argument;
+      break;
+    }
+  }
+  const rushJsonPath: string | undefined = RushConfiguration.tryFindRushJsonLocation({
+    startingFolder: cwd,
+    showVerbose: false
+  });
+  const commandLine: CommandLineConfiguration = CommandLineConfiguration.loadFromFileOrDefault(
+    rushJsonPath && path.join(path.dirname(rushJsonPath), 'common', 'config', 'rush', 'command-line.json')
+  );
+  const command: Command | undefined =
+    commandName === undefined ? undefined : commandLine.commands.get(commandName);
+  if (
+    commandName !== undefined &&
+    (!command || (command.commandKind === 'global' && command.providedByPlugin))
+  ) {
+    // An unknown or plugin-owned command can declare options outside the repository configuration.
+    return [];
+  }
+  const commandOwnedFlags: Set<string> = new Set(
+    [...(command?.associatedParameters ?? [])].map((parameter) => parameter.longName)
+  );
   const outputs: (string | undefined)[] = [];
   const logLevels: (string | undefined)[] = [];
   for (let index: number = 0; index < argv.length; index++) {
@@ -493,6 +524,9 @@ function getImplicitHelpValueFlagsToStrip(argv: readonly string[]): readonly str
     }
     const equalsIndex: number = argument.indexOf('=');
     const flag: string = equalsIndex < 0 ? argument : argument.slice(0, equalsIndex);
+    if (commandOwnedFlags.has(flag)) {
+      continue;
+    }
     const values: (string | undefined)[] | undefined =
       flag === '--output' ? outputs : flag === '--log-level' ? logLevels : undefined;
     if (values) {
@@ -514,7 +548,9 @@ function getImplicitHelpValueFlagsToStrip(argv: readonly string[]): readonly str
   const isReporterOutput = (value: string | undefined): boolean =>
     value !== undefined && /^(?:file|json):\/\//.test(value);
   if (outputs.some(isReporterOutput)) {
-    return outputs.every(isReporterOutput) && logLevelsAreOwned ? REPORTER_OUTPUT_VALUE_FLAGS : [];
+    return outputs.every(isReporterOutput) && logLevelsAreOwned
+      ? REPORTER_OUTPUT_VALUE_FLAGS.filter((flag) => !commandOwnedFlags.has(flag))
+      : [];
   }
   return logLevels.length > 0 && logLevelsAreOwned ? ['--log-level'] : [];
 }
@@ -724,7 +760,7 @@ export function resolveRushReporterSelection(options: IRushReporterHostOptions =
           ? REPORTER_SELECTION_FLAG
           : ALL_REPORTER_VALUE_FLAGS
         : options.repositoryOptIn
-          ? getImplicitHelpValueFlagsToStrip(argv)
+          ? getImplicitHelpValueFlagsToStrip(argv, cwd)
           : [];
     return {
       reporter: 'legacy',

--- a/apps/rush/src/start.ts
+++ b/apps/rush/src/start.ts
@@ -31,6 +31,7 @@ import * as rushLib from '@microsoft/rush-lib';
 
 import { MinimalRushConfiguration } from './MinimalRushConfiguration';
 import { launchRushFrontendAsync } from './RushFrontend';
+import { getRushPreviewVersion } from './RushPreviewVersion';
 
 // Load the configuration
 const configuration: MinimalRushConfiguration | undefined =
@@ -40,7 +41,7 @@ const currentPackageVersion: string = PackageJsonLookup.loadOwnPackageJson(__dir
 
 let rushVersionToLoad: string | undefined = undefined;
 
-const previewVersion: string | undefined = process.env[EnvironmentVariableNames.RUSH_PREVIEW_VERSION];
+const previewVersion: string | undefined = getRushPreviewVersion();
 
 if (previewVersion) {
   if (!semver.valid(previewVersion, false)) {

--- a/apps/rush/src/test/MinimalRushConfiguration.test.ts
+++ b/apps/rush/src/test/MinimalRushConfiguration.test.ts
@@ -3,11 +3,30 @@
 
 import * as path from 'node:path';
 
+import { EnvironmentConfiguration } from '@microsoft/rush-lib/lib/api/EnvironmentConfiguration';
+import { PackageJsonLookup } from '@rushstack/node-core-library';
+
 import { MinimalRushConfiguration } from '../MinimalRushConfiguration';
 
 describe(MinimalRushConfiguration.name, () => {
+  const originalArgv: string[] = process.argv;
+  const originalRushTempFolder: string | undefined = process.env.RUSH_TEMP_FOLDER;
+  const originalRushPreviewVersion: string | undefined = process.env.RUSH_PREVIEW_VERSION;
+
   afterEach(() => {
     jest.restoreAllMocks();
+    process.argv = originalArgv;
+    if (originalRushTempFolder === undefined) {
+      delete process.env.RUSH_TEMP_FOLDER;
+    } else {
+      process.env.RUSH_TEMP_FOLDER = originalRushTempFolder;
+    }
+    if (originalRushPreviewVersion === undefined) {
+      delete process.env.RUSH_PREVIEW_VERSION;
+    } else {
+      process.env.RUSH_PREVIEW_VERSION = originalRushPreviewVersion;
+    }
+    EnvironmentConfiguration.reset();
   });
 
   describe('legacy rush config', () => {
@@ -33,6 +52,157 @@ describe(MinimalRushConfiguration.name, () => {
         MinimalRushConfiguration.loadFromDefaultLocation() as MinimalRushConfiguration;
       expect(config.rushVersion).toEqual('4.0.0');
       expect(config.useRushReporter).toBe(true);
+      expect(config.commonTempFolder).toBe(path.resolve(__dirname, 'sandbox', 'repo', 'common', 'temp'));
     });
+
+    it('uses the normalized RUSH_TEMP_FOLDER override', () => {
+      process.env.RUSH_TEMP_FOLDER = path.join(
+        __dirname,
+        'sandbox',
+        'repo',
+        'custom-temp',
+        '..',
+        'rush-temp'
+      );
+      EnvironmentConfiguration.reset();
+
+      const config: MinimalRushConfiguration =
+        MinimalRushConfiguration.loadFromDefaultLocation() as MinimalRushConfiguration;
+
+      expect(config.commonTempFolder).toBe(path.resolve(__dirname, 'sandbox', 'repo', 'rush-temp'));
+    });
+  });
+
+  it('preserves legacy discovery text and blank-line behavior exactly', () => {
+    const legacyRepo: string = path.join(__dirname, 'sandbox', 'legacy-repo');
+    const consoleLog: jest.SpiedFunction<typeof console.log> = jest
+      .spyOn(console, 'log')
+      .mockImplementation(() => undefined);
+    jest.spyOn(PackageJsonLookup, 'loadOwnPackageJson').mockReturnValue({
+      name: '@microsoft/rush',
+      version: '2.5.0'
+    });
+    jest.spyOn(process, 'cwd').mockReturnValue(path.join(legacyRepo, 'project'));
+    process.argv = ['node', 'rush', 'build', '--verbose'];
+
+    MinimalRushConfiguration.loadFromDefaultLocation();
+
+    expect(consoleLog.mock.calls).toEqual([
+      [`Found configuration in ${path.join(legacyRepo, 'rush.json')}`],
+      ['']
+    ]);
+  });
+
+  it('prints the legacy discovery line and blank line when rush.json is in the current folder', () => {
+    const legacyRepo: string = path.join(__dirname, 'sandbox', 'legacy-repo');
+    const consoleLog: jest.SpiedFunction<typeof console.log> = jest
+      .spyOn(console, 'log')
+      .mockImplementation(() => undefined);
+    jest.spyOn(process, 'cwd').mockReturnValue(legacyRepo);
+    process.argv = ['node', 'rush', 'build', '--verbose'];
+
+    MinimalRushConfiguration.loadFromDefaultLocation();
+
+    expect(consoleLog.mock.calls).toEqual([
+      [`Found configuration in ${path.join(legacyRepo, 'rush.json')}`],
+      ['']
+    ]);
+  });
+
+  it('suppresses legacy discovery output for an explicit reporter', () => {
+    const legacyRepo: string = path.join(__dirname, 'sandbox', 'legacy-repo');
+    const consoleLog: jest.SpiedFunction<typeof console.log> = jest
+      .spyOn(console, 'log')
+      .mockImplementation(() => undefined);
+    jest.spyOn(PackageJsonLookup, 'loadOwnPackageJson').mockReturnValue({
+      name: '@microsoft/rush',
+      version: '2.5.0'
+    });
+    jest.spyOn(process, 'cwd').mockReturnValue(path.join(legacyRepo, 'project'));
+    process.argv = ['node', 'rush', 'build', '--verbose', '--reporter=json'];
+
+    MinimalRushConfiguration.loadFromDefaultLocation();
+
+    expect(consoleLog).not.toHaveBeenCalled();
+  });
+
+  it('restores legacy discovery output under the emergency fallback', () => {
+    const legacyRepo: string = path.join(__dirname, 'sandbox', 'legacy-repo');
+    const consoleLog: jest.SpiedFunction<typeof console.log> = jest
+      .spyOn(console, 'log')
+      .mockImplementation(() => undefined);
+    jest.spyOn(process, 'cwd').mockReturnValue(path.join(legacyRepo, 'project'));
+    process.argv = ['node', 'rush', 'build', '--reporter=json'];
+    process.env.RUSH_REPORTER = 'legacy';
+
+    MinimalRushConfiguration.loadFromDefaultLocation();
+
+    expect(consoleLog.mock.calls).toEqual([
+      [`Found configuration in ${path.join(legacyRepo, 'rush.json')}`],
+      ['']
+    ]);
+  });
+
+  it.each([
+    ['environment fallback', ['build', '--reporter=json'], 'legacy'],
+    ['explicit legacy reporter', ['build', '--reporter=legacy'], undefined],
+    ['help fallback', ['build', '--reporter=json', '--help'], undefined],
+    ['cross-version fallback', ['build', '--reporter=json'], undefined]
+  ])('restores legacy discovery output in an opted-in repository for %s', (testName, args, envValue) => {
+    void testName;
+    const repo: string = path.join(__dirname, 'sandbox', 'repo');
+    const consoleLog: jest.SpiedFunction<typeof console.log> = jest
+      .spyOn(console, 'log')
+      .mockImplementation(() => undefined);
+    jest.spyOn(process, 'cwd').mockReturnValue(path.join(repo, 'project'));
+    process.argv = ['node', 'rush', ...args];
+    if (envValue === undefined) {
+      delete process.env.RUSH_REPORTER;
+    } else {
+      process.env.RUSH_REPORTER = envValue;
+    }
+
+    MinimalRushConfiguration.loadFromDefaultLocation();
+
+    expect(consoleLog.mock.calls).toEqual([[`Found configuration in ${path.join(repo, 'rush.json')}`], ['']]);
+  });
+
+  it.each([
+    ['custom reporter value', ['custom', '--reporter', 'junit']],
+    ['value-less custom reporter flag', ['custom', '--reporter', '--verbose']],
+    ['pass-through reporter flag', ['build', '--', '--reporter=json']]
+  ])('preserves legacy discovery output for %s', (testName, args) => {
+    void testName;
+    const legacyRepo: string = path.join(__dirname, 'sandbox', 'legacy-repo');
+    const consoleLog: jest.SpiedFunction<typeof console.log> = jest
+      .spyOn(console, 'log')
+      .mockImplementation(() => undefined);
+    jest.spyOn(process, 'cwd').mockReturnValue(path.join(legacyRepo, 'project'));
+    process.argv = ['node', 'rush', ...args];
+
+    MinimalRushConfiguration.loadFromDefaultLocation();
+
+    expect(consoleLog.mock.calls).toEqual([
+      [`Found configuration in ${path.join(legacyRepo, 'rush.json')}`],
+      ['']
+    ]);
+  });
+
+  it('uses the effective preview version when deciding discovery ownership', () => {
+    const repo: string = path.join(__dirname, 'sandbox', 'repo');
+    const consoleLog: jest.SpiedFunction<typeof console.log> = jest
+      .spyOn(console, 'log')
+      .mockImplementation(() => undefined);
+    jest.spyOn(PackageJsonLookup, 'loadOwnPackageJson').mockReturnValue({
+      name: '@microsoft/rush',
+      version: '5.178.1'
+    });
+    jest.spyOn(process, 'cwd').mockReturnValue(path.join(repo, 'project'));
+    process.argv = ['node', 'rush', 'build', '--reporter=json'];
+    process.env.RUSH_PREVIEW_VERSION = '5.178.1';
+
+    MinimalRushConfiguration.loadFromDefaultLocation();
+
+    expect(consoleLog).not.toHaveBeenCalled();
   });
 });

--- a/apps/rush/src/test/MinimalRushConfiguration.test.ts
+++ b/apps/rush/src/test/MinimalRushConfiguration.test.ts
@@ -123,6 +123,12 @@ describe(MinimalRushConfiguration.name, () => {
     ['help', ['build', '--reporter=json', '--help'], undefined, true],
     ['custom reporter', ['custom', '--reporter=junit'], undefined, true],
     ['custom flag', ['custom', '--reporter', '--verbose'], undefined, true],
+    [
+      'reporter-shaped custom values',
+      ['custom-output', '--output=json://./custom.jsonl', '--log-level=debug', '--verbose'],
+      undefined,
+      true
+    ],
     ['pass-through', ['build', '--', '--reporter=json'], undefined, true],
     ['quiet', ['--quiet', 'build'], undefined, false]
   ])('preserves discovery ownership when rush.json cannot load: %s', (name, args, reporter, visible) => {

--- a/apps/rush/src/test/MinimalRushConfiguration.test.ts
+++ b/apps/rush/src/test/MinimalRushConfiguration.test.ts
@@ -4,7 +4,7 @@
 import * as path from 'node:path';
 
 import { EnvironmentConfiguration } from '@microsoft/rush-lib/lib/api/EnvironmentConfiguration';
-import { PackageJsonLookup } from '@rushstack/node-core-library';
+import { JsonFile, PackageJsonLookup } from '@rushstack/node-core-library';
 
 import { MinimalRushConfiguration } from '../MinimalRushConfiguration';
 
@@ -12,6 +12,7 @@ describe(MinimalRushConfiguration.name, () => {
   const originalArgv: string[] = process.argv;
   const originalRushTempFolder: string | undefined = process.env.RUSH_TEMP_FOLDER;
   const originalRushPreviewVersion: string | undefined = process.env.RUSH_PREVIEW_VERSION;
+  const originalRushReporter: string | undefined = process.env.RUSH_REPORTER;
 
   afterEach(() => {
     jest.restoreAllMocks();
@@ -25,6 +26,11 @@ describe(MinimalRushConfiguration.name, () => {
       delete process.env.RUSH_PREVIEW_VERSION;
     } else {
       process.env.RUSH_PREVIEW_VERSION = originalRushPreviewVersion;
+    }
+    if (originalRushReporter === undefined) {
+      delete process.env.RUSH_REPORTER;
+    } else {
+      process.env.RUSH_REPORTER = originalRushReporter;
     }
     EnvironmentConfiguration.reset();
   });
@@ -107,6 +113,37 @@ describe(MinimalRushConfiguration.name, () => {
       [`Found configuration in ${path.join(legacyRepo, 'rush.json')}`],
       ['']
     ]);
+  });
+
+  it.each<[string, string[], string | undefined, boolean]>([
+    ['legacy', ['build', '--verbose'], undefined, true],
+    ['explicit JSON', ['build', '--reporter=json'], undefined, false],
+    ['explicit legacy', ['build', '--reporter=legacy'], undefined, true],
+    ['emergency legacy', ['build', '--reporter=json'], 'legacy', true],
+    ['help', ['build', '--reporter=json', '--help'], undefined, true],
+    ['custom reporter', ['custom', '--reporter=junit'], undefined, true],
+    ['custom flag', ['custom', '--reporter', '--verbose'], undefined, true],
+    ['pass-through', ['build', '--', '--reporter=json'], undefined, true],
+    ['quiet', ['--quiet', 'build'], undefined, false]
+  ])('preserves discovery ownership when rush.json cannot load: %s', (name, args, reporter, visible) => {
+    void name;
+    const repo: string = path.join(__dirname, 'sandbox', 'legacy-repo');
+    const consoleLog = jest.spyOn(console, 'log').mockImplementation(() => undefined);
+    jest.spyOn(process, 'cwd').mockReturnValue(path.join(repo, 'project'));
+    jest.spyOn(JsonFile, 'load').mockImplementation(() => {
+      throw new SyntaxError('Malformed rush.json');
+    });
+    process.argv = ['node', 'rush', ...args];
+    if (reporter === undefined) {
+      delete process.env.RUSH_REPORTER;
+    } else {
+      process.env.RUSH_REPORTER = reporter;
+    }
+
+    expect(MinimalRushConfiguration.loadFromDefaultLocation()).toBeUndefined();
+    expect(consoleLog.mock.calls).toEqual(
+      visible ? [[`Found configuration in ${path.join(repo, 'rush.json')}`], ['']] : []
+    );
   });
 
   it('suppresses legacy discovery output for an explicit reporter', () => {

--- a/apps/rush/src/test/RushFrontend.test.ts
+++ b/apps/rush/src/test/RushFrontend.test.ts
@@ -41,6 +41,7 @@ async function createInitializedHostAsync(
   return {
     host,
     sink: host.getSink(),
+    logArtifact: undefined,
     selection: {
       reporter: 'legacy',
       logLevel: 'normal',
@@ -69,6 +70,7 @@ async function createEnabledHostAsync(
   return {
     host,
     sink: host.getSink(),
+    logArtifact: undefined,
     selection: {
       reporter: 'json',
       logLevel: 'normal',
@@ -106,6 +108,7 @@ async function createPhaseHangingHostAsync(
   return {
     host,
     sink: host.getSink(),
+    logArtifact: undefined,
     selection: {
       reporter: 'json',
       logLevel: 'normal',
@@ -258,6 +261,43 @@ describe(launchRushFrontendAsync.name, () => {
       expect(order).toEqual(['host', 'close']);
     } finally {
       launchSpy.mockRestore();
+      process.argv = originalArgv;
+    }
+  });
+
+  it('keeps an active purge reporter log outside the temp folder being purged', async () => {
+    const order: string[] = [];
+    let commonTempFolder: string | undefined = 'not-captured';
+    let actionName: string | undefined;
+    const originalArgv: string[] = process.argv;
+    process.argv = ['node', 'rush', 'purge', '--reporter=file'];
+
+    try {
+      await launchRushFrontendAsync({
+        currentPackageVersion: '5.178.1',
+        rushVersionToLoad: undefined,
+        configuration: {
+          commonTempFolder: '/repo/common/temp',
+          useRushReporter: false
+        } as MinimalRushConfiguration,
+        launchOptions: { isManaged: false },
+        currentRushLib: rushLib,
+        initializeReporterHostAsync: async (options) => {
+          commonTempFolder = options.commonTempFolder;
+          actionName = options.actionName;
+          return createInitializedHostAsync(order, 'explicit --reporter');
+        },
+        executeCurrentRush: (version, selectedRushLib, launchOptions) => {
+          void version;
+          void selectedRushLib;
+          return launchOptions.reporterCloseAsync();
+        },
+        processLifecycle: createTestProcessLifecycle()
+      });
+
+      expect(actionName).toBe('purge');
+      expect(commonTempFolder).toBeUndefined();
+    } finally {
       process.argv = originalArgv;
     }
   });
@@ -626,7 +666,7 @@ describe(launchRushFrontendAsync.name, () => {
         expect(selection).toMatchObject({
           reporter: 'legacy',
           enabled: false,
-          reporterControlsOwnedByFrontend: false
+          reporterControlsOwnedByFrontend: rollback
         });
         expect(
           JSON.parse(

--- a/apps/rush/src/test/RushReporterArtifactClose.test.ts
+++ b/apps/rush/src/test/RushReporterArtifactClose.test.ts
@@ -1,0 +1,117 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import type { IReporterEventEnvelope } from '@rushstack/rush-reporter';
+
+import { initializeRushReporterHostAsync } from '../RushReporterHost';
+
+describe('reporter artifact completion boundary', () => {
+  it.each(['success', 'fsync failure', 'close failure'] as const)(
+    'publishes final artifact status only after physical closure: %s',
+    async (outcome) => {
+      const directory: string = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'rush-artifact-close-'));
+      const fsModule: typeof fs = jest.requireActual('node:fs');
+      const originalClose: typeof fs.closeSync = fsModule.closeSync;
+      const trace: string[] = [];
+      let output: string = '';
+      const warnings: string[] = [];
+      const initialized = await initializeRushReporterHostAsync({
+        argv: ['build', '--reporter=json', '--log-level=debug'],
+        env: {},
+        commonTempFolder: directory,
+        stdout: {
+          isTTY: false,
+          write: (text: string) => {
+            output += text;
+            const event = JSON.parse(text) as IReporterEventEnvelope<{ complete?: boolean }>;
+            if (event.type === 'artifactAvailable' && event.payload.complete === true) {
+              trace.push('complete notification');
+            }
+          }
+        }
+      });
+      const stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation((text) => {
+        warnings.push(String(text));
+        return true;
+      });
+      const closeSpy = jest.spyOn(fsModule, 'closeSync').mockImplementation((fd: number) => {
+        trace.push('close attempt');
+        originalClose(fd);
+        if (outcome === 'close failure') {
+          throw new Error('injected close failure');
+        }
+        trace.push('close succeeded');
+      });
+      const fsyncSpy = jest.spyOn(fsModule, 'fsyncSync');
+      if (outcome === 'fsync failure') {
+        fsyncSpy.mockImplementation(() => {
+          throw new Error('injected fsync failure');
+        });
+      }
+      const base = {
+        protocolVersion: { major: 1, minor: 1 },
+        sessionId: 'session',
+        source: { packageName: '@microsoft/rush', packageVersion: '5.178.1' }
+      };
+      try {
+        initialized.sink.emit({
+          ...base,
+          privacy: 'local-sensitive',
+          type: 'artifactAvailable',
+          payload: { role: 'log', path: initialized.logArtifact?.path, format: 'plaintext', complete: false }
+        });
+        initialized.sink.emit({
+          ...base,
+          privacy: 'public',
+          type: 'commandResult',
+          payload: { commandName: 'build', succeeded: true, exitCode: 0 }
+        });
+        initialized.sink.emit({
+          ...base,
+          privacy: 'public',
+          type: 'sessionCompleted',
+          payload: { exitCode: 0 }
+        });
+        await initialized.closeAsync();
+        await initialized.closeAsync();
+
+        const events: IReporterEventEnvelope<{ complete?: boolean; exitCode?: number }>[] = output
+          .trim()
+          .split('\n')
+          .map((line) => JSON.parse(line));
+        const completeEvents = events.filter(
+          (event) => event.type === 'artifactAvailable' && event.payload.complete === true
+        );
+        expect(closeSpy).toHaveBeenCalledTimes(1);
+        expect(events.find((event) => event.type === 'commandResult')?.payload.exitCode).toBe(0);
+        if (outcome === 'success') {
+          expect(completeEvents).toHaveLength(1);
+          expect(trace).toEqual(['close attempt', 'close succeeded', 'complete notification']);
+          const log: string = await fs.promises.readFile(initialized.logArtifact!.path!, 'utf8');
+          expect(log).toContain('"type":"commandResult"');
+          expect(log).toContain('"type":"sessionCompleted"');
+          const metadata = log
+            .split('\n')
+            .filter((line) => line.startsWith('# {'))
+            .map((line) => JSON.parse(line.slice(2)));
+          expect(
+            metadata.some((event) => event.type === 'artifactAvailable' && event.payload.complete === true)
+          ).toBe(false);
+          expect(warnings).toEqual([]);
+        } else {
+          expect(completeEvents).toHaveLength(0);
+          expect(warnings.some((warning) => warning.includes(`injected ${outcome}`))).toBe(true);
+        }
+      } finally {
+        fsyncSpy.mockRestore();
+        closeSpy.mockRestore();
+        stderrSpy.mockRestore();
+        await fs.promises.rm(directory, { recursive: true, force: true });
+      }
+    }
+  );
+});

--- a/apps/rush/src/test/RushReporterHelp.test.ts
+++ b/apps/rush/src/test/RushReporterHelp.test.ts
@@ -1,0 +1,78 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import * as path from 'node:path';
+
+import * as rushLib from '@microsoft/rush-lib';
+import { EnvironmentConfiguration } from '@microsoft/rush-lib/lib/api/EnvironmentConfiguration';
+import { RushCommandLineParser } from '@microsoft/rush-lib/lib/cli/RushCommandLineParser';
+
+import { launchRushFrontendAsync } from '../RushFrontend';
+import type { MinimalRushConfiguration } from '../MinimalRushConfiguration';
+
+describe('reporter help forwarding', () => {
+  it.each([false, true])('forwards only help to the real engine with repository opt-in %s', async (optIn) => {
+    const originalArgv: string[] = process.argv;
+    const originalEnv: NodeJS.ProcessEnv = { ...process.env };
+    const originalExitCode: typeof process.exitCode = process.exitCode;
+    const output: string[] = [];
+    const errors: string[] = [];
+    const stdoutSpy = jest.spyOn(process.stdout, 'write').mockImplementation((text) => {
+      output.push(String(text));
+      return true;
+    });
+    const stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation((text) => {
+      errors.push(String(text));
+      return true;
+    });
+    const logSpy = jest.spyOn(console, 'log').mockImplementation((text) => output.push(String(text)));
+    process.argv = [
+      'node',
+      'rush',
+      'build',
+      ...(optIn ? [] : ['--reporter=json']),
+      '--output=json://./help-events.jsonl',
+      '--log-level=debug',
+      '--help'
+    ];
+    delete process.env.RUSH_REPORTER;
+    process.env.RUSH_LOG_LEVEL = 'debug';
+    try {
+      EnvironmentConfiguration.reset();
+      await launchRushFrontendAsync({
+        currentPackageVersion: '5.178.1',
+        rushVersionToLoad: undefined,
+        configuration: { useRushReporter: optIn } as MinimalRushConfiguration,
+        launchOptions: { isManaged: true },
+        currentRushLib: rushLib,
+        executeCurrentRush: (version, selectedRushLib, options) => {
+          void version;
+          void selectedRushLib;
+          expect(process.argv).toEqual(['node', 'rush', 'build', '--help']);
+          expect(process.env.RUSH_LOG_LEVEL).toBeUndefined();
+          expect(options.reporter.operationStreamEnabled).toBe(false);
+          const parser: RushCommandLineParser = new RushCommandLineParser({
+            cwd: path.resolve(
+              __dirname,
+              '../../../../libraries/rush-lib/src/cli/test/basicAndRunBuildActionRepo'
+            ),
+            reporterCloseAsync: options.reporterCloseAsync
+          });
+          return parser.executeAsync().then((succeeded) => {
+            expect(succeeded).toBe(true);
+          });
+        }
+      });
+      expect(output.join('')).toContain('usage: rush build');
+      expect(errors).toEqual([]);
+    } finally {
+      process.argv = originalArgv;
+      process.env = originalEnv;
+      process.exitCode = originalExitCode;
+      EnvironmentConfiguration.reset();
+      stdoutSpy.mockRestore();
+      stderrSpy.mockRestore();
+      logSpy.mockRestore();
+    }
+  });
+});

--- a/apps/rush/src/test/RushReporterHelp.test.ts
+++ b/apps/rush/src/test/RushReporterHelp.test.ts
@@ -1,14 +1,18 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+import * as fs from 'node:fs';
+import * as os from 'node:os';
 import * as path from 'node:path';
 
 import * as rushLib from '@microsoft/rush-lib';
+import type { ICommandLineJson } from '@microsoft/rush-lib/lib/api/CommandLineJson';
 import { EnvironmentConfiguration } from '@microsoft/rush-lib/lib/api/EnvironmentConfiguration';
 import { RushCommandLineParser } from '@microsoft/rush-lib/lib/cli/RushCommandLineParser';
+import { JsonFile } from '@rushstack/node-core-library';
 
 import { launchRushFrontendAsync } from '../RushFrontend';
-import type { MinimalRushConfiguration } from '../MinimalRushConfiguration';
+import { MinimalRushConfiguration } from '../MinimalRushConfiguration';
 
 describe('reporter help forwarding', () => {
   it.each([false, true])('forwards only help to the real engine with repository opt-in %s', async (optIn) => {
@@ -73,6 +77,114 @@ describe('reporter help forwarding', () => {
       stdoutSpy.mockRestore();
       stderrSpy.mockRestore();
       logSpy.mockRestore();
+    }
+  });
+
+  it.each([
+    { command: 'custom-output', globalHelp: false, customValueControls: ['--output', '--log-level'] },
+    { command: 'custom-output', globalHelp: true, customValueControls: ['--output', '--log-level'] },
+    { command: 'build', globalHelp: false, customValueControls: ['--output', '--log-level'] },
+    { command: 'custom-output', globalHelp: false, customValueControls: ['--output'] },
+    { command: 'custom-output', globalHelp: false, customValueControls: ['--log-level'] }
+  ])('preserves declared reporter-shaped parameters for opted-in help: %j', async (testCase) => {
+    const directory: string = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'rush-custom-help-'));
+    const repoPath: string = path.join(directory, 'repo');
+    await fs.promises.cp(
+      path.resolve(__dirname, '../../../../libraries/rush-lib/src/cli/test/basicAndRunBuildActionRepo'),
+      repoPath,
+      { recursive: true }
+    );
+    const commandLinePath: string = path.join(repoPath, 'common/config/rush/command-line.json');
+    const commandLine: ICommandLineJson = JsonFile.load(commandLinePath);
+    commandLine.parameters = commandLine.parameters?.filter(
+      (parameter) =>
+        (parameter.longName !== '--output' && parameter.longName !== '--log-level') ||
+        testCase.customValueControls.includes(parameter.longName)
+    );
+    for (const parameter of commandLine.parameters ?? []) {
+      if (parameter.longName === '--output' || parameter.longName === '--log-level') {
+        parameter.associatedCommands?.push('build');
+      }
+    }
+    JsonFile.save(commandLine, commandLinePath);
+    const originalArgv: string[] = process.argv;
+    const originalEnv: NodeJS.ProcessEnv = { ...process.env };
+    const originalExitCode: typeof process.exitCode = process.exitCode;
+    const output: string[] = [];
+    const errors: string[] = [];
+    const stdoutSpy = jest.spyOn(process.stdout, 'write').mockImplementation((text) => {
+      output.push(String(text));
+      return true;
+    });
+    const stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation((text) => {
+      errors.push(String(text));
+      return true;
+    });
+    const logSpy = jest.spyOn(console, 'log').mockImplementation((text) => output.push(String(text)));
+    const cwdSpy = jest.spyOn(process, 'cwd').mockReturnValue(repoPath);
+    process.argv = [
+      'node',
+      'rush',
+      ...(testCase.globalHelp ? ['--help'] : []),
+      testCase.command,
+      '--output=json://./custom-events.jsonl',
+      '--log-level=debug',
+      '--verbose',
+      ...(testCase.globalHelp ? [] : ['--help'])
+    ];
+    const expectedArgv: string[] = process.argv.filter(
+      (argument) =>
+        (!argument.startsWith('--output=') || testCase.customValueControls.includes('--output')) &&
+        (!argument.startsWith('--log-level=') || testCase.customValueControls.includes('--log-level'))
+    );
+    delete process.env.RUSH_REPORTER;
+    delete process.env.RUSH_LOG_LEVEL;
+    try {
+      EnvironmentConfiguration.reset();
+      await launchRushFrontendAsync({
+        currentPackageVersion: '5.178.1',
+        rushVersionToLoad: undefined,
+        configuration: { useRushReporter: true } as MinimalRushConfiguration,
+        launchOptions: { isManaged: true },
+        currentRushLib: rushLib,
+        executeCurrentRush: (version, selectedRushLib, options) => {
+          void version;
+          void selectedRushLib;
+          const forwardedArgv: string[] = [...process.argv];
+          const parser: RushCommandLineParser = new RushCommandLineParser({
+            cwd: repoPath,
+            reporterCloseAsync: options.reporterCloseAsync
+          });
+          return parser.executeAsync().then((succeeded) => {
+            expect(succeeded).toBe(true);
+            expect(forwardedArgv).toEqual(expectedArgv);
+          });
+        }
+      });
+      expect(output.join('')).toContain(
+        testCase.globalHelp ? 'usage: rush' : `usage: rush ${testCase.command}`
+      );
+      expect(errors).toEqual([]);
+      expect(fs.existsSync(path.join(repoPath, 'custom-events.jsonl'))).toBe(false);
+      expect(fs.existsSync(path.join(repoPath, 'custom-output-args.json'))).toBe(false);
+
+      await fs.promises.writeFile(path.join(repoPath, 'rush.json'), '{ malformed rush.json');
+      logSpy.mockClear();
+      expect(MinimalRushConfiguration.loadFromDefaultLocation()).toBeUndefined();
+      expect(logSpy.mock.calls).toEqual([
+        [`Found configuration in ${path.join(repoPath, 'rush.json')}`],
+        ['']
+      ]);
+    } finally {
+      process.argv = originalArgv;
+      process.env = originalEnv;
+      process.exitCode = originalExitCode;
+      EnvironmentConfiguration.reset();
+      stdoutSpy.mockRestore();
+      stderrSpy.mockRestore();
+      logSpy.mockRestore();
+      cwdSpy.mockRestore();
+      await fs.promises.rm(directory, { recursive: true, force: true });
     }
   });
 });

--- a/apps/rush/src/test/RushReporterHelp.test.ts
+++ b/apps/rush/src/test/RushReporterHelp.test.ts
@@ -16,6 +16,8 @@ import { MinimalRushConfiguration } from '../MinimalRushConfiguration';
 
 describe('reporter help forwarding', () => {
   it.each([
+    { optIn: false, command: undefined, verbose: undefined },
+    { optIn: true, command: undefined, verbose: undefined },
     { optIn: false, command: 'build', verbose: undefined },
     { optIn: true, command: 'build', verbose: undefined },
     { optIn: false, command: 'list', verbose: '--verbose' },
@@ -45,7 +47,7 @@ describe('reporter help forwarding', () => {
     process.argv = [
       'node',
       'rush',
-      command,
+      ...(command ? [command] : []),
       ...(optIn ? [] : ['--reporter=json']),
       '--output=json://./help-events.jsonl',
       '--log-level=debug',
@@ -68,7 +70,7 @@ describe('reporter help forwarding', () => {
           expect(process.argv).toEqual([
             'node',
             'rush',
-            command,
+            ...(command ? [command] : []),
             ...(verbose && (verbose === '-v' || command === 'build') ? [verbose] : []),
             '--help'
           ]);
@@ -83,7 +85,7 @@ describe('reporter help forwarding', () => {
           });
         }
       });
-      expect(output.join('')).toContain(`usage: rush ${command}`);
+      expect(output.join('')).toContain(command ? `usage: rush ${command}` : 'usage: rush');
       expect(errors).toEqual([]);
     } finally {
       process.argv = originalArgv;

--- a/apps/rush/src/test/RushReporterHost.test.ts
+++ b/apps/rush/src/test/RushReporterHost.test.ts
@@ -313,6 +313,125 @@ describe(resolveRushReporterSelection.name, () => {
     });
   });
 
+  it.each([
+    ['build', '--reporter=json', '--output=file://./help.log', '--log-level=debug', '--help'],
+    ['build', '--help', '--reporter=default', '--output', 'json://./events.jsonl', '--log-level', 'quiet']
+  ])('strips explicit reporter-owned value controls for help: %s', (...argv: string[]) => {
+    const selection: IRushReporterSelection = resolve(argv);
+    expect(selection).toMatchObject({
+      reporter: 'legacy',
+      enabled: false,
+      reporterControlsOwnedByFrontend: true
+    });
+    expect(stripReporterValueControls(argv, new Set(selection.reporterValueFlagsToStrip))).toEqual([
+      'build',
+      '--help'
+    ]);
+  });
+
+  it.each([
+    [
+      ['build', '--output=json://./events.jsonl', '--log-level=debug', '--help'],
+      ['build', '--help']
+    ],
+    [
+      ['build', '--log-level=debug', '--help'],
+      ['build', '--help']
+    ],
+    [
+      ['custom', '--output', 'artifact.zip', '--log-level', 'custom-level', '--help'],
+      ['custom', '--output', 'artifact.zip', '--log-level', 'custom-level', '--help']
+    ],
+    [
+      ['custom', '--output', 'artifact.zip', '--log-level', 'debug', '--help'],
+      ['custom', '--output', 'artifact.zip', '--help']
+    ],
+    [
+      ['custom', '--output', '--log-level=debug', '--help'],
+      ['custom', '--output', '--help']
+    ],
+    [
+      ['custom', '--output=file://./log', '--log-level=custom', '--help'],
+      ['custom', '--output=file://./log', '--log-level=custom', '--help']
+    ],
+    [
+      ['custom', '--output=file://./log', '--output=custom.zip', '--log-level=debug', '--help'],
+      ['custom', '--output=file://./log', '--output=custom.zip', '--log-level=debug', '--help']
+    ],
+    [
+      ['custom', '--log-level', '--help'],
+      ['custom', '--log-level', '--help']
+    ],
+    [
+      ['build', '--log-level=debug', '--help', '--', '--output=json://./child'],
+      ['build', '--help', '--', '--output=json://./child']
+    ]
+  ])('uses selective implicit ownership for repository help: %j', (argv, expected) => {
+    const selection: IRushReporterSelection = resolve(argv, {}, false, true);
+    expect(selection.enabled).toBe(false);
+    expect(stripReporterValueControls(argv, new Set(selection.reporterValueFlagsToStrip))).toEqual(expected);
+  });
+
+  it('owns RUSH_LOG_LEVEL for repository help without enabling reporters', () => {
+    expect(resolve(['build', '--help'], { RUSH_LOG_LEVEL: 'debug' }, false, true)).toMatchObject({
+      reporter: 'legacy',
+      enabled: false,
+      reporterControlsOwnedByFrontend: true,
+      reporterValueFlagsToStrip: []
+    });
+    expect(resolve(['custom', '--help'], { RUSH_LOG_LEVEL: 'debug' })).toMatchObject({
+      reporterControlsOwnedByFrontend: false,
+      reporterValueFlagsToStrip: []
+    });
+  });
+
+  it('does not use implicit reporter value controls to opt in on help', () => {
+    const argv: string[] = ['custom', '--output=file://./log', '--log-level=debug', '--help'];
+    const selection: IRushReporterSelection = resolve(argv);
+    expect(selection.reporterControlsOwnedByFrontend).toBe(false);
+    expect(stripReporterValueControls(argv, new Set(selection.reporterValueFlagsToStrip))).toEqual(argv);
+  });
+
+  it('preserves command-owned help values under explicit and emergency legacy', () => {
+    const argv: string[] = [
+      'custom',
+      '--reporter=legacy',
+      '--output',
+      'artifact.zip',
+      '--log-level',
+      'custom',
+      '--help'
+    ];
+    for (const env of [{}, { RUSH_REPORTER: 'legacy', RUSH_LOG_LEVEL: 'invalid' }]) {
+      const selection: IRushReporterSelection = resolve(argv, env, false, true);
+      expect(stripReporterValueControls(argv, new Set(selection.reporterValueFlagsToStrip))).toEqual([
+        'custom',
+        '--output',
+        'artifact.zip',
+        '--log-level',
+        'custom',
+        '--help'
+      ]);
+    }
+  });
+
+  it('does not consume following flags while stripping incomplete owned controls for help', () => {
+    expect(stripReporterValueControls(['build', '--reporter=json', '--output', '--help'])).toEqual([
+      'build',
+      '--help'
+    ]);
+    expect(
+      stripReporterValueControls([
+        'build',
+        '--reporter=json',
+        '--log-level',
+        '--help',
+        '--',
+        '--output=child'
+      ])
+    ).toEqual(['build', '--help', '--', '--output=child']);
+  });
+
   it('ignores help controls after the pass-through separator', () => {
     expect(resolve(['build', '--reporter=json', '--', '--help'])).toMatchObject({
       reporter: 'json',

--- a/apps/rush/src/test/RushReporterHost.test.ts
+++ b/apps/rush/src/test/RushReporterHost.test.ts
@@ -728,7 +728,7 @@ describe(resolveRushReporterSelection.name, () => {
 
 describe(initializeRushReporterHostAsync.name, () => {
   it.each([false, true])(
-    'retains primary file debug details unless normal is explicit: %s',
+    'retains full log debug details independently of the selected level: %s',
     async (normal) => {
       const directory: string = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'rush-file-level-'));
       const osModule: typeof os = jest.requireActual('node:os');
@@ -740,6 +740,7 @@ describe(initializeRushReporterHostAsync.name, () => {
           stdout: { write: () => undefined },
           includeDefaultFileReporter: false
         });
+        expect(initialized.selection.logLevel).toBe(normal ? 'normal' : 'debug');
         initialized.sink.emit({
           protocolVersion: { major: 1, minor: 0 },
           sessionId: 'primary-file-level',
@@ -757,7 +758,7 @@ describe(initializeRushReporterHostAsync.name, () => {
         );
         expect(logName).toBeDefined();
         const text: string = await fs.promises.readFile(path.join(directory, logFolder, logName!), 'utf8');
-        expect(text.includes('retained-debug-detail')).toBe(!normal);
+        expect(text).toContain('retained-debug-detail');
       } finally {
         tmpdirSpy.mockRestore();
         await fs.promises.rm(directory, { recursive: true, force: true });

--- a/apps/rush/src/test/RushReporterHost.test.ts
+++ b/apps/rush/src/test/RushReporterHost.test.ts
@@ -344,11 +344,11 @@ describe(resolveRushReporterSelection.name, () => {
     ],
     [
       ['custom', '--output', 'artifact.zip', '--log-level', 'debug', '--help'],
-      ['custom', '--output', 'artifact.zip', '--help']
+      ['custom', '--output', 'artifact.zip', '--log-level', 'debug', '--help']
     ],
     [
       ['custom', '--output', '--log-level=debug', '--help'],
-      ['custom', '--output', '--help']
+      ['custom', '--output', '--log-level=debug', '--help']
     ],
     [
       ['custom', '--output=file://./log', '--log-level=custom', '--help'],
@@ -361,6 +361,10 @@ describe(resolveRushReporterSelection.name, () => {
     [
       ['custom', '--log-level', '--help'],
       ['custom', '--log-level', '--help']
+    ],
+    [
+      ['plugin-command', '--output=json://./custom.jsonl', '--log-level=debug', '--verbose', '--help'],
+      ['plugin-command', '--output=json://./custom.jsonl', '--log-level=debug', '--verbose', '--help']
     ],
     [
       ['build', '--log-level=debug', '--help', '--', '--output=json://./child'],

--- a/apps/rush/src/test/RushReporterHost.test.ts
+++ b/apps/rush/src/test/RushReporterHost.test.ts
@@ -5,7 +5,13 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
-import type { IReporterEventSink } from '@rushstack/rush-reporter';
+import {
+  ReporterManager,
+  type IReporter,
+  type IReporterContext,
+  type IReporterEventEnvelope,
+  type IReporterEventSink
+} from '@rushstack/rush-reporter';
 
 import {
   initializeRushReporterHostAsync,
@@ -156,6 +162,23 @@ describe(resolveRushReporterSelection.name, () => {
     });
   });
 
+  it('owns standalone log-level controls when the repository experiment is enabled', () => {
+    expect(resolve(['build', '--log-level=debug'], {}, false, true)).toMatchObject({
+      reporter: 'plaintext',
+      logLevel: 'debug',
+      enabled: true,
+      reporterControlsOwnedByFrontend: true,
+      reporterValueFlagsToStrip: ['--log-level']
+    });
+    expect(resolve(['build'], { RUSH_LOG_LEVEL: 'debug' }, false, true)).toMatchObject({
+      reporter: 'plaintext',
+      logLevel: 'debug',
+      enabled: true,
+      reporterControlsOwnedByFrontend: true,
+      reporterValueFlagsToStrip: []
+    });
+  });
+
   it('preserves custom value parameters when the repository experiment selects the reporter implicitly', () => {
     expect(
       resolve(
@@ -247,7 +270,7 @@ describe(resolveRushReporterSelection.name, () => {
       expect(selection).toMatchObject({
         enabled: false,
         reporter: 'legacy',
-        reporterControlsOwnedByFrontend: false,
+        reporterControlsOwnedByFrontend: true,
         reporterValueFlagsToStrip: []
       });
       expect(
@@ -280,6 +303,22 @@ describe(resolveRushReporterSelection.name, () => {
       '--reporter=junit',
       '--output=child-output'
     ]);
+  });
+
+  it('keeps help on the legacy parser-only path', () => {
+    expect(resolve(['build', '--help', '--reporter=json'], {}, false)).toMatchObject({
+      reporter: 'legacy',
+      enabled: false,
+      reporterControlsOwnedByFrontend: true
+    });
+  });
+
+  it('ignores help controls after the pass-through separator', () => {
+    expect(resolve(['build', '--reporter=json', '--', '--help'])).toMatchObject({
+      reporter: 'json',
+      enabled: true,
+      reporterControlsOwnedByFrontend: true
+    });
   });
 
   it('removes reporter-only value controls before invoking a legacy engine', () => {
@@ -373,6 +412,13 @@ describe(resolveRushReporterSelection.name, () => {
     );
   });
 
+  it('preserves RUSH_QUIET_MODE as a quiet reporter alias', () => {
+    expect(resolve(['build', '--reporter=plaintext'], { RUSH_QUIET_MODE: 'true' }).logLevel).toBe('quiet');
+    expect(() =>
+      resolve(['build', '--reporter=plaintext'], { RUSH_QUIET_MODE: '1', RUSH_LOG_LEVEL: 'debug' })
+    ).toThrow(/contradicts RUSH_LOG_LEVEL/);
+  });
+
   it('preserves legacy verbosity combinations when the reporter path is disabled', () => {
     expect(resolve(['build', '--quiet', '--debug'])).toMatchObject({
       reporter: 'legacy',
@@ -448,21 +494,24 @@ describe(resolveRushReporterSelection.name, () => {
     expect(resolve(['build', '--reporter=default'], {}, true).reporter).toBe('default');
   });
 
-  it('parses output targets and preserves command-specific --json independently', () => {
-    const selection: IRushReporterSelection = resolve(
-      [
-        'list',
-        '--json',
-        '--reporter=json',
-        '--output=file://./rush.log?logLevel=debug',
-        '--output=json://./events.jsonl'
-      ],
-      {},
-      false
+  it('preserves command-specific --json as the sole stdout owner', () => {
+    expect(() => resolve(['list', '--json', '--reporter=json'])).toThrow(
+      /command-specific --json output owns stdout/
     );
 
-    expect(selection.commandJson).toBe(true);
-    expect(selection.reporter).toBe('json');
+    const selection: IRushReporterSelection = resolve(
+      ['list', '--json', '--output=file://./rush.log?logLevel=debug', '--output=json://./events.jsonl'],
+      {},
+      false,
+      true
+    );
+
+    expect(selection).toMatchObject({
+      commandJson: true,
+      reporter: 'file',
+      enabled: true,
+      reason: 'repository experiment'
+    });
     expect(selection.outputs).toEqual([
       {
         reporter: 'file',
@@ -475,6 +524,21 @@ describe(resolveRushReporterSelection.name, () => {
         params: {}
       }
     ]);
+    expect(selection).toMatchObject({
+      reporterControlsOwnedByFrontend: true,
+      reporterValueFlagsToStrip: ['--output', '--log-level']
+    });
+    expect(resolve(['list', '--json', '--reporter=file']).reporter).toBe('file');
+  });
+
+  it('forces legacy selection for an incompatible Rush engine', () => {
+    expect(() =>
+      resolveRushReporterSelection({
+        argv: ['build', '--reporter=json'],
+        env: {},
+        forceLegacy: true
+      })
+    ).toThrow(/cannot safely use --reporter=json/);
   });
 
   it('surfaces unsupported and incomplete controls with actionable errors', () => {
@@ -508,16 +572,18 @@ describe(resolveRushReporterSelection.name, () => {
 
 describe(initializeRushReporterHostAsync.name, () => {
   it.each([
-    { target: 'stdout', outputs: ['json://stdout'] },
-    { target: 'stderr', outputs: ['json://stderr', 'file://stderr'] }
-  ])('rejects conflicting $target ownership before opening files', async ({ target, outputs }) => {
+    { reporter: 'json', target: 'stdout', outputs: ['json://stdout'] },
+    { reporter: 'json', target: 'stderr', outputs: ['json://stderr', 'file://stderr'] },
+    { reporter: 'file', target: 'stderr', outputs: ['json://stderr'] }
+  ])('rejects conflicting $target ownership before opening files', async ({ reporter, target, outputs }) => {
     const directory: string = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'rush-stream-conflict-'));
     try {
       await expect(
         initializeRushReporterHostAsync({
-          argv: ['build', '--reporter=json', ...outputs.map((output) => `--output=${output}`)],
+          argv: ['build', `--reporter=${reporter}`, ...outputs.map((output) => `--output=${output}`)],
           env: {},
           cwd: directory,
+          commonTempFolder: directory,
           stdout: { write: () => undefined },
           includeDefaultFileReporter: false
         }).then(async (initialized) => {
@@ -535,15 +601,14 @@ describe(initializeRushReporterHostAsync.name, () => {
     'writes reserved %s output to the stream without creating a same-named file',
     async (target) => {
       const directory: string = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'rush-stream-output-'));
-      const osModule: typeof os = jest.requireActual('node:os');
-      const tmpdirSpy: jest.SpyInstance = jest.spyOn(osModule, 'tmpdir').mockReturnValue(directory);
       const stdout = { write: jest.fn(), end: jest.fn() };
       const stderr = { write: jest.fn(), end: jest.fn() };
       try {
         const initialized = await initializeRushReporterHostAsync({
-          argv: ['build', '--reporter=file', `--output=json://${target}`],
+          argv: ['build', `--reporter=${target === 'stdout' ? 'file' : 'json'}`, `--output=json://${target}`],
           env: {},
           cwd: directory,
+          commonTempFolder: directory,
           stdout,
           stderr,
           includeDefaultFileReporter: false
@@ -552,16 +617,20 @@ describe(initializeRushReporterHostAsync.name, () => {
         await initialized.closeAsync();
 
         const stream = target === 'stdout' ? stdout : stderr;
-        expect(JSON.parse(stream.write.mock.calls.map(([text]) => text).join('')).type).toBe(
-          'commandStarted'
-        );
+        expect(
+          stream.write.mock.calls
+            .map(([text]) => text)
+            .join('')
+            .trim()
+            .split('\n')
+            .map((line) => JSON.parse(line))
+        ).toContainEqual(expect.objectContaining({ type: 'commandStarted' }));
         expect(stdout.end).not.toHaveBeenCalled();
         expect(stderr.end).not.toHaveBeenCalled();
         await expect(fs.promises.stat(path.join(directory, target))).rejects.toMatchObject({
           code: 'ENOENT'
         });
       } finally {
-        tmpdirSpy.mockRestore();
         await fs.promises.rm(directory, { recursive: true, force: true });
       }
     }
@@ -608,7 +677,105 @@ describe(initializeRushReporterHostAsync.name, () => {
     await initialized.closeAsync();
 
     expect(initialized.selection.enabled).toBe(false);
+    expect(initialized.logArtifact).toBeUndefined();
     expect(output).toBe('');
+  });
+
+  it('always creates a repository full-detail log on the enabled path', async () => {
+    const directory: string = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'rush-full-log-'));
+    try {
+      const initialized = await initializeRushReporterHostAsync({
+        argv: ['build', '--reporter=plaintext'],
+        env: {},
+        commonTempFolder: directory,
+        actionName: 'build',
+        stdout: { isTTY: false, write: () => undefined }
+      });
+
+      expect(initialized.logArtifact).toMatchObject({ available: true });
+      expect(initialized.logArtifact?.path).toMatch(
+        new RegExp(`^${directory.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`)
+      );
+      await initialized.closeAsync();
+    } finally {
+      await fs.promises.rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('prints the file path for a parser-only failure without commandResult', async () => {
+    const directory: string = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'rush-file-only-'));
+    let stderrText: string = '';
+    try {
+      const initialized = await initializeRushReporterHostAsync({
+        argv: ['missing-command', '--reporter=file'],
+        env: {},
+        commonTempFolder: directory,
+        actionName: 'missing-command',
+        stdout: { isTTY: false, write: () => undefined },
+        stderr: {
+          write: (text: string) => {
+            stderrText += text;
+          }
+        }
+      });
+      initialized.sink.emit({
+        protocolVersion: { major: 1, minor: 1 },
+        sessionId: 'session',
+        source: { packageName: '@microsoft/rush', packageVersion: '5.178.1' },
+        privacy: 'local-sensitive',
+        type: 'artifactAvailable',
+        payload: {
+          role: 'log',
+          path: initialized.logArtifact?.path,
+          format: 'plaintext',
+          complete: false
+        }
+      });
+      initialized.sink.emit({
+        protocolVersion: { major: 1, minor: 1 },
+        sessionId: 'session',
+        source: { packageName: '@microsoft/rush-lib', packageVersion: '5.178.1' },
+        privacy: 'public',
+        type: 'sessionCompleted',
+        payload: { exitCode: 1 }
+      });
+      await initialized.closeAsync();
+
+      expect(stderrText.match(/Rush full log:/g)).toHaveLength(1);
+      expect(stderrText).toContain(initialized.logArtifact?.path);
+    } finally {
+      await fs.promises.rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('does not render operation output at quiet plaintext log level', async () => {
+    let output: string = '';
+    const quietHost = await initializeRushReporterHostAsync({
+      argv: ['build', '--reporter=plaintext', '--log-level=quiet'],
+      env: {},
+      stdout: {
+        isTTY: false,
+        write: (text: string) => {
+          output += text;
+        }
+      },
+      includeDefaultFileReporter: false
+    });
+
+    emitCommandStarted(quietHost.sink);
+    emitOperationEvents(quietHost.sink);
+    quietHost.sink.emit({
+      protocolVersion: { major: 1, minor: 1 },
+      sessionId: 'session',
+      source: { packageName: '@microsoft/rush-lib', packageVersion: '5.178.1' },
+      privacy: 'public',
+      type: 'commandResult',
+      payload: { commandName: 'build', succeeded: true, exitCode: 0 }
+    });
+    await quietHost.closeAsync();
+
+    expect(output).not.toContain('raw operation output');
+    expect(output).toContain('rush build succeeded');
   });
 
   it('initializes the explicitly selected reporter and output destinations', async () => {
@@ -647,7 +814,14 @@ describe(initializeRushReporterHostAsync.name, () => {
         .trim()
         .split('\n')
         .map((line: string) => JSON.parse(line) as Record<string, unknown>);
-      expect(stdoutEvents.map(({ type }) => type)).toEqual(['commandStarted']);
+      expect(stdoutEvents.map(({ type }) => type)).toEqual([
+        'commandStarted',
+        'operationRegistered',
+        'operationStatusChanged',
+        'externalOutput',
+        'operationStreamClosed',
+        'operationCompleted'
+      ]);
       expect(fileEvents.map(({ type }) => type)).toEqual([
         'commandStarted',
         'operationRegistered',
@@ -656,6 +830,125 @@ describe(initializeRushReporterHostAsync.name, () => {
         'operationStreamClosed',
         'operationCompleted'
       ]);
+    } finally {
+      await fs.promises.rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('publishes a completed artifact before the final AI record', async () => {
+    const directory: string = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'rush-ai-artifact-'));
+    let stdoutText: string = '';
+    try {
+      const initialized = await initializeRushReporterHostAsync({
+        argv: ['build', '--reporter=ai'],
+        env: {},
+        commonTempFolder: directory,
+        actionName: 'build',
+        stdout: {
+          isTTY: false,
+          write: (text: string) => {
+            stdoutText += text;
+          }
+        }
+      });
+
+      emitCommandStarted(initialized.sink);
+      initialized.sink.emit({
+        protocolVersion: { major: 1, minor: 1 },
+        sessionId: 'session',
+        source: { packageName: '@microsoft/rush', packageVersion: '5.178.1' },
+        privacy: 'local-sensitive',
+        type: 'artifactAvailable',
+        payload: {
+          role: 'log',
+          path: initialized.logArtifact?.path,
+          format: 'plaintext',
+          complete: false
+        }
+      });
+      initialized.sink.emit({
+        protocolVersion: { major: 1, minor: 1 },
+        sessionId: 'session',
+        source: { packageName: '@microsoft/rush-lib', packageVersion: '5.178.1' },
+        privacy: 'public',
+        type: 'commandResult',
+        payload: { commandName: 'build', succeeded: true, exitCode: 0 }
+      });
+      await initialized.closeAsync();
+
+      const finalRecord: { log?: { complete?: boolean; path?: string } } = JSON.parse(
+        stdoutText.trim().split('\n').at(-1)!
+      );
+      expect(finalRecord.log).toMatchObject({
+        complete: true,
+        path: initialized.logArtifact?.path
+      });
+    } finally {
+      await fs.promises.rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('publishes artifact completeness as a frozen boolean snapshot', async () => {
+    const directory: string = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'rush-artifact-snapshot-'));
+    const reported: IReporterEventEnvelope<unknown>[] = [];
+    const manager: ReporterManager = new ReporterManager();
+    const captureReporter: IReporter = {
+      name: 'capture',
+      initializeAsync: async (context: IReporterContext) => {
+        void context;
+      },
+      report: (event: IReporterEventEnvelope<unknown>) => {
+        reported.push(event);
+      },
+      flushAsync: async () => undefined,
+      closeAsync: async () => undefined
+    };
+    manager.addReporter(captureReporter);
+    try {
+      const initialized = await initializeRushReporterHostAsync({
+        argv: ['build', '--reporter=json'],
+        env: {},
+        commonTempFolder: directory,
+        actionName: 'build',
+        stdout: { isTTY: false, write: () => undefined },
+        manager
+      });
+      initialized.sink.emit({
+        protocolVersion: { major: 1, minor: 1 },
+        sessionId: 'session',
+        source: { packageName: '@microsoft/rush', packageVersion: '5.178.1' },
+        privacy: 'local-sensitive',
+        type: 'artifactAvailable',
+        payload: {
+          role: 'log',
+          path: initialized.logArtifact?.path,
+          format: 'plaintext',
+          complete: false
+        }
+      });
+      initialized.sink.emit({
+        protocolVersion: { major: 1, minor: 1 },
+        sessionId: 'session',
+        source: { packageName: '@microsoft/rush-lib', packageVersion: '5.178.1' },
+        privacy: 'public',
+        type: 'commandResult',
+        payload: { commandName: 'build', succeeded: true, exitCode: 0 }
+      });
+      await initialized.closeAsync();
+
+      const finalArtifact: IReporterEventEnvelope<unknown> = reported
+        .filter(({ type }) => type === 'artifactAvailable')
+        .at(-1)!;
+      const descriptor: PropertyDescriptor | undefined = Object.getOwnPropertyDescriptor(
+        finalArtifact.payload as object,
+        'complete'
+      );
+      expect(descriptor).toMatchObject({ value: true, writable: false });
+      expect(typeof (finalArtifact.payload as { complete: unknown }).complete).toBe('boolean');
+      expect(finalArtifact.source).toEqual({
+        packageName: '@microsoft/rush',
+        packageVersion: '5.178.1'
+      });
     } finally {
       await fs.promises.rm(directory, { recursive: true, force: true });
     }

--- a/apps/rush/src/test/sandbox/reporter-demo/README.md
+++ b/apps/rush/src/test/sandbox/reporter-demo/README.md
@@ -1,0 +1,32 @@
+# Direct Rush reporter demo
+
+Build the three reporter projects, then run the self-checking direct invocation demo:
+
+```sh
+rush build --to @microsoft/rush
+node apps/rush/src/test/sandbox/reporter-demo/run.mjs
+```
+
+The script runs the same `rush build --only @rushstack/rush-reporter` operation stream through legacy,
+plaintext, JSON, AI, file, and quiet modes, plus parser failure, help, and command-specific JSON cases.
+It verifies payload-only machine stdout, one visible writer, ordered/lossless plaintext grouping from a
+same-invocation JSON sidecar, final artifact completeness, owner-only log permissions, failure flushing,
+AI parser-error context, command-JSON ownership, CI plaintext output, cache-path output, normalized
+`RUSH_TEMP_FOLDER` log placement, matching purge-path selection, and the `RUSH_REPORTER=legacy` rollback
+transcript. Captured stdout/stderr files are written to a temporary folder.
+
+For an individual invocation:
+
+```sh
+node apps/rush/bin/rush build --only @rushstack/rush-reporter --reporter=plaintext
+node apps/rush/bin/rush build --only @rushstack/rush-reporter --reporter=json --log-level=debug
+node apps/rush/bin/rush build --only @rushstack/rush-reporter --reporter=ai
+node apps/rush/bin/rush build --only @rushstack/rush-reporter --reporter=file
+node apps/rush/bin/rush build --only @rushstack/rush-reporter --reporter=plaintext --log-level=quiet
+RUSH_REPORTER=legacy node apps/rush/bin/rush build --only @rushstack/rush-reporter --reporter=json
+node apps/rush/bin/rush list --json --reporter=file
+```
+
+Repositories can opt in without a command-line flag by setting `"useRushReporter": true` in
+`common/config/rush/experiments.json`. Remove that setting or use `RUSH_REPORTER=legacy` for immediate
+rollback.

--- a/apps/rush/src/test/sandbox/reporter-demo/README.md
+++ b/apps/rush/src/test/sandbox/reporter-demo/README.md
@@ -30,3 +30,8 @@ node apps/rush/bin/rush list --json --reporter=file
 Repositories can opt in without a command-line flag by setting `"useRushReporter": true` in
 `common/config/rush/experiments.json`. Remove that setting or use `RUSH_REPORTER=legacy` for immediate
 rollback.
+
+Help stays on the legacy parser path. With repository opt-in, parameters declared for a command remain
+command-owned even when their values look like reporter controls (for example, `--output=json://...`
+or `--log-level=debug`). Custom `--verbose` flags are preserved as well; help does not run the command
+or open reporter output files.

--- a/apps/rush/src/test/sandbox/reporter-demo/run.mjs
+++ b/apps/rush/src/test/sandbox/reporter-demo/run.mjs
@@ -1,0 +1,222 @@
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptFolder = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptFolder, '..', '..', '..', '..', '..', '..');
+const rushBin = path.join(repoRoot, 'apps', 'rush', 'bin', 'rush');
+const outputFolder = fs.mkdtempSync(path.join(os.tmpdir(), 'rush-reporter-demo-'));
+const commonArgs = ['build', '--only', '@rushstack/rush-reporter'];
+
+function run(name, args, env = {}, expectedStatus = 0) {
+  const result = spawnSync(process.execPath, [rushBin, ...args], {
+    cwd: repoRoot,
+    env: { ...process.env, ...env },
+    encoding: 'utf8'
+  });
+  fs.writeFileSync(path.join(outputFolder, `${name}.stdout`), result.stdout);
+  fs.writeFileSync(path.join(outputFolder, `${name}.stderr`), result.stderr);
+  if (result.status !== expectedStatus) {
+    throw new Error(
+      `${name} exited with ${result.status}; expected ${expectedStatus}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`
+    );
+  }
+  return result;
+}
+
+run('warmup', commonArgs);
+const legacy = run('legacy', commonArgs).stdout;
+const rollback = run('rollback', [...commonArgs, '--reporter=json'], { RUSH_REPORTER: 'legacy' }).stdout;
+const normalizeDurations = (text) => text.replace(/\d+\.\d+ seconds/g, '<time> seconds');
+if (normalizeDurations(legacy) !== normalizeDurations(rollback)) {
+  throw new Error('RUSH_REPORTER=legacy did not reproduce the feature-off output.');
+}
+const plaintextEventsPath = path.join(outputFolder, 'plaintext-events.jsonl');
+const plaintext = run('plaintext', [
+  ...commonArgs,
+  '--reporter=plaintext',
+  `--output=json://${plaintextEventsPath}?logLevel=debug`
+]).stdout;
+const json = run('json', [...commonArgs, '--reporter=json', '--log-level=debug']).stdout;
+const ai = run('ai', [...commonArgs, '--reporter=ai']).stdout;
+const file = run('file', [...commonArgs, '--reporter=file']);
+const quiet = run('quiet', [...commonArgs, '--reporter=plaintext', '--log-level=quiet']).stdout;
+const verbose = run('verbose', [...commonArgs, '--reporter=plaintext', '--verbose']).stdout;
+const debug = run('debug', [...commonArgs, '--reporter=plaintext', '--log-level=debug']).stdout;
+const ci = run('ci', [...commonArgs, '--reporter=plaintext'], { CI: 'true' }).stdout;
+const failureJson = run(
+  'failure-json',
+  ['build', '--only', '@rushstack/does-not-exist', '--reporter=json'],
+  {},
+  1
+).stdout;
+const failureAi = run(
+  'failure-ai',
+  ['build', '--only', '@rushstack/does-not-exist', '--reporter=ai'],
+  {},
+  1
+).stdout;
+const flagOffHelp = run('help-flag-off', ['--help']).stdout;
+const help = run('help', ['--help', '--reporter=json'], { RUSH_REPORTER: 'legacy' }).stdout;
+const commandJson = run('command-json', ['list', '--json', '--reporter=file']);
+const commandJsonConflict = run('command-json-conflict', ['list', '--json', '--reporter=json'], {}, 1);
+const tempOverride = path.join(outputFolder, 'rush-temp-override');
+const tempOverrideFile = run('temp-override', [...commonArgs, '--reporter=file'], {
+  RUSH_TEMP_FOLDER: tempOverride
+});
+const tempOverrideLogMatch = tempOverrideFile.stderr.match(/^Rush full log: (.+)$/m);
+if (
+  !tempOverrideLogMatch ||
+  !tempOverrideLogMatch[1].startsWith(path.join(tempOverride, 'rush-logs')) ||
+  !fs.existsSync(tempOverrideLogMatch[1])
+) {
+  throw new Error('RUSH_TEMP_FOLDER did not own the full-detail log path.');
+}
+const tempPurge = run('temp-purge', ['purge', '--reporter=file'], { RUSH_TEMP_FOLDER: tempOverride });
+if (!tempPurge.stdout.includes(`Purging ${tempOverride}`)) {
+  throw new Error('rush purge did not use the same normalized RUSH_TEMP_FOLDER path as the reporter log.');
+}
+const purgeLogMatch = tempPurge.stderr.match(/^Rush full log: (.+)$/m);
+if (!purgeLogMatch || purgeLogMatch[1].startsWith(tempOverride) || !fs.existsSync(purgeLogMatch[1])) {
+  throw new Error('The active purge reporter log was not preserved outside RUSH_TEMP_FOLDER.');
+}
+
+function parseNdjson(text, name) {
+  if (text.includes('\u001b')) {
+    throw new Error(`${name} stdout contains terminal control sequences.`);
+  }
+  return text
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+const jsonEvents = parseNdjson(json, 'json');
+const aiRecords = parseNdjson(ai, 'ai');
+const failureJsonEvents = parseNdjson(failureJson, 'failure-json');
+const failureAiRecords = parseNdjson(failureAi, 'failure-ai');
+const plaintextEvents = parseNdjson(fs.readFileSync(plaintextEventsPath, 'utf8'), 'plaintext sidecar');
+
+for (const [name, events] of [
+  ['json', jsonEvents],
+  ['plaintext sidecar', plaintextEvents]
+]) {
+  const completedArtifact = events.findLast(
+    (event) => event.type === 'artifactAvailable' && event.payload?.role === 'log'
+  );
+  if (completedArtifact?.payload?.complete !== true) {
+    throw new Error(`${name} did not publish a complete final log artifact.`);
+  }
+  const operations = new Map();
+  for (const event of events) {
+    const operationId = event.scope?.operationId;
+    if (!operationId) {
+      continue;
+    }
+    const record = operations.get(operationId) ?? { closed: 0, completed: 0 };
+    if (event.type === 'operationStreamClosed') record.closed++;
+    if (event.type === 'operationCompleted') record.completed++;
+    operations.set(operationId, record);
+  }
+  for (const [operationId, record] of operations) {
+    if (record.closed !== 1 || record.completed !== 1) {
+      throw new Error(
+        `${name} operation ${operationId} had ${record.closed} close events and ${record.completed} completion events.`
+      );
+    }
+  }
+}
+
+const logMatch = plaintext.match(/^Full log: (.+)$/m);
+if (!logMatch || !path.isAbsolute(logMatch[1]) || !fs.existsSync(logMatch[1])) {
+  throw new Error('The plaintext reporter did not expose an existing absolute full-log path.');
+}
+if (process.platform !== 'win32' && (fs.statSync(logMatch[1]).mode & 0o777) !== 0o600) {
+  throw new Error('The full-detail log is not owner-only.');
+}
+
+const operationId = '@rushstack/rush-reporter#_phase:build';
+const rawOutput = plaintextEvents
+  .filter((event) => event.type === 'externalOutput' && event.scope?.operationId === operationId)
+  .map((event) => event.payload.text)
+  .join('');
+const groupHeader = '==[ @rushstack/rush-reporter (_phase:build) ]==\n';
+const groupStart = plaintext.indexOf(groupHeader);
+const groupEnd = ['success', 'successWithWarnings', 'fromCache']
+  .map((status) => plaintext.indexOf(`@rushstack/rush-reporter: ${status}`, groupStart))
+  .filter((index) => index >= 0)
+  .sort((a, b) => a - b)[0];
+if (groupStart < 0 || groupEnd === undefined) {
+  throw new Error('The plaintext reporter did not reconstruct the expected operation group.');
+}
+const groupedOutput = plaintext.slice(groupStart + groupHeader.length, groupEnd);
+if (groupedOutput !== rawOutput) {
+  throw new Error('Plaintext grouping lost, duplicated, or reordered operation chunks.');
+}
+if ((rawOutput.match(/---- build started ----/g) ?? []).length !== 1) {
+  throw new Error('The operation output contains a duplicated or missing build-start marker.');
+}
+if (!/build cache/i.test(rawOutput)) {
+  throw new Error('Cache-path output was not preserved in the raw operation stream.');
+}
+if (plaintext.includes('Rush Multi-Project Build Tool') || plaintext.includes('1 of 1 ]==')) {
+  throw new Error('The reporter path has more than one visible terminal writer.');
+}
+
+const aiFinal = aiRecords.at(-1);
+if (aiFinal?.kind !== 'ai.final' || aiFinal.log?.complete !== true) {
+  throw new Error('AI output did not include a complete full-log reference.');
+}
+const failureAiFinal = failureAiRecords.at(-1);
+if (
+  failureAiFinal?.result !== 'failed' ||
+  failureAiFinal.errorCount < 1 ||
+  JSON.stringify(failureAiFinal).includes('does not exist')
+) {
+  throw new Error('AI failure output did not count and redact the parser error.');
+}
+if (
+  !failureJsonEvents.some((event) => event.type === 'commandResult' && event.payload?.exitCode === 1) ||
+  !failureJsonEvents.some((event) => event.type === 'sessionCompleted' && event.payload?.exitCode === 1)
+) {
+  throw new Error('JSON failure output did not flush its final lifecycle records.');
+}
+if (quiet.includes('build started') || quiet.includes('==[ @rushstack/rush-reporter')) {
+  throw new Error('Quiet output leaked detailed operation output.');
+}
+if (!verbose.includes('Incremental strategy:') || !debug.includes('Incremental strategy:')) {
+  throw new Error('Verbose and debug reporter output did not preserve Rush terminal verbosity.');
+}
+if (
+  ci.includes('\u001b') ||
+  !/@rushstack\/rush-reporter: (?:success|successWithWarnings|fromCache)/.test(ci)
+) {
+  throw new Error('CI output was not append-only plaintext.');
+}
+
+const fileLogMatch = file.stderr.match(/^Rush full log: (.+)$/m);
+if (file.stdout !== '' || !fileLogMatch || !fs.existsSync(fileLogMatch[1])) {
+  throw new Error('The file reporter did not keep stdout empty and expose its log path on stderr.');
+}
+if (!help.includes('usage: rush') || help.includes('"type":"')) {
+  throw new Error('Help output did not remain on the legacy parser-only path.');
+}
+if (help !== flagOffHelp) {
+  throw new Error('RUSH_REPORTER=legacy changed the byte-for-byte parser output.');
+}
+const commandJsonPayload = JSON.parse(commandJson.stdout);
+if (!Array.isArray(commandJsonPayload.projects) || commandJson.stdout.includes('"protocolVersion"')) {
+  throw new Error('Command-specific JSON was mixed with reporter records.');
+}
+if (
+  !commandJson.stderr.includes('Rush full log:') ||
+  commandJsonConflict.stdout !== '' ||
+  !commandJsonConflict.stderr.includes('command-specific --json output owns stdout')
+) {
+  throw new Error('Command-specific JSON ownership arbitration failed.');
+}
+
+console.log(`Reporter demo outputs: ${outputFolder}`);
+console.log(`Full detail log: ${logMatch[1]}`);

--- a/common/changes/@microsoft/rush/copilot-reporter-r5b-demo-reporters_2026-08-28-07-10.json
+++ b/common/changes/@microsoft/rush/copilot-reporter-r5b-demo-reporters_2026-08-28-07-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Add the opt-in direct build reporter demo path with reporter-owned output, a complete full-detail log, and an immediate legacy rollback.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/rush",
+  "email": "TheLarkInn@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/rush/reporter-custom-help-ownership_2026-09-10.json
+++ b/common/changes/@microsoft/rush/reporter-custom-help-ownership_2026-09-10.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Preserve command-declared output and log-level parameters on repository-opted-in help, even when their values resemble valid reporter controls.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/reporter-help-ownership_2026-09-10.json
+++ b/common/changes/@microsoft/rush/reporter-help-ownership_2026-09-10.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Remove reporter-owned output and log-level controls from legacy help while preserving custom command options and emergency rollback behavior.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@microsoft/rush/reporter-malformed-discovery_2026-09-10.json
+++ b/common/changes/@microsoft/rush/reporter-malformed-discovery_2026-09-10.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/rush",
+      "comment": "Preserve legacy configuration discovery output when rush.json cannot be loaded, without contaminating explicitly selected reporter output.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/rush"
+}

--- a/common/changes/@rushstack/rush-reporter/copilot-reporter-r5b-demo-reporters_2026-08-28-07-10.json
+++ b/common/changes/@rushstack/rush-reporter/copilot-reporter-r5b-demo-reporters_2026-08-28-07-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/rush-reporter",
+      "comment": "Render phase-aware compact progress and grouped plaintext full logs from the canonical operation stream.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@rushstack/rush-reporter",
+  "email": "TheLarkInn@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/rush-reporter/reporter-artifact-close-contract_2026-09-10.json
+++ b/common/changes/@rushstack/rush-reporter/reporter-artifact-close-contract_2026-09-10.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/rush-reporter",
+      "comment": "Clarify that final full-detail artifact completeness is published only after physical closure and is not appended back to the closed log.",
+      "type": "none"
+    }
+  ],
+  "packageName": "@rushstack/rush-reporter"
+}

--- a/common/changes/@rushstack/rush-reporter/reporter-heft-diagnostics_2026-09-09.json
+++ b/common/changes/@rushstack/rush-reporter/reporter-heft-diagnostics_2026-09-09.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/rush-reporter",
+      "comment": "Preserve readable tool, compiler code, source location, and message details in human diagnostic output while redacting secret values.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/rush-reporter",
+  "email": "TheLarkInn@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/rush-reporter/reporter-secret-source-aliases_2026-09-09.json
+++ b/common/changes/@rushstack/rush-reporter/reporter-secret-source-aliases_2026-09-09.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/rush-reporter",
+      "comment": "Prevent human diagnostic source labels and lower-classified parameters from redisplaying explicitly secret parameter values.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/rush-reporter",
+  "email": "TheLarkInn@users.noreply.github.com"
+}

--- a/common/changes/@rushstack/rush-reporter/reporter-watch-and-short-writes_2026-09-09.json
+++ b/common/changes/@rushstack/rush-reporter/reporter-watch-and-short-writes_2026-09-09.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/rush-reporter",
+      "comment": "Show bounded interactive errors immediately and warnings once per watch cycle, and preserve grouped output across short writes without overstating log completeness.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/rush-reporter",
+  "email": "TheLarkInn@users.noreply.github.com"
+}

--- a/common/reviews/api/rush-lib.api.md
+++ b/common/reviews/api/rush-lib.api.md
@@ -254,6 +254,8 @@ export class EnvironmentConfiguration {
     //
     // @internal
     static _getRushGlobalFolderOverride(processEnv: IEnvironment): string | undefined;
+    // @internal
+    static _getRushTempFolderOverride(processEnv: IEnvironment): string | undefined;
     static get gitBinaryPath(): string | undefined;
     static get hasBeenValidated(): boolean;
     // (undocumented)
@@ -640,6 +642,7 @@ export interface _IOperationBuildCacheOptions {
 export interface IOperationExecutionResult extends IBaseOperationExecutionResult, IOperationLastState {
     readonly enabled: boolean;
     readonly error: Error | undefined;
+    readonly iterationId: number;
     readonly logFilePaths: ILogFilePaths | undefined;
     readonly nonCachedDurationMs: number | undefined;
     readonly problemCollector: IProblemCollector;
@@ -683,12 +686,12 @@ export interface IOperationGraphContext extends ICreateOperationsContext {
 // @internal
 export interface _IOperationGraphEventSink {
     onActivity?(text: string, options?: _IOperationActivityOptions): void;
-    onOperationChunk?(operationId: string, chunk: ITerminalChunk, result?: IOperationExecutionResult): void;
+    onOperationChunk?(operationId: string, chunk: ITerminalChunk, result?: IOperationExecutionResult, iterationId?: number): void;
     onOperationCompleted?(result: IOperationExecutionResult): void;
     onOperationHeader?(operationId: string, completedOperations: number, totalOperations: number): void;
-    onOperationRegistered?(operationId: string, silent: boolean, result?: IOperationExecutionResult): void;
+    onOperationRegistered?(operationId: string, silent: boolean, result?: IOperationExecutionResult, iterationId?: number): void;
     onOperationStatusChanged?(result: IOperationExecutionResult, previousStatus: OperationStatus): void;
-    onOperationStreamClosed?(operationId: string, result?: IOperationExecutionResult): void;
+    onOperationStreamClosed?(operationId: string, result?: IOperationExecutionResult, iterationId?: number): void;
 }
 
 // @alpha
@@ -1017,6 +1020,8 @@ export interface IRushSessionOptions {
 // @beta
 export interface IRushSessionReporterOptions {
     readonly eventSink: IReporterEventSink;
+    // @internal
+    readonly flushAsync?: () => Promise<void>;
     // @internal
     readonly operationStreamEnabled?: boolean;
     readonly sessionId: string;

--- a/common/reviews/api/rush-reporter.api.md
+++ b/common/reviews/api/rush-reporter.api.md
@@ -222,6 +222,8 @@ export interface IAiDiagnostic {
     readonly remediation?: readonly IRushRemediationAction[];
     // (undocumented)
     readonly severity: string;
+    // (undocumented)
+    readonly summary?: string;
 }
 
 // @beta
@@ -448,6 +450,7 @@ export interface IEngineSinkResolution {
 
 // @beta
 export interface IExternalOutputChunk {
+    readonly iterationId?: number;
     readonly operationId?: string;
     readonly stream: string;
     readonly text: string;
@@ -456,6 +459,7 @@ export interface IExternalOutputChunk {
 // @beta
 export interface IFileReporterArtifact {
     readonly available: boolean;
+    readonly complete: boolean;
     readonly path?: string;
 }
 
@@ -580,6 +584,7 @@ export interface ILiveRegionState {
 
 // @beta
 export interface IMessageEmittedPayload {
+    readonly minimumLogLevel?: ReporterLogLevel;
     readonly privacy?: ReporterPrivacyClassification;
     readonly severity: ReporterMessageSeverity;
     readonly text: string;
@@ -607,12 +612,14 @@ export interface IOldEngineOutputAdapterOptions {
 // @beta
 export interface IOperationCompletedPayload {
     readonly durationMs?: number;
+    readonly iterationId?: number;
     readonly operationId: string;
     readonly status: OperationStatus;
 }
 
 // @beta
 export interface IOperationRegisteredPayload {
+    readonly iterationId?: number;
     readonly operationId: string;
     readonly phaseName?: string;
     readonly projectName?: string;
@@ -622,6 +629,7 @@ export interface IOperationRegisteredPayload {
 // @beta
 export interface IOperationStatusChangedPayload {
     readonly durationMs?: number;
+    readonly iterationId?: number;
     readonly operationId: string;
     readonly previousStatus?: OperationStatus;
     readonly status: OperationStatus;
@@ -629,6 +637,7 @@ export interface IOperationStatusChangedPayload {
 
 // @beta
 export interface IOperationStreamClosedPayload {
+    readonly iterationId?: number;
     readonly operationId: string;
 }
 
@@ -646,6 +655,7 @@ export interface IOperationStreamEmitterOptions {
 export interface IPlaintextReporterOptions {
     readonly color?: boolean;
     readonly heartbeatIntervalMs?: number;
+    readonly logLevel?: ReporterLogLevel;
     readonly nowMs?: () => number;
     readonly variant?: PlaintextVariant;
     readonly write: (text: string) => void;
@@ -941,6 +951,7 @@ export interface IRushDiagnostic {
     readonly code: RushDiagnosticCode;
     readonly detailKey?: string;
     readonly diagnosticId: string;
+    readonly iterationId?: number;
     readonly parameters?: {
         readonly [name: string]: IClassifiedDiagnosticValue;
     };
@@ -1033,6 +1044,7 @@ export interface IScopedLogger {
 
 // @beta
 export interface IScopedMessageOptions {
+    readonly minimumLogLevel?: ReporterLogLevel;
     readonly privacy?: ReporterPrivacyClassification;
     readonly severity: ReporterMessageSeverity;
     readonly text: string;
@@ -1130,6 +1142,7 @@ export function iterateExternalOutput(events: readonly IReporterEventEnvelope<un
 // @beta
 export interface IWatchCycleCompletedPayload {
     readonly changedProjects?: readonly string[];
+    readonly iterationId?: number;
     readonly succeeded: boolean;
 }
 
@@ -1266,14 +1279,14 @@ export type OperationStatus = 'ready' | 'waiting' | 'queued' | 'executing' | 'su
 // @beta
 export class OperationStreamEmitter {
     constructor(options: IOperationStreamEmitterOptions);
-    changeStatus(operationId: string, status: OperationStatus, durationMs?: number, previousStatus?: OperationStatus): string;
-    closeOperationStream(operationId: string): string;
+    changeStatus(operationId: string, status: OperationStatus, durationMs?: number, previousStatus?: OperationStatus, iterationId?: number): string;
+    closeOperationStream(operationId: string, iterationId?: number): string;
     completeCommand(commandName: string, succeeded: boolean, exitCode: number, operationCounts?: {
         readonly [status: string]: number;
     }): string;
-    completeOperation(operationId: string, status: OperationStatus, durationMs?: number): string;
-    registerOperation(operationId: string, projectName?: string, phaseName?: string, silent?: boolean): string;
-    writeOutput(operationId: string, stream: 'stdout' | 'stderr', text: string): string[];
+    completeOperation(operationId: string, status: OperationStatus, durationMs?: number, iterationId?: number): string;
+    registerOperation(operationId: string, projectName?: string, phaseName?: string, silent?: boolean, iterationId?: number): string;
+    writeOutput(operationId: string, stream: 'stdout' | 'stderr', text: string, iterationId?: number): string[];
 }
 
 // @beta
@@ -1405,6 +1418,8 @@ export class ReporterManager implements IReporterEventSink {
     addReporter(reporter: IReporter, options?: IReporterRegistrationOptions): void;
     closeAsync(timeoutMs?: number): Promise<void>;
     emit<TPayload>(event: IReporterEmitEventInput<TPayload>): string;
+    // @internal
+    _flushAndConfirmAsync(timeoutMs?: number): Promise<boolean>;
     flushAsync(timeoutMs?: number): Promise<void>;
     getPendingEventCount(): number;
     ingestForeignEnvelope(envelope: IReporterEventEnvelope<unknown>): string;

--- a/libraries/reporter/README.md
+++ b/libraries/reporter/README.md
@@ -4,6 +4,15 @@ Canonical event protocol, reporter manager, and built-in reporters for Rush.
 
 This package is released as a public beta. Exported contracts may change before the stable release.
 
+## Full-detail log completion
+
+The frontend reports an invocation log as complete only after its accepted events and grouped
+output have been persisted and the file has closed successfully. Its final `artifactAvailable`
+notification is delivered to the remaining reporters after that close; it is not appended to the
+same closed log. The log retains command results and session completion, including failed commands.
+Flush or close failures leave the artifact incomplete or unavailable and produce an emergency warning
+without replacing the command's native exit result.
+
 ## Links
 
 - [CHANGELOG.md](https://github.com/microsoft/rushstack/blob/main/libraries/reporter/CHANGELOG.md) - Find out

--- a/libraries/reporter/src/config/LogLevelFilter.ts
+++ b/libraries/reporter/src/config/LogLevelFilter.ts
@@ -64,7 +64,14 @@ export function getEventMinimumLogLevel(event: IReporterEventEnvelope<unknown>):
     case 'artifactAvailable':
       return 'normal';
     case 'messageEmitted': {
-      const severity: string | undefined = (event.payload as { severity?: string }).severity;
+      const payload: { severity?: string; minimumLogLevel?: ReporterLogLevel } = event.payload as {
+        severity?: string;
+        minimumLogLevel?: ReporterLogLevel;
+      };
+      if (payload.minimumLogLevel !== undefined) {
+        return payload.minimumLogLevel;
+      }
+      const severity: string | undefined = payload.severity;
       if (severity === 'error' || severity === 'warning') {
         return 'quiet';
       }

--- a/libraries/reporter/src/diagnostics/IRushDiagnostic.ts
+++ b/libraries/reporter/src/diagnostics/IRushDiagnostic.ts
@@ -38,6 +38,11 @@ export interface IRushDiagnostic {
   readonly diagnosticId: string;
 
   /**
+   * The operation graph iteration that produced this diagnostic, when applicable.
+   */
+  readonly iterationId?: number;
+
+  /**
    * A stable, never-reused code of the form `RUSH_<DOMAIN>_<NAME>` that
    * identifies the diagnostic and keys its English template, for example
    * `RUSH_DEPENDENCY_TOOL_FAILED`.

--- a/libraries/reporter/src/events/IMessageEmittedPayload.ts
+++ b/libraries/reporter/src/events/IMessageEmittedPayload.ts
@@ -3,6 +3,7 @@
 
 import type { ReporterPrivacyClassification } from './ReporterPrivacyClassification';
 import type { ReporterMessageSeverity } from '../producers/IScopedReporter';
+import type { ReporterLogLevel } from '../config/ReporterNames';
 
 /**
  * The payload of a `messageEmitted` event: a human-oriented message from a
@@ -29,6 +30,11 @@ export interface IMessageEmittedPayload {
    * The human-readable message text.
    */
   readonly text: string;
+
+  /**
+   * An optional minimum reporter log level for this message.
+   */
+  readonly minimumLogLevel?: ReporterLogLevel;
 
   /**
    * The privacy classification of {@link IMessageEmittedPayload.text}.

--- a/libraries/reporter/src/lifecycle/LifecycleEvents.ts
+++ b/libraries/reporter/src/lifecycle/LifecycleEvents.ts
@@ -100,6 +100,11 @@ export interface ICommandCompletedPayload {
  */
 export interface IOperationRegisteredPayload {
   /**
+   * The graph iteration that owns this event.
+   */
+  readonly iterationId?: number;
+
+  /**
    * The operation id.
    */
   readonly operationId: string;
@@ -126,6 +131,11 @@ export interface IOperationRegisteredPayload {
  * @beta
  */
 export interface IOperationStatusChangedPayload {
+  /**
+   * The graph iteration that owns this event.
+   */
+  readonly iterationId?: number;
+
   /**
    * The operation id.
    */
@@ -154,6 +164,11 @@ export interface IOperationStatusChangedPayload {
  */
 export interface IOperationStreamClosedPayload {
   /**
+   * The graph iteration that owns this event.
+   */
+  readonly iterationId?: number;
+
+  /**
    * The operation whose output stream has closed.
    */
   readonly operationId: string;
@@ -165,6 +180,11 @@ export interface IOperationStreamClosedPayload {
  * @beta
  */
 export interface IOperationCompletedPayload {
+  /**
+   * The graph iteration that owns this event.
+   */
+  readonly iterationId?: number;
+
   /**
    * The completed operation.
    */
@@ -214,6 +234,11 @@ export interface ICommandResultPayload {
  * @beta
  */
 export interface IWatchCycleCompletedPayload {
+  /**
+   * The completed graph iteration.
+   */
+  readonly iterationId?: number;
+
   /**
    * Whether the watch cycle succeeded.
    */

--- a/libraries/reporter/src/manager/ReporterManager.ts
+++ b/libraries/reporter/src/manager/ReporterManager.ts
@@ -276,6 +276,20 @@ export class ReporterManager implements IReporterEventSink {
   }
 
   /**
+   * Flushes reporters and reports whether every lifecycle action completed before the timeout.
+   *
+   * @internal
+   */
+  public async _flushAndConfirmAsync(timeoutMs: number = DEFAULT_FLUSH_TIMEOUT_MS): Promise<boolean> {
+    return await this._settleAndConfirmAsync(async (entry: IReporterEntry): Promise<void> => {
+      await entry.drainPromise;
+      if (!entry.disabled) {
+        await entry.reporter.flushAsync();
+      }
+    }, timeoutMs);
+  }
+
+  /**
    * Performs a best-effort flush suitable for signal termination.
    *
    * @remarks
@@ -425,6 +439,26 @@ export class ReporterManager implements IReporterEventSink {
 
     try {
       await Promise.race([work, timeout]);
+    } finally {
+      if (timer !== undefined) {
+        clearTimeout(timer);
+      }
+    }
+  }
+
+  private async _settleAndConfirmAsync(
+    action: (entry: IReporterEntry) => Promise<void>,
+    timeoutMs: number
+  ): Promise<boolean> {
+    const work: Promise<true> = Promise.all(
+      this._entries.map((entry: IReporterEntry) => this._scheduleLifecycleAction(entry, action))
+    ).then(() => true as const);
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timeout: Promise<false> = new Promise<false>((resolve: (value: false) => void) => {
+      timer = setTimeout(() => resolve(false), timeoutMs);
+    });
+    try {
+      return await Promise.race([work, timeout]);
     } finally {
       if (timer !== undefined) {
         clearTimeout(timer);

--- a/libraries/reporter/src/producers/IScopedReporter.ts
+++ b/libraries/reporter/src/producers/IScopedReporter.ts
@@ -3,6 +3,7 @@
 
 import type { ReporterPrivacyClassification } from '../events/ReporterPrivacyClassification';
 import type { ReporterJsonValue } from '../events/ReporterJsonValue';
+import type { ReporterLogLevel } from '../config/ReporterNames';
 import type { IRushDiagnostic } from '../diagnostics/IRushDiagnostic';
 import type { ReporterExtensionEventName } from './ReporterExtensionEventName';
 
@@ -32,6 +33,11 @@ export interface IScopedMessageOptions {
    * The human-readable message text.
    */
   readonly text: string;
+
+  /**
+   * An optional minimum reporter log level for this message.
+   */
+  readonly minimumLogLevel?: ReporterLogLevel;
 
   /**
    * The privacy classification of the message text. Defaults to

--- a/libraries/reporter/src/reporters/AiReporter.ts
+++ b/libraries/reporter/src/reporters/AiReporter.ts
@@ -16,8 +16,43 @@ const TERMINAL_STATUSES: ReadonlySet<string> = new Set([
   'blocked',
   'skipped',
   'fromCache',
-  'noOp'
+  'noOp',
+  'aborted'
 ]);
+
+interface IAiDiagnosticState {
+  readonly errorDiagnostics: IAiDiagnostic[];
+  readonly warningDiagnostics: IAiDiagnostic[];
+  readonly errorCodes: Set<string>;
+  readonly diagnosticCategoryCounts: { [category: string]: number };
+  errorDiagnosticsTruncated: boolean;
+  warningDiagnosticsTruncated: boolean;
+  errorCount: number;
+  warningCount: number;
+}
+
+interface IAiWatchCycleState {
+  readonly registeredOperations: Set<string>;
+  readonly projectByOperation: Map<string, string>;
+  readonly silentOperations: Set<string>;
+  readonly operationCounts: { [status: string]: number };
+  readonly failedProjects: string[];
+  readonly diagnostics: IAiDiagnosticState;
+  watchCompleted: boolean;
+}
+
+function createDiagnosticState(): IAiDiagnosticState {
+  return {
+    errorDiagnostics: [],
+    warningDiagnostics: [],
+    errorCodes: new Set(),
+    diagnosticCategoryCounts: {},
+    errorDiagnosticsTruncated: false,
+    warningDiagnosticsTruncated: false,
+    errorCount: 0,
+    warningCount: 0
+  };
+}
 
 /**
  * A bounded diagnostic in an AI record.
@@ -28,6 +63,7 @@ export interface IAiDiagnostic {
   readonly code: string;
   readonly category: string;
   readonly severity: string;
+  readonly summary?: string;
   readonly remediation?: readonly IRushRemediationAction[];
 }
 
@@ -108,21 +144,18 @@ export class AiReporter implements IReporter {
 
   private _protocolVersion: IReporterProtocolVersion;
   private _commandName: string | undefined;
-  private readonly _projectByOperation: Map<string, string>;
-  private readonly _operationCounts: { [status: string]: number };
-  private readonly _failedProjects: string[];
-  private readonly _errorDiagnostics: IAiDiagnostic[];
-  private readonly _warningDiagnostics: IAiDiagnostic[];
-  private readonly _errorCodes: Set<string>;
-  private readonly _diagnosticCategoryCounts: { [category: string]: number };
-  private _errorDiagnosticsTruncated: boolean;
-  private _warningDiagnosticsTruncated: boolean;
-  private _errorCount: number;
-  private _warningCount: number;
+  private readonly _watchCycles: Map<number, IAiWatchCycleState>;
+  private readonly _globalDiagnostics: IAiDiagnosticState;
+  private readonly _fallbackErrorMessages: string[];
+  private _fallbackErrorCount: number;
+  private _fallbackErrorsTruncated: boolean;
   private _logPath: string | undefined;
   private _logFormat: string | undefined;
   private _artifactComplete: boolean;
   private _finalEmitted: boolean;
+  private _pendingResult: { succeeded: boolean; exitCode: number } | undefined;
+  private _legacyIterationId: number;
+  private _latestIterationId: number;
 
   public constructor(options: IAiReporterOptions) {
     this._write = options.write;
@@ -138,21 +171,18 @@ export class AiReporter implements IReporter {
 
     this._protocolVersion = REPORTER_PROTOCOL_VERSION;
     this._commandName = undefined;
-    this._projectByOperation = new Map();
-    this._operationCounts = {};
-    this._failedProjects = [];
-    this._errorDiagnostics = [];
-    this._warningDiagnostics = [];
-    this._errorCodes = new Set();
-    this._diagnosticCategoryCounts = {};
-    this._errorDiagnosticsTruncated = false;
-    this._warningDiagnosticsTruncated = false;
-    this._errorCount = 0;
-    this._warningCount = 0;
+    this._watchCycles = new Map();
+    this._globalDiagnostics = createDiagnosticState();
+    this._fallbackErrorMessages = [];
+    this._fallbackErrorCount = 0;
+    this._fallbackErrorsTruncated = false;
     this._logPath = undefined;
     this._logFormat = undefined;
     this._artifactComplete = true;
     this._finalEmitted = false;
+    this._pendingResult = undefined;
+    this._legacyIterationId = 0;
+    this._latestIterationId = 0;
   }
 
   public async initializeAsync(): Promise<void> {
@@ -174,34 +204,107 @@ export class AiReporter implements IReporter {
         break;
       }
       case 'operationRegistered': {
-        const payload: { operationId: string; projectName?: string } = event.payload as {
+        const payload: {
           operationId: string;
           projectName?: string;
+          silent?: boolean;
+          iterationId?: number;
+        } = event.payload as {
+          operationId: string;
+          projectName?: string;
+          silent?: boolean;
+          iterationId?: number;
         };
+        const cycle: IAiWatchCycleState = this._getWatchCycle(payload.iterationId);
+        if (cycle.registeredOperations.has(payload.operationId)) {
+          break;
+        }
+        cycle.registeredOperations.add(payload.operationId);
+        if (payload.silent) {
+          cycle.silentOperations.add(payload.operationId);
+        }
         if (payload.projectName !== undefined) {
-          this._projectByOperation.set(payload.operationId, payload.projectName);
+          cycle.projectByOperation.set(payload.operationId, payload.projectName);
         }
         break;
       }
       case 'operationStatusChanged': {
-        const payload: { operationId: string; status: string } = event.payload as {
+        break;
+      }
+      case 'operationCompleted': {
+        const payload: { operationId: string; status: string; iterationId?: number } = event.payload as {
           operationId: string;
           status: string;
+          iterationId?: number;
         };
+        const cycle: IAiWatchCycleState = this._getWatchCycle(payload.iterationId);
+        if (cycle.silentOperations.has(payload.operationId)) {
+          cycle.silentOperations.delete(payload.operationId);
+          break;
+        }
         if (TERMINAL_STATUSES.has(payload.status)) {
-          this._operationCounts[payload.status] = (this._operationCounts[payload.status] ?? 0) + 1;
+          cycle.operationCounts[payload.status] = (cycle.operationCounts[payload.status] ?? 0) + 1;
           if (payload.status === 'failure') {
             const projectName: string =
-              this._projectByOperation.get(payload.operationId) ??
+              cycle.projectByOperation.get(payload.operationId) ??
               event.scope?.projectName ??
               payload.operationId;
-            this._failedProjects.push(projectName);
+            cycle.failedProjects.push(projectName);
           }
         }
         break;
       }
       case 'diagnosticEmitted': {
-        this._collectDiagnostic(event.payload as IAiDiagnostic);
+        const diagnostic: IAiDiagnostic & { iterationId?: number } = event.payload as IAiDiagnostic & {
+          iterationId?: number;
+        };
+        this._collectDiagnostic(
+          diagnostic,
+          diagnostic.iterationId === undefined
+            ? this._globalDiagnostics
+            : this._getWatchCycle(diagnostic.iterationId).diagnostics
+        );
+        break;
+      }
+      case 'watchCycleCompleted': {
+        const payload: { succeeded?: boolean; iterationId?: number } = event.payload as {
+          succeeded?: boolean;
+          iterationId?: number;
+        };
+        const cycle: IAiWatchCycleState = this._getWatchCycle(payload.iterationId);
+        const succeeded: boolean = payload.succeeded === true;
+        this._write(
+          `${JSON.stringify({
+            kind: 'ai.watchCycle',
+            protocolVersion: this._protocolVersion,
+            succeeded,
+            operationCounts: { ...cycle.operationCounts },
+            failedProjects: [...cycle.failedProjects]
+          })}\n`
+        );
+        if (payload.iterationId === undefined) {
+          this._legacyIterationId++;
+        }
+        cycle.watchCompleted = true;
+        this._pruneCompletedWatchCycles();
+        break;
+      }
+      case 'messageEmitted': {
+        const payload: { severity?: string; text?: string } = event.payload as {
+          severity?: string;
+          text?: string;
+        };
+        if (payload.severity === 'error' && payload.text) {
+          this._fallbackErrorCount++;
+          if (
+            event.privacy === 'public' &&
+            this._fallbackErrorMessages.length < this._maxDetailedDiagnostics
+          ) {
+            this._fallbackErrorMessages.push(payload.text.trim());
+          } else {
+            this._fallbackErrorsTruncated = true;
+          }
+        }
         break;
       }
       case 'artifactAvailable': {
@@ -219,7 +322,14 @@ export class AiReporter implements IReporter {
           succeeded: boolean;
           exitCode: number;
         };
-        this._emitFinal(payload.succeeded, payload.exitCode);
+        this._pendingResult = payload;
+        break;
+      }
+      case 'sessionCompleted': {
+        if (!this._pendingResult) {
+          const exitCode: number = (event.payload as { exitCode?: number }).exitCode ?? 1;
+          this._pendingResult = { succeeded: exitCode === 0, exitCode };
+        }
         break;
       }
       default:
@@ -233,39 +343,77 @@ export class AiReporter implements IReporter {
 
   public async closeAsync(): Promise<void> {
     if (!this._finalEmitted) {
-      this._emitFinal(false, 1);
+      const result: { succeeded: boolean; exitCode: number } = this._pendingResult ?? {
+        succeeded: false,
+        exitCode: 1
+      };
+      this._emitFinal(result.succeeded, result.exitCode);
     }
   }
 
-  private _collectDiagnostic(diagnostic: IAiDiagnostic): void {
+  private _collectDiagnostic(diagnostic: IAiDiagnostic, state: IAiDiagnosticState): void {
     if (diagnostic.category !== undefined) {
-      this._diagnosticCategoryCounts[diagnostic.category] =
-        (this._diagnosticCategoryCounts[diagnostic.category] ?? 0) + 1;
+      state.diagnosticCategoryCounts[diagnostic.category] =
+        (state.diagnosticCategoryCounts[diagnostic.category] ?? 0) + 1;
     }
     if (diagnostic.severity === 'error') {
-      this._errorCount++;
-      this._errorCodes.add(diagnostic.code);
-      if (this._errorDiagnostics.length < this._maxDetailedDiagnostics) {
-        this._errorDiagnostics.push({
+      state.errorCount++;
+      state.errorCodes.add(diagnostic.code);
+      if (state.errorDiagnostics.length < this._maxDetailedDiagnostics) {
+        state.errorDiagnostics.push({
           code: diagnostic.code,
           category: diagnostic.category,
           severity: 'error',
+          summary: diagnostic.summary,
           remediation: diagnostic.remediation
         });
       } else {
-        this._errorDiagnosticsTruncated = true;
+        state.errorDiagnosticsTruncated = true;
       }
     } else if (diagnostic.severity === 'warning') {
-      this._warningCount++;
-      if (this._warningDiagnostics.length < this._maxDetailedDiagnostics) {
-        this._warningDiagnostics.push({
+      state.warningCount++;
+      if (state.warningDiagnostics.length < this._maxDetailedDiagnostics) {
+        state.warningDiagnostics.push({
           code: diagnostic.code,
           category: diagnostic.category,
           severity: 'warning',
+          summary: diagnostic.summary,
           remediation: diagnostic.remediation
         });
       } else {
-        this._warningDiagnosticsTruncated = true;
+        state.warningDiagnosticsTruncated = true;
+      }
+    }
+  }
+
+  private _getWatchCycle(iterationId?: number): IAiWatchCycleState {
+    const resolvedIterationId: number = iterationId ?? this._legacyIterationId;
+    let cycle: IAiWatchCycleState | undefined = this._watchCycles.get(resolvedIterationId);
+    if (!cycle) {
+      cycle = {
+        registeredOperations: new Set(),
+        projectByOperation: new Map(),
+        silentOperations: new Set(),
+        operationCounts: {},
+        failedProjects: [],
+        diagnostics: createDiagnosticState(),
+        watchCompleted: false
+      };
+      this._watchCycles.set(resolvedIterationId, cycle);
+    }
+    this._latestIterationId = Math.max(this._latestIterationId, resolvedIterationId);
+    this._pruneCompletedWatchCycles();
+    return cycle;
+  }
+
+  private _getLatestWatchCycle(): IAiWatchCycleState {
+    return this._getWatchCycle(this._latestIterationId);
+  }
+
+  private _pruneCompletedWatchCycles(): void {
+    for (const [iterationId, cycle] of this._watchCycles) {
+      if (iterationId < this._latestIterationId && cycle.watchCompleted) {
+        this._watchCycles.delete(iterationId);
       }
     }
   }
@@ -276,10 +424,49 @@ export class AiReporter implements IReporter {
     }
     this._finalEmitted = true;
 
-    const hasFailures: boolean = !succeeded || this._errorCount > 0;
+    const cycle: IAiWatchCycleState = this._getLatestWatchCycle();
+    const cycleDiagnostics: IAiDiagnosticState = cycle.diagnostics;
+    const errorCountWithoutFallback: number =
+      this._globalDiagnostics.errorCount + cycleDiagnostics.errorCount;
+    const warningCount: number = this._globalDiagnostics.warningCount + cycleDiagnostics.warningCount;
+    const collectedErrorDiagnostics: IAiDiagnostic[] = [
+      ...this._globalDiagnostics.errorDiagnostics,
+      ...cycleDiagnostics.errorDiagnostics
+    ];
+    const collectedWarningDiagnostics: IAiDiagnostic[] = [
+      ...this._globalDiagnostics.warningDiagnostics,
+      ...cycleDiagnostics.warningDiagnostics
+    ];
+    const fallbackDiagnostics: IAiDiagnostic[] =
+      errorCountWithoutFallback === 0
+        ? this._fallbackErrorMessages.map((summary) => ({
+            code: 'RUSH_COMMAND_FAILED',
+            category: 'command',
+            severity: 'error',
+            summary
+          }))
+        : [];
+    const hasFallbackErrors: boolean = errorCountWithoutFallback === 0 && this._fallbackErrorCount > 0;
+    const errorDiagnostics: IAiDiagnostic[] = hasFallbackErrors
+      ? fallbackDiagnostics
+      : collectedErrorDiagnostics;
+    const errorCount: number = errorCountWithoutFallback + (hasFallbackErrors ? this._fallbackErrorCount : 0);
+    const errorCodes: string[] = hasFallbackErrors
+      ? ['RUSH_COMMAND_FAILED']
+      : [...new Set([...this._globalDiagnostics.errorCodes, ...cycleDiagnostics.errorCodes])].sort();
+    const diagnosticCategoryCounts: { [category: string]: number } = {
+      ...this._globalDiagnostics.diagnosticCategoryCounts
+    };
+    for (const [category, count] of Object.entries(cycleDiagnostics.diagnosticCategoryCounts)) {
+      diagnosticCategoryCounts[category] = (diagnosticCategoryCounts[category] ?? 0) + count;
+    }
+    if (hasFallbackErrors) {
+      diagnosticCategoryCounts.command = (diagnosticCategoryCounts.command ?? 0) + this._fallbackErrorCount;
+    }
+    const hasFailures: boolean = !succeeded || errorCount > 0;
     // When failures exist, warnings are represented by counts only. Warning-only
     // success may include bounded warning details.
-    const detailedSource: IAiDiagnostic[] = hasFailures ? this._errorDiagnostics : this._warningDiagnostics;
+    const detailedSource: IAiDiagnostic[] = hasFailures ? errorDiagnostics : collectedWarningDiagnostics;
 
     const record: {
       kind: 'ai.final';
@@ -300,14 +487,18 @@ export class AiReporter implements IReporter {
       protocolVersion: this._protocolVersion,
       result: succeeded ? 'succeeded' : 'failed',
       exitCode,
-      scope: { commandName: this._commandName, failedProjects: [...this._failedProjects] },
-      errorCodes: [...this._errorCodes].sort(),
-      diagnosticCategoryCounts: { ...this._diagnosticCategoryCounts },
+      scope: { commandName: this._commandName, failedProjects: [...cycle.failedProjects] },
+      errorCodes,
+      diagnosticCategoryCounts,
       diagnostics: detailedSource.slice(0, this._maxDetailedDiagnostics),
-      errorCount: this._errorCount,
-      warningCount: this._warningCount,
-      operationCounts: { ...this._operationCounts },
-      truncated: hasFailures ? this._errorDiagnosticsTruncated : this._warningDiagnosticsTruncated
+      errorCount,
+      warningCount,
+      operationCounts: { ...cycle.operationCounts },
+      truncated: hasFailures
+        ? this._globalDiagnostics.errorDiagnosticsTruncated ||
+          cycleDiagnostics.errorDiagnosticsTruncated ||
+          (hasFallbackErrors && this._fallbackErrorsTruncated)
+        : this._globalDiagnostics.warningDiagnosticsTruncated || cycleDiagnostics.warningDiagnosticsTruncated
     };
 
     if (this._logPath !== undefined) {

--- a/libraries/reporter/src/reporters/DefaultInteractiveReporter.ts
+++ b/libraries/reporter/src/reporters/DefaultInteractiveReporter.ts
@@ -1,8 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+import { createHash } from 'node:crypto';
+
 import type { IReporterEventEnvelope } from '../events/IReporterEventEnvelope';
 import type { IReporter } from '../manager/IReporter';
+import { getHumanReadableMessageText } from './ReporterRedaction';
+import { formatHumanReadableDiagnostic } from './HumanReadableDiagnostic';
 import {
   SPINNER_FRAMES,
   MIN_REFRESH_INTERVAL_MS,
@@ -17,15 +21,27 @@ import {
 const HIDE_CURSOR: string = '\u001b[?25l';
 const SHOW_CURSOR: string = '\u001b[?25h';
 const MAX_FINAL_DIAGNOSTICS: number = 10;
-const TERMINAL_STATUSES: ReadonlySet<string> = new Set([
-  'success',
-  'successWithWarnings',
-  'failure',
-  'blocked',
-  'skipped',
-  'fromCache',
-  'noOp'
-]);
+const MAX_DIAGNOSTIC_TEXT_LENGTH: number = 512;
+
+interface IDiagnosticState {
+  readonly identities: Set<string>;
+  readonly warnings: Map<string, string>;
+  suppressed: number;
+  summarized: boolean;
+}
+
+interface IWatchCycleState {
+  totalOperations: number;
+  completedOperations: number;
+  failedOperations: number;
+  readonly registeredOperations: Set<string>;
+  readonly projectByOperation: Map<string, string>;
+  readonly silentOperations: Set<string>;
+  readonly activeProjects: Map<string, string>;
+  latestActivity: string;
+  watchCompleted: boolean;
+  readonly diagnostics: IDiagnosticState;
+}
 
 /**
  * The terminal an interactive reporter writes to.
@@ -110,13 +126,11 @@ export class DefaultInteractiveReporter implements IReporter {
   private readonly _minRefreshIntervalMs: number;
 
   private _commandName: string | undefined;
-  private _totalOperations: number;
-  private _completedOperations: number;
-  private _failedOperations: number;
-  private readonly _projectByOperation: Map<string, string>;
-  private readonly _activeProjects: Map<string, string>;
+  private readonly _watchCycles: Map<number, IWatchCycleState>;
+  private _legacyIterationId: number;
+  private _latestIterationId: number;
   private _latestActivity: string;
-  private readonly _diagnostics: string[];
+  private _latestCompletedIterationId: number;
   private _result: { succeeded: boolean; exitCode: number } | undefined;
   private _logPath: string | undefined;
 
@@ -135,13 +149,11 @@ export class DefaultInteractiveReporter implements IReporter {
     this._minRefreshIntervalMs = options.minRefreshIntervalMs ?? MIN_REFRESH_INTERVAL_MS;
 
     this._commandName = undefined;
-    this._totalOperations = 0;
-    this._completedOperations = 0;
-    this._failedOperations = 0;
-    this._projectByOperation = new Map();
-    this._activeProjects = new Map();
+    this._watchCycles = new Map();
+    this._legacyIterationId = 0;
+    this._latestIterationId = 0;
     this._latestActivity = '';
-    this._diagnostics = [];
+    this._latestCompletedIterationId = -1;
     this._result = undefined;
     this._logPath = options.logPath;
 
@@ -157,6 +169,9 @@ export class DefaultInteractiveReporter implements IReporter {
   }
 
   public report(event: IReporterEventEnvelope<unknown>): void {
+    if (this._finalized) {
+      return;
+    }
     this._update(event);
     if (event.type === 'watchCycleCompleted') {
       this._appendWatchSummary(event);
@@ -184,54 +199,122 @@ export class DefaultInteractiveReporter implements IReporter {
         break;
       }
       case 'operationRegistered': {
-        const payload: { operationId: string; projectName?: string } = event.payload as {
+        const payload: {
           operationId: string;
           projectName?: string;
+          phaseName?: string;
+          silent?: boolean;
+          iterationId?: number;
+        } = event.payload as {
+          operationId: string;
+          projectName?: string;
+          phaseName?: string;
+          silent?: boolean;
+          iterationId?: number;
         };
-        this._totalOperations++;
-        this._projectByOperation.set(
+        const cycle: IWatchCycleState = this._getWatchCycle(payload.iterationId);
+        if (cycle.registeredOperations.has(payload.operationId)) {
+          break;
+        }
+        cycle.registeredOperations.add(payload.operationId);
+        if (payload.silent) {
+          cycle.silentOperations.add(payload.operationId);
+          break;
+        }
+        cycle.silentOperations.delete(payload.operationId);
+        cycle.totalOperations++;
+        const projectName: string = payload.projectName ?? event.scope?.projectName ?? payload.operationId;
+        cycle.projectByOperation.set(
           payload.operationId,
-          payload.projectName ?? event.scope?.projectName ?? payload.operationId
+          payload.phaseName ? `${projectName} (${payload.phaseName})` : projectName
         );
         break;
       }
       case 'operationStatusChanged': {
-        const payload: { operationId: string; status: string; projectName?: string } = event.payload as {
+        const payload: {
           operationId: string;
           status: string;
           projectName?: string;
+          iterationId?: number;
+        } = event.payload as {
+          operationId: string;
+          status: string;
+          projectName?: string;
+          iterationId?: number;
         };
+        const cycle: IWatchCycleState = this._getWatchCycle(payload.iterationId);
         const projectName: string =
           payload.projectName ??
           event.scope?.projectName ??
-          this._projectByOperation.get(payload.operationId) ??
+          cycle.projectByOperation.get(payload.operationId) ??
           payload.operationId;
-        if (payload.status === 'executing') {
-          this._activeProjects.set(payload.operationId, projectName);
-        } else if (TERMINAL_STATUSES.has(payload.status)) {
-          this._activeProjects.delete(payload.operationId);
-          this._completedOperations++;
-          if (payload.status === 'failure') {
-            this._failedOperations++;
-          }
+        if (cycle.silentOperations.has(payload.operationId)) {
+          break;
         }
-        this._latestActivity = `${payload.status} ${projectName}`;
+        if (payload.status === 'executing') {
+          cycle.activeProjects.set(payload.operationId, projectName);
+        }
+        cycle.latestActivity = `${payload.status} ${projectName}`;
+        break;
+      }
+      case 'operationCompleted': {
+        const payload: { operationId: string; status: string; iterationId?: number } = event.payload as {
+          operationId: string;
+          status: string;
+          iterationId?: number;
+        };
+        const cycle: IWatchCycleState = this._getWatchCycle(payload.iterationId);
+        if (cycle.silentOperations.delete(payload.operationId)) {
+          break;
+        }
+        const projectName: string =
+          cycle.projectByOperation.get(payload.operationId) ??
+          event.scope?.projectName ??
+          payload.operationId;
+        cycle.activeProjects.delete(payload.operationId);
+        cycle.completedOperations++;
+        if (payload.status === 'failure') {
+          cycle.failedOperations++;
+        }
+        cycle.latestActivity = `${payload.status} ${projectName}`;
         break;
       }
       case 'activityChanged': {
         const payload: { kind?: string; text?: string } = event.payload as { kind?: string; text?: string };
         if (payload.text !== undefined) {
-          this._latestActivity = payload.text;
+          this._latestActivity = this._toSingleLine(payload.text);
+        }
+        break;
+      }
+      case 'messageEmitted': {
+        const payload: { severity?: string; iterationId?: number } = event.payload as {
+          severity?: string;
+          iterationId?: number;
+        };
+        const text: string | undefined = getHumanReadableMessageText(event);
+        if (text !== undefined) {
+          if (payload.severity === 'error' || payload.severity === 'warning') {
+            this._recordDiagnostic(event, payload.severity, text, payload.iterationId);
+          } else {
+            this._latestActivity = this._toSingleLine(text);
+          }
         }
         break;
       }
       case 'diagnosticEmitted': {
-        const payload: { code?: string; severity?: string } = event.payload as {
-          code?: string;
+        const payload: { diagnosticId?: string; severity?: string; iterationId?: number } = event.payload as {
+          diagnosticId?: string;
           severity?: string;
+          iterationId?: number;
         };
         if (payload.severity === 'error' || payload.severity === 'warning') {
-          this._diagnostics.push(`[${payload.severity}] ${payload.code ?? 'unknown'}`);
+          this._recordDiagnostic(
+            event,
+            payload.severity,
+            formatHumanReadableDiagnostic(event),
+            payload.iterationId,
+            payload.diagnosticId
+          );
         }
         break;
       }
@@ -251,14 +334,81 @@ export class DefaultInteractiveReporter implements IReporter {
     }
   }
 
+  private _toSingleLine(text: string): string {
+    const lines: string[] = text
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean);
+    return lines.at(-1) ?? '';
+  }
+
+  private _recordDiagnostic(
+    event: IReporterEventEnvelope<unknown>,
+    severity: 'error' | 'warning',
+    text: string,
+    iterationId: number = this._latestIterationId,
+    diagnosticId?: string
+  ): void {
+    const existingCycle: IWatchCycleState | undefined = this._watchCycles.get(iterationId);
+    if (
+      existingCycle?.watchCompleted ||
+      (!existingCycle && iterationId <= this._latestCompletedIterationId)
+    ) {
+      return;
+    }
+    const { diagnostics } = this._getWatchCycle(iterationId);
+    const identity: string = createHash('sha256')
+      .update(`${event.sessionId ?? ''}\0${diagnosticId ?? event.eventId ?? `${severity}\0${text}`}`)
+      .digest('hex');
+    if (diagnostics.identities.has(identity)) {
+      return;
+    }
+    if (diagnostics.identities.size >= MAX_FINAL_DIAGNOSTICS) {
+      diagnostics.suppressed++;
+      const warningIdentity: string | undefined = diagnostics.warnings.keys().next().value;
+      if (severity !== 'error' || warningIdentity === undefined) {
+        return;
+      }
+      diagnostics.warnings.delete(warningIdentity);
+      diagnostics.identities.delete(warningIdentity);
+    }
+    diagnostics.identities.add(identity);
+    const singleLine: string = text.replace(/\s+/g, ' ').trim();
+    const boundedText: string =
+      singleLine.length > MAX_DIAGNOSTIC_TEXT_LENGTH
+        ? `${singleLine.slice(0, MAX_DIAGNOSTIC_TEXT_LENGTH - 1).replace(/[\uD800-\uDBFF]$/, '')}…`
+        : singleLine;
+    if (severity === 'error') {
+      this._terminal.write(`${this._clearRegion()}${boundedText}\n`);
+      this._paintedRowCount = 0;
+    } else {
+      diagnostics.warnings.set(identity, boundedText);
+    }
+  }
+
+  private _takeDiagnosticSummary(cycle: IWatchCycleState): string[] {
+    const { diagnostics } = cycle;
+    if (diagnostics.summarized) {
+      return [];
+    }
+    diagnostics.summarized = true;
+    const lines: string[] = [...diagnostics.warnings.values()];
+    diagnostics.warnings.clear();
+    if (diagnostics.suppressed > 0) {
+      lines.push(`+${diagnostics.suppressed} more diagnostic events; see the full log`);
+    }
+    return lines;
+  }
+
   private _snapshot(): ILiveRegionState {
+    const cycle: IWatchCycleState = this._getLatestWatchCycle();
     return {
       commandName: this._commandName,
-      totalOperations: this._totalOperations,
-      completedOperations: this._completedOperations,
-      failedOperations: this._failedOperations,
-      activeProjects: [...this._activeProjects.values()],
-      latestActivity: this._latestActivity
+      totalOperations: cycle.totalOperations,
+      completedOperations: cycle.completedOperations,
+      failedOperations: cycle.failedOperations,
+      activeProjects: [...cycle.activeProjects.values()],
+      latestActivity: cycle.latestActivity || this._latestActivity
     };
   }
 
@@ -287,13 +437,78 @@ export class DefaultInteractiveReporter implements IReporter {
   }
 
   private _appendWatchSummary(event: IReporterEventEnvelope<unknown>): void {
-    const payload: { succeeded?: boolean } = event.payload as { succeeded?: boolean };
+    const payload: { succeeded?: boolean; iterationId?: number } = event.payload as {
+      succeeded?: boolean;
+      iterationId?: number;
+    };
+    const cycle: IWatchCycleState = this._getWatchCycle(payload.iterationId);
     const marker: string = payload.succeeded ? this._color.green('✔') : this._color.red('✖');
-    const summary: string = `${marker} watch cycle ${payload.succeeded ? 'succeeded' : 'failed'}`;
-    this._terminal.write(`${this._clearRegion()}${summary}\n`);
+    const summary: string =
+      `${marker} watch cycle ${payload.succeeded ? 'succeeded' : 'failed'} - ` +
+      `${cycle.completedOperations}/${cycle.totalOperations} operations`;
+    const diagnosticLines: string[] = [];
+    const startupCycle: IWatchCycleState | undefined = this._watchCycles.get(0);
+    if (payload.iterationId !== undefined && payload.iterationId > 0 && startupCycle && startupCycle !== cycle) {
+      diagnosticLines.push(...this._takeDiagnosticSummary(startupCycle));
+      startupCycle.watchCompleted = true;
+    }
+    diagnosticLines.push(...this._takeDiagnosticSummary(cycle));
+    if (this._logPath && (!payload.succeeded || cycle.diagnostics.suppressed > 0)) {
+      diagnosticLines.push(`Log: ${this._logPath}`);
+    }
+    this._terminal.write(`${this._clearRegion()}${[...diagnosticLines, summary].join('\n')}\n`);
     this._paintedRowCount = 0;
+    cycle.watchCompleted = true;
+    this._latestCompletedIterationId = Math.max(
+      this._latestCompletedIterationId,
+      payload.iterationId ?? this._legacyIterationId
+    );
+    this._pruneCompletedWatchCycles();
+    if (payload.iterationId === undefined) {
+      this._legacyIterationId++;
+    }
     if (this._terminal.isTTY) {
       this._paint();
+    }
+  }
+
+  private _getWatchCycle(iterationId?: number): IWatchCycleState {
+    const resolvedIterationId: number = iterationId ?? this._legacyIterationId;
+    let cycle: IWatchCycleState | undefined = this._watchCycles.get(resolvedIterationId);
+    if (!cycle) {
+      cycle = {
+        totalOperations: 0,
+        completedOperations: 0,
+        failedOperations: 0,
+        registeredOperations: new Set(),
+        projectByOperation: new Map(),
+        silentOperations: new Set(),
+        activeProjects: new Map(),
+        latestActivity: '',
+        watchCompleted: false,
+        diagnostics: {
+          identities: new Set(),
+          warnings: new Map(),
+          suppressed: 0,
+          summarized: false
+        }
+      };
+      this._watchCycles.set(resolvedIterationId, cycle);
+    }
+    this._latestIterationId = Math.max(this._latestIterationId, resolvedIterationId);
+    this._pruneCompletedWatchCycles();
+    return cycle;
+  }
+
+  private _getLatestWatchCycle(): IWatchCycleState {
+    return this._getWatchCycle(this._latestIterationId);
+  }
+
+  private _pruneCompletedWatchCycles(): void {
+    for (const [iterationId, cycle] of this._watchCycles) {
+      if (iterationId < this._latestIterationId && cycle.watchCompleted) {
+        this._watchCycles.delete(iterationId);
+      }
     }
   }
 
@@ -304,22 +519,23 @@ export class DefaultInteractiveReporter implements IReporter {
     this._finalized = true;
 
     const lines: string[] = [];
+    for (const cycle of this._watchCycles.values()) {
+      lines.push(...this._takeDiagnosticSummary(cycle));
+    }
+    const cycle: IWatchCycleState = this._getLatestWatchCycle();
     const succeeded: boolean = this._result?.succeeded ?? false;
     if (succeeded) {
       lines.push(
         `${this._color.green('✔')} ${this._commandName ?? 'rush'} succeeded — ` +
-          `${this._completedOperations}/${this._totalOperations} operations`
+          `${cycle.completedOperations}/${cycle.totalOperations} operations`
       );
+      if (this._logPath !== undefined) {
+        lines.push(this._color.dim(`Log: ${this._logPath}`));
+      }
     } else {
       lines.push(
-        `${this._color.red('✖')} ${this._commandName ?? 'rush'} failed — ${this._failedOperations} failed`
+        `${this._color.red('✖')} ${this._commandName ?? 'rush'} failed — ${cycle.failedOperations} failed`
       );
-      for (const diagnostic of this._diagnostics.slice(0, MAX_FINAL_DIAGNOSTICS)) {
-        lines.push(`  ${diagnostic}`);
-      }
-      if (this._diagnostics.length > MAX_FINAL_DIAGNOSTICS) {
-        lines.push(`  +${this._diagnostics.length - MAX_FINAL_DIAGNOSTICS} more diagnostics`);
-      }
       if (this._logPath !== undefined) {
         lines.push(`  ${this._color.dim(`Log: ${this._logPath}`)}`);
       }

--- a/libraries/reporter/src/reporters/FileReporter.ts
+++ b/libraries/reporter/src/reporters/FileReporter.ts
@@ -8,6 +8,7 @@ import * as path from 'node:path';
 import type { IReporterEventEnvelope } from '../events/IReporterEventEnvelope';
 import type { IReporter } from '../manager/IReporter';
 import { redactReporterEvent } from './ReporterRedaction';
+import { writeAllSync, WriteAllSyncError } from '../utilities/writeAllSync';
 
 /**
  * The subdirectory that holds full-detail invocation logs. `rush purge` removes it.
@@ -28,11 +29,38 @@ const DEFAULT_MAX_SESSIONS: number = 20;
 const OWNER_ONLY_MODE: number = 0o600;
 const OWNER_ONLY_DIRECTORY_MODE: number = 0o700;
 const MS_PER_DAY: number = 24 * 60 * 60 * 1000;
+const TERMINAL_STATUSES: ReadonlySet<string> = new Set([
+  'success',
+  'successWithWarnings',
+  'failure',
+  'blocked',
+  'skipped',
+  'fromCache',
+  'noOp',
+  'aborted'
+]);
+
+interface IFileOperationRecord {
+  readonly operationId: string;
+  readonly title: string;
+  spoolPath?: string;
+  spoolFileDescriptor?: number;
+  spoolFailed?: boolean;
+}
 
 function getUserTempDirectoryName(): string {
   const identity: string =
     typeof process.getuid === 'function' ? String(process.getuid()) : os.userInfo().username;
   return `${RUSH_LOGS_DIR_NAME}-${identity.replace(/[^a-zA-Z0-9_.-]/g, '_')}`;
+}
+
+function sanitizeActionName(actionName: string): string {
+  const sanitized: string = actionName.replace(/[^a-zA-Z0-9_.-]+/g, '_');
+  return sanitized === '.' || sanitized === '..' || sanitized.length === 0 ? 'rush' : sanitized;
+}
+
+function getOperationKey(operationId: string, iterationId: number | undefined): string {
+  return iterationId === undefined ? operationId : `${iterationId}\u0000${operationId}`;
 }
 
 /**
@@ -50,6 +78,11 @@ export interface IFileReporterArtifact {
    * The absolute path to the log, when available.
    */
   readonly path?: string;
+
+  /**
+   * Whether every event and grouped output chunk has been persisted.
+   */
+  readonly complete: boolean;
 }
 
 /**
@@ -127,17 +160,21 @@ export class FileReporter implements IReporter {
   private readonly _emergencyWarn: (message: string) => void;
 
   private readonly _lines: string[];
+  private readonly _operations: Map<string, IFileOperationRecord>;
   private _fileDescriptor: number | undefined;
   private _targetResolved: boolean;
   private _available: boolean;
+  private _complete: boolean;
+  private _canComplete: boolean;
   private _targetPath: string | undefined;
   private _latestCopyPath: string | undefined;
   private readonly _fileName: string;
+  private _nextSpoolId: number;
 
   public constructor(options: IFileReporterOptions = {}) {
     this._commonTempFolder = options.commonTempFolder;
     this._osTempFolder = options.osTempFolder ?? os.tmpdir();
-    this._actionName = options.actionName ?? 'rush';
+    this._actionName = sanitizeActionName(options.actionName ?? 'rush');
     this._pid = options.pid ?? process.pid;
     this._nowMs = options.nowMs ?? (() => Date.now());
     this._retentionDays = options.retentionDays ?? DEFAULT_RETENTION_DAYS;
@@ -149,11 +186,15 @@ export class FileReporter implements IReporter {
       });
 
     this._lines = [];
+    this._operations = new Map();
     this._fileDescriptor = undefined;
     this._targetResolved = false;
     this._available = false;
+    this._complete = false;
+    this._canComplete = true;
     this._targetPath = undefined;
     this._latestCopyPath = undefined;
+    this._nextSpoolId = 1;
 
     const timestamp: string = new Date(this._nowMs()).toISOString().replace(/[:.]/g, '-');
     this._fileName = `${timestamp}-${this._pid}-${this._actionName}.log`;
@@ -165,14 +206,16 @@ export class FileReporter implements IReporter {
   }
 
   public report(event: IReporterEventEnvelope<unknown>): void {
-    const line: string = this._formatLine(event);
-    if (this._fileDescriptor === undefined) {
-      if (!this._targetResolved) {
-        this._lines.push(line);
+    const lines: readonly string[] = this._formatEvent(event);
+    for (const line of lines) {
+      if (this._fileDescriptor === undefined) {
+        if (!this._targetResolved) {
+          this._lines.push(line);
+        }
+      } else {
+        this._writeLine(line);
       }
-      return;
     }
-    this._writeLine(line);
   }
 
   public async flushAsync(): Promise<void> {
@@ -189,12 +232,18 @@ export class FileReporter implements IReporter {
   }
 
   public async closeAsync(): Promise<void> {
+    for (const record of this._operations.values()) {
+      this._writeGroupedOperation(record.operationId, record, 'aborted');
+    }
+    this._operations.clear();
     await this.flushAsync();
     if (this._fileDescriptor !== undefined) {
       try {
         fs.closeSync(this._fileDescriptor);
       } catch (error) {
         this._available = false;
+        this._complete = false;
+        this._canComplete = false;
         this._emergencyWarn(
           `[reporter] Unable to close the full-detail log; the artifact is unavailable: ${(error as Error).message}`
         );
@@ -203,6 +252,7 @@ export class FileReporter implements IReporter {
       }
     }
     await this._refreshLatestCopyAsync();
+    this._complete = this._available && this._canComplete;
   }
 
   /**
@@ -210,12 +260,233 @@ export class FileReporter implements IReporter {
    */
   public getArtifact(): IFileReporterArtifact {
     return this._targetPath !== undefined
-      ? { available: this._available, path: this._targetPath }
-      : { available: this._available };
+      ? { available: this._available, path: this._targetPath, complete: this._available && this._complete }
+      : { available: this._available, complete: false };
   }
 
-  private _formatLine(event: IReporterEventEnvelope<unknown>): string {
-    return `${JSON.stringify(redactReporterEvent(event))}\n`;
+  private _formatEvent(event: IReporterEventEnvelope<unknown>): readonly string[] {
+    if (event.privacy === 'secret') {
+      return [this._formatMetadata(event)];
+    }
+
+    if (event.type === 'operationRegistered') {
+      const payload: {
+        operationId: string;
+        projectName?: string;
+        phaseName?: string;
+        iterationId?: number;
+      } = event.payload as {
+        operationId: string;
+        projectName?: string;
+        phaseName?: string;
+        iterationId?: number;
+      };
+      const projectName: string = payload.projectName ?? payload.operationId;
+      const operationKey: string = getOperationKey(payload.operationId, payload.iterationId);
+      const previousOperation: IFileOperationRecord | undefined = this._operations.get(operationKey);
+      if (previousOperation) {
+        return [this._formatMetadata(event)];
+      }
+      this._operations.set(
+        operationKey,
+        this._createOperationRecord(
+          payload.operationId,
+          payload.phaseName ? `${projectName} (${payload.phaseName})` : projectName
+        )
+      );
+      return [this._formatMetadata(event)];
+    }
+
+    if (event.type === 'externalOutput') {
+      const operationId: string | undefined = event.scope?.operationId;
+      const payload: { text?: string; iterationId?: number; stream?: string } = event.payload as {
+        text?: string;
+        iterationId?: number;
+        stream?: string;
+      };
+      const text: string = payload.text ?? '';
+      const operationKey: string | undefined =
+        operationId === undefined ? undefined : getOperationKey(operationId, payload.iterationId);
+      const operation: IFileOperationRecord | undefined =
+        operationKey === undefined ? undefined : this._operations.get(operationKey);
+      if (operationId !== undefined && operation) {
+        return this._spoolOperationOutput(operationId, operation, payload.stream ?? 'stdout', text);
+      }
+      return operationId ? [`# [${operationId}]\n`, text] : [text];
+    }
+
+    if (event.type === 'operationStatusChanged') {
+      return [this._formatMetadata(event)];
+    }
+
+    if (event.type === 'operationCompleted') {
+      const payload: { operationId: string; status: string; iterationId?: number } = event.payload as {
+        operationId: string;
+        status: string;
+        iterationId?: number;
+      };
+      const operationKey: string = getOperationKey(payload.operationId, payload.iterationId);
+      const operation: IFileOperationRecord | undefined = this._operations.get(operationKey);
+      if (operation && TERMINAL_STATUSES.has(payload.status)) {
+        this._operations.delete(operationKey);
+        this._writeGroupedOperation(payload.operationId, operation, payload.status);
+        return [];
+      }
+    }
+
+    return [this._formatMetadata(event)];
+  }
+
+  private _formatMetadata(event: IReporterEventEnvelope<unknown>): string {
+    return `# ${JSON.stringify(redactReporterEvent(event))}\n`;
+  }
+
+  private _createOperationRecord(operationId: string, title: string): IFileOperationRecord {
+    return { operationId, title };
+  }
+
+  private _spoolOperationOutput(
+    operationId: string,
+    operation: IFileOperationRecord,
+    stream: string,
+    text: string
+  ): readonly string[] {
+    if (operation.spoolFailed || !this._targetPath) {
+      return [`# [${operationId} ${stream}]\n`, text];
+    }
+
+    if (!operation.spoolPath) {
+      operation.spoolPath = `${this._targetPath}.${this._nextSpoolId++}.operation`;
+      try {
+        operation.spoolFileDescriptor = fs.openSync(operation.spoolPath, 'wx', OWNER_ONLY_MODE);
+      } catch (error) {
+        operation.spoolFailed = true;
+        operation.spoolPath = undefined;
+        operation.spoolFileDescriptor = undefined;
+        this._emergencyWarn(
+          `[reporter] Unable to create grouped-output spool file; output will remain ungrouped: ${(error as Error).message}`
+        );
+        return [`# [${operationId} ${stream}]\n`, text];
+      }
+    }
+
+    try {
+      if (operation.spoolFileDescriptor === undefined) {
+        throw new Error('The grouped-output spool descriptor is not available.');
+      }
+      writeAllSync(operation.spoolFileDescriptor, text);
+      return [];
+    } catch (error) {
+      this._complete = false;
+      this._canComplete = false;
+      const remainingOutput: Buffer = Buffer.from(text, 'utf8').subarray(
+        error instanceof WriteAllSyncError ? error.bytesWritten : 0
+      );
+      const closeError: Error | undefined = this._closeOperationSpool(operation, false);
+      if (closeError) {
+        this._complete = false;
+        this._canComplete = false;
+      }
+      if (operation.spoolPath) {
+        this._writeOrBuffer(`# [${operationId} ${stream}]\n`);
+        if (!this._appendSpoolFile(operation.spoolPath, false)) {
+          this._complete = false;
+          this._canComplete = false;
+        }
+      }
+      try {
+        fs.rmSync(operation.spoolPath, { force: true });
+      } catch {
+        /* Best-effort cleanup. */
+      }
+      operation.spoolPath = undefined;
+      operation.spoolFailed = true;
+      this._emergencyWarn(
+        `[reporter] Unable to spool grouped output for ${JSON.stringify(operationId)}; output will remain ungrouped: ${(error as Error).message}`
+      );
+      this._writeLine(remainingOutput);
+      return [];
+    }
+  }
+
+  private _writeGroupedOperation(operationId: string, operation: IFileOperationRecord, status: string): void {
+    if (operation.spoolFailed) {
+      this._writeOrBuffer(`==[ ${operationId}: ${status} ]==\n`);
+      return;
+    }
+    this._writeOrBuffer(`\n==[ ${operation.title} ]==\n`);
+    if (operation.spoolPath !== undefined) {
+      const closeError: Error | undefined = this._closeOperationSpool(operation, true);
+      if (closeError) {
+        this._complete = false;
+        this._canComplete = false;
+        this._emergencyWarn(
+          `[reporter] Unable to close grouped output for ${JSON.stringify(operationId)}: ${closeError.message}`
+        );
+      }
+      try {
+        if (!this._appendSpoolFile(operation.spoolPath)) {
+          throw new Error('The grouped output could not be appended to the full-detail log.');
+        }
+      } catch (error) {
+        this._complete = false;
+        this._canComplete = false;
+        this._emergencyWarn(
+          `[reporter] Unable to append grouped output for ${JSON.stringify(operationId)}: ${(error as Error).message}`
+        );
+      } finally {
+        try {
+          fs.rmSync(operation.spoolPath, { force: true });
+        } catch {
+          /* Best-effort cleanup. */
+        }
+      }
+    }
+    this._writeOrBuffer(`==[ ${operationId}: ${status} ]==\n`);
+  }
+
+  private _appendSpoolFile(spoolPath: string, ensureNewlineAtEnd: boolean = true): boolean {
+    if (this._fileDescriptor === undefined) {
+      return false;
+    }
+    let source: number | undefined;
+    let appended: boolean = false;
+    let closed: boolean = true;
+    try {
+      source = fs.openSync(spoolPath, 'r');
+      const buffer: Buffer = Buffer.allocUnsafe(64 * 1024);
+      let bytesRead: number;
+      let lastByte: number | undefined;
+      while ((bytesRead = fs.readSync(source, buffer, 0, buffer.length, null)) > 0) {
+        writeAllSync(this._fileDescriptor, buffer.subarray(0, bytesRead));
+        lastByte = buffer[bytesRead - 1];
+      }
+      if (ensureNewlineAtEnd && lastByte !== undefined && lastByte !== 0x0a) {
+        this._writeLine('\n');
+      }
+      appended = true;
+    } catch {
+      appended = false;
+    } finally {
+      if (source !== undefined) {
+        try {
+          fs.closeSync(source);
+        } catch {
+          closed = false;
+        }
+      }
+    }
+    return appended && closed;
+  }
+
+  private _writeOrBuffer(line: string): void {
+    if (this._fileDescriptor === undefined) {
+      if (!this._targetResolved) {
+        this._lines.push(line);
+      }
+    } else {
+      this._writeLine(line);
+    }
   }
 
   private async _ensureTargetAsync(): Promise<void> {
@@ -238,12 +509,12 @@ export class FileReporter implements IReporter {
     }
   }
 
-  private _writeLine(line: string): boolean {
+  private _writeLine(line: string | Uint8Array): boolean {
     if (this._fileDescriptor === undefined) {
       return false;
     }
     try {
-      fs.writeSync(this._fileDescriptor, line, null, 'utf8');
+      writeAllSync(this._fileDescriptor, line);
       return true;
     } catch (error) {
       this._markUnavailable(error as Error);
@@ -267,7 +538,13 @@ export class FileReporter implements IReporter {
       return;
     }
     this._available = false;
+    this._complete = false;
+    this._canComplete = false;
     this._lines.length = 0;
+    for (const operation of this._operations.values()) {
+      this._discardOperationSpool(operation);
+      operation.spoolFailed = true;
+    }
     if (this._fileDescriptor !== undefined) {
       try {
         fs.closeSync(this._fileDescriptor);
@@ -279,6 +556,45 @@ export class FileReporter implements IReporter {
     this._emergencyWarn(
       `[reporter] Unable to write the full-detail log; the artifact is unavailable: ${error.message}`
     );
+  }
+
+  private _closeOperationSpool(operation: IFileOperationRecord, flush: boolean): Error | undefined {
+    const fileDescriptor: number | undefined = operation.spoolFileDescriptor;
+    if (fileDescriptor === undefined) {
+      return undefined;
+    }
+    operation.spoolFileDescriptor = undefined;
+
+    let closeError: Error | undefined;
+    if (flush) {
+      try {
+        fs.fsyncSync(fileDescriptor);
+      } catch (error) {
+        closeError = error as Error;
+      }
+    }
+    try {
+      fs.closeSync(fileDescriptor);
+    } catch (error) {
+      closeError ??= error as Error;
+    }
+    return closeError;
+  }
+
+  private _discardOperationSpool(operation: IFileOperationRecord): void {
+    const closeError: Error | undefined = this._closeOperationSpool(operation, false);
+    if (closeError) {
+      this._complete = false;
+      this._canComplete = false;
+    }
+    if (operation.spoolPath) {
+      try {
+        fs.rmSync(operation.spoolPath, { force: true });
+      } catch {
+        /* Best-effort cleanup. */
+      }
+      operation.spoolPath = undefined;
+    }
   }
 
   private async _resolveTargetAsync(): Promise<void> {
@@ -318,6 +634,8 @@ export class FileReporter implements IReporter {
     }
 
     this._available = false;
+    this._complete = false;
+    this._canComplete = false;
     this._lines.length = 0;
     this._emergencyWarn(
       `[reporter] Unable to write the full-detail log; the artifact is unavailable: ${lastError?.message ?? 'unknown error'}`
@@ -346,12 +664,21 @@ export class FileReporter implements IReporter {
     const cutoff: number = this._nowMs() - this._retentionDays * MS_PER_DAY;
     const logs: { path: string; mtimeMs: number }[] = [];
     for (const entry of entries) {
-      if (entry === LATEST_LOG_NAME || !entry.endsWith('.log')) {
+      if (entry === LATEST_LOG_NAME) {
         continue;
       }
       const entryPath: string = path.join(dir, entry);
       try {
         const stats: fs.Stats = await fs.promises.stat(entryPath);
+        if (entry.endsWith('.operation')) {
+          if (stats.mtimeMs < cutoff) {
+            await fs.promises.rm(entryPath, { force: true });
+          }
+          continue;
+        }
+        if (!entry.endsWith('.log')) {
+          continue;
+        }
         if (stats.mtimeMs < cutoff) {
           await fs.promises.rm(entryPath, { force: true });
         } else {

--- a/libraries/reporter/src/reporters/FileReporter.ts
+++ b/libraries/reporter/src/reporters/FileReporter.ts
@@ -80,7 +80,9 @@ export interface IFileReporterArtifact {
   readonly path?: string;
 
   /**
-   * Whether every event and grouped output chunk has been persisted.
+   * Whether all events and grouped output chunks accepted before closing were persisted
+   * and the log closed successfully. The frontend publishes the final completeness
+   * notification after closure; that notification is not appended to this log.
    */
   readonly complete: boolean;
 }

--- a/libraries/reporter/src/reporters/HumanReadableDiagnostic.ts
+++ b/libraries/reporter/src/reporters/HumanReadableDiagnostic.ts
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import type { IRushDiagnostic } from '../diagnostics/IRushDiagnostic';
+import type { IClassifiedDiagnosticValue } from '../diagnostics/IClassifiedDiagnosticValue';
+import { RUSH_DIAGNOSTIC_TEMPLATES } from '../diagnostics/RushDiagnosticCodeRegistry';
+import type { IReporterEventEnvelope } from '../events/IReporterEventEnvelope';
+
+export function formatHumanReadableDiagnostic(event: IReporterEventEnvelope<unknown>): string {
+  if (event.privacy === 'secret') {
+    return '[secret]';
+  }
+
+  const diagnostic: Partial<IRushDiagnostic> = event.payload as Partial<IRushDiagnostic>;
+  const secretStrings: string[] = [];
+  for (const parameter of Object.values(diagnostic.parameters ?? {})) {
+    if (parameter.privacy === 'secret' && typeof parameter.value === 'string' && parameter.value.length > 0) {
+      secretStrings.push(parameter.value);
+    }
+  }
+  // Source metadata and other parameters can repeat a value classified as secret elsewhere.
+  function containsSecret(text: string): boolean {
+    return secretStrings.some((secret: string) => text.includes(secret));
+  }
+
+  const templates: Readonly<Record<string, string>> = RUSH_DIAGNOSTIC_TEMPLATES;
+  const template: string | undefined = diagnostic.summaryKey ? templates[diagnostic.summaryKey] : undefined;
+  const summary: string | undefined =
+    typeof template === 'string'
+      ? template.replace(/\{([^}]+)\}/g, (placeholder: string, name: string) => {
+          const parameter: IClassifiedDiagnosticValue | undefined = diagnostic.parameters?.[name];
+          if (!parameter) {
+            return placeholder;
+          }
+          if (parameter.privacy === 'secret') {
+            return '[secret]';
+          }
+          const value: string =
+            typeof parameter.value === 'string' ? parameter.value : JSON.stringify(parameter.value);
+          return containsSecret(value) ? '[secret]' : value;
+        })
+      : undefined;
+
+  const source: IRushDiagnostic['source'] = diagnostic.source;
+  let location: string = '';
+  if (source?.kind === 'file' && !containsSecret(source.file)) {
+    location = source.file;
+    if (source.line !== undefined) {
+      location += `:${source.line}`;
+      if (source.column !== undefined) {
+        location += `:${source.column}`;
+      }
+    }
+  }
+  if (
+    source?.toolName &&
+    diagnostic.parameters?.tool === undefined &&
+    !containsSecret(source.toolName)
+  ) {
+    location = location ? `[${source.toolName}] ${location}` : source.toolName;
+  }
+
+  const detail: string = [location, summary].filter(Boolean).join(' - ');
+  return `[${diagnostic.severity ?? 'error'}] ${diagnostic.code ?? 'unknown'}${detail ? `: ${detail}` : ''}`;
+}

--- a/libraries/reporter/src/reporters/JsonReporter.ts
+++ b/libraries/reporter/src/reporters/JsonReporter.ts
@@ -50,17 +50,43 @@ export class JsonReporter implements IReporter {
   }
 
   public report(event: IReporterEventEnvelope<unknown>): void {
+    const machineEvent: IReporterEventEnvelope<unknown> =
+      event.type === 'messageEmitted' && event.privacy === 'local-sensitive'
+        ? {
+            ...event,
+            payload: {
+              ...(event.payload as Record<string, unknown>),
+              text: '[local-sensitive]'
+            }
+          }
+        : event;
+    const redactedEvent: IReporterEventEnvelope<unknown> = redactReporterEvent(machineEvent);
     try {
-      this._write(
-        encodeNdjsonRecord(redactReporterEvent(event), { maxRecordBytes: this._maxRecordBytes })
-      );
+      this._write(encodeNdjsonRecord(redactedEvent, { maxRecordBytes: this._maxRecordBytes }));
     } catch (error) {
       if (error instanceof NdjsonRecordTooLargeError) {
+        const source: IReporterEventEnvelope<unknown>['source'] =
+          redactedEvent.privacy === 'public'
+            ? redactedEvent.source
+            : {
+                packageName: '[private-producer]',
+                packageVersion: '[private-version]'
+              };
         this._write(
           encodeNdjsonRecord(
             {
-              ...event,
-              privacy: 'public',
+              protocolVersion: redactedEvent.protocolVersion,
+              eventId: redactedEvent.eventId,
+              sessionId: redactedEvent.sessionId,
+              parentSessionId: redactedEvent.parentSessionId,
+              parentOperationId: redactedEvent.parentOperationId,
+              sequence: redactedEvent.sequence,
+              sourceSequence: redactedEvent.sourceSequence,
+              timestamp: redactedEvent.timestamp,
+              source,
+              scope: redactedEvent.privacy === 'public' ? redactedEvent.scope : undefined,
+              privacy: redactedEvent.privacy,
+              required: redactedEvent.required,
               type: 'extension',
               payload: {
                 name: 'rush.reporter.record-too-large',

--- a/libraries/reporter/src/reporters/LegacyReporter.ts
+++ b/libraries/reporter/src/reporters/LegacyReporter.ts
@@ -12,7 +12,8 @@ const TERMINAL_STATUSES: ReadonlySet<string> = new Set([
   'blocked',
   'skipped',
   'fromCache',
-  'noOp'
+  'noOp',
+  'aborted'
 ]);
 
 /**
@@ -249,5 +250,4 @@ export class LegacyReporter implements IReporter {
   private _seconds(durationMs: number): string {
     return (durationMs / 1000).toFixed(2);
   }
-
 }

--- a/libraries/reporter/src/reporters/PlaintextReporter.ts
+++ b/libraries/reporter/src/reporters/PlaintextReporter.ts
@@ -1,12 +1,23 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { StringDecoder } from 'node:string_decoder';
+
 import type { IReporterEventEnvelope } from '../events/IReporterEventEnvelope';
 import type { IReporter } from '../manager/IReporter';
+import { getHumanReadableMessageText } from './ReporterRedaction';
+import { formatHumanReadableDiagnostic } from './HumanReadableDiagnostic';
 import type { PlaintextVariant } from '../config/AutomaticReporterMatrix';
+import type { ReporterLogLevel } from '../config/ReporterNames';
 import { createColorizer, type IColorizer } from './InteractiveRendering';
+import { writeAllSync, WriteAllSyncError } from '../utilities/writeAllSync';
 
 const HEARTBEAT_INTERVAL_MS: number = 30000;
+const OWNER_ONLY_MODE: number = 0o600;
+const OWNER_ONLY_DIRECTORY_MODE: number = 0o700;
 const TERMINAL_STATUSES: ReadonlySet<string> = new Set([
   'success',
   'successWithWarnings',
@@ -14,13 +25,29 @@ const TERMINAL_STATUSES: ReadonlySet<string> = new Set([
   'blocked',
   'skipped',
   'fromCache',
-  'noOp'
+  'noOp',
+  'aborted'
 ]);
 
 interface IOperationRecord {
   readonly projectName: string;
   readonly phaseName?: string;
-  readonly buffer: string[];
+  readonly silent: boolean;
+  spoolPath?: string;
+  spoolFileDescriptor?: number;
+  spoolFailed?: boolean;
+}
+
+interface IWatchCycleState {
+  readonly operations: Map<string, IOperationRecord>;
+  total: number;
+  completed: number;
+  failed: number;
+  watchCompleted: boolean;
+}
+
+function getIterationId(payload: { iterationId?: number }, fallback: number): number {
+  return payload.iterationId ?? fallback;
 }
 
 /**
@@ -54,6 +81,11 @@ export interface IPlaintextReporterOptions {
    * The heartbeat interval in milliseconds. Defaults to 30000.
    */
   readonly heartbeatIntervalMs?: number;
+
+  /**
+   * The selected reporter log level. Defaults to `normal`.
+   */
+  readonly logLevel?: ReporterLogLevel;
 }
 
 /**
@@ -76,14 +108,17 @@ export class PlaintextReporter implements IReporter {
   private readonly _color: IColorizer;
   private readonly _nowMs: () => number;
   private readonly _heartbeatIntervalMs: number;
+  private readonly _logLevel: ReporterLogLevel;
 
   private _commandName: string | undefined;
-  private _total: number;
-  private _completed: number;
-  private _failed: number;
   private _lastOutputMs: number;
   private _atLineStart: boolean;
-  private readonly _operations: Map<string, IOperationRecord>;
+  private _logPath: string | undefined;
+  private readonly _watchCycles: Map<number, IWatchCycleState>;
+  private _spoolDirectory: string | undefined;
+  private _nextSpoolId: number;
+  private _legacyIterationId: number;
+  private _latestIterationId: number;
 
   public constructor(options: IPlaintextReporterOptions) {
     this._write = options.write;
@@ -91,14 +126,17 @@ export class PlaintextReporter implements IReporter {
     this._color = createColorizer(options.color ?? false);
     this._nowMs = options.nowMs ?? (() => Date.now());
     this._heartbeatIntervalMs = options.heartbeatIntervalMs ?? HEARTBEAT_INTERVAL_MS;
+    this._logLevel = options.logLevel ?? 'normal';
 
     this._commandName = undefined;
-    this._total = 0;
-    this._completed = 0;
-    this._failed = 0;
     this._lastOutputMs = 0;
     this._atLineStart = true;
-    this._operations = new Map();
+    this._logPath = undefined;
+    this._watchCycles = new Map();
+    this._spoolDirectory = undefined;
+    this._nextSpoolId = 1;
+    this._legacyIterationId = 0;
+    this._latestIterationId = 0;
   }
 
   public async initializeAsync(): Promise<void> {
@@ -113,21 +151,40 @@ export class PlaintextReporter implements IReporter {
         break;
       }
       case 'operationRegistered': {
-        const payload: { operationId: string; projectName?: string; phaseName?: string } = event.payload as {
+        const payload: {
           operationId: string;
           projectName?: string;
           phaseName?: string;
+          silent?: boolean;
+          iterationId?: number;
+        } = event.payload as {
+          operationId: string;
+          projectName?: string;
+          phaseName?: string;
+          silent?: boolean;
+          iterationId?: number;
         };
-        this._operations.set(payload.operationId, {
+        const iterationId: number = getIterationId(payload, this._legacyIterationId);
+        const cycle: IWatchCycleState = this._getWatchCycle(iterationId);
+        const previousRecord: IOperationRecord | undefined = cycle.operations.get(payload.operationId);
+        if (previousRecord) {
+          break;
+        }
+        cycle.operations.set(payload.operationId, {
           projectName: payload.projectName ?? payload.operationId,
           phaseName: payload.phaseName,
-          buffer: []
+          silent: payload.silent === true
         });
-        this._total++;
+        if (!payload.silent) {
+          cycle.total++;
+        }
         break;
       }
       case 'operationStatusChanged': {
-        this._onStatusChanged(event);
+        break;
+      }
+      case 'operationCompleted': {
+        this._onOperationCompleted(event);
         break;
       }
       case 'externalOutput': {
@@ -140,13 +197,53 @@ export class PlaintextReporter implements IReporter {
           severity?: string;
         };
         if (payload.severity === 'error' || payload.severity === 'warning') {
-          this._writeLine(this._formatDiagnostic(payload.severity, payload.code ?? 'unknown'));
+          this._writeLine(this._formatDiagnostic(payload.severity, formatHumanReadableDiagnostic(event)));
+        }
+        break;
+      }
+      case 'artifactAvailable': {
+        const payload: { role?: string; path?: string } = event.payload as {
+          role?: string;
+          path?: string;
+        };
+        if (payload.role === 'log') {
+          this._logPath = payload.path;
+        }
+        break;
+      }
+      case 'messageEmitted': {
+        if (event.scope?.operationId === undefined) {
+          const payload: { severity?: string } = event.payload as {
+            severity?: string;
+          };
+          const text: string | undefined = getHumanReadableMessageText(event);
+          if (
+            text &&
+            (this._logLevel !== 'quiet' || payload.severity === 'warning' || payload.severity === 'error')
+          ) {
+            this._writeRaw(text.endsWith('\n') ? text : `${text}\n`);
+          }
         }
         break;
       }
       case 'watchCycleCompleted': {
-        const succeeded: boolean = (event.payload as { succeeded?: boolean }).succeeded === true;
-        this._writeLine(`Watch cycle ${succeeded ? 'succeeded' : 'failed'}`);
+        const payload: { succeeded?: boolean; iterationId?: number } = event.payload as {
+          succeeded?: boolean;
+          iterationId?: number;
+        };
+        const iterationId: number = getIterationId(payload, this._legacyIterationId);
+        const cycle: IWatchCycleState = this._getWatchCycle(iterationId);
+        const succeeded: boolean = payload.succeeded === true;
+        this._writeLine(
+          `Watch cycle ${succeeded ? 'succeeded' : 'failed'} ` +
+            `(${cycle.completed}/${cycle.total} operations, ${cycle.failed} failed)`
+        );
+        this._latestIterationId = Math.max(this._latestIterationId, iterationId);
+        cycle.watchCompleted = true;
+        this._pruneCompletedWatchCycles();
+        if (payload.iterationId === undefined) {
+          this._legacyIterationId++;
+        }
         break;
       }
       case 'commandResult': {
@@ -163,7 +260,22 @@ export class PlaintextReporter implements IReporter {
   }
 
   public async closeAsync(): Promise<void> {
-    /* no-op */
+    for (const cycle of this._watchCycles.values()) {
+      for (const [operationId, record] of cycle.operations) {
+        if (!record.silent && this._variant === 'detailed') {
+          const phase: string = record.phaseName ? ` (${record.phaseName})` : '';
+          this._writeLine('');
+          this._writeLine(`==[ ${record.projectName}${phase} ]==`);
+          this._writeSpooledOutput(record);
+          this._writeLine(this._formatStatus(record.projectName, 'aborted'));
+        } else {
+          this._deleteSpool(record);
+        }
+        cycle.operations.delete(operationId);
+      }
+    }
+    this._watchCycles.clear();
+    this._removeSpoolDirectory();
   }
 
   /**
@@ -171,30 +283,47 @@ export class PlaintextReporter implements IReporter {
    * last output. Returns whether a heartbeat was emitted.
    */
   public emitHeartbeatIfDue(): boolean {
+    const cycle: IWatchCycleState = this._getLatestWatchCycle();
     if (this._nowMs() - this._lastOutputMs >= this._heartbeatIntervalMs) {
       this._writeLine(
-        `... ${this._commandName ?? 'rush'} still running — ${this._completed}/${this._total} operations`
+        `... ${this._commandName ?? 'rush'} still running — ${cycle.completed}/${cycle.total} operations`
       );
       return true;
     }
     return false;
   }
 
-  private _onStatusChanged(event: IReporterEventEnvelope<unknown>): void {
-    const payload: { operationId: string; status: string } = event.payload as {
+  private _onOperationCompleted(event: IReporterEventEnvelope<unknown>): void {
+    const payload: { operationId: string; status: string; iterationId?: number } = event.payload as {
       operationId: string;
       status: string;
+      iterationId?: number;
     };
-    const record: IOperationRecord | undefined = this._operations.get(payload.operationId);
+    const iterationId: number = getIterationId(payload, this._legacyIterationId);
+    const cycle: IWatchCycleState = this._getWatchCycle(iterationId);
+    const record: IOperationRecord | undefined = cycle.operations.get(payload.operationId);
     const projectName: string = record?.projectName ?? event.scope?.projectName ?? payload.operationId;
 
     if (!TERMINAL_STATUSES.has(payload.status)) {
       return;
     }
+    if (record?.silent) {
+      this._deleteSpool(record);
+      cycle.operations.delete(payload.operationId);
+      return;
+    }
 
-    this._completed++;
+    cycle.completed++;
     if (payload.status === 'failure') {
-      this._failed++;
+      cycle.failed++;
+    }
+
+    if (this._logLevel === 'quiet') {
+      if (record) {
+        this._deleteSpool(record);
+      }
+      cycle.operations.delete(payload.operationId);
+      return;
     }
 
     if (this._variant === 'detailed') {
@@ -202,14 +331,13 @@ export class PlaintextReporter implements IReporter {
       this._writeLine('');
       this._writeLine(`==[ ${projectName}${phase} ]==`);
       if (record) {
-        this._writeRaw(record.buffer.join(''));
-        record.buffer.length = 0;
+        this._writeSpooledOutput(record);
       }
       this._writeLine(this._formatStatus(projectName, payload.status));
     } else {
       this._writeLine(this._formatStatus(projectName, payload.status));
     }
-    this._operations.delete(payload.operationId);
+    cycle.operations.delete(payload.operationId);
   }
 
   private _onExternalOutput(event: IReporterEventEnvelope<unknown>): void {
@@ -217,26 +345,197 @@ export class PlaintextReporter implements IReporter {
       return;
     }
     const operationId: string | undefined = event.scope?.operationId;
-    const text: string = (event.payload as { text?: string }).text ?? '';
+    const payload: { text?: string; iterationId?: number } = event.payload as {
+      text?: string;
+      iterationId?: number;
+    };
+    const text: string = payload.text ?? '';
+    const cycle: IWatchCycleState = this._getWatchCycle(getIterationId(payload, this._legacyIterationId));
     const record: IOperationRecord | undefined =
-      operationId !== undefined ? this._operations.get(operationId) : undefined;
+      operationId !== undefined ? cycle.operations.get(operationId) : undefined;
     if (record) {
-      record.buffer.push(text);
+      this._spoolOutput(record, text);
     } else {
       this._writeRaw(text);
     }
   }
 
+  private _spoolOutput(record: IOperationRecord, text: string): void {
+    if (record.spoolFailed) {
+      this._writeRaw(text);
+      return;
+    }
+
+    try {
+      if (!record.spoolPath) {
+        const spoolDirectory: string = this._ensureSpoolDirectory();
+        record.spoolPath = path.join(spoolDirectory, `${this._nextSpoolId++}.operation`);
+        record.spoolFileDescriptor = fs.openSync(record.spoolPath, 'wx', OWNER_ONLY_MODE);
+      }
+      if (record.spoolFileDescriptor === undefined) {
+        throw new Error('The grouped plaintext spool descriptor is not available.');
+      }
+      writeAllSync(record.spoolFileDescriptor, text);
+    } catch (error) {
+      this._closeSpool(record, false);
+      this._writeSpooledOutput(
+        record,
+        Buffer.from(text, 'utf8').subarray(error instanceof WriteAllSyncError ? error.bytesWritten : 0)
+      );
+      record.spoolFailed = true;
+      this._writeLine(`[reporter] Unable to spool grouped plaintext output: ${(error as Error).message}`);
+    }
+  }
+
+  private _writeSpooledOutput(record: IOperationRecord, remainingOutput?: Uint8Array): void {
+    if (!record.spoolPath) {
+      if (remainingOutput) {
+        this._writeRaw(Buffer.from(remainingOutput).toString('utf8'));
+      }
+      return;
+    }
+    const spoolCloseError: Error | undefined = this._closeSpool(record, true);
+    if (spoolCloseError) {
+      this._writeLine(`[reporter] Unable to close grouped plaintext output: ${spoolCloseError.message}`);
+    }
+    let fileDescriptor: number | undefined;
+    let readError: Error | undefined;
+    let readCloseError: Error | undefined;
+    const decoder: StringDecoder = new StringDecoder('utf8');
+    try {
+      fileDescriptor = fs.openSync(record.spoolPath, 'r');
+      const buffer: Buffer = Buffer.allocUnsafe(64 * 1024);
+      let bytesRead: number;
+      while ((bytesRead = fs.readSync(fileDescriptor, buffer, 0, buffer.length, null)) > 0) {
+        this._writeRaw(decoder.write(buffer.subarray(0, bytesRead)));
+      }
+    } catch (error) {
+      readError = error as Error;
+    } finally {
+      if (fileDescriptor !== undefined) {
+        try {
+          fs.closeSync(fileDescriptor);
+        } catch (error) {
+          readCloseError = error as Error;
+        }
+      }
+      this._deleteSpool(record);
+    }
+    if (remainingOutput) {
+      this._writeRaw(decoder.write(remainingOutput));
+    }
+    this._writeRaw(decoder.end());
+    if (readError) {
+      this._writeLine(
+        `[reporter] Unable to read grouped plaintext output; see the full log: ${readError.message}`
+      );
+    }
+    if (readCloseError) {
+      this._writeLine(`[reporter] Unable to close grouped plaintext input: ${readCloseError.message}`);
+    }
+  }
+
+  private _ensureSpoolDirectory(): string {
+    if (!this._spoolDirectory) {
+      this._spoolDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'rush-plaintext-reporter-'));
+      fs.chmodSync(this._spoolDirectory, OWNER_ONLY_DIRECTORY_MODE);
+    }
+    return this._spoolDirectory;
+  }
+
+  private _deleteSpool(record: IOperationRecord): void {
+    this._closeSpool(record, false);
+    if (!record.spoolPath) {
+      return;
+    }
+    try {
+      fs.rmSync(record.spoolPath, { force: true });
+    } catch {
+      /* Best-effort cleanup. */
+    }
+    record.spoolPath = undefined;
+  }
+
+  private _closeSpool(record: IOperationRecord, flush: boolean): Error | undefined {
+    const fileDescriptor: number | undefined = record.spoolFileDescriptor;
+    if (fileDescriptor === undefined) {
+      return undefined;
+    }
+    record.spoolFileDescriptor = undefined;
+    let closeError: Error | undefined;
+    if (flush) {
+      try {
+        fs.fsyncSync(fileDescriptor);
+      } catch (error) {
+        closeError = error as Error;
+      }
+    }
+    try {
+      fs.closeSync(fileDescriptor);
+    } catch (error) {
+      closeError ??= error as Error;
+    }
+    return closeError;
+  }
+
+  private _removeSpoolDirectory(): void {
+    if (!this._spoolDirectory) {
+      return;
+    }
+    try {
+      fs.rmdirSync(this._spoolDirectory);
+    } catch {
+      /* Best-effort cleanup. */
+    }
+    this._spoolDirectory = undefined;
+  }
+
+  private _getWatchCycle(iterationId: number): IWatchCycleState {
+    let cycle: IWatchCycleState | undefined = this._watchCycles.get(iterationId);
+    if (!cycle) {
+      cycle = {
+        operations: new Map(),
+        total: 0,
+        completed: 0,
+        failed: 0,
+        watchCompleted: false
+      };
+      this._watchCycles.set(iterationId, cycle);
+    }
+    this._latestIterationId = Math.max(this._latestIterationId, iterationId);
+    this._pruneCompletedWatchCycles();
+    return cycle;
+  }
+
+  private _getLatestWatchCycle(): IWatchCycleState {
+    return this._getWatchCycle(this._latestIterationId);
+  }
+
+  private _pruneCompletedWatchCycles(): void {
+    for (const [iterationId, cycle] of this._watchCycles) {
+      if (iterationId < this._latestIterationId && cycle.watchCompleted) {
+        for (const record of cycle.operations.values()) {
+          this._deleteSpool(record);
+        }
+        this._watchCycles.delete(iterationId);
+      }
+    }
+  }
+
   private _onResult(payload: { commandName: string; succeeded: boolean; exitCode: number }): void {
     const commandName: string = payload.commandName ?? this._commandName ?? 'rush';
+    const cycle: IWatchCycleState = this._getLatestWatchCycle();
     if (payload.succeeded) {
       this._writeLine(
         this._color.green(
-          `rush ${commandName} succeeded (${this._completed}/${this._total} operations, ${this._failed} failed)`
+          `rush ${commandName} succeeded (${cycle.completed}/${cycle.total} operations, ${cycle.failed} failed)`
         )
       );
     } else {
-      this._writeLine(this._color.red(`rush ${commandName} failed (${this._failed} failed)`));
+      this._writeLine(this._color.red(`rush ${commandName} failed (${cycle.failed} failed)`));
+    }
+    if (this._logPath) {
+      this._writeLine(`Full log: ${this._logPath}`);
     }
   }
 
@@ -248,8 +547,7 @@ export class PlaintextReporter implements IReporter {
     return line;
   }
 
-  private _formatDiagnostic(severity: string, code: string): string {
-    const line: string = `[${severity}] ${code}`;
+  private _formatDiagnostic(severity: string, line: string): string {
     if (severity === 'error') {
       return this._color.red(line);
     }

--- a/libraries/reporter/src/reporters/ReporterRedaction.ts
+++ b/libraries/reporter/src/reporters/ReporterRedaction.ts
@@ -8,13 +8,36 @@ interface IClassifiedValue {
   readonly privacy: string;
 }
 
-export function redactReporterEvent(
-  event: IReporterEventEnvelope<unknown>
-): IReporterEventEnvelope<unknown> {
-  let payload: unknown = event.payload;
+export function getHumanReadableMessageText(event: IReporterEventEnvelope<unknown>): string | undefined {
   if (event.privacy === 'secret') {
-    payload = '[secret]';
-  } else if (event.type === 'diagnosticEmitted') {
+    return '[secret]';
+  }
+  const text: unknown = (event.payload as { readonly text?: unknown }).text;
+  return typeof text === 'string' ? text : undefined;
+}
+
+export function redactReporterEvent(event: IReporterEventEnvelope<unknown>): IReporterEventEnvelope<unknown> {
+  if (event.privacy === 'secret') {
+    return {
+      protocolVersion: event.protocolVersion,
+      eventId: event.eventId,
+      sessionId: event.sessionId,
+      sequence: event.sequence,
+      sourceSequence: event.sourceSequence,
+      timestamp: event.timestamp,
+      source: {
+        packageName: '[private-producer]',
+        packageVersion: '[private-version]'
+      },
+      privacy: 'secret',
+      required: event.required,
+      type: event.type,
+      payload: '[secret]'
+    };
+  }
+
+  let payload: unknown = event.payload;
+  if (event.type === 'diagnosticEmitted') {
     const diagnostic: { readonly parameters?: Readonly<Record<string, IClassifiedValue>> } =
       event.payload as {
         readonly parameters?: Readonly<Record<string, IClassifiedValue>>;

--- a/libraries/reporter/src/scheduler/OperationOutputGrouping.ts
+++ b/libraries/reporter/src/scheduler/OperationOutputGrouping.ts
@@ -10,6 +10,11 @@ import type { IReporterEventEnvelope } from '../events/IReporterEventEnvelope';
  */
 export interface IExternalOutputChunk {
   /**
+   * The graph iteration that produced this chunk.
+   */
+  readonly iterationId?: number;
+
+  /**
    * The operation the chunk belongs to, when scoped.
    */
   readonly operationId?: string;
@@ -41,11 +46,13 @@ export function iterateExternalOutput(
   const chunks: IExternalOutputChunk[] = [];
   for (const event of events) {
     if (event.type === 'externalOutput') {
-      const payload: { stream?: string; text?: string } = event.payload as {
+      const payload: { iterationId?: number; stream?: string; text?: string } = event.payload as {
+        iterationId?: number;
         stream?: string;
         text?: string;
       };
       chunks.push({
+        ...(payload.iterationId === undefined ? {} : { iterationId: payload.iterationId }),
         operationId: event.scope?.operationId,
         stream: payload.stream ?? 'stdout',
         text: payload.text ?? ''

--- a/libraries/reporter/src/scheduler/OperationStreamEmitter.ts
+++ b/libraries/reporter/src/scheduler/OperationStreamEmitter.ts
@@ -91,7 +91,8 @@ export class OperationStreamEmitter {
     operationId: string,
     projectName?: string,
     phaseName?: string,
-    silent?: boolean
+    silent?: boolean,
+    iterationId?: number
   ): string {
     return this._emit(
       'operationRegistered',
@@ -99,7 +100,8 @@ export class OperationStreamEmitter {
         operationId,
         projectName,
         phaseName,
-        ...(silent === undefined ? {} : { silent })
+        ...(silent === undefined ? {} : { silent }),
+        ...(iterationId === undefined ? {} : { iterationId })
       },
       { operationId, projectName, phaseName },
       'public'
@@ -113,7 +115,8 @@ export class OperationStreamEmitter {
     operationId: string,
     status: OperationStatus,
     durationMs?: number,
-    previousStatus?: OperationStatus
+    previousStatus?: OperationStatus,
+    iterationId?: number
   ): string {
     return this._emit(
       'operationStatusChanged',
@@ -121,7 +124,8 @@ export class OperationStreamEmitter {
         operationId,
         status,
         ...(previousStatus === undefined ? {} : { previousStatus }),
-        ...(durationMs === undefined ? {} : { durationMs })
+        ...(durationMs === undefined ? {} : { durationMs }),
+        ...(iterationId === undefined ? {} : { iterationId })
       },
       { operationId },
       'public'
@@ -136,7 +140,12 @@ export class OperationStreamEmitter {
    * @param text - the raw output text
    * @returns the emitted event ids
    */
-  public writeOutput(operationId: string, stream: 'stdout' | 'stderr', text: string): string[] {
+  public writeOutput(
+    operationId: string,
+    stream: 'stdout' | 'stderr',
+    text: string,
+    iterationId?: number
+  ): string[] {
     const eventIds: string[] = [];
     let offset: number = 0;
     while (offset < text.length) {
@@ -158,7 +167,12 @@ export class OperationStreamEmitter {
       }
       const chunk: string = text.slice(offset, end);
       eventIds.push(
-        this._emit('externalOutput', { stream, text: chunk }, { operationId }, 'local-sensitive')
+        this._emit(
+          'externalOutput',
+          { stream, text: chunk, ...(iterationId === undefined ? {} : { iterationId }) },
+          { operationId },
+          'local-sensitive'
+        )
       );
       offset = end;
     }
@@ -168,17 +182,32 @@ export class OperationStreamEmitter {
   /**
    * Emits the authoritative signal that no more output will be emitted for an operation.
    */
-  public closeOperationStream(operationId: string): string {
-    return this._emit('operationStreamClosed', { operationId }, { operationId }, 'public');
+  public closeOperationStream(operationId: string, iterationId?: number): string {
+    return this._emit(
+      'operationStreamClosed',
+      { operationId, ...(iterationId === undefined ? {} : { iterationId }) },
+      { operationId },
+      'public'
+    );
   }
 
   /**
    * Emits the final outcome of an operation.
    */
-  public completeOperation(operationId: string, status: OperationStatus, durationMs?: number): string {
+  public completeOperation(
+    operationId: string,
+    status: OperationStatus,
+    durationMs?: number,
+    iterationId?: number
+  ): string {
     return this._emit(
       'operationCompleted',
-      { operationId, status, ...(durationMs === undefined ? {} : { durationMs }) },
+      {
+        operationId,
+        status,
+        ...(durationMs === undefined ? {} : { durationMs }),
+        ...(iterationId === undefined ? {} : { iterationId })
+      },
       { operationId },
       'public'
     );

--- a/libraries/reporter/src/session/ScopedReporterFactory.ts
+++ b/libraries/reporter/src/session/ScopedReporterFactory.ts
@@ -74,7 +74,13 @@ export function createScopedReporter(options: ICreateScopedReporterOptions): ISc
         // Message text fails safe at local-sensitive by default.
         privacy: messageOptions.privacy ?? 'local-sensitive',
         type: 'messageEmitted',
-        payload: { severity: messageOptions.severity, text: messageOptions.text }
+        payload: {
+          severity: messageOptions.severity,
+          text: messageOptions.text,
+          ...(messageOptions.minimumLogLevel === undefined
+            ? {}
+            : { minimumLogLevel: messageOptions.minimumLogLevel })
+        }
       });
     },
 

--- a/libraries/reporter/src/test/DefaultInteractiveReporter.test.ts
+++ b/libraries/reporter/src/test/DefaultInteractiveReporter.test.ts
@@ -34,9 +34,10 @@ class FakeTerminal implements IInteractiveTerminal {
 function ev(
   type: string,
   payload: unknown = {},
-  scope?: { projectName?: string }
+  scope?: { projectName?: string },
+  privacy: IReporterEventEnvelope<unknown>['privacy'] = 'public'
 ): IReporterEventEnvelope<unknown> {
-  return { type, payload, scope, required: true } as unknown as IReporterEventEnvelope<unknown>;
+  return { type, payload, scope, privacy, required: true } as unknown as IReporterEventEnvelope<unknown>;
 }
 
 describe('interactive rendering helpers', () => {
@@ -155,6 +156,7 @@ describe('DefaultInteractiveReporter', () => {
     reporter.report(
       ev('operationStatusChanged', { operationId: 'op1', status: 'success' }, { projectName: 'p' })
     );
+    reporter.report(ev('operationCompleted', { operationId: 'op1', status: 'success' }));
     reporter.report(ev('commandResult', { commandName: 'build', succeeded: true, exitCode: 0 }));
     await reporter.closeAsync();
 
@@ -170,12 +172,53 @@ describe('DefaultInteractiveReporter', () => {
       color: false,
       nowMs: () => 0
     });
-    reporter.report(ev('operationRegistered', { operationId: 'op1', projectName: 'project-a' }));
+    reporter.report(
+      ev('operationRegistered', {
+        operationId: 'op1',
+        projectName: 'project-a',
+        phaseName: '_phase:build'
+      })
+    );
     reporter.report(ev('operationStatusChanged', { operationId: 'op1', status: 'executing' }));
+    reporter.report(ev('operationCompleted', { operationId: 'op1', status: 'success' }));
     await reporter.flushAsync();
 
-    expect(terminal.output).toContain('project-a');
+    expect(terminal.output).toContain('project-a (_phase:build)');
     expect(terminal.output).not.toContain('executing op1');
+  });
+
+  it('normalizes multiline activity to one live-region row', async () => {
+    const terminal: FakeTerminal = new FakeTerminal();
+    const reporter: DefaultInteractiveReporter = new DefaultInteractiveReporter({
+      terminal,
+      color: false,
+      nowMs: () => 0
+    });
+    reporter.report(ev('commandStarted', { commandName: 'build' }));
+    reporter.report(ev('messageEmitted', { severity: 'info', text: 'first line\nsecond line\n' }));
+    await reporter.flushAsync();
+
+    expect(terminal.output).toContain('second line');
+    expect(terminal.output).not.toContain('first line\nsecond line');
+  });
+
+  it('omits silent operations from progress totals', async () => {
+    const terminal: FakeTerminal = new FakeTerminal();
+    const reporter: DefaultInteractiveReporter = new DefaultInteractiveReporter({
+      terminal,
+      color: false,
+      nowMs: () => 0
+    });
+    reporter.report(
+      ev('operationRegistered', { operationId: 'silent', projectName: 'hidden', silent: true })
+    );
+    reporter.report(ev('operationStatusChanged', { operationId: 'silent', status: 'success' }));
+    reporter.report(ev('operationCompleted', { operationId: 'silent', status: 'success' }));
+    reporter.report(ev('commandResult', { commandName: 'build', succeeded: true, exitCode: 0 }));
+    await reporter.closeAsync();
+
+    expect(terminal.output).toContain('0/0 operations');
+    expect(terminal.output).not.toContain('hidden');
   });
 
   it('appends a bounded diagnostic block and log path on failure', async () => {
@@ -191,6 +234,7 @@ describe('DefaultInteractiveReporter', () => {
     reporter.report(
       ev('operationStatusChanged', { operationId: 'op1', status: 'failure' }, { projectName: 'p' })
     );
+    reporter.report(ev('operationCompleted', { operationId: 'op1', status: 'failure' }));
     reporter.report(ev('diagnosticEmitted', { code: 'RUSH_OPERATION_FAILED', severity: 'error' }));
     reporter.report(ev('commandResult', { commandName: 'build', succeeded: false, exitCode: 1 }));
     await reporter.closeAsync();
@@ -199,6 +243,173 @@ describe('DefaultInteractiveReporter', () => {
     expect(terminal.output).toContain('build failed — 1 failed');
     expect(terminal.output).toContain('[error] RUSH_OPERATION_FAILED');
     expect(terminal.output).toContain('Log: /tmp/rush-logs/latest.log');
+  });
+
+  it('preserves actionable lock contention text on failure', async () => {
+    const terminal: FakeTerminal = new FakeTerminal();
+    const reporter: DefaultInteractiveReporter = new DefaultInteractiveReporter({
+      terminal,
+      color: false,
+      nowMs: () => 0
+    });
+    await reporter.initializeAsync();
+    reporter.report(ev('commandStarted', { commandName: 'build' }));
+    reporter.report(
+      ev('messageEmitted', {
+        severity: 'error',
+        text: 'Another Rush command is already running in this repository.\n'
+      })
+    );
+    reporter.report(ev('commandResult', { commandName: 'build', succeeded: false, exitCode: 1 }));
+    await reporter.closeAsync();
+
+    expect(
+      terminal.output.match(/Another Rush command is already running in this repository\./g)
+    ).toHaveLength(1);
+  });
+
+  it('renders errors immediately during watch and never repeats them at close', async () => {
+    const terminal: FakeTerminal = new FakeTerminal();
+    const reporter: DefaultInteractiveReporter = new DefaultInteractiveReporter({
+      terminal,
+      color: false,
+      nowMs: () => 0
+    });
+    await reporter.initializeAsync();
+    reporter.report(ev('commandStarted', { commandName: 'build' }));
+    reporter.report(ev('operationRegistered', { iterationId: 1, operationId: 'op' }));
+    const diagnostic: IReporterEventEnvelope<unknown> = ev('diagnosticEmitted', {
+      diagnosticId: 'problem',
+      iterationId: 1,
+      code: 'RUSH_EXTERNAL_TOOL_PROBLEM',
+      severity: 'error',
+      summaryKey: 'diagnostic.RUSH_EXTERNAL_TOOL_PROBLEM.summary',
+      parameters: {
+        tool: { value: 'typescript', privacy: 'public' },
+        code: { value: 'TS1005', privacy: 'public' },
+        message: { value: 'ACTIONABLE-WATCH-ERROR', privacy: 'local-sensitive' }
+      }
+    });
+    try {
+      reporter.report(diagnostic);
+      expect(terminal.output).toContain('ACTIONABLE-WATCH-ERROR');
+      reporter.report(diagnostic);
+      reporter.report(ev('watchCycleCompleted', { iterationId: 1, succeeded: false }));
+      reporter.report(ev('commandResult', { succeeded: false, exitCode: 1 }));
+      await reporter.closeAsync();
+      expect(terminal.output.match(/ACTIONABLE-WATCH-ERROR/g)).toHaveLength(1);
+    } finally {
+      await reporter.closeAsync();
+    }
+  });
+
+  it('renders warnings once per completed cycle, including successful recovery', async () => {
+    const terminal: FakeTerminal = new FakeTerminal();
+    const reporter: DefaultInteractiveReporter = new DefaultInteractiveReporter({
+      terminal,
+      color: false,
+      nowMs: () => 0
+    });
+    await reporter.initializeAsync();
+    reporter.report(ev('commandStarted', { commandName: 'build' }));
+    try {
+      for (const iterationId of [1, 2]) {
+        reporter.report(ev('operationRegistered', { iterationId, operationId: 'op' }));
+        const warning: IReporterEventEnvelope<unknown> = ev('diagnosticEmitted', {
+          diagnosticId: 'same-id-in-another-cycle',
+          iterationId,
+          code: 'RUSH_OPERATION_FAILED',
+          severity: 'warning'
+        });
+        const beforeWarning: string = terminal.output;
+        reporter.report(warning);
+        reporter.report(warning);
+        expect(terminal.output).toBe(beforeWarning);
+        reporter.report(ev('watchCycleCompleted', { iterationId, succeeded: iterationId === 2 }));
+        expect(terminal.output.match(/\[warning\] RUSH_OPERATION_FAILED/g)).toHaveLength(iterationId);
+      }
+      const beforeClose: string = terminal.output;
+      reporter.report(ev('commandResult', { succeeded: true, exitCode: 0 }));
+      await reporter.closeAsync();
+      expect(terminal.output.slice(beforeClose.length)).not.toContain('[warning]');
+    } finally {
+      await reporter.closeAsync();
+    }
+  });
+
+  it('bounds diagnostic details per cycle and renders warning-only success', async () => {
+    const terminal: FakeTerminal = new FakeTerminal(80, false);
+    const reporter: DefaultInteractiveReporter = new DefaultInteractiveReporter({ terminal, color: false });
+    await reporter.initializeAsync();
+    try {
+      for (let index: number = 0; index < 100; index++) {
+        reporter.report(
+          ev('messageEmitted', {
+            severity: 'warning',
+            text: `bounded-warning-${index} ${'x'.repeat(10000)}`
+          })
+        );
+      }
+      reporter.report(ev('commandResult', { commandName: 'build', succeeded: true, exitCode: 0 }));
+      await reporter.closeAsync();
+      expect(terminal.output.match(/bounded-warning-/g)).toHaveLength(10);
+      expect(terminal.output).toContain('+90 more diagnostic');
+      expect(terminal.output.length).toBeLessThan(16000);
+    } finally {
+      await reporter.closeAsync();
+    }
+  });
+
+  it('flushes startup warnings at the first explicit watch boundary', async () => {
+    const terminal: FakeTerminal = new FakeTerminal(80, false);
+    const reporter: DefaultInteractiveReporter = new DefaultInteractiveReporter({ terminal, color: false });
+    reporter.report(ev('messageEmitted', { severity: 'warning', text: 'startup warning' }));
+    reporter.report(ev('operationRegistered', { iterationId: 1, operationId: 'op' }));
+    reporter.report(ev('watchCycleCompleted', { iterationId: 1, succeeded: true }));
+    expect(terminal.output.match(/startup warning/g)).toHaveLength(1);
+    const previousOutput: string = terminal.output;
+    await reporter.closeAsync();
+    expect(terminal.output.slice(previousOutput.length)).not.toContain('startup warning');
+  });
+
+  it('does not let held warnings consume the capacity needed to show an error', async () => {
+    const terminal: FakeTerminal = new FakeTerminal(80, false);
+    const reporter: DefaultInteractiveReporter = new DefaultInteractiveReporter({
+      terminal,
+      color: false,
+      logPath: '/abs/watch.log'
+    });
+    reporter.report(ev('operationRegistered', { iterationId: 1, operationId: 'op' }));
+    for (let index: number = 0; index < 10; index++) {
+      reporter.report(ev('messageEmitted', { severity: 'warning', text: `held-warning-${index}` }));
+    }
+    reporter.report(ev('messageEmitted', { severity: 'error', text: 'urgent error' }));
+    expect(terminal.output).toContain('urgent error');
+    reporter.report(ev('watchCycleCompleted', { iterationId: 1, succeeded: false }));
+    expect(terminal.output.match(/held-warning-/g)).toHaveLength(9);
+    expect(terminal.output).toContain('+1 more diagnostic');
+    expect(terminal.output).toContain('Log: /abs/watch.log');
+    await reporter.closeAsync();
+    expect(terminal.output.match(/urgent error/g)).toHaveLength(1);
+  });
+
+  it('redacts secret message text', async () => {
+    const terminal: FakeTerminal = new FakeTerminal(80, false);
+    const reporter: DefaultInteractiveReporter = new DefaultInteractiveReporter({
+      terminal,
+      color: false,
+      nowMs: () => 0
+    });
+    await reporter.initializeAsync();
+    reporter.report(ev('commandStarted', { commandName: 'build' }));
+    reporter.report(
+      ev('messageEmitted', { severity: 'error', text: 'TOP_SECRET_VALUE' }, undefined, 'secret')
+    );
+    reporter.report(ev('commandResult', { commandName: 'build', succeeded: false, exitCode: 1 }));
+    await reporter.closeAsync();
+
+    expect(terminal.output).toContain('[secret]');
+    expect(terminal.output).not.toContain('TOP_SECRET_VALUE');
   });
 
   it('fails closed when commandResult is missing', async () => {
@@ -217,7 +428,7 @@ describe('DefaultInteractiveReporter', () => {
     expect(terminal.output).not.toContain('build succeeded');
   });
 
-  it('appends one summary per completed watch cycle while keeping the live region', async () => {
+  it('reports overlapping watch iterations independently and recovers from failure', async () => {
     const terminal: FakeTerminal = new FakeTerminal();
     const reporter: DefaultInteractiveReporter = new DefaultInteractiveReporter({
       terminal,
@@ -226,9 +437,36 @@ describe('DefaultInteractiveReporter', () => {
     });
     await reporter.initializeAsync();
     reporter.report(ev('commandStarted', { commandName: 'build' }));
-    reporter.report(ev('watchCycleCompleted', { succeeded: true }));
+    reporter.report(
+      ev('operationRegistered', { iterationId: 1, operationId: 'op1', projectName: 'project-a' })
+    );
+    reporter.report(
+      ev('operationRegistered', { iterationId: 1, operationId: 'abort', projectName: 'project-abort' })
+    );
+    reporter.report(
+      ev('operationRegistered', { iterationId: 2, operationId: 'op1', projectName: 'project-a' })
+    );
+    reporter.report(
+      ev('operationRegistered', {
+        iterationId: 2,
+        operationId: 'silent',
+        projectName: 'hidden',
+        silent: true
+      })
+    );
+    reporter.report(ev('operationCompleted', { iterationId: 1, operationId: 'op1', status: 'failure' }));
+    reporter.report(ev('operationCompleted', { iterationId: 1, operationId: 'abort', status: 'aborted' }));
+    reporter.report(ev('watchCycleCompleted', { iterationId: 1, succeeded: false }));
+    reporter.report(ev('operationCompleted', { iterationId: 2, operationId: 'op1', status: 'success' }));
+    reporter.report(ev('operationCompleted', { iterationId: 2, operationId: 'silent', status: 'noOp' }));
+    reporter.report(ev('watchCycleCompleted', { iterationId: 2, succeeded: true }));
+    reporter.report(ev('commandResult', { commandName: 'build', succeeded: true, exitCode: 0 }));
+    await reporter.closeAsync();
 
-    expect(terminal.output).toContain('watch cycle succeeded');
+    expect(terminal.output).toContain('watch cycle failed - 2/2 operations');
+    expect(terminal.output).toContain('watch cycle succeeded - 1/1 operations');
+    expect(terminal.output).not.toContain('3/3 operations');
+    expect(terminal.output).not.toContain('hidden');
   });
 
   it('does not paint a live region on a non-TTY but still writes the final summary', async () => {

--- a/libraries/reporter/src/test/FileReporter.test.ts
+++ b/libraries/reporter/src/test/FileReporter.test.ts
@@ -45,6 +45,119 @@ async function withTempDir(action: (directory: string) => Promise<void>): Promis
 }
 
 describe('FileReporter', () => {
+  it('preserves UTF-8 through short spool, copy, and invocation-log writes', async () => {
+    await withTempDir(async (base: string) => {
+      const fsModule: typeof fs = jest.requireActual('node:fs');
+      const originalWrite: typeof fs.writeSync = fsModule.writeSync;
+      const reporter: FileReporter = new FileReporter({ commonTempFolder: base, nowMs: () => FIXED_NOW });
+      await reporter.initializeAsync();
+      const writeSpy = jest.spyOn(fsModule, 'writeSync').mockImplementation(
+        (
+          fd: number,
+          data: string | NodeJS.ArrayBufferView,
+          offset?: number | null,
+          length?: number | BufferEncoding | null
+        ): number => {
+          const buffer: Buffer =
+            typeof data === 'string'
+              ? Buffer.from(data, 'utf8')
+              : Buffer.from(data.buffer, data.byteOffset, data.byteLength);
+          const start: number = typeof data === 'string' ? 0 : (offset ?? 0);
+          const count: number = typeof length === 'number' ? length : buffer.length - start;
+          return originalWrite(fd, buffer, start, Math.min(3, count));
+        }
+      );
+      const text: string = 'OUTPUT-BEGIN \u{1f680} \u4e2d OUTPUT-END\n';
+      try {
+        reporter.report(ev('operationRegistered', { operationId: 'op', projectName: 'project' }));
+        reporter.report({ ...ev('externalOutput', { text }), scope: { operationId: 'op' } });
+        reporter.report(ev('operationCompleted', { operationId: 'op', status: 'success' }));
+        await reporter.closeAsync();
+      } finally {
+        writeSpy.mockRestore();
+        await reporter.closeAsync();
+      }
+
+      const content: string = await fs.promises.readFile(reporter.getArtifact().path!, 'utf8');
+      expect(content).toContain('"type":"operationRegistered"');
+      expect(content).toContain(text);
+      expect(content.match(/OUTPUT-BEGIN/g)).toHaveLength(1);
+      expect(reporter.getArtifact().complete).toBe(true);
+    });
+  });
+
+  it('reports a zero-progress spool failure and does not claim a complete artifact', async () => {
+    await withTempDir(async (base: string) => {
+      const fsModule: typeof fs = jest.requireActual('node:fs');
+      const warnings: string[] = [];
+      const reporter: FileReporter = new FileReporter({
+        commonTempFolder: base,
+        nowMs: () => FIXED_NOW,
+        emergencyWarn: (warning) => warnings.push(warning)
+      });
+      await reporter.initializeAsync();
+      reporter.report(ev('operationRegistered', { operationId: 'op', projectName: 'project' }));
+      const writeSpy = jest.spyOn(fsModule, 'writeSync').mockReturnValueOnce(0);
+      try {
+        reporter.report({
+          ...ev('externalOutput', { text: 'RECOVERED-OUTPUT\n' }),
+          scope: { operationId: 'op' }
+        });
+        reporter.report(ev('operationCompleted', { operationId: 'op', status: 'success' }));
+        await reporter.closeAsync();
+      } finally {
+        writeSpy.mockRestore();
+        await reporter.closeAsync();
+      }
+
+      expect(warnings.some((warning) => warning.includes('Unable to spool'))).toBe(true);
+      expect(reporter.getArtifact().complete).toBe(false);
+      const content: string = await fs.promises.readFile(reporter.getArtifact().path!, 'utf8');
+      expect(content.match(/RECOVERED-OUTPUT/g)).toHaveLength(1);
+    });
+  });
+
+  it('recovers a failed spool suffix without repeating a partial UTF-8 prefix', async () => {
+    await withTempDir(async (base: string) => {
+      const fsModule: typeof fs = jest.requireActual('node:fs');
+      const originalWrite: typeof fs.writeSync = fsModule.writeSync;
+      const warnings: string[] = [];
+      const reporter: FileReporter = new FileReporter({
+        commonTempFolder: base,
+        nowMs: () => FIXED_NOW,
+        emergencyWarn: (warning) => warnings.push(warning)
+      });
+      await reporter.initializeAsync();
+      reporter.report(ev('operationRegistered', { operationId: 'op', projectName: 'project' }));
+      const writeSpy = jest
+        .spyOn(fsModule, 'writeSync')
+        .mockImplementationOnce((fd, data: string | NodeJS.ArrayBufferView) => {
+          const buffer: Buffer =
+            typeof data === 'string'
+              ? Buffer.from(data, 'utf8')
+              : Buffer.from(data.buffer, data.byteOffset, data.byteLength);
+          return originalWrite(fd, buffer, 0, 3);
+        })
+        .mockImplementationOnce(() => {
+          throw new Error('spool full');
+        });
+      const text: string = 'A\u{1f680}B\n';
+      try {
+        reporter.report({ ...ev('externalOutput', { text }), scope: { operationId: 'op' } });
+        reporter.report(ev('operationCompleted', { operationId: 'op', status: 'success' }));
+        await reporter.closeAsync();
+      } finally {
+        writeSpy.mockRestore();
+        await reporter.closeAsync();
+      }
+      const content: string = await fs.promises.readFile(reporter.getArtifact().path!, 'utf8');
+      expect(content.split(text)).toHaveLength(2);
+      expect(content).not.toContain('\ufffd');
+      expect(warnings.some((warning) => warning.includes('spool full'))).toBe(true);
+      expect(reporter.getArtifact().complete).toBe(false);
+    });
+  });
+
   it('streams events after initialization instead of retaining the full log', async () => {
     await withTempDir(async (base: string) => {
       const reporter: FileReporter = new FileReporter({ commonTempFolder: base, nowMs: () => FIXED_NOW });
@@ -57,7 +170,7 @@ describe('FileReporter', () => {
     });
   });
 
-  it('writes a debug NDJSON log with owner-only permissions and a latest.log pointer', async () => {
+  it('writes a grouped full-detail log with owner-only permissions and a latest.log pointer', async () => {
     await withTempDir(async (base: string) => {
       const reporter: FileReporter = new FileReporter({
         commonTempFolder: base,
@@ -65,22 +178,35 @@ describe('FileReporter', () => {
         pid: 4242,
         nowMs: () => FIXED_NOW
       });
+      await reporter.initializeAsync();
       reporter.report(ev('commandStarted', { commandName: 'build' }));
-      reporter.report(ev('externalOutput', { stream: 'stdout', text: 'Building...\n' }));
+      reporter.report(
+        ev('operationRegistered', {
+          operationId: 'project#build',
+          projectName: 'project',
+          phaseName: 'build'
+        })
+      );
+      reporter.report({
+        ...ev('externalOutput', { stream: 'stdout', text: 'Building...\n' }),
+        scope: { operationId: 'project#build' }
+      });
+      reporter.report(ev('operationStatusChanged', { operationId: 'project#build', status: 'success' }));
+      reporter.report(ev('operationCompleted', { operationId: 'project#build', status: 'success' }));
       reporter.report(ev('commandResult', { commandName: 'build', succeeded: true, exitCode: 0 }));
       await reporter.closeAsync();
 
       const artifact: IFileReporterArtifact = reporter.getArtifact();
       expect(artifact.available).toBe(true);
+      expect(artifact.complete).toBe(true);
       expect(artifact.path).toContain(path.join(base, RUSH_LOGS_DIR_NAME));
       expect(path.basename(artifact.path!)).toBe('2026-07-15T01-00-00-000Z-4242-build.log');
 
       const content: string = await fs.promises.readFile(artifact.path!, 'utf8');
-      const records: Record<string, unknown>[] = content
-        .trim()
-        .split('\n')
-        .map((line: string) => JSON.parse(line) as Record<string, unknown>);
-      expect(records.map((r) => r.type)).toEqual(['commandStarted', 'externalOutput', 'commandResult']);
+      expect(content).toContain('"type":"commandStarted"');
+      expect(content).toContain('==[ project (build) ]==');
+      expect(content).toContain('Building...\n==[ project#build: success ]==');
+      expect(content).toContain('"type":"commandResult"');
 
       const latestPath: string = path.join(base, RUSH_LOGS_DIR_NAME, LATEST_LOG_NAME);
       expect(fs.existsSync(latestPath)).toBe(true);
@@ -89,6 +215,22 @@ describe('FileReporter', () => {
         const stats: fs.Stats = await fs.promises.stat(artifact.path!);
         expect(stats.mode % 0o1000).toBe(0o600);
       }
+    });
+  });
+
+  it('sanitizes action names so the log cannot escape rush-logs', async () => {
+    await withTempDir(async (base: string) => {
+      const reporter: FileReporter = new FileReporter({
+        commonTempFolder: base,
+        actionName: 'x/../../../../victim',
+        nowMs: () => FIXED_NOW
+      });
+      await reporter.initializeAsync();
+      await reporter.closeAsync();
+
+      const artifactPath: string = reporter.getArtifact().path!;
+      expect(path.dirname(artifactPath)).toBe(path.join(base, RUSH_LOGS_DIR_NAME));
+      expect(path.basename(artifactPath)).not.toContain('/');
     });
   });
 
@@ -128,6 +270,166 @@ describe('FileReporter', () => {
     });
   });
 
+  it('preserves stdout and stderr chunk order while grouping parallel operations', async () => {
+    await withTempDir(async (base: string) => {
+      const reporter: FileReporter = new FileReporter({ commonTempFolder: base, nowMs: () => FIXED_NOW });
+      await reporter.initializeAsync();
+      for (const operationId of ['a', 'b']) {
+        reporter.report(
+          ev('operationRegistered', {
+            operationId,
+            projectName: `project-${operationId}`,
+            phaseName: 'build'
+          })
+        );
+      }
+      reporter.report({
+        ...ev('externalOutput', { stream: 'stdout', text: 'a-out\n' }),
+        scope: { operationId: 'a' }
+      });
+      reporter.report({
+        ...ev('externalOutput', { stream: 'stdout', text: 'b-out\n' }),
+        scope: { operationId: 'b' }
+      });
+      reporter.report({
+        ...ev('externalOutput', { stream: 'stderr', text: 'a-err\n' }),
+        scope: { operationId: 'a' }
+      });
+      reporter.report(ev('operationStatusChanged', { operationId: 'a', status: 'failure' }));
+      reporter.report(ev('operationCompleted', { operationId: 'a', status: 'failure' }));
+      reporter.report(ev('operationStatusChanged', { operationId: 'b', status: 'blocked' }));
+      reporter.report(ev('operationCompleted', { operationId: 'b', status: 'blocked' }));
+      await reporter.closeAsync();
+
+      const content: string = await fs.promises.readFile(reporter.getArtifact().path!, 'utf8');
+      expect(content).toContain('a-out\na-err\n==[ a: failure ]==');
+      expect(content).toContain('b-out\n==[ b: blocked ]==');
+      expect(content.indexOf('a-out')).toBeLessThan(content.indexOf('a-err'));
+    });
+  });
+
+  it('treats duplicate active registration as idempotent without losing spooled output', async () => {
+    await withTempDir(async (base: string) => {
+      const reporter: FileReporter = new FileReporter({ commonTempFolder: base, nowMs: () => FIXED_NOW });
+      await reporter.initializeAsync();
+      const registration = ev('operationRegistered', {
+        operationId: 'duplicate',
+        projectName: 'project',
+        phaseName: 'build'
+      });
+      reporter.report(registration);
+      reporter.report({
+        ...ev('externalOutput', { stream: 'stdout', text: 'first\n' }),
+        scope: { operationId: 'duplicate' }
+      });
+      reporter.report(registration);
+      reporter.report({
+        ...ev('externalOutput', { stream: 'stdout', text: 'second\n' }),
+        scope: { operationId: 'duplicate' }
+      });
+      reporter.report(ev('operationCompleted', { operationId: 'duplicate', status: 'success' }));
+      await reporter.closeAsync();
+
+      const content: string = await fs.promises.readFile(reporter.getArtifact().path!, 'utf8');
+      expect(content).toContain('first\nsecond\n==[ duplicate: success ]==');
+    });
+  });
+
+  it('does not retain a file descriptor for every registered operation', async () => {
+    await withTempDir(async (base: string) => {
+      const reporter: FileReporter = new FileReporter({ commonTempFolder: base, nowMs: () => FIXED_NOW });
+      await reporter.initializeAsync();
+      for (let index: number = 0; index < 2000; index++) {
+        reporter.report(
+          ev('operationRegistered', {
+            operationId: `operation-${index}`,
+            projectName: `project-${index}`,
+            phaseName: 'build'
+          })
+        );
+      }
+
+      const logsDir: string = path.join(base, RUSH_LOGS_DIR_NAME);
+      expect((await fs.promises.readdir(logsDir)).filter((entry) => entry.endsWith('.operation'))).toEqual(
+        []
+      );
+      await reporter.closeAsync();
+    });
+  });
+
+  it('keeps bounded persistent spool descriptors and closes each one exactly once', async () => {
+    await withTempDir(async (base: string) => {
+      const reporter: FileReporter = new FileReporter({
+        commonTempFolder: base,
+        nowMs: () => FIXED_NOW
+      });
+      await reporter.initializeAsync();
+      const logsDir: string = path.join(base, RUSH_LOGS_DIR_NAME);
+      const countOpenOperationDescriptors = (): number | undefined => {
+        const processFdFolder: string = '/proc/self/fd';
+        if (!fs.existsSync(processFdFolder)) {
+          return undefined;
+        }
+        let count: number = 0;
+        for (const entry of fs.readdirSync(processFdFolder)) {
+          try {
+            if (fs.readlinkSync(path.join(processFdFolder, entry)).endsWith('.operation')) {
+              count++;
+            }
+          } catch {
+            /* Ignore descriptors that close during enumeration. */
+          }
+        }
+        return count;
+      };
+      const baselineOpenDescriptors: number | undefined = countOpenOperationDescriptors();
+
+      for (const [operationId, iterationId] of [
+        ['completed', 6],
+        ['closed', 7]
+      ] as const) {
+        reporter.report(
+          ev('operationRegistered', {
+            iterationId,
+            operationId,
+            projectName: operationId,
+            phaseName: 'build'
+          })
+        );
+        reporter.report({
+          ...ev('externalOutput', { iterationId, stream: 'stdout', text: `${operationId}-1\n` }),
+          scope: { operationId }
+        });
+        reporter.report({
+          ...ev('externalOutput', { iterationId, stream: 'stdout', text: `${operationId}-2\n` }),
+          scope: { operationId }
+        });
+      }
+
+      expect(
+        (await fs.promises.readdir(logsDir)).filter((entry) => entry.endsWith('.operation'))
+      ).toHaveLength(2);
+      if (baselineOpenDescriptors !== undefined) {
+        expect(countOpenOperationDescriptors()).toBe(baselineOpenDescriptors + 2);
+      }
+
+      reporter.report(
+        ev('operationCompleted', { iterationId: 6, operationId: 'completed', status: 'success' })
+      );
+      await reporter.closeAsync();
+
+      const content: string = await fs.promises.readFile(reporter.getArtifact().path!, 'utf8');
+      expect(content).toContain('closed-1\nclosed-2\n==[ closed: aborted ]==');
+      expect(content).not.toContain('\u0000');
+      expect((await fs.promises.readdir(logsDir)).filter((entry) => entry.endsWith('.operation'))).toEqual(
+        []
+      );
+      if (baselineOpenDescriptors !== undefined) {
+        expect(countOpenOperationDescriptors()).toBe(baselineOpenDescriptors);
+      }
+    });
+  });
+
   it('excludes secret fields but keeps local-sensitive values', async () => {
     await withTempDir(async (base: string) => {
       const reporter: FileReporter = new FileReporter({ commonTempFolder: base, nowMs: () => FIXED_NOW });
@@ -151,6 +453,43 @@ describe('FileReporter', () => {
     });
   });
 
+  it('never groups or spools secret operation values', async () => {
+    await withTempDir(async (base: string) => {
+      const reporter: FileReporter = new FileReporter({ commonTempFolder: base, nowMs: () => FIXED_NOW });
+      reporter.report(
+        ev(
+          'operationRegistered',
+          { operationId: 'secret-operation', projectName: '@secret/project', phaseName: 'secret-phase' },
+          'secret'
+        )
+      );
+      reporter.report({
+        ...ev('externalOutput', { stream: 'stdout', text: 'TOP_SECRET_OUTPUT' }, 'secret'),
+        scope: { operationId: 'secret-operation' }
+      });
+      reporter.report(
+        ev('operationCompleted', { operationId: 'secret-operation', status: 'failure' }, 'secret')
+      );
+      reporter.report(
+        ev(
+          'operationRegistered',
+          { operationId: 'unfinished-secret', projectName: '@secret/unfinished' },
+          'secret'
+        )
+      );
+      await reporter.closeAsync();
+
+      const content: string = await fs.promises.readFile(reporter.getArtifact().path!, 'utf8');
+      expect(content).toContain('[secret]');
+      expect(content).not.toContain('secret-operation');
+      expect(content).not.toContain('@secret/project');
+      expect(content).not.toContain('secret-phase');
+      expect(content).not.toContain('TOP_SECRET_OUTPUT');
+      expect(content).not.toContain('unfinished-secret');
+      expect(content).not.toContain('@secret/unfinished');
+    });
+  });
+
   it('deletes logs older than the retention window and caps the session count', async () => {
     await withTempDir(async (base: string) => {
       const logsDir: string = path.join(base, RUSH_LOGS_DIR_NAME);
@@ -158,8 +497,11 @@ describe('FileReporter', () => {
 
       const oldLog: string = path.join(logsDir, 'old-1-build.log');
       await fs.promises.writeFile(oldLog, '{}\n');
+      const oldSpool: string = path.join(logsDir, 'abandoned.operation');
+      await fs.promises.writeFile(oldSpool, 'abandoned output');
       const oldTime: Date = new Date(FIXED_NOW - 20 * MS_PER_DAY);
       await fs.promises.utimes(oldLog, oldTime, oldTime);
+      await fs.promises.utimes(oldSpool, oldTime, oldTime);
 
       // Create more than the cap of recent logs.
       for (let i: number = 0; i < 22; i++) {
@@ -182,6 +524,7 @@ describe('FileReporter', () => {
       );
       expect(remaining).not.toContain('old-1-build.log');
       expect(remaining.length).toBe(20);
+      expect(fs.existsSync(oldSpool)).toBe(false);
     });
   });
 

--- a/libraries/reporter/src/test/HumanReadableDiagnostic.test.ts
+++ b/libraries/reporter/src/test/HumanReadableDiagnostic.test.ts
@@ -1,0 +1,142 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import type { IRushDiagnostic } from '../diagnostics/IRushDiagnostic';
+import type { IReporterEventEnvelope } from '../events/IReporterEventEnvelope';
+import { DefaultInteractiveReporter } from '../reporters/DefaultInteractiveReporter';
+import { formatHumanReadableDiagnostic } from '../reporters/HumanReadableDiagnostic';
+import { PlaintextReporter } from '../reporters/PlaintextReporter';
+
+const PRIVATE_PRODUCER: string = '@private/example-rush-plugin';
+const PRIVATE_COMPONENT: string = 'PrivatePluginImplementation';
+
+function createEvent(overrides: Partial<IRushDiagnostic> = {}): IReporterEventEnvelope<IRushDiagnostic> {
+  return {
+    protocolVersion: { major: 1, minor: 1 },
+    eventId: 'plugin-api-incompatible',
+    sessionId: 'fixture',
+    sequence: 1,
+    timestamp: '2026-08-28T08:45:34.000Z',
+    source: {
+      packageName: PRIVATE_PRODUCER,
+      packageVersion: '1.0.0',
+      component: PRIVATE_COMPONENT
+    },
+    privacy: 'local-sensitive',
+    required: true,
+    type: 'diagnosticEmitted',
+    payload: {
+      diagnosticId: 'plugin-api-incompatible-diagnostic',
+      code: 'RUSH_PLUGIN_API_INCOMPATIBLE',
+      category: 'configuration',
+      severity: 'error',
+      summaryKey: 'diagnostic.RUSH_PLUGIN_API_INCOMPATIBLE.summary',
+      parameters: {
+        pluginName: { value: PRIVATE_PRODUCER, privacy: 'secret' },
+        rushVersion: { value: '5.200.0', privacy: 'public' },
+        rushVersionRange: { value: '^5.100.0', privacy: 'public' }
+      },
+      remediation: [
+        {
+          descriptionKey: 'remediation.update-plugin',
+          command: 'rush update',
+          automatedExecutionSafety: 'requires-confirmation'
+        }
+      ],
+      source: { kind: 'tool', toolName: PRIVATE_PRODUCER },
+      ...overrides
+    }
+  };
+}
+
+describe(formatHumanReadableDiagnostic.name, () => {
+  it('does not redisplay the qualification fixture secret through its source alias', () => {
+    const event: IReporterEventEnvelope<IRushDiagnostic> = createEvent();
+    const original: string = JSON.stringify(event);
+    const output: string = formatHumanReadableDiagnostic(event);
+
+    expect(output).not.toContain(PRIVATE_PRODUCER);
+    expect(output).not.toContain(PRIVATE_COMPONENT);
+    expect(output).toContain('The plugin [secret] supports Rush ^5.100.0');
+    expect(output).toContain('5.200.0');
+    expect(JSON.stringify(event)).toBe(original);
+  });
+
+  it.each(['default', 'plaintext'] as const)('keeps secret source aliases out of %s output', async (kind) => {
+    let output: string = '';
+    const write = (text: string): void => {
+      output += text;
+    };
+    const reporter =
+      kind === 'default'
+        ? new DefaultInteractiveReporter({ terminal: { isTTY: false, columns: 100, write }, color: false })
+        : new PlaintextReporter({ write, variant: 'detailed', color: false });
+    reporter.report(createEvent());
+    await reporter.closeAsync();
+
+    expect(output).not.toContain(PRIVATE_PRODUCER);
+    expect(output).not.toContain(PRIVATE_COMPONENT);
+    expect(output).toContain('The plugin [secret]');
+  });
+
+  it('omits a source path containing a secret alias without losing an unrelated tool', () => {
+    const output: string = formatHumanReadableDiagnostic(
+      createEvent({
+        source: {
+          kind: 'file',
+          file: `/repo/node_modules/${PRIVATE_PRODUCER}/plugin.js`,
+          line: 4,
+          column: 2,
+          toolName: 'typescript'
+        }
+      })
+    );
+
+    expect(output).not.toContain(PRIVATE_PRODUCER);
+    expect(output).not.toContain(':4:2');
+    expect(output).toContain('typescript');
+  });
+
+  it('redacts a lower-classified template parameter repeating a secret value', () => {
+    const output: string = formatHumanReadableDiagnostic(
+      createEvent({
+        code: 'RUSH_EXTERNAL_TOOL_PROBLEM',
+        category: 'operation',
+        summaryKey: 'diagnostic.RUSH_EXTERNAL_TOOL_PROBLEM.summary',
+        parameters: {
+          pluginName: { value: PRIVATE_PRODUCER, privacy: 'secret' },
+          tool: { value: 'typescript', privacy: 'public' },
+          code: { value: 'TS1005', privacy: 'public' },
+          message: { value: `Failure inside ${PRIVATE_PRODUCER}`, privacy: 'local-sensitive' }
+        },
+        source: { kind: 'tool', toolName: 'typescript' }
+      })
+    );
+
+    expect(output).not.toContain(PRIVATE_PRODUCER);
+    expect(output).toContain('typescript reported TS1005: [secret]');
+  });
+
+  it('preserves unrelated local source context', () => {
+    const output: string = formatHumanReadableDiagnostic(
+      createEvent({
+        source: { kind: 'file', file: 'src/index.ts', line: 4, column: 2, toolName: 'typescript' }
+      })
+    );
+
+    expect(output).toContain('typescript');
+    expect(output).toContain('src/index.ts:4:2');
+    expect(output).toContain('^5.100.0');
+  });
+
+  it('does not treat an empty secret parameter as an alias of every source string', () => {
+    const output: string = formatHumanReadableDiagnostic(
+      createEvent({
+        parameters: { pluginName: { value: '', privacy: 'secret' } },
+        source: { kind: 'tool', toolName: 'typescript' }
+      })
+    );
+
+    expect(output).toContain('typescript');
+  });
+});

--- a/libraries/reporter/src/test/JsonAiReporter.test.ts
+++ b/libraries/reporter/src/test/JsonAiReporter.test.ts
@@ -13,7 +13,8 @@ import {
 function ev(
   type: string,
   payload: unknown = {},
-  scope?: { operationId?: string; projectName?: string }
+  scope?: { operationId?: string; projectName?: string },
+  privacy: IReporterEventEnvelope<unknown>['privacy'] = 'public'
 ): IReporterEventEnvelope<unknown> {
   return {
     protocolVersion: { major: 1, minor: 0 },
@@ -22,7 +23,7 @@ function ev(
     sequence: 1,
     timestamp: '2026-01-01T00:00:00.000Z',
     source: { packageName: '@microsoft/rush-lib', packageVersion: '5.177.2' },
-    privacy: 'public',
+    privacy,
     required: true,
     type,
     payload,
@@ -90,6 +91,44 @@ describe('JsonReporter', () => {
     expect(output).toContain('[secret]');
     expect(output).toContain('/tmp/log');
   });
+
+  it('redacts local-sensitive message text from machine output', () => {
+    let output: string = '';
+    const reporter: JsonReporter = new JsonReporter({ write: (text: string) => (output += text) });
+    reporter.report(
+      ev('messageEmitted', { severity: 'error', text: '/private/path' }, undefined, 'local-sensitive')
+    );
+
+    expect(output).toContain('[local-sensitive]');
+    expect(output).not.toContain('/private/path');
+  });
+
+  it('removes secret envelope metadata from machine output', () => {
+    let output: string = '';
+    const reporter: JsonReporter = new JsonReporter({ write: (text: string) => (output += text) });
+    reporter.report({
+      ...ev(
+        'messageEmitted',
+        { severity: 'error', text: 'TOP_SECRET_VALUE' },
+        { operationId: 'private-operation', projectName: '@private/project' },
+        'secret'
+      ),
+      source: { packageName: '@private/producer', packageVersion: '1.0.0' },
+      parentSessionId: 'private-parent-session',
+      parentOperationId: 'private-parent-operation'
+    });
+
+    const record: Record<string, unknown> = parseLines(output)[0];
+    expect(record.source).toEqual({
+      packageName: '[private-producer]',
+      packageVersion: '[private-version]'
+    });
+    expect(record.scope).toBeUndefined();
+    expect(record.parentSessionId).toBeUndefined();
+    expect(record.parentOperationId).toBeUndefined();
+    expect(output).not.toContain('TOP_SECRET_VALUE');
+    expect(output).not.toContain('@private/project');
+  });
 });
 
 describe('AiReporter', () => {
@@ -108,6 +147,7 @@ describe('AiReporter', () => {
     for (const event of events) {
       reporter.report(event);
     }
+    void reporter.closeAsync();
     const records: Record<string, unknown>[] = parseLines(output);
     return { records, final: records[records.length - 1] as unknown as IAiFinalRecord };
   }
@@ -123,11 +163,72 @@ describe('AiReporter', () => {
     expect(final.exitCode).toBe(1);
   });
 
+  it('counts secret fallback errors without rendering their text', () => {
+    const { final } = run([
+      ev('messageEmitted', { severity: 'error', text: 'TOP_SECRET_VALUE' }, undefined, 'secret'),
+      ev('commandResult', { commandName: 'build', succeeded: false, exitCode: 1 })
+    ]);
+
+    expect(final.errorCount).toBe(1);
+    expect(JSON.stringify(final)).not.toContain('TOP_SECRET_VALUE');
+  });
+
+  it('uses sessionCompleted as the parser-only fallback result', () => {
+    const { final } = run([
+      ev('sessionStarted', { rushVersion: '5.178.1' }),
+      ev('sessionCompleted', { exitCode: 0 })
+    ]);
+
+    expect(final.result).toBe('succeeded');
+    expect(final.exitCode).toBe(0);
+  });
+
+  it('preserves an actionable parser error when no structured diagnostic was emitted', () => {
+    const { final } = run([
+      ev('commandStarted', { commandName: 'build' }),
+      ev('messageEmitted', {
+        severity: 'error',
+        text: 'The project \"missing\" passed to \"--only\" does not exist in rush.json.'
+      }),
+      ev('commandResult', { commandName: 'build', succeeded: false, exitCode: 1 })
+    ]);
+
+    expect(final.errorCodes).toEqual(['RUSH_COMMAND_FAILED']);
+    expect(final.errorCount).toBe(1);
+    expect(final.diagnostics).toEqual([
+      expect.objectContaining({
+        category: 'command',
+        severity: 'error',
+        summary: 'The project \"missing\" passed to \"--only\" does not exist in rush.json.'
+      })
+    ]);
+  });
+
+  it('counts fallback errors even when detailed diagnostics are disabled', async () => {
+    let output: string = '';
+    const reporter: AiReporter = new AiReporter({
+      write: (text: string) => (output += text),
+      maxDetailedDiagnostics: 0
+    });
+    reporter.report(ev('messageEmitted', { severity: 'error', text: 'first error' }));
+    reporter.report(ev('messageEmitted', { severity: 'error', text: 'second error' }));
+    reporter.report(ev('commandResult', { commandName: 'build', succeeded: false, exitCode: 1 }));
+    await reporter.closeAsync();
+
+    const final: IAiFinalRecord = parseLines(output).at(-1)! as unknown as IAiFinalRecord;
+    expect(final.errorCount).toBe(2);
+    expect(final.errorCodes).toEqual(['RUSH_COMMAND_FAILED']);
+    expect(final.diagnosticCategoryCounts.command).toBe(2);
+    expect(final.diagnostics).toEqual([]);
+    expect(final.truncated).toBe(true);
+  });
+
   it('emits a status record and a bounded final record with scope, codes, and log', () => {
     const { records, final } = run([
       ev('commandStarted', { commandName: 'build' }),
       ev('operationRegistered', { operationId: 'op1', projectName: 'project-a' }),
       ev('operationStatusChanged', { operationId: 'op1', status: 'failure' }),
+      ev('operationCompleted', { operationId: 'op1', status: 'failure' }),
       ev('diagnosticEmitted', {
         code: 'RUSH_OPERATION_FAILED',
         category: 'operation',
@@ -148,6 +249,95 @@ describe('AiReporter', () => {
     expect(final.diagnostics[0].remediation?.[0].command).toBe('rush rebuild');
     expect(final.operationCounts).toEqual({ failure: 1 });
     expect(final.log).toEqual({ path: '/abs/rush.log', format: 'plaintext', complete: true });
+  });
+
+  it('excludes silent operations from AI result counts', () => {
+    const { final } = run([
+      ev('commandStarted', { commandName: 'build' }),
+      ev('operationRegistered', { operationId: 'hidden', projectName: 'hidden', silent: true }),
+      ev('operationStatusChanged', { operationId: 'hidden', status: 'success' }),
+      ev('operationCompleted', { operationId: 'hidden', status: 'success' }),
+      ev('operationRegistered', { operationId: 'visible', projectName: 'visible' }),
+      ev('operationStatusChanged', { operationId: 'visible', status: 'fromCache' }),
+      ev('operationCompleted', { operationId: 'visible', status: 'fromCache' }),
+      ev('commandResult', { commandName: 'build', succeeded: true, exitCode: 0 })
+    ]);
+
+    expect(final.operationCounts).toEqual({ fromCache: 1 });
+  });
+
+  it('keeps overlapping AI watch iterations and final recovery scope coherent', async () => {
+    let output: string = '';
+    const reporter: AiReporter = new AiReporter({ write: (text: string) => (output += text) });
+    reporter.report(ev('commandStarted', { commandName: 'build' }));
+    reporter.report(
+      ev('operationRegistered', { iterationId: 1, operationId: 'op1', projectName: 'project-a' })
+    );
+    reporter.report(
+      ev('operationRegistered', { iterationId: 1, operationId: 'abort', projectName: 'project-abort' })
+    );
+    reporter.report(
+      ev('operationRegistered', { iterationId: 2, operationId: 'op1', projectName: 'project-a' })
+    );
+    reporter.report(
+      ev('operationRegistered', {
+        iterationId: 2,
+        operationId: 'silent',
+        projectName: 'hidden',
+        silent: true
+      })
+    );
+    reporter.report(ev('operationCompleted', { iterationId: 1, operationId: 'op1', status: 'failure' }));
+    reporter.report(
+      ev('diagnosticEmitted', {
+        iterationId: 1,
+        code: 'RUSH_OPERATION_FAILED',
+        category: 'operation',
+        severity: 'error'
+      })
+    );
+    reporter.report(ev('operationCompleted', { iterationId: 1, operationId: 'abort', status: 'aborted' }));
+    reporter.report(ev('watchCycleCompleted', { iterationId: 1, succeeded: false }));
+    reporter.report(ev('operationCompleted', { iterationId: 2, operationId: 'op1', status: 'success' }));
+    reporter.report(ev('operationCompleted', { iterationId: 2, operationId: 'silent', status: 'noOp' }));
+    reporter.report(ev('watchCycleCompleted', { iterationId: 2, succeeded: true }));
+    reporter.report(ev('commandResult', { commandName: 'build', succeeded: true, exitCode: 0 }));
+    await reporter.closeAsync();
+
+    const records: Record<string, unknown>[] = parseLines(output);
+    const cycles: Array<{
+      succeeded: boolean;
+      operationCounts: Record<string, number>;
+      failedProjects: string[];
+    }> = records.filter(({ kind }) => kind === 'ai.watchCycle') as Array<{
+      succeeded: boolean;
+      operationCounts: Record<string, number>;
+      failedProjects: string[];
+    }>;
+    expect(
+      cycles.map(({ succeeded, operationCounts, failedProjects }) => ({
+        succeeded,
+        operationCounts,
+        failedProjects
+      }))
+    ).toEqual([
+      {
+        succeeded: false,
+        operationCounts: { failure: 1, aborted: 1 },
+        failedProjects: ['project-a']
+      },
+      {
+        succeeded: true,
+        operationCounts: { success: 1 },
+        failedProjects: []
+      }
+    ]);
+    const final: IAiFinalRecord = records.at(-1) as unknown as IAiFinalRecord;
+    expect(final.operationCounts).toEqual({ success: 1 });
+    expect(final.scope.failedProjects).toEqual([]);
+    expect(final.errorCount).toBe(0);
+    expect(final.errorCodes).toEqual([]);
+    expect(final.diagnostics).toEqual([]);
   });
 
   it('caps detailed diagnostics at 20 and marks the record truncated', () => {
@@ -188,6 +378,7 @@ describe('AiReporter', () => {
     for (const event of events) {
       reporter.report(event);
     }
+    void reporter.closeAsync();
     const finalLine: string = output.trim().split('\n').pop() ?? '';
     expect(Buffer.byteLength(finalLine, 'utf8')).toBeLessThanOrEqual(512);
     expect((JSON.parse(finalLine) as IAiFinalRecord).truncated).toBe(true);
@@ -204,6 +395,7 @@ describe('AiReporter', () => {
     for (const event of events) {
       reporter.report(event);
     }
+    void reporter.closeAsync();
 
     const finalLine: string = output.trim().split('\n').pop()!;
     const final: IAiFinalRecord = JSON.parse(finalLine) as IAiFinalRecord;
@@ -252,6 +444,7 @@ describe('AiReporter', () => {
     reporter.report(ev('commandStarted', { commandName: 'build' }));
     reporter.report(ev('externalOutput', { stream: 'stdout', text: 'SENSITIVE-RAW-abc' }));
     reporter.report(ev('commandResult', { commandName: 'build', succeeded: true, exitCode: 0 }));
+    void reporter.closeAsync();
 
     expect(output).not.toContain('SENSITIVE-RAW-abc');
     // Every emitted line parses as JSON.

--- a/libraries/reporter/src/test/LogLevelFilter.test.ts
+++ b/libraries/reporter/src/test/LogLevelFilter.test.ts
@@ -50,6 +50,11 @@ describe('getEventMinimumLogLevel', () => {
     expect(getEventMinimumLogLevel(ev('externalOutput', { stream: 'stdout', text: 'x' }))).toBe('debug');
     expect(getEventMinimumLogLevel(ev('operationStreamClosed', {}))).toBe('debug');
     expect(getEventMinimumLogLevel(ev('messageEmitted', { severity: 'debug', text: 'd' }))).toBe('debug');
+    expect(
+      getEventMinimumLogLevel(
+        ev('messageEmitted', { severity: 'debug', text: 'v', minimumLogLevel: 'verbose' })
+      )
+    ).toBe('verbose');
     expect(getEventMinimumLogLevel(ev('extension', { name: 'a.b' }, false))).toBe('normal');
   });
 });

--- a/libraries/reporter/src/test/Manager.test.ts
+++ b/libraries/reporter/src/test/Manager.test.ts
@@ -372,6 +372,21 @@ describe('ReporterManager flush and close', () => {
     expect(true).toBe(true);
   });
 
+  it('reports whether a flush completed before its timeout', async () => {
+    let resolveFlush: (() => void) | undefined;
+    const reporter: RecordingReporter = new RecordingReporter('confirm');
+    reporter.flushAsync = () =>
+      new Promise<void>((resolve: () => void) => {
+        resolveFlush = resolve;
+      });
+    const manager: ReporterManager = new ReporterManager();
+    manager.addReporter(reporter);
+    await manager.initializeAsync();
+
+    await expect(manager._flushAndConfirmAsync(10)).resolves.toBe(false);
+    resolveFlush?.();
+  });
+
   it('does not overlap close with a timed-out flush', async () => {
     let resolveFlush: (() => void) | undefined;
     let closeCount: number = 0;

--- a/libraries/reporter/src/test/OperationStreamEmitter.test.ts
+++ b/libraries/reporter/src/test/OperationStreamEmitter.test.ts
@@ -61,12 +61,12 @@ describe('OperationStreamEmitter', () => {
   it('emits registration, status, output, and result with operation scope', () => {
     const sink: CapturingSink = new CapturingSink();
     const emitter: OperationStreamEmitter = makeEmitter(sink);
-    emitter.registerOperation('op1', 'project-a', 'build', false);
-    emitter.changeStatus('op1', 'executing', 0, 'queued');
-    emitter.writeOutput('op1', 'stdout', 'hello\n');
-    emitter.changeStatus('op1', 'success', 100, 'executing');
-    emitter.closeOperationStream('op1');
-    emitter.completeOperation('op1', 'success', 100);
+    emitter.registerOperation('op1', 'project-a', 'build', false, 7);
+    emitter.changeStatus('op1', 'executing', 0, 'queued', 7);
+    emitter.writeOutput('op1', 'stdout', 'hello\n', 7);
+    emitter.changeStatus('op1', 'success', 100, 'executing', 7);
+    emitter.closeOperationStream('op1', 7);
+    emitter.completeOperation('op1', 'success', 100, 7);
     emitter.completeCommand('build', true, 0, { success: 1 });
 
     expect(sink.inputs.map((i) => i.type)).toEqual([
@@ -80,6 +80,10 @@ describe('OperationStreamEmitter', () => {
     ]);
     expect(sink.inputs[2].scope).toEqual({ commandName: 'build', operationId: 'op1' });
     expect(sink.inputs[2].privacy).toBe('local-sensitive');
+    for (const input of sink.inputs.slice(0, 6)) {
+      expect(input.payload).toMatchObject({ iterationId: 7 });
+      expect(input.scope?.operationId).toBe('op1');
+    }
     expect(sink.inputs[0].payload).toMatchObject({ operationId: 'op1', silent: false });
     expect(sink.inputs[3].payload).toMatchObject({
       operationId: 'op1',
@@ -178,6 +182,8 @@ describe('reporter parity with StreamCollator', () => {
     emitter.writeOutput('op2', 'stdout', 'B2\n');
     emitter.changeStatus('op1', 'success', 100);
     emitter.changeStatus('op2', 'success', 200);
+    emitter.completeOperation('op1', 'success', 100);
+    emitter.completeOperation('op2', 'success', 200);
     emitter.completeCommand('build', true, 0);
 
     let output: string = '';
@@ -204,6 +210,7 @@ describe('reporter parity with StreamCollator', () => {
     emitter.changeStatus('op1', 'executing');
     emitter.writeOutput('op1', 'stdout', 'RAW-PROJECT-OUTPUT\n');
     emitter.changeStatus('op1', 'success', 100);
+    emitter.completeOperation('op1', 'success', 100);
     emitter.completeCommand('build', true, 0);
 
     const terminal: FakeTerminal = new FakeTerminal();

--- a/libraries/reporter/src/test/PlaintextReporter.test.ts
+++ b/libraries/reporter/src/test/PlaintextReporter.test.ts
@@ -1,14 +1,17 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+import type * as fs from 'node:fs';
+
 import { PlaintextReporter, type IReporterEventEnvelope } from '../index';
 
 function ev(
   type: string,
   payload: unknown = {},
-  scope?: { operationId?: string; projectName?: string }
+  scope?: { operationId?: string; projectName?: string },
+  privacy: IReporterEventEnvelope<unknown>['privacy'] = 'public'
 ): IReporterEventEnvelope<unknown> {
-  return { type, payload, scope, required: true } as unknown as IReporterEventEnvelope<unknown>;
+  return { type, payload, scope, privacy, required: true } as unknown as IReporterEventEnvelope<unknown>;
 }
 
 interface ICapture {
@@ -46,6 +49,7 @@ describe('PlaintextReporter', () => {
     capture.reporter.report(ev('commandStarted', { commandName: 'build' }));
     capture.reporter.report(ev('operationRegistered', { operationId: 'op1', projectName: 'project-a' }));
     capture.reporter.report(ev('operationStatusChanged', { operationId: 'op1', status: 'success' }));
+    capture.reporter.report(ev('operationCompleted', { operationId: 'op1', status: 'success' }));
     capture.reporter.report(ev('commandResult', { commandName: 'build', succeeded: true, exitCode: 0 }));
 
     // No escape sequences of any kind (no color, no cursor movement).
@@ -58,10 +62,12 @@ describe('PlaintextReporter', () => {
     capture.reporter.report(ev('operationRegistered', { operationId: 'op1', projectName: 'project-a' }));
     capture.reporter.report(ev('operationRegistered', { operationId: 'op2', projectName: 'project-b' }));
     capture.reporter.report(ev('operationStatusChanged', { operationId: 'op1', status: 'success' }));
+    capture.reporter.report(ev('operationCompleted', { operationId: 'op1', status: 'success' }));
     capture.reporter.report(
       ev('diagnosticEmitted', { code: 'RUSH_INPUT_UNKNOWN_PROJECT', severity: 'warning' })
     );
     capture.reporter.report(ev('operationStatusChanged', { operationId: 'op2', status: 'failure' }));
+    capture.reporter.report(ev('operationCompleted', { operationId: 'op2', status: 'failure' }));
     capture.reporter.report(ev('commandResult', { commandName: 'build', succeeded: false, exitCode: 1 }));
 
     expect(capture.getOutput()).toMatchSnapshot();
@@ -78,9 +84,70 @@ describe('PlaintextReporter', () => {
       ev('externalOutput', { stream: 'stdout', text: 'Building project-a...\n' }, { operationId: 'op1' })
     );
     capture.reporter.report(ev('operationStatusChanged', { operationId: 'op1', status: 'success' }));
+    capture.reporter.report(ev('operationCompleted', { operationId: 'op1', status: 'success' }));
     capture.reporter.report(ev('commandResult', { commandName: 'build', succeeded: true, exitCode: 0 }));
 
     expect(capture.getOutput()).toMatchSnapshot();
+  });
+
+  it('redacts secret message text', () => {
+    const capture: ICapture = makeConcise();
+    capture.reporter.report(
+      ev('messageEmitted', { severity: 'error', text: 'TOP_SECRET_VALUE' }, undefined, 'secret')
+    );
+
+    expect(capture.getOutput()).toContain('[secret]');
+    expect(capture.getOutput()).not.toContain('TOP_SECRET_VALUE');
+  });
+
+  it('renders negotiated compiler details without a duplicate raw diagnostic', () => {
+    const capture: ICapture = makeDetailed();
+    capture.reporter.report(
+      ev('diagnosticEmitted', {
+        code: 'RUSH_EXTERNAL_TOOL_PROBLEM',
+        severity: 'error',
+        summaryKey: 'diagnostic.RUSH_EXTERNAL_TOOL_PROBLEM.summary',
+        parameters: {
+          tool: { value: 'typescript', privacy: 'public' },
+          code: { value: 'TS1005', privacy: 'public' },
+          message: { value: 'semicolon expected', privacy: 'local-sensitive' }
+        },
+        source: { kind: 'file', file: 'src/index.ts', line: 4, column: 2, toolName: 'typescript' }
+      })
+    );
+
+    expect(capture.getOutput()).toContain('typescript');
+    expect(capture.getOutput()).toContain('TS1005');
+    expect(capture.getOutput()).toContain('src/index.ts:4:2');
+    expect(capture.getOutput().match(/semicolon expected/g)).toHaveLength(1);
+  });
+
+  it('redacts secret diagnostic values and the whole secret envelope', () => {
+    const capture: ICapture = makeDetailed();
+    const payload = {
+      code: 'RUSH_EXTERNAL_TOOL_PROBLEM',
+      severity: 'warning',
+      summaryKey: 'diagnostic.RUSH_EXTERNAL_TOOL_PROBLEM.summary',
+      parameters: {
+        tool: { value: 'typescript', privacy: 'public' },
+        code: { value: 'TS1005', privacy: 'public' },
+        message: { value: 'TOP_SECRET_MESSAGE', privacy: 'secret' }
+      },
+      source: { kind: 'file', file: 'src/index.ts', line: 4, column: 2 }
+    };
+    capture.reporter.report(ev('diagnosticEmitted', payload, undefined, 'local-sensitive'));
+    capture.reporter.report(
+      ev(
+        'diagnosticEmitted',
+        { ...payload, source: { kind: 'file', file: 'TOP_SECRET_FILE' } },
+        undefined,
+        'secret'
+      )
+    );
+
+    expect(capture.getOutput()).toContain('[secret]');
+    expect(capture.getOutput()).toContain('src/index.ts:4:2');
+    expect(capture.getOutput()).not.toContain('TOP_SECRET');
   });
 
   it('preserves partial-line chunks within grouped output', () => {
@@ -91,9 +158,206 @@ describe('PlaintextReporter', () => {
     capture.reporter.report(ev('externalOutput', { text: 'Building ' }, { operationId: 'op1' }));
     capture.reporter.report(ev('externalOutput', { text: 'project-a' }, { operationId: 'op1' }));
     capture.reporter.report(ev('operationStatusChanged', { operationId: 'op1', status: 'success' }));
+    capture.reporter.report(ev('operationCompleted', { operationId: 'op1', status: 'success' }));
 
     expect(capture.getOutput()).toContain('Building project-a\nproject-a: success');
     expect(capture.getOutput()).not.toContain('Building \nproject-a');
+  });
+
+  it.each([3, 0])('preserves grouped UTF-8 when the first spool write returns %s bytes', async (count) => {
+    const fsModule: typeof fs = jest.requireActual('node:fs');
+    const originalWrite: typeof fs.writeSync = fsModule.writeSync;
+    const capture: ICapture = makeDetailed();
+    const text: string = 'A\u{1f680}B\n';
+    capture.reporter.report(ev('operationRegistered', { operationId: 'op', projectName: 'project' }));
+    const writeSpy = jest
+      .spyOn(fsModule, 'writeSync')
+      .mockImplementationOnce((fd, data: string | NodeJS.ArrayBufferView) => {
+        const buffer: Buffer =
+          typeof data === 'string'
+            ? Buffer.from(data, 'utf8')
+            : Buffer.from(data.buffer, data.byteOffset, data.byteLength);
+        return count === 0 ? 0 : originalWrite(fd, buffer, 0, count);
+      });
+    try {
+      capture.reporter.report(ev('externalOutput', { text }, { operationId: 'op' }));
+      capture.reporter.report(ev('operationCompleted', { operationId: 'op', status: 'success' }));
+      await capture.reporter.closeAsync();
+    } finally {
+      writeSpy.mockRestore();
+      await capture.reporter.closeAsync();
+    }
+
+    expect(capture.getOutput().split(text)).toHaveLength(2);
+    expect(capture.getOutput().includes('Unable to spool')).toBe(count === 0);
+    expect(capture.getOutput()).not.toContain('\ufffd');
+  });
+
+  it('does not repeat a partially persisted UTF-8 prefix when the spool then fails', async () => {
+    const fsModule: typeof fs = jest.requireActual('node:fs');
+    const originalWrite: typeof fs.writeSync = fsModule.writeSync;
+    const capture: ICapture = makeDetailed();
+    const text: string = 'A\u{1f680}B\n';
+    capture.reporter.report(ev('operationRegistered', { operationId: 'op', projectName: 'project' }));
+    const writeSpy = jest
+      .spyOn(fsModule, 'writeSync')
+      .mockImplementationOnce((fd, data: string | NodeJS.ArrayBufferView) => {
+        const buffer: Buffer =
+          typeof data === 'string'
+            ? Buffer.from(data, 'utf8')
+            : Buffer.from(data.buffer, data.byteOffset, data.byteLength);
+        return originalWrite(fd, buffer, 0, 3);
+      })
+      .mockImplementationOnce(() => {
+        throw new Error('spool full');
+      });
+    try {
+      capture.reporter.report(ev('externalOutput', { text }, { operationId: 'op' }));
+      capture.reporter.report(ev('operationCompleted', { operationId: 'op', status: 'success' }));
+      await capture.reporter.closeAsync();
+    } finally {
+      writeSpy.mockRestore();
+      await capture.reporter.closeAsync();
+    }
+    expect(capture.getOutput().split(text)).toHaveLength(2);
+    expect(capture.getOutput()).toContain('Unable to spool');
+    expect(capture.getOutput()).not.toContain('\ufffd');
+  });
+
+  it('treats duplicate active registration as idempotent', () => {
+    const capture: ICapture = makeDetailed();
+    const registration: IReporterEventEnvelope<unknown> = ev('operationRegistered', {
+      operationId: 'op1',
+      projectName: 'project-a',
+      phaseName: 'build'
+    });
+    capture.reporter.report(ev('commandStarted', { commandName: 'build' }));
+    capture.reporter.report(registration);
+    capture.reporter.report(ev('externalOutput', { text: 'first\n' }, { operationId: 'op1' }));
+    capture.reporter.report(registration);
+    capture.reporter.report(ev('externalOutput', { text: 'second\n' }, { operationId: 'op1' }));
+    capture.reporter.report(ev('operationCompleted', { operationId: 'op1', status: 'success' }));
+    capture.reporter.report(ev('commandResult', { commandName: 'build', succeeded: true, exitCode: 0 }));
+
+    expect(capture.getOutput()).toContain('first\nsecond\nproject-a: success');
+    expect(capture.getOutput()).toContain('rush build succeeded (1/1 operations');
+  });
+
+  it('streams large grouped output from disk without retaining it in the operation record', async () => {
+    const capture: ICapture = makeDetailed();
+    const chunk: string = `${'x'.repeat(256 * 1024)}\n`;
+    capture.reporter.report(
+      ev('operationRegistered', { operationId: 'op1', projectName: 'project-a', phaseName: 'build' })
+    );
+    for (let index: number = 0; index < 8; index++) {
+      capture.reporter.report(ev('externalOutput', { text: chunk }, { operationId: 'op1' }));
+    }
+    capture.reporter.report(ev('operationCompleted', { operationId: 'op1', status: 'success' }));
+    await capture.reporter.closeAsync();
+
+    expect(capture.getOutput()).toContain(`${'x'.repeat(1024)}x`);
+    expect(capture.getOutput()).toContain('project-a: success');
+  });
+
+  it('omits silent operations and exposes the full log path', () => {
+    const capture: ICapture = makeDetailed();
+    capture.reporter.report(ev('commandStarted', { commandName: 'build' }));
+    capture.reporter.report(
+      ev('operationRegistered', { operationId: 'silent', projectName: 'hidden', silent: true })
+    );
+    capture.reporter.report(ev('operationStatusChanged', { operationId: 'silent', status: 'aborted' }));
+    capture.reporter.report(ev('operationCompleted', { operationId: 'silent', status: 'aborted' }));
+    capture.reporter.report(
+      ev('artifactAvailable', { role: 'log', path: '/abs/common/temp/rush-logs/build.log' })
+    );
+    capture.reporter.report(ev('commandResult', { commandName: 'build', succeeded: true, exitCode: 0 }));
+
+    expect(capture.getOutput()).toContain('0/0 operations');
+    expect(capture.getOutput()).toContain('Full log: /abs/common/temp/rush-logs/build.log');
+    expect(capture.getOutput()).not.toContain('hidden');
+  });
+
+  it('uses operationCompleted as the authoritative final outcome', () => {
+    const capture: ICapture = makeDetailed();
+    capture.reporter.report(
+      ev('operationRegistered', { operationId: 'op1', projectName: 'project-a', phaseName: 'build' })
+    );
+    capture.reporter.report(ev('operationStatusChanged', { operationId: 'op1', status: 'success' }));
+    capture.reporter.report(ev('operationCompleted', { operationId: 'op1', status: 'failure' }));
+
+    expect(capture.getOutput()).toContain('project-a: failure');
+    expect(capture.getOutput()).not.toContain('project-a: success');
+  });
+
+  it('keeps overlapping watch totals and grouped output isolated by iteration', () => {
+    const capture: ICapture = makeDetailed();
+    capture.reporter.report(ev('commandStarted', { commandName: 'build' }));
+    capture.reporter.report(
+      ev('operationRegistered', {
+        iterationId: 1,
+        operationId: 'op1',
+        projectName: 'project-a',
+        phaseName: 'build'
+      })
+    );
+    capture.reporter.report(
+      ev('operationRegistered', {
+        iterationId: 1,
+        operationId: 'abort',
+        projectName: 'project-abort',
+        phaseName: 'build'
+      })
+    );
+    capture.reporter.report(
+      ev('operationRegistered', {
+        iterationId: 2,
+        operationId: 'op1',
+        projectName: 'project-a',
+        phaseName: 'build'
+      })
+    );
+    capture.reporter.report(
+      ev('operationRegistered', {
+        iterationId: 2,
+        operationId: 'silent',
+        projectName: 'hidden',
+        silent: true
+      })
+    );
+    capture.reporter.report(
+      ev('externalOutput', { iterationId: 1, stream: 'stdout', text: 'OLD-CYCLE\n' }, { operationId: 'op1' })
+    );
+    capture.reporter.report(
+      ev('externalOutput', { iterationId: 2, stream: 'stdout', text: 'NEW-CYCLE\n' }, { operationId: 'op1' })
+    );
+    capture.reporter.report(
+      ev('operationCompleted', { iterationId: 1, operationId: 'op1', status: 'failure' })
+    );
+    capture.reporter.report(
+      ev('operationCompleted', { iterationId: 1, operationId: 'abort', status: 'aborted' })
+    );
+    capture.reporter.report(ev('watchCycleCompleted', { iterationId: 1, succeeded: false }));
+    capture.reporter.report(
+      ev('operationCompleted', { iterationId: 2, operationId: 'op1', status: 'success' })
+    );
+    capture.reporter.report(
+      ev('operationCompleted', { iterationId: 2, operationId: 'silent', status: 'noOp' })
+    );
+    capture.reporter.report(ev('watchCycleCompleted', { iterationId: 2, succeeded: true }));
+    capture.reporter.report(ev('commandResult', { commandName: 'build', succeeded: true, exitCode: 0 }));
+
+    expect(capture.getOutput()).toContain('Watch cycle failed (2/2 operations, 1 failed)');
+    expect(capture.getOutput()).toContain('Watch cycle succeeded (1/1 operations, 0 failed)');
+    expect(capture.getOutput()).toContain('rush build succeeded (1/1 operations, 0 failed)');
+    expect(capture.getOutput()).not.toContain('hidden');
+    expect(capture.getOutput().match(/OLD-CYCLE/g)).toHaveLength(1);
+    expect(capture.getOutput().match(/NEW-CYCLE/g)).toHaveLength(1);
+    expect(capture.getOutput().indexOf('OLD-CYCLE')).toBeLessThan(
+      capture.getOutput().indexOf('project-a: failure')
+    );
+    expect(capture.getOutput().indexOf('project-a: failure')).toBeLessThan(
+      capture.getOutput().indexOf('NEW-CYCLE')
+    );
   });
 
   it('emits a compact heartbeat only after the interval elapses', () => {

--- a/libraries/reporter/src/test/WriteAllSync.test.ts
+++ b/libraries/reporter/src/test/WriteAllSync.test.ts
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import type * as fs from 'node:fs';
+
+import { writeAllSync, WriteAllSyncError } from '../utilities/writeAllSync';
+
+describe(writeAllSync.name, () => {
+  it('retries byte offsets rather than splitting UTF-8 strings', () => {
+    const fsModule: typeof fs = jest.requireActual('node:fs');
+    const chunks: Buffer[] = [];
+    const writeSpy = jest.spyOn(fsModule, 'writeSync').mockImplementation(
+      (
+        fd: number,
+        buffer: string | NodeJS.ArrayBufferView,
+        offset?: number | null,
+        length?: number | BufferEncoding | null
+      ): number => {
+        expect(fd).toBe(123);
+        if (typeof buffer === 'string' || typeof offset !== 'number' || typeof length !== 'number') {
+          throw new Error('Expected a byte-oriented write.');
+        }
+        const count: number = Math.min(2, length);
+        chunks.push(Buffer.from(buffer.buffer, buffer.byteOffset + offset, count));
+        return count;
+      }
+    );
+    try {
+      writeAllSync(123, 'A\u{1f680}\u4e2dB');
+      expect(Buffer.concat(chunks).toString('utf8')).toBe('A\u{1f680}\u4e2dB');
+      expect(writeSpy).toHaveBeenCalledTimes(5);
+    } finally {
+      writeSpy.mockRestore();
+    }
+  });
+
+  it.each([0, -1, Number.NaN, 100])('rejects invalid progress %s with the persisted offset', (written) => {
+    const fsModule: typeof fs = jest.requireActual('node:fs');
+    const writeSpy = jest.spyOn(fsModule, 'writeSync').mockReturnValueOnce(2).mockReturnValueOnce(written);
+    try {
+      expect(() => writeAllSync(123, 'abcdef')).toThrow(WriteAllSyncError);
+      expect(writeSpy).toHaveBeenCalledTimes(2);
+    } finally {
+      writeSpy.mockRestore();
+    }
+  });
+
+  it('preserves an I/O failure and the number of bytes already persisted', () => {
+    const fsModule: typeof fs = jest.requireActual('node:fs');
+    const failure: Error = new Error('disk full');
+    const writeSpy = jest
+      .spyOn(fsModule, 'writeSync')
+      .mockReturnValueOnce(2)
+      .mockImplementationOnce(() => {
+        throw failure;
+      });
+    try {
+      try {
+        writeAllSync(123, 'abcdef');
+        throw new Error('Expected the I/O failure.');
+      } catch (error) {
+        expect(error).toBeInstanceOf(WriteAllSyncError);
+        if (!(error instanceof WriteAllSyncError)) {
+          throw error;
+        }
+        expect(error.bytesWritten).toBe(2);
+        expect(error.cause).toBe(failure);
+      }
+    } finally {
+      writeSpy.mockRestore();
+    }
+  });
+});

--- a/libraries/reporter/src/utilities/writeAllSync.ts
+++ b/libraries/reporter/src/utilities/writeAllSync.ts
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import * as fs from 'node:fs';
+
+export class WriteAllSyncError extends Error {
+  public readonly bytesWritten: number;
+
+  public constructor(cause: Error, bytesWritten: number) {
+    super(cause.message, { cause });
+    this.name = 'WriteAllSyncError';
+    this.bytesWritten = bytesWritten;
+  }
+}
+
+export function writeAllSync(fileDescriptor: number, data: string | Uint8Array): void {
+  const buffer: Uint8Array = typeof data === 'string' ? Buffer.from(data, 'utf8') : data;
+  let offset: number = 0;
+  try {
+    while (offset < buffer.byteLength) {
+      const remaining: number = buffer.byteLength - offset;
+      const written: number = fs.writeSync(fileDescriptor, buffer, offset, remaining);
+      if (!Number.isSafeInteger(written) || written <= 0 || written > remaining) {
+        throw new Error(`The output writer made invalid progress (${written} of ${remaining} bytes).`);
+      }
+      offset += written;
+    }
+  } catch (error) {
+    throw new WriteAllSyncError(error instanceof Error ? error : new Error(String(error)), offset);
+  }
+}

--- a/libraries/rush-daemon/src/PhasedRequestEventMultiplexer.ts
+++ b/libraries/rush-daemon/src/PhasedRequestEventMultiplexer.ts
@@ -42,11 +42,12 @@ export class PhasedRequestEventMultiplexer implements _IOperationGraphEventSink 
   public onOperationRegistered(
     operationId: string,
     silent: boolean,
-    result?: IOperationExecutionResult
+    result?: IOperationExecutionResult,
+    iterationId?: number
   ): void {
-    this.#workspaceSink?.onOperationRegistered?.(operationId, silent, result);
+    this.#workspaceSink?.onOperationRegistered?.(operationId, silent, result, iterationId);
     for (const requestSink of this.#requestSinks) {
-      requestSink.onOperationRegistered?.(operationId, silent, result);
+      requestSink.onOperationRegistered?.(operationId, silent, result, iterationId);
     }
   }
 
@@ -67,18 +68,23 @@ export class PhasedRequestEventMultiplexer implements _IOperationGraphEventSink 
   public onOperationChunk(
     operationId: string,
     chunk: ITerminalChunk,
-    result?: IOperationExecutionResult
+    result?: IOperationExecutionResult,
+    iterationId?: number
   ): void {
-    this.#workspaceSink?.onOperationChunk?.(operationId, chunk, result);
+    this.#workspaceSink?.onOperationChunk?.(operationId, chunk, result, iterationId);
     for (const requestSink of this.#requestSinks) {
-      requestSink.onOperationChunk?.(operationId, chunk, result);
+      requestSink.onOperationChunk?.(operationId, chunk, result, iterationId);
     }
   }
 
-  public onOperationStreamClosed(operationId: string, result?: IOperationExecutionResult): void {
-    this.#workspaceSink?.onOperationStreamClosed?.(operationId, result);
+  public onOperationStreamClosed(
+    operationId: string,
+    result?: IOperationExecutionResult,
+    iterationId?: number
+  ): void {
+    this.#workspaceSink?.onOperationStreamClosed?.(operationId, result, iterationId);
     for (const requestSink of this.#requestSinks) {
-      requestSink.onOperationStreamClosed?.(operationId, result);
+      requestSink.onOperationStreamClosed?.(operationId, result, iterationId);
     }
   }
 

--- a/libraries/rush-daemon/src/test/PhasedRequestEventMultiplexer.test.ts
+++ b/libraries/rush-daemon/src/test/PhasedRequestEventMultiplexer.test.ts
@@ -6,16 +6,9 @@ import type { IOperationExecutionResult, _IOperationGraphEventSink } from '@micr
 import { PhasedRequestEventMultiplexer } from '../PhasedRequestEventMultiplexer';
 
 describe(PhasedRequestEventMultiplexer.name, () => {
-  it('forwards execution identity, stream closure, and completion to every sink', () => {
+  it('forwards stream closure before completion to workspace and request sinks', () => {
     const events: string[] = [];
-    const result: IOperationExecutionResult = {} as IOperationExecutionResult;
     const workspaceSink: _IOperationGraphEventSink = {
-      onOperationRegistered: (operationId, silent, forwardedResult) => {
-        expect(operationId).toBe('operation');
-        expect(silent).toBe(false);
-        expect(forwardedResult).toBe(result);
-        events.push('workspace-registered');
-      },
       onOperationStreamClosed: () => events.push('workspace-closed'),
       onOperationCompleted: () => events.push('workspace-completed')
     };
@@ -23,25 +16,17 @@ describe(PhasedRequestEventMultiplexer.name, () => {
       onIterationScheduled(records: Iterable<IOperationExecutionResult>): void;
     } = {
       onIterationScheduled: () => {},
-      onOperationRegistered: (operationId, silent, forwardedResult) => {
-        expect(operationId).toBe('operation');
-        expect(silent).toBe(false);
-        expect(forwardedResult).toBe(result);
-        events.push('request-registered');
-      },
       onOperationStreamClosed: () => events.push('request-closed'),
       onOperationCompleted: () => events.push('request-completed')
     };
     const multiplexer: PhasedRequestEventMultiplexer = new PhasedRequestEventMultiplexer(workspaceSink);
     multiplexer.subscribe(requestSink);
+    const result: IOperationExecutionResult = { iterationId: 1 } as IOperationExecutionResult;
 
-    multiplexer.onOperationRegistered('operation', false, result);
-    multiplexer.onOperationStreamClosed('operation', result);
+    multiplexer.onOperationStreamClosed('operation', result, 1);
     multiplexer.onOperationCompleted(result);
 
     expect(events).toEqual([
-      'workspace-registered',
-      'request-registered',
       'workspace-closed',
       'request-closed',
       'workspace-completed',

--- a/libraries/rush-lib/src/api/EnvironmentConfiguration.ts
+++ b/libraries/rush-lib/src/api/EnvironmentConfiguration.ts
@@ -495,6 +495,18 @@ export class EnvironmentConfiguration {
   }
 
   /**
+   * Reads and normalizes `RUSH_TEMP_FOLDER` without initializing the global environment state.
+   *
+   * @internal
+   */
+  public static _getRushTempFolderOverride(processEnv: IEnvironment): string | undefined {
+    const value: string | undefined = processEnv[EnvironmentVariableNames.RUSH_TEMP_FOLDER];
+    if (value) {
+      return _normalizeDeepestParentFolderPath(value) || value;
+    }
+  }
+
+  /**
    * Reads and validates environment variables. If any are invalid, this function will throw.
    */
   public static validate(options: IEnvironmentConfigurationInitializeOptions = {}): void {
@@ -510,7 +522,7 @@ export class EnvironmentConfiguration {
           case EnvironmentVariableNames.RUSH_TEMP_FOLDER: {
             _rushTempFolderOverride =
               value && !options.doNotNormalizePaths
-                ? _normalizeDeepestParentFolderPath(value) || value
+                ? EnvironmentConfiguration._getRushTempFolderOverride(process.env)
                 : value;
             break;
           }

--- a/libraries/rush-lib/src/api/Rush.ts
+++ b/libraries/rush-lib/src/api/Rush.ts
@@ -96,7 +96,7 @@ export class Rush {
     options = _normalizeLaunchOptions(options);
     const frontendOptions: IRushFrontendLaunchOptions = options;
 
-    if (!RushCommandLineParser.shouldRestrictConsoleOutput()) {
+    if (!options.reporter?.operationStreamEnabled && !RushCommandLineParser.shouldRestrictConsoleOutput()) {
       RushStartupBanner.logBanner(Rush.version, options.isManaged);
     }
 

--- a/libraries/rush-lib/src/cli/RushCommandLineParser.ts
+++ b/libraries/rush-lib/src/cli/RushCommandLineParser.ts
@@ -8,15 +8,23 @@ import {
   type CommandLineFlagParameter,
   CommandLineHelper
 } from '@rushstack/ts-command-line';
+import {
+  createRushDiagnostic,
+  type IRushDiagnostic,
+  type IScopedReporter,
+  type LifecycleEmitter,
+  type ReporterMessageSeverity
+} from '@rushstack/rush-reporter';
 import { InternalError, AlreadyReportedError, Text } from '@rushstack/node-core-library';
 import {
   ConsoleTerminalProvider,
   Terminal,
   PrintUtilities,
   Colorize,
-  type ITerminal
+  type ITerminal,
+  type ITerminalProvider,
+  TerminalProviderSeverity
 } from '@rushstack/terminal';
-import { createRushDiagnostic, type IRushDiagnostic, type LifecycleEmitter } from '@rushstack/rush-reporter';
 
 import { RushConfiguration } from '../api/RushConfiguration';
 import { RushConstants } from '../logic/RushConstants';
@@ -67,9 +75,11 @@ import { measureAsyncFn } from '../utilities/performance';
 import { EnvironmentVariableNames } from '../api/EnvironmentConfiguration';
 import {
   _correlateRushSessionError,
+  _flushRushSessionReporterAsync,
   _getRushSessionDerivedExitStatus,
   _getRushSessionLifecycleEmitter,
   _getRushSessionReporterSourceVersion,
+  _isRushSessionOperationStreamEnabled,
   _isRushSessionErrorRepresented
 } from '../pluginFramework/RushSession';
 
@@ -84,6 +94,79 @@ export interface IRushCommandLineParserOptions {
   reporterCloseAsync?: () => Promise<void>;
 }
 
+class ReporterTerminalProvider implements ITerminalProvider {
+  public verboseEnabled: boolean = true;
+  public debugEnabled: boolean = true;
+  public readonly supportsColor: boolean = false;
+  public readonly eolCharacter: string = '\n';
+
+  private readonly _bufferedMessages: Array<{
+    severity: ReporterMessageSeverity;
+    text: string;
+    minimumLogLevel?: 'verbose' | 'debug';
+  }> = [];
+  private _reporter: IScopedReporter | undefined;
+
+  public setReporter(reporter: IScopedReporter | undefined): void {
+    this._reporter = reporter;
+    if (reporter) {
+      for (const message of this._bufferedMessages.splice(0)) {
+        reporter.emitMessage({ ...message, privacy: 'local-sensitive' });
+      }
+    }
+  }
+
+  public write(data: string, severity: TerminalProviderSeverity): void {
+    if (
+      (severity === TerminalProviderSeverity.verbose && !this.verboseEnabled) ||
+      (severity === TerminalProviderSeverity.debug && !this.debugEnabled)
+    ) {
+      return;
+    }
+
+    const message: {
+      severity: ReporterMessageSeverity;
+      text: string;
+      minimumLogLevel?: 'verbose' | 'debug';
+    } = {
+      severity: this._toReporterSeverity(severity),
+      text: data,
+      ...this._getMinimumLogLevel(severity)
+    };
+    if (this._reporter) {
+      this._reporter.emitMessage({ ...message, privacy: 'local-sensitive' });
+    } else {
+      this._bufferedMessages.push(message);
+    }
+  }
+
+  private _toReporterSeverity(severity: TerminalProviderSeverity): ReporterMessageSeverity {
+    switch (severity) {
+      case TerminalProviderSeverity.error:
+        return 'error';
+      case TerminalProviderSeverity.warning:
+        return 'warning';
+      case TerminalProviderSeverity.debug:
+        return 'debug';
+      case TerminalProviderSeverity.verbose:
+        return 'debug';
+      default:
+        return 'info';
+    }
+  }
+
+  private _getMinimumLogLevel(severity: TerminalProviderSeverity): { minimumLogLevel?: 'verbose' | 'debug' } {
+    switch (severity) {
+      case TerminalProviderSeverity.verbose:
+        return { minimumLogLevel: 'verbose' };
+      case TerminalProviderSeverity.debug:
+        return { minimumLogLevel: 'debug' };
+      default:
+        return {};
+    }
+  }
+}
+
 export class RushCommandLineParser extends CommandLineParser {
   public telemetry: Telemetry | undefined;
   public rushGlobalFolder: RushGlobalFolder;
@@ -95,7 +178,7 @@ export class RushCommandLineParser extends CommandLineParser {
   readonly #quietParameter: CommandLineFlagParameter;
   readonly #restrictConsoleOutput: boolean = RushCommandLineParser.shouldRestrictConsoleOutput();
   readonly #rushOptions: IRushCommandLineParserOptions;
-  readonly #terminalProvider: ConsoleTerminalProvider;
+  readonly #terminalProvider: ConsoleTerminalProvider | ReporterTerminalProvider;
   readonly #terminal: Terminal;
   readonly #autocreateBuildCommand: boolean;
   #initializationFailed: boolean = false;
@@ -140,12 +223,16 @@ export class RushCommandLineParser extends CommandLineParser {
       description: 'Hide rush startup information'
     });
 
-    const terminalProvider: ConsoleTerminalProvider = new ConsoleTerminalProvider();
-    this.#terminalProvider = terminalProvider;
-    const terminal: Terminal = new Terminal(this.#terminalProvider);
-    this.#terminal = terminal;
     this.#rushOptions = this.#normalizeOptions(options || {});
     const { cwd, alreadyReportedNodeTooNewError, builtInPluginConfigurations, reporter } = this.#rushOptions;
+    const reporterTerminalProvider: ReporterTerminalProvider | undefined = reporter?.operationStreamEnabled
+      ? new ReporterTerminalProvider()
+      : undefined;
+    const terminalProvider: ConsoleTerminalProvider | ReporterTerminalProvider =
+      reporterTerminalProvider ?? new ConsoleTerminalProvider();
+    this.#terminalProvider = terminalProvider;
+    const terminal: Terminal = new Terminal(terminalProvider);
+    this.#terminal = terminal;
 
     this.rushSession = new RushSession({
       getIsDebugMode: () => this.isDebug,
@@ -153,12 +240,13 @@ export class RushCommandLineParser extends CommandLineParser {
       reporter
     });
     this.#sessionLifecycleEmitter = _getRushSessionLifecycleEmitter(this.rushSession);
+    reporterTerminalProvider?.setReporter(this.rushSession.getReporter());
 
     let rushJsonFilePath: string | undefined;
     try {
       rushJsonFilePath = RushConfiguration.tryFindRushJsonLocation({
         startingFolder: cwd,
-        showVerbose: !this.#restrictConsoleOutput
+        showVerbose: !this.#restrictConsoleOutput && !reporter?.operationStreamEnabled
       });
 
       initializeDotEnv(terminal, rushJsonFilePath);
@@ -271,13 +359,15 @@ export class RushCommandLineParser extends CommandLineParser {
     }
 
     // debugParameter will be correctly parsed during super.executeAsync(), so manually parse here.
-    const passThroughSeparatorIndex: number = process.argv.indexOf('--', 2);
-    const rushArgv: string[] =
-      passThroughSeparatorIndex < 0
-        ? process.argv.slice(2)
-        : process.argv.slice(2, passThroughSeparatorIndex);
-    this.#terminalProvider.verboseEnabled = this.#terminalProvider.debugEnabled =
-      rushArgv.includes('--debug') || rushArgv.includes('-d');
+    if (this.#terminalProvider instanceof ConsoleTerminalProvider) {
+      const passThroughSeparatorIndex: number = process.argv.indexOf('--', 2);
+      const rushArgv: string[] =
+        passThroughSeparatorIndex < 0
+          ? process.argv.slice(2)
+          : process.argv.slice(2, passThroughSeparatorIndex);
+      this.#terminalProvider.verboseEnabled = this.#terminalProvider.debugEnabled =
+        rushArgv.includes('--debug') || rushArgv.includes('-d');
+    }
 
     this._startReporterSession();
 
@@ -613,6 +703,7 @@ export class RushCommandLineParser extends CommandLineParser {
 
   private _reportErrorAndSetExitCode(error: Error): void {
     this._emitReporterFailureDiagnostic(error);
+    const rushSession: RushSession | undefined = this.rushSession;
 
     if (!(error instanceof AlreadyReportedError)) {
       const prefix: string = 'ERROR: ';
@@ -623,15 +714,29 @@ export class RushCommandLineParser extends CommandLineParser {
       const message: string = Text.splitByNewLines(PrintUtilities.wrapWords(prefix + error.message))
         .map((line) => Colorize.red(line))
         .join('\n');
-      // eslint-disable-next-line no-console
-      console.error(`\n${message}`);
+      if (
+        (rushSession && _isRushSessionOperationStreamEnabled(rushSession)) ||
+        this.#rushOptions.reporter?.operationStreamEnabled
+      ) {
+        this.#terminal.writeErrorLine(message);
+      } else {
+        // eslint-disable-next-line no-console
+        console.error(`\n${message}`);
+      }
     }
 
     if (this.#debugParameter.value) {
       // If catchSyncErrors() called this, then show a call stack similar to what Node.js
       // would show for an uncaught error
-      // eslint-disable-next-line no-console
-      console.error(`\n${error.stack}`);
+      if (
+        (rushSession && _isRushSessionOperationStreamEnabled(rushSession)) ||
+        this.#rushOptions.reporter?.operationStreamEnabled
+      ) {
+        this.#terminal.writeErrorLine(error.stack ?? error.message);
+      } else {
+        // eslint-disable-next-line no-console
+        console.error(`\n${error.stack}`);
+      }
     }
 
     const configuredExitCode: string | number | undefined = process.exitCode;
@@ -659,18 +764,17 @@ export class RushCommandLineParser extends CommandLineParser {
         ? this.telemetry.ensureFlushedAsync()
         : undefined;
 
-    if (this.#rushOptions.reporterCloseAsync || telemetryFlushAsync) {
-      const pendingFlushes: Promise<unknown>[] = [];
-      if (this.#rushOptions.reporterCloseAsync) {
-        pendingFlushes.push(this._closeReporterAsync());
-      }
-      if (telemetryFlushAsync) {
-        pendingFlushes.push(telemetryFlushAsync);
-      }
-      void Promise.allSettled(pendingFlushes).then(handleExit);
-    } else {
-      handleExit();
+    const pendingFlushes: Promise<unknown>[] = [
+      this.#rushOptions.reporterCloseAsync
+        ? this._closeReporterAsync()
+        : rushSession
+          ? _flushRushSessionReporterAsync(rushSession)
+          : Promise.resolve()
+    ];
+    if (telemetryFlushAsync) {
+      pendingFlushes.push(telemetryFlushAsync);
     }
+    void Promise.allSettled(pendingFlushes).then(handleExit);
   }
 
   private _reportInitializationErrorAndSetExitCode(error: Error): void {

--- a/libraries/rush-lib/src/cli/actions/BaseRushAction.ts
+++ b/libraries/rush-lib/src/cli/actions/BaseRushAction.ts
@@ -4,7 +4,7 @@
 import * as path from 'node:path';
 
 import { CommandLineAction, type ICommandLineActionOptions } from '@rushstack/ts-command-line';
-import { LockFile } from '@rushstack/node-core-library';
+import { AlreadyReportedError, LockFile } from '@rushstack/node-core-library';
 import { Colorize, type ITerminal } from '@rushstack/terminal';
 import type { IScopedReporter } from '@rushstack/rush-reporter';
 
@@ -14,6 +14,7 @@ import { RushCommandLineParser } from '../RushCommandLineParser';
 import { Utilities } from '../../utilities/Utilities';
 import type { RushGlobalFolder } from '../../api/RushGlobalFolder';
 import type { RushSession } from '../../pluginFramework/RushSession';
+import { _isRushSessionOperationStreamEnabled } from '../../pluginFramework/RushSession';
 import type { IRushCommand } from '../../pluginFramework/RushLifeCycle';
 import { measureAsyncFn } from '../../utilities/performance';
 
@@ -69,15 +70,21 @@ export abstract class BaseConfiglessRushAction extends CommandLineAction impleme
     if (this.rushConfiguration) {
       if (!this.#safeForSimultaneousRushProcesses) {
         if (!LockFile.tryAcquire(this.rushConfiguration.commonTempFolder, 'rush')) {
-          this.terminal.writeLine(
-            Colorize.red(`Another Rush command is already running in this repository.`)
-          );
+          const message: string = 'Another Rush command is already running in this repository.';
+          if (_isRushSessionOperationStreamEnabled(this.rushSession)) {
+            this.terminal.writeErrorLine(message);
+            throw new AlreadyReportedError();
+          }
+          this.terminal.writeLine(Colorize.red(message));
           process.exit(1);
         }
       }
     }
 
-    if (!RushCommandLineParser.shouldRestrictConsoleOutput()) {
+    if (
+      !RushCommandLineParser.shouldRestrictConsoleOutput() &&
+      !_isRushSessionOperationStreamEnabled(this.rushSession)
+    ) {
       this.terminal.write(`Starting "rush ${this.actionName}"\n`);
     }
 

--- a/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
+++ b/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
@@ -6,7 +6,14 @@ import { once } from 'node:events';
 import type { AsyncSeriesHook } from 'tapable';
 
 import { AlreadyReportedError } from '@rushstack/node-core-library';
-import { type ITerminal, Terminal, Colorize, StdioWritable } from '@rushstack/terminal';
+import {
+  type ITerminal,
+  Terminal,
+  Colorize,
+  StdioWritable,
+  CallbackWritable,
+  NoOpTerminalProvider
+} from '@rushstack/terminal';
 import type {
   CommandLineFlagParameter,
   CommandLineParameter,
@@ -63,6 +70,7 @@ import { TrimRushEnvironmentVariablesPlugin } from '../../logic/operations/TrimR
 import { DebugHashesPlugin } from '../../logic/operations/DebugHashesPlugin';
 import { measureAsyncFn, measureFn } from '../../utilities/performance';
 import { attachReporterOperationEventSink } from '../../logic/operations/ReporterOperationEventSink';
+import { _isRushSessionOperationStreamEnabled } from '../../pluginFramework/RushSession';
 
 const PERF_PREFIX: 'rush:phasedScriptAction' = 'rush:phasedScriptAction';
 
@@ -388,6 +396,9 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> i
 
     const hooks: PhasedCommandHooks = this.hooks;
     const terminal: ITerminal = this.#terminal;
+    const presentationTerminal: ITerminal = _isRushSessionOperationStreamEnabled(this.rushSession)
+      ? new Terminal(new NoOpTerminalProvider())
+      : terminal;
 
     // if this is parallelizable, then use the value from the flag (undefined or a number),
     // if parallelism is not enabled, then restrict to 1 core
@@ -423,7 +434,7 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> i
           /* webpackChunkName: 'ConsoleTimelinePlugin' */
           '../../logic/operations/ConsoleTimelinePlugin'
         );
-        new ConsoleTimelinePlugin(terminal).apply(this.hooks);
+        new ConsoleTimelinePlugin(presentationTerminal).apply(this.hooks);
       }
 
       const diagnosticDir: string | undefined = this.#nodeDiagnosticDirParameter.value;
@@ -434,7 +445,7 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> i
       }
 
       // Enable the standard summary
-      new OperationResultSummarizerPlugin(terminal).apply(this.hooks);
+      new OperationResultSummarizerPlugin(presentationTerminal).apply(this.hooks);
     });
 
     const { hooks: sessionHooks } = this.rushSession;
@@ -559,9 +570,8 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> i
         }
 
         if (isPnpm && usePnpmSyncForInjectedDependencies) {
-          const { PnpmSyncCopyOperationPlugin } = await import(
-            '../../logic/operations/PnpmSyncCopyOperationPlugin'
-          );
+          const { PnpmSyncCopyOperationPlugin } =
+            await import('../../logic/operations/PnpmSyncCopyOperationPlugin');
           new PnpmSyncCopyOperationPlugin(terminal).apply(this.hooks);
         }
       });
@@ -606,7 +616,7 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> i
       const [getInputsSnapshotAsync, initialSnapshot] = await measureAsyncFn(
         `${PERF_PREFIX}:analyzeRepoState`,
         async () => {
-          terminal.write('Analyzing repo state... ');
+          presentationTerminal.write('Analyzing repo state... ');
           const repoStateStopwatch: Stopwatch = new Stopwatch();
           repoStateStopwatch.start();
 
@@ -623,8 +633,8 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> i
             : undefined;
 
           repoStateStopwatch.stop();
-          terminal.writeLine(`DONE (${repoStateStopwatch.toString()})`);
-          terminal.writeLine();
+          presentationTerminal.writeLine(`DONE (${repoStateStopwatch.toString()})`);
+          presentationTerminal.writeLine();
           return [innerGetInputsSnapshotAsync, innerInitialSnapshot];
         }
       );
@@ -653,7 +663,11 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> i
       const graphOptions: IOperationGraphOptions = {
         quietMode: isQuietMode,
         debugMode: this.parser.isDebug,
-        destinations: [StdioWritable.instance],
+        destinations: [
+          _isRushSessionOperationStreamEnabled(this.rushSession)
+            ? new CallbackWritable({ onWriteChunk: () => undefined })
+            : StdioWritable.instance
+        ],
         parallelism,
         maxParallelism,
         allowOversubscription: this.#allowOversubscription,
@@ -679,14 +693,14 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> i
       await measureAsyncFn(`${PERF_PREFIX}:executionManager`, async () => {
         await hooks.onGraphCreatedAsync.promise(graph, graphContext);
       });
-      attachReporterOperationEventSink(graph, this.rushSession, this.actionName);
+      attachReporterOperationEventSink(graph, this.rushSession, this.actionName, isWatch);
 
       const executeOptions: IExecuteOperationsOptions = {
         graph,
         ignoreHooks: !!this.#ignoreHooksParameter.value,
         isWatch,
         stopwatch,
-        terminal
+        terminal: presentationTerminal
       };
 
       const initialIterationOptions: IOperationGraphIterationOptions = {
@@ -712,7 +726,8 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> i
           graph,
           initialSnapshot,
           terminal,
-          debounceMs: this.#watchDebounceMs
+          debounceMs: this.#watchDebounceMs,
+          renderStatusInPlace: !_isRushSessionOperationStreamEnabled(this.rushSession)
         });
         watcher.clearStatus();
 

--- a/libraries/rush-lib/src/cli/test/RushCommandLineParser.test.ts
+++ b/libraries/rush-lib/src/cli/test/RushCommandLineParser.test.ts
@@ -29,7 +29,7 @@ jest.mock(`@rushstack/package-deps-hash`, () => {
 import './mockRushCommandLineParser';
 
 import type { SpawnOptions } from 'node:child_process';
-import { FileSystem, JsonFile, Path } from '@rushstack/node-core-library';
+import { FileSystem, JsonFile, LockFile, Path } from '@rushstack/node-core-library';
 import type { IDetailedRepoState } from '@rushstack/package-deps-hash';
 import type { IReporterEmitEventInput, IReporterEventSink } from '@rushstack/rush-reporter';
 import { Autoinstaller } from '../../logic/Autoinstaller';
@@ -142,6 +142,73 @@ describe('RushCommandLineParser', () => {
             expect(scope.operationId).toBe(`${scope.projectName}#${scope.phaseName}`);
           }
           expect(reporterSink.inputs.some(({ type }) => type === 'externalOutput')).toBe(false);
+        });
+
+        it('makes the opted-in reporter stream the sole visible operation writer', async () => {
+          const reporterSink: CapturingReporterSink = new CapturingReporterSink();
+          const stdoutSpy: jest.SpiedFunction<typeof process.stdout.write> = jest
+            .spyOn(process.stdout, 'write')
+            .mockImplementation(() => true);
+          const stderrSpy: jest.SpiedFunction<typeof process.stderr.write> = jest
+            .spyOn(process.stderr, 'write')
+            .mockImplementation(() => true);
+          try {
+            const { parser } = await getCommandLineParserInstanceAsync(
+              'basicAndRunBuildActionRepo',
+              'build',
+              {
+                eventSink: reporterSink,
+                sessionId: 'parser-visible-cutover',
+                operationStreamEnabled: true
+              }
+            );
+
+            await expect(parser.executeAsync()).resolves.toEqual(true);
+
+            expect(stdoutSpy).not.toHaveBeenCalled();
+            expect(stderrSpy).not.toHaveBeenCalled();
+            expect(reporterSink.inputs.some(({ type }) => type === 'operationCompleted')).toBe(true);
+          } finally {
+            stdoutSpy.mockRestore();
+            stderrSpy.mockRestore();
+          }
+        });
+
+        it('preserves the actionable lock contention reason in reporter mode', async () => {
+          const reporterSink: CapturingReporterSink = new CapturingReporterSink();
+          const lockSpy: jest.SpiedFunction<typeof LockFile.tryAcquire> = jest
+            .spyOn(LockFile, 'tryAcquire')
+            .mockReturnValue(undefined);
+          const exitSpy: jest.SpiedFunction<typeof process.exit> = jest
+            .spyOn(process, 'exit')
+            .mockImplementation(() => undefined as never);
+          try {
+            const { parser } = await getCommandLineParserInstanceAsync(
+              'basicAndRunBuildActionRepo',
+              'build',
+              {
+                eventSink: reporterSink,
+                sessionId: 'parser-lock-conflict',
+                operationStreamEnabled: true
+              }
+            );
+
+            await parser.executeAsync();
+            await new Promise<void>((resolve: () => void) => setImmediate(resolve));
+
+            expect(reporterSink.inputs).toContainEqual(
+              expect.objectContaining({
+                type: 'messageEmitted',
+                payload: expect.objectContaining({
+                  severity: 'error',
+                  text: expect.stringContaining('Another Rush command is already running')
+                })
+              })
+            );
+          } finally {
+            exitSpy.mockRestore();
+            lockSpy.mockRestore();
+          }
         });
       });
 

--- a/libraries/rush-lib/src/cli/test/RushCommandLineParserReporterLifecycle.test.ts
+++ b/libraries/rush-lib/src/cli/test/RushCommandLineParserReporterLifecycle.test.ts
@@ -5,7 +5,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
-import { JsonFile } from '@rushstack/node-core-library';
+import { JsonFile, LockFile } from '@rushstack/node-core-library';
 import type { IReporterEmitEventInput, IReporterEventSink } from '@rushstack/rush-reporter';
 
 import { EnvironmentConfiguration } from '../../api/EnvironmentConfiguration';
@@ -37,6 +37,7 @@ describe('RushCommandLineParser reporter lifecycle', () => {
   let originalArgv: string[];
   let stdoutSpy: jest.SpyInstance;
   let stderrSpy: jest.SpyInstance;
+  let lockSpy: jest.SpiedFunction<typeof LockFile.tryAcquire>;
 
   async function copyRepositoryAsync(): Promise<string> {
     const directory: string = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'rush-reporter-lifecycle-'));
@@ -54,9 +55,15 @@ describe('RushCommandLineParser reporter lifecycle', () => {
     EnvironmentConfiguration.reset();
     stdoutSpy = jest.spyOn(console, 'log').mockImplementation(() => undefined);
     stderrSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    lockSpy = jest.spyOn(LockFile, 'tryAcquire');
   });
 
   afterEach(async () => {
+    for (const result of lockSpy.mock.results) {
+      if (result.type === 'return' && result.value && !result.value.isReleased) {
+        result.value.release();
+      }
+    }
     await Promise.all(
       temporaryFolders
         .splice(0)
@@ -81,7 +88,8 @@ describe('RushCommandLineParser reporter lifecycle', () => {
     for (const reporting of [false, true]) {
       process.exitCode = undefined;
       EnvironmentConfiguration.reset();
-      jest.clearAllMocks();
+      stdoutSpy.mockClear();
+      stderrSpy.mockClear();
       const sink: CapturingReporterSink = new CapturingReporterSink();
       let eventsAtExit: readonly IReporterEmitEventInput<unknown>[] = [];
       let eventsAtClose: readonly IReporterEmitEventInput<unknown>[] = [];
@@ -92,15 +100,15 @@ describe('RushCommandLineParser reporter lifecycle', () => {
       const closeAsync: jest.Mock<Promise<void>, []> = jest.fn(async () => {
         eventsAtClose = [...sink.events];
       });
+      const flushAsync: jest.Mock<Promise<void>, []> = jest.fn(async () => undefined);
       const parser: RushCommandLineParser = new RushCommandLineParser({
         cwd: repoPath,
-        reporter: reporting ? { eventSink: sink, sessionId: 'initialization-failure' } : undefined,
+        reporter: reporting
+          ? { eventSink: sink, sessionId: 'initialization-failure', flushAsync }
+          : undefined,
         reporterCloseAsync: withClose ? closeAsync : undefined
       });
 
-      if (!withClose) {
-        expect(exitSpy).toHaveBeenCalledWith(1);
-      }
       await expect(parser.executeAsync(['custom-output'])).resolves.toBe(false);
       await new Promise<void>((resolve) => setImmediate(resolve));
 
@@ -108,6 +116,7 @@ describe('RushCommandLineParser reporter lifecycle', () => {
       expect(exitSpy).toHaveBeenCalledTimes(1);
       expect(exitSpy).toHaveBeenCalledWith(1);
       expect(closeAsync).toHaveBeenCalledTimes(withClose ? 1 : 0);
+      expect(flushAsync).toHaveBeenCalledTimes(reporting && !withClose ? 1 : 0);
       expect(sink.events.map(({ type }) => type)).toEqual(
         reporting ? ['sessionStarted', 'diagnosticEmitted', 'sessionCompleted'] : []
       );
@@ -134,6 +143,50 @@ describe('RushCommandLineParser reporter lifecycle', () => {
     }
 
     expect(visibleOutput[1]).toEqual(visibleOutput[0]);
+  });
+
+  it('binds the native reporter terminal before configuration failure and waits for its sink flush', async () => {
+    const repoPath: string = await copyRepositoryAsync();
+    await fs.promises.writeFile(path.join(repoPath, 'rush.json'), '{');
+    const sink: CapturingReporterSink = new CapturingReporterSink();
+    const exitSpy: jest.SpyInstance = jest
+      .spyOn(process, 'exit')
+      .mockImplementation(() => undefined as never);
+    let releaseFlush: (() => void) | undefined;
+    const flushGate: Promise<void> = new Promise((resolve) => {
+      releaseFlush = resolve;
+    });
+    const flushAsync: jest.Mock<Promise<void>, []> = jest.fn(() => flushGate);
+    const parser: RushCommandLineParser = new RushCommandLineParser({
+      cwd: repoPath,
+      reporter: {
+        eventSink: sink,
+        sessionId: 'native-initialization-failure',
+        operationStreamEnabled: true,
+        flushAsync
+      }
+    });
+    await expect(parser.executeAsync(['custom-output'])).resolves.toBe(false);
+    const exitsBeforeFlush: number = exitSpy.mock.calls.length;
+    const flushCalls: number = flushAsync.mock.calls.length;
+    releaseFlush!();
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(exitsBeforeFlush).toBe(0);
+    expect(flushCalls).toBe(1);
+    expect(sink.events[0].type).toBe('sessionStarted');
+    expect(sink.events[1].type).toBe('diagnosticEmitted');
+    expect(sink.events.slice(2, -1)).toContainEqual(
+      expect.objectContaining({
+        type: 'messageEmitted',
+        payload: expect.objectContaining({ severity: 'error', text: expect.stringContaining('rush.json') })
+      })
+    );
+    expect(sink.events.at(-1)).toMatchObject({ type: 'sessionCompleted', payload: { exitCode: 1 } });
+    expect(stdoutSpy).not.toHaveBeenCalled();
+    expect(stderrSpy).not.toHaveBeenCalled();
+    expect(exitSpy).toHaveBeenCalledTimes(1);
+    expect(exitSpy).toHaveBeenCalledWith(1);
   });
 
   it('emits and correlates a session diagnostic when plugin initialization fails before action selection', async () => {
@@ -172,7 +225,8 @@ describe('RushCommandLineParser reporter lifecycle', () => {
     for (const reporting of [false, true]) {
       process.exitCode = undefined;
       EnvironmentConfiguration.reset();
-      jest.clearAllMocks();
+      stdoutSpy.mockClear();
+      stderrSpy.mockClear();
       const repoPath: string = await copyRepositoryAsync();
       const rushJsonPath: string = path.join(repoPath, 'rush.json');
       const rushJson: IRushConfigurationJson = JsonFile.load(rushJsonPath);

--- a/libraries/rush-lib/src/logic/ProjectWatcher.ts
+++ b/libraries/rush-lib/src/logic/ProjectWatcher.ts
@@ -23,6 +23,7 @@ export interface IProjectWatcherOptions {
   debounceMs: number;
   rushConfiguration: RushConfiguration;
   terminal: ITerminal;
+  renderStatusInPlace?: boolean;
   /** Initial inputs snapshot; required so watcher can enumerate nested folders immediately */
   initialSnapshot: IInputsSnapshot;
 }
@@ -70,6 +71,7 @@ export class ProjectWatcher {
   readonly #rushConfiguration: RushConfiguration;
   readonly #terminal: ITerminal;
   readonly #graph: IOperationGraph;
+  readonly #renderStatusInPlace: boolean;
 
   #repoRoot: string | undefined;
   #watchers: Map<string, fs.FSWatcher> | undefined;
@@ -84,11 +86,19 @@ export class ProjectWatcher {
   #onStdinDataBound: ((chunk: Buffer | string) => void) | undefined;
 
   public constructor(options: IProjectWatcherOptions) {
-    const { graph, debounceMs, rushConfiguration, terminal, initialSnapshot } = options;
+    const {
+      graph,
+      debounceMs,
+      rushConfiguration,
+      terminal,
+      initialSnapshot,
+      renderStatusInPlace = true
+    } = options;
     this.#graph = graph;
     this.#debounceMs = debounceMs;
     this.#rushConfiguration = rushConfiguration;
     this.#terminal = terminal;
+    this.#renderStatusInPlace = renderStatusInPlace;
     this.#lastSnapshot = initialSnapshot; // Seed snapshot
 
     const gitPath: string = new Git(rushConfiguration).getGitPathOrThrow();
@@ -162,7 +172,7 @@ export class ProjectWatcher {
       lines.push(` keys(active): ${KEYBIND_HELP}`);
       statusLines.push(...lines.map((l) => `  ${l}`));
     }
-    if (graph.status !== OperationStatus.Executing) {
+    if (this.#renderStatusInPlace && graph.status !== OperationStatus.Executing) {
       // If rendering during execution, don't try to clean previous output.
       if (this.#renderedStatusLines > 0) {
         readline.cursorTo(process.stdout, 0);

--- a/libraries/rush-lib/src/logic/operations/IOperationExecutionResult.ts
+++ b/libraries/rush-lib/src/logic/operations/IOperationExecutionResult.ts
@@ -81,6 +81,11 @@ export interface IConfigurableOperation extends IBaseOperationExecutionResult {
  */
 export interface IOperationExecutionResult extends IBaseOperationExecutionResult, IOperationLastState {
   /**
+   * The graph iteration that owns this result.
+   */
+  readonly iterationId: number;
+
+  /**
    * The current execution status of an operation. Operations start in the 'ready' state,
    * but can be 'blocked' if an upstream operation failed. It is 'executing' when
    * the operation is executing. Once execution is complete, it is either 'success' or

--- a/libraries/rush-lib/src/logic/operations/OperationEventSink.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationEventSink.ts
@@ -40,7 +40,12 @@ export interface IOperationGraphEventSink {
   /**
    * Invoked when an operation is prepared for an iteration.
    */
-  onOperationRegistered?(operationId: string, silent: boolean, result?: IOperationExecutionResult): void;
+  onOperationRegistered?(
+    operationId: string,
+    silent: boolean,
+    result?: IOperationExecutionResult,
+    iterationId?: number
+  ): void;
 
   /**
    * Invoked synchronously on every operation status transition. The result's
@@ -59,14 +64,23 @@ export interface IOperationGraphEventSink {
    * Invoked for each chunk of an operation's raw output, upstream of any
    * newline normalization or quiet-mode filtering.
    */
-  onOperationChunk?(operationId: string, chunk: ITerminalChunk, result?: IOperationExecutionResult): void;
+  onOperationChunk?(
+    operationId: string,
+    chunk: ITerminalChunk,
+    result?: IOperationExecutionResult,
+    iterationId?: number
+  ): void;
 
   /**
    * Invoked when an operation's collated output stream is closed at the end of
    * its execution, after all status lines and output have been written. This
    * is the authoritative "no more output for this operation" signal.
    */
-  onOperationStreamClosed?(operationId: string, result?: IOperationExecutionResult): void;
+  onOperationStreamClosed?(
+    operationId: string,
+    result?: IOperationExecutionResult,
+    iterationId?: number
+  ): void;
 
   /**
    * Invoked after the operation stream is closed and the final outcome is authoritative.

--- a/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationExecutionRecord.ts
@@ -44,6 +44,7 @@ import {
  * @internal
  */
 export interface IOperationExecutionRecordContext {
+  iterationId: number;
   streamCollator: StreamCollator;
   onOperationStateChanged?: (record: OperationExecutionRecord) => void;
   createEnvironment?: (record: OperationExecutionRecord) => IEnvironment;
@@ -207,6 +208,10 @@ export class OperationExecutionRecord implements IOperationRunnerContext, IOpera
     return this.runner.name;
   }
 
+  public get iterationId(): number {
+    return this.#context.iterationId;
+  }
+
   public get debugMode(): boolean {
     return this.#context.debugMode;
   }
@@ -293,7 +298,7 @@ export class OperationExecutionRecord implements IOperationRunnerContext, IOpera
   public closeOperationStream(): void {
     if (!this.#operationStreamClosed) {
       this.#operationStreamClosed = true;
-      this.#context.eventSink?.onOperationStreamClosed?.(this.name, this);
+      this.#context.eventSink?.onOperationStreamClosed?.(this.name, this, this.iterationId);
     }
   }
 
@@ -333,11 +338,9 @@ export class OperationExecutionRecord implements IOperationRunnerContext, IOpera
     return new SplitterTransform({
       destinations: [
         destination,
-        new OperationChunkTap(this.name, (operationId, chunk) => {
-          if (operationId === this.name) {
-            eventSink.onOperationChunk?.(operationId, chunk, this);
-          }
-        })
+        new OperationChunkTap(this.name, (operationId, chunk) =>
+          eventSink.onOperationChunk?.(operationId, chunk, this, this.iterationId)
+        )
       ]
     });
   }

--- a/libraries/rush-lib/src/logic/operations/OperationGraph.ts
+++ b/libraries/rush-lib/src/logic/operations/OperationGraph.ts
@@ -205,6 +205,7 @@ export class OperationGraph implements IOperationGraph {
   /** Tracks if a graph state change notification has been scheduled for next tick. */
   #graphStateChangeScheduled: boolean = false;
   #status: OperationStatus = OperationStatus.Ready;
+  #nextIterationId: number = 1;
 
   public constructor(operations: Set<Operation>, options: IOperationGraphOptions) {
     const {
@@ -533,6 +534,14 @@ export class OperationGraph implements IOperationGraph {
 
     this.#currentIteration = iteration;
     this.#setScheduledIteration(undefined);
+    for (const executionRecord of iteration.records.values()) {
+      iteration.eventSink?.onOperationRegistered?.(
+        executionRecord.name,
+        executionRecord.silent,
+        executionRecord,
+        executionRecord.iterationId
+      );
+    }
 
     iteration.promise = this.#executeInnerAsync(this.#currentIteration).finally(() => {
       this.#currentIteration = undefined;
@@ -646,6 +655,7 @@ export class OperationGraph implements IOperationGraph {
 
     // Convert the developer graph to the mutable execution graph
     const iterationContext: IExecutionIterationContext = {
+      iterationId: this.#nextIterationId++,
       abortController,
       startTime,
       streamCollator,
@@ -713,8 +723,13 @@ export class OperationGraph implements IOperationGraph {
     }
 
     if (iterationContext.totalOperations === 0) {
-      registerOperations();
       for (const executionRecord of executionRecords.values()) {
+        eventSink?.onOperationRegistered?.(
+          executionRecord.name,
+          executionRecord.silent,
+          executionRecord,
+          executionRecord.iterationId
+        );
         executionRecord.status = OperationStatus.NoOp;
         executionRecord.finalizeOperation();
         executionRecord.stdioSummarizer.close();
@@ -734,19 +749,12 @@ export class OperationGraph implements IOperationGraph {
       terminal.writeStderrLine(Colorize.red(errorMessage));
       throw e;
     }
-    registerOperations();
     if (!this.#currentIteration) {
       this.#setIdleTimeout();
     } else if (!this.pauseNextIteration) {
       void this.abortCurrentIterationAsync();
     }
     return iterationContext;
-
-    function registerOperations(): void {
-      for (const executionRecord of executionRecords.values()) {
-        eventSink?.onOperationRegistered?.(executionRecord.name, executionRecord.silent, executionRecord);
-      }
-    }
 
     function onWriterActive(writer: CollatedWriter | undefined): void {
       if (writer) {

--- a/libraries/rush-lib/src/logic/operations/ReporterOperationEventSink.ts
+++ b/libraries/rush-lib/src/logic/operations/ReporterOperationEventSink.ts
@@ -19,7 +19,7 @@ import {
 import type { IOperationExecutionResult } from './IOperationExecutionResult';
 import type { IOperationGraphEventSink, IOperationActivityOptions } from './OperationEventSink';
 import type { Operation } from './Operation';
-import { OperationStatus } from './OperationStatus';
+import { OperationStatus, SUCCESS_STATUSES } from './OperationStatus';
 import type { OperationGraph } from './OperationGraph';
 
 interface IReporterOperation {
@@ -29,7 +29,8 @@ interface IReporterOperation {
   readonly phaseName: string;
   readonly projectName: string;
   readonly streamEmitter: OperationStreamEmitter | undefined;
-  registrationCycle: IReporterOperationCycle | undefined;
+  readonly cycles: Map<number, IReporterOperationCycle>;
+  latestCompletedIterationId: number | undefined;
 }
 
 interface IReporterOperationCycle {
@@ -37,7 +38,6 @@ interface IReporterOperationCycle {
   readonly statuses: Map<string, OperationStatus>;
   readonly closedOperationIds: Set<string>;
   readonly completedResults: Map<string, IOperationExecutionResult>;
-  diagnosed: boolean;
   lastEmittedStatus: ReporterOperationStatus | undefined;
   silent: boolean;
   streamClosed: boolean;
@@ -45,20 +45,27 @@ interface IReporterOperationCycle {
 
 class ReporterOperationEventSink implements IOperationGraphEventSink {
   public readonly onOperationChunk:
-    | ((operationId: string, chunk: ITerminalChunk, result?: IOperationExecutionResult) => void)
+    | ((
+        operationId: string,
+        chunk: ITerminalChunk,
+        result?: IOperationExecutionResult,
+        iterationId?: number
+      ) => void)
     | undefined;
   public readonly onOperationStreamClosed:
-    | ((operationId: string, result?: IOperationExecutionResult) => void)
+    | ((operationId: string, result?: IOperationExecutionResult, iterationId?: number) => void)
     | undefined;
   public readonly onOperationCompleted: ((result: IOperationExecutionResult) => void) | undefined;
 
   private readonly _operationsByLegacyId: Map<string, IReporterOperation> = new Map();
-  private readonly _cyclesByResult: WeakMap<IOperationExecutionResult, IReporterOperationCycle> =
-    new WeakMap();
+  private readonly _diagnosedOperations: Set<string> = new Set();
+  private readonly _commandName: string;
   private readonly _rushSession: RushSession;
+  private readonly _operationStreamEnabled: boolean;
 
   public constructor(rushSession: RushSession, commandName: string, operations: Iterable<Operation>) {
     this._rushSession = rushSession;
+    this._commandName = commandName;
     const operationsByReporterId: Map<string, IReporterOperation> = new Map();
 
     for (const operation of operations) {
@@ -92,7 +99,8 @@ class ReporterOperationEventSink implements IOperationGraphEventSink {
           phaseName,
           projectName,
           streamEmitter,
-          registrationCycle: undefined
+          cycles: new Map(),
+          latestCompletedIterationId: undefined
         };
         operationsByReporterId.set(operationId, reporterOperation);
       }
@@ -100,49 +108,43 @@ class ReporterOperationEventSink implements IOperationGraphEventSink {
       this._operationsByLegacyId.set(operation.name, reporterOperation);
     }
 
-    if (Array.from(this._operationsByLegacyId.values()).some(({ streamEmitter }) => !!streamEmitter)) {
-      this.onOperationChunk = (operationId, chunk, result) =>
-        this._onOperationChunk(operationId, chunk, result);
-      this.onOperationStreamClosed = (operationId, result) =>
-        this._onOperationStreamClosed(operationId, result);
-      this.onOperationCompleted = (result) => this._onOperationCompleted(result);
+    this._operationStreamEnabled = Array.from(this._operationsByLegacyId.values()).some(
+      ({ streamEmitter }) => !!streamEmitter
+    );
+    if (this._operationStreamEnabled) {
+      this.onOperationChunk = (operationId, chunk, result, iterationId) =>
+        this._onOperationChunk(operationId, chunk, result, iterationId);
+      this.onOperationStreamClosed = (operationId, result, iterationId) =>
+        this._onOperationStreamClosed(operationId, result, iterationId);
     } else {
       this.onOperationChunk = undefined;
       this.onOperationStreamClosed = undefined;
-      this.onOperationCompleted = undefined;
     }
+    this.onOperationCompleted = this.isEnabled ? (result) => this._onOperationCompleted(result) : undefined;
   }
 
   public get isEnabled(): boolean {
     return this._operationsByLegacyId.size > 0;
   }
 
+  public get operationStreamEnabled(): boolean {
+    return this._operationStreamEnabled;
+  }
+
   public onOperationRegistered(
     operationId: string,
     silent: boolean,
-    result?: IOperationExecutionResult
+    result?: IOperationExecutionResult,
+    iterationId?: number
   ): void {
     const operation: IReporterOperation | undefined = this._operationsByLegacyId.get(operationId);
-    if (!operation || !result) {
+    const resolvedIterationId: number | undefined = iterationId ?? result?.iterationId;
+    if (!operation || resolvedIterationId === undefined) {
       return;
     }
 
-    let cycle: IReporterOperationCycle | undefined = operation.registrationCycle;
-    if (!cycle || cycle.registeredOperationIds.size === operation.legacyOperationIds.size) {
-      cycle = {
-        registeredOperationIds: new Set(),
-        statuses: new Map(),
-        closedOperationIds: new Set(),
-        completedResults: new Map(),
-        diagnosed: false,
-        lastEmittedStatus: undefined,
-        silent: true,
-        streamClosed: false
-      };
-      operation.registrationCycle = cycle;
-    }
+    const cycle: IReporterOperationCycle = this._getCycle(operation, resolvedIterationId);
 
-    this._cyclesByResult.set(result, cycle);
     cycle.registeredOperationIds.add(operationId);
     cycle.silent &&= silent;
     if (cycle.registeredOperationIds.size !== operation.legacyOperationIds.size) {
@@ -154,10 +156,12 @@ class ReporterOperationEventSink implements IOperationGraphEventSink {
         operation.operationId,
         operation.projectName,
         operation.phaseName,
-        cycle.silent
+        cycle.silent,
+        resolvedIterationId
       );
     } else if (!cycle.silent) {
       operation.emitter.emitOperationRegistered({
+        iterationId: resolvedIterationId,
         operationId: operation.operationId,
         projectName: operation.projectName,
         phaseName: operation.phaseName
@@ -170,11 +174,14 @@ class ReporterOperationEventSink implements IOperationGraphEventSink {
     if (!operation) {
       return;
     }
-    const cycle: IReporterOperationCycle | undefined = this._cyclesByResult.get(result);
-    if (!cycle) {
+    if (
+      operation.latestCompletedIterationId !== undefined &&
+      result.iterationId <= operation.latestCompletedIterationId
+    ) {
       return;
     }
 
+    const cycle: IReporterOperationCycle = this._getCycle(operation, result.iterationId);
     if (
       result.status === OperationStatus.Ready &&
       cycle.registeredOperationIds.size === operation.legacyOperationIds.size
@@ -183,14 +190,15 @@ class ReporterOperationEventSink implements IOperationGraphEventSink {
     }
 
     cycle.statuses.set(result.operation.name, result.status);
-    if (result.status === OperationStatus.Failure && !cycle.diagnosed) {
-      cycle.diagnosed = true;
+    const diagnosticKey: string = `${result.iterationId}:${operation.operationId}`;
+    if (result.status === OperationStatus.Failure && !this._diagnosedOperations.has(diagnosticKey)) {
+      this._diagnosedOperations.add(diagnosticKey);
       const diagnostic: IRushDiagnostic = createRushDiagnostic('RUSH_OPERATION_FAILED', {
         parameters: {
           projectName: { value: operation.projectName, privacy: 'public' }
         }
       });
-      operation.emitter.emitDiagnostic(diagnostic);
+      operation.emitter.emitDiagnostic({ ...diagnostic, iterationId: result.iterationId });
       if (result.error) {
         _correlateRushSessionError(this._rushSession, result.error, diagnostic.diagnosticId);
       }
@@ -213,10 +221,12 @@ class ReporterOperationEventSink implements IOperationGraphEventSink {
         operation.operationId,
         status,
         durationMs,
-        aggregatePreviousStatus
+        aggregatePreviousStatus,
+        result.iterationId
       );
     } else if (!cycle.silent) {
       operation.emitter.emitOperationStatusChanged({
+        iterationId: result.iterationId,
         operationId: operation.operationId,
         status,
         ...(durationMs === undefined ? {} : { durationMs })
@@ -224,46 +234,74 @@ class ReporterOperationEventSink implements IOperationGraphEventSink {
     }
   }
 
+  public onActivity(text: string, options: IOperationActivityOptions = {}): void {
+    if (!this.operationStreamEnabled) {
+      return;
+    }
+    const operation: IReporterOperation | undefined = options.operationId
+      ? this._operationsByLegacyId.get(options.operationId)
+      : undefined;
+    this._rushSession
+      .getReporter({
+        commandName: this._commandName,
+        operationId: operation?.operationId,
+        projectName: operation?.projectName,
+        phaseName: operation?.phaseName
+      })
+      ?.emitMessage({
+        severity: options.stderr ? 'warning' : 'info',
+        text,
+        privacy: 'local-sensitive'
+      });
+  }
+
   private _onOperationChunk(
     operationId: string,
     chunk: ITerminalChunk,
-    result?: IOperationExecutionResult
+    result?: IOperationExecutionResult,
+    iterationId?: number
   ): void {
     const operation: IReporterOperation | undefined = this._operationsByLegacyId.get(operationId);
-    if (!operation?.streamEmitter || !result || !this._cyclesByResult.has(result)) {
+    const resolvedIterationId: number | undefined = iterationId ?? result?.iterationId;
+    if (!operation?.streamEmitter || resolvedIterationId === undefined) {
       return;
     }
 
     if (chunk.kind === TerminalChunkKind.Stdout) {
-      operation.streamEmitter.writeOutput(operation.operationId, 'stdout', chunk.text);
+      operation.streamEmitter.writeOutput(operation.operationId, 'stdout', chunk.text, resolvedIterationId);
     } else if (chunk.kind === TerminalChunkKind.Stderr) {
-      operation.streamEmitter.writeOutput(operation.operationId, 'stderr', chunk.text);
+      operation.streamEmitter.writeOutput(operation.operationId, 'stderr', chunk.text, resolvedIterationId);
     }
   }
 
-  private _onOperationStreamClosed(operationId: string, result?: IOperationExecutionResult): void {
+  private _onOperationStreamClosed(
+    operationId: string,
+    result?: IOperationExecutionResult,
+    iterationId?: number
+  ): void {
     const operation: IReporterOperation | undefined = this._operationsByLegacyId.get(operationId);
-    const cycle: IReporterOperationCycle | undefined = result ? this._cyclesByResult.get(result) : undefined;
-    if (!operation?.streamEmitter || !cycle || cycle.streamClosed) {
+    const resolvedIterationId: number | undefined = iterationId ?? result?.iterationId;
+    if (!operation?.streamEmitter || resolvedIterationId === undefined) {
+      return;
+    }
+    const cycle: IReporterOperationCycle = this._getCycle(operation, resolvedIterationId);
+    if (cycle.streamClosed) {
       return;
     }
     cycle.closedOperationIds.add(operationId);
     if (cycle.closedOperationIds.size === operation.legacyOperationIds.size) {
       cycle.streamClosed = true;
-      operation.streamEmitter.closeOperationStream(operation.operationId);
+      operation.streamEmitter.closeOperationStream(operation.operationId, resolvedIterationId);
     }
   }
 
   private _onOperationCompleted(result: IOperationExecutionResult): void {
     const operation: IReporterOperation | undefined = this._operationsByLegacyId.get(result.operation.name);
-    if (!operation?.streamEmitter) {
-      return;
-    }
-    const cycle: IReporterOperationCycle | undefined = this._cyclesByResult.get(result);
-    if (!cycle) {
+    if (!operation) {
       return;
     }
 
+    const cycle: IReporterOperationCycle = this._getCycle(operation, result.iterationId);
     cycle.completedResults.set(result.operation.name, result);
     if (cycle.completedResults.size !== operation.legacyOperationIds.size) {
       return;
@@ -272,16 +310,44 @@ class ReporterOperationEventSink implements IOperationGraphEventSink {
       Array.from(cycle.completedResults.values(), ({ status: resultStatus }) => resultStatus)
     );
     const durationMs: number | undefined = _getAggregateDurationMs(cycle.completedResults);
-    operation.streamEmitter.completeOperation(operation.operationId, status, durationMs);
+    operation.streamEmitter?.completeOperation(operation.operationId, status, durationMs, result.iterationId);
+    operation.latestCompletedIterationId = Math.max(
+      operation.latestCompletedIterationId ?? result.iterationId,
+      result.iterationId
+    );
+    operation.cycles.delete(result.iterationId);
+    this._diagnosedOperations.delete(`${result.iterationId}:${operation.operationId}`);
+  }
+
+  private _getCycle(operation: IReporterOperation, iterationId: number): IReporterOperationCycle {
+    let cycle: IReporterOperationCycle | undefined = operation.cycles.get(iterationId);
+    if (!cycle) {
+      cycle = {
+        registeredOperationIds: new Set(),
+        statuses: new Map(),
+        closedOperationIds: new Set(),
+        completedResults: new Map(),
+        lastEmittedStatus: undefined,
+        silent: true,
+        streamClosed: false
+      };
+      operation.cycles.set(iterationId, cycle);
+    }
+    return cycle;
   }
 }
 
 class CompositeOperationGraphEventSink implements IOperationGraphEventSink {
   public readonly onOperationChunk:
-    | ((operationId: string, chunk: ITerminalChunk, result?: IOperationExecutionResult) => void)
+    | ((
+        operationId: string,
+        chunk: ITerminalChunk,
+        result?: IOperationExecutionResult,
+        iterationId?: number
+      ) => void)
     | undefined;
   public readonly onOperationStreamClosed:
-    | ((operationId: string, result?: IOperationExecutionResult) => void)
+    | ((operationId: string, result?: IOperationExecutionResult, iterationId?: number) => void)
     | undefined;
   public readonly onOperationCompleted: ((result: IOperationExecutionResult) => void) | undefined;
 
@@ -293,16 +359,16 @@ class CompositeOperationGraphEventSink implements IOperationGraphEventSink {
     this._second = second;
     this.onOperationChunk =
       first.onOperationChunk || second.onOperationChunk
-        ? (operationId, chunk, result) => {
-            first.onOperationChunk?.(operationId, chunk, result);
-            second.onOperationChunk?.(operationId, chunk, result);
+        ? (operationId, chunk, result, iterationId) => {
+            first.onOperationChunk?.(operationId, chunk, result, iterationId);
+            second.onOperationChunk?.(operationId, chunk, result, iterationId);
           }
         : undefined;
     this.onOperationStreamClosed =
       first.onOperationStreamClosed || second.onOperationStreamClosed
-        ? (operationId, result) => {
-            first.onOperationStreamClosed?.(operationId, result);
-            second.onOperationStreamClosed?.(operationId, result);
+        ? (operationId, result, iterationId) => {
+            first.onOperationStreamClosed?.(operationId, result, iterationId);
+            second.onOperationStreamClosed?.(operationId, result, iterationId);
           }
         : undefined;
     this.onOperationCompleted =
@@ -317,10 +383,11 @@ class CompositeOperationGraphEventSink implements IOperationGraphEventSink {
   public onOperationRegistered(
     operationId: string,
     silent: boolean,
-    result?: IOperationExecutionResult
+    result?: IOperationExecutionResult,
+    iterationId?: number
   ): void {
-    this._first.onOperationRegistered?.(operationId, silent, result);
-    this._second.onOperationRegistered?.(operationId, silent, result);
+    this._first.onOperationRegistered?.(operationId, silent, result, iterationId);
+    this._second.onOperationRegistered?.(operationId, silent, result, iterationId);
   }
 
   public onOperationStatusChanged(result: IOperationExecutionResult, previousStatus: OperationStatus): void {
@@ -347,7 +414,8 @@ class CompositeOperationGraphEventSink implements IOperationGraphEventSink {
 export function attachReporterOperationEventSink(
   graph: OperationGraph,
   rushSession: RushSession,
-  commandName: string
+  commandName: string,
+  isWatch: boolean = false
 ): void {
   const reporterSink: ReporterOperationEventSink = new ReporterOperationEventSink(
     rushSession,
@@ -361,6 +429,24 @@ export function attachReporterOperationEventSink(
   graph.eventSink = graph.eventSink
     ? new CompositeOperationGraphEventSink(graph.eventSink, reporterSink)
     : reporterSink;
+
+  if (isWatch && reporterSink.operationStreamEnabled) {
+    const lifecycleEmitter: LifecycleEmitter | undefined = _getRushSessionLifecycleEmitter(rushSession, {
+      commandName
+    });
+    lifecycleEmitter &&
+      graph.hooks.afterExecuteIterationAsync.tapPromise(
+        'RushReporterWatchCycle',
+        async (status: OperationStatus, records: ReadonlyMap<Operation, IOperationExecutionResult>) => {
+          const iterationId: number | undefined = records.values().next().value?.iterationId;
+          lifecycleEmitter.emitWatchCycleCompleted({
+            succeeded: SUCCESS_STATUSES.has(status),
+            ...(iterationId === undefined ? {} : { iterationId })
+          });
+          return status;
+        }
+      );
+  }
 }
 
 function _toReporterStatus(status: OperationStatus): ReporterOperationStatus {

--- a/libraries/rush-lib/src/logic/operations/test/OperationGraphEventSink.test.ts
+++ b/libraries/rush-lib/src/logic/operations/test/OperationGraphEventSink.test.ts
@@ -86,6 +86,7 @@ function createOperation(
 
 class RecordingSink implements IOperationGraphEventSink {
   public readonly registered: [string, boolean][] = [];
+  public readonly registeredIterations: number[] = [];
   public readonly transitions: [string, string][] = [];
   public readonly headers: [string, number, number][] = [];
   public readonly activities: string[] = [];
@@ -93,8 +94,14 @@ class RecordingSink implements IOperationGraphEventSink {
   public readonly closed: string[] = [];
   public readonly completed: [string, string][] = [];
 
-  public onOperationRegistered(operationId: string, silent: boolean): void {
+  public onOperationRegistered(
+    operationId: string,
+    silent: boolean,
+    result?: IOperationExecutionResult,
+    iterationId?: number
+  ): void {
     this.registered.push([operationId, silent]);
+    this.registeredIterations.push(iterationId ?? result?.iterationId ?? -1);
   }
   public onOperationStatusChanged(result: IOperationExecutionResult): void {
     this.transitions.push([result.operation.name, result.status]);
@@ -580,7 +587,7 @@ describe('OperationGraph event sink (dual-emit)', () => {
       new Set([createOperation('silent only', silentRunner, mockPhase, '@scope/silent')]),
       createGraphOptions(mockWritable, false)
     );
-    attachReporterOperationEventSink(graph, rushSession, 'build');
+    attachReporterOperationEventSink(graph, rushSession, 'build', true);
 
     await graph.executeAsync({});
     await graph.executeAsync({});
@@ -596,6 +603,163 @@ describe('OperationGraph event sink (dual-emit)', () => {
         .filter(({ type }) => type === 'operationCompleted')
         .map(({ payload }) => (payload as { status: string }).status)
     ).toEqual(['noOp', 'noOp']);
+  });
+
+  it('does not emit status changes after completion for a deferred invalidation', async () => {
+    const reporterSink: CapturingReporterSink = new CapturingReporterSink();
+    const rushSession: RushSession = new RushSession({
+      terminalProvider: new StringBufferTerminalProvider(),
+      getIsDebugMode: () => false,
+      reporter: {
+        eventSink: reporterSink,
+        sessionId: 'deferred-invalidation',
+        operationStreamEnabled: true
+      }
+    });
+    const runner: IOperationRunner = {
+      name: 'deferred invalidation',
+      reportTiming: true,
+      silent: false,
+      cacheable: false,
+      warningsAreAllowed: false,
+      isNoOp: false,
+      executeAsync: async (context: IOperationRunnerContext) => {
+        context.getInvalidateCallback()('during execution');
+        return OperationStatus.Success;
+      },
+      getConfigHash: () => 'deferred-invalidation'
+    };
+    const graph: OperationGraph = new OperationGraph(
+      new Set([createOperation('deferred invalidation', runner)]),
+      createGraphOptions(mockWritable, false)
+    );
+    attachReporterOperationEventSink(graph, rushSession, 'build', true);
+
+    await graph.executeAsync({});
+
+    const operationEvents: IReporterEmitEventInput<unknown>[] = reporterSink.inputs.filter(
+      ({ scope }) => scope?.operationId === 'deferred invalidation#phase'
+    );
+    const completedIndex: number = operationEvents.findIndex(({ type }) => type === 'operationCompleted');
+    expect(completedIndex).toBeGreaterThanOrEqual(0);
+    expect(
+      operationEvents.slice(completedIndex + 1).some(({ type }) => type === 'operationStatusChanged')
+    ).toBe(false);
+  });
+
+  it('emits failure and blocked outcomes for a dependency chain', async () => {
+    const reporterSink: CapturingReporterSink = new CapturingReporterSink();
+    const rushSession: RushSession = new RushSession({
+      terminalProvider: new StringBufferTerminalProvider(),
+      getIsDebugMode: () => false,
+      reporter: {
+        eventSink: reporterSink,
+        sessionId: 'failure-and-blocked',
+        operationStreamEnabled: true
+      }
+    });
+    const failing: Operation = createOperation(
+      'failing',
+      new MockOperationRunner('failing', async () => OperationStatus.Failure),
+      mockPhase,
+      '@scope/failing'
+    );
+    const blocked: Operation = createOperation(
+      'blocked',
+      new MockOperationRunner('blocked', async () => OperationStatus.Success),
+      mockPhase,
+      '@scope/blocked'
+    );
+    blocked.addDependency(failing);
+    const graph: OperationGraph = new OperationGraph(
+      new Set([failing, blocked]),
+      createGraphOptions(mockWritable, false)
+    );
+
+    attachReporterOperationEventSink(graph, rushSession, 'build');
+    await graph.executeAsync({});
+
+    const completions: string[] = reporterSink.inputs
+      .filter(({ type }) => type === 'operationCompleted')
+      .map(({ payload }) => (payload as { status: string }).status);
+    expect(completions).toEqual(expect.arrayContaining(['failure', 'blocked']));
+    expect(reporterSink.inputs).toContainEqual(
+      expect.objectContaining({
+        type: 'diagnosticEmitted',
+        payload: expect.objectContaining({ code: 'RUSH_OPERATION_FAILED' })
+      })
+    );
+  });
+
+  it('emits aborted outcomes for a cancelled iteration', async () => {
+    const reporterSink: CapturingReporterSink = new CapturingReporterSink();
+    const rushSession: RushSession = new RushSession({
+      terminalProvider: new StringBufferTerminalProvider(),
+      getIsDebugMode: () => false,
+      reporter: {
+        eventSink: reporterSink,
+        sessionId: 'cancelled-iteration',
+        operationStreamEnabled: true
+      }
+    });
+    const graph: OperationGraph = new OperationGraph(
+      new Set([createOperation('cancelled', new MockOperationRunner('cancelled'))]),
+      createGraphOptions(mockWritable, false)
+    );
+    graph.hooks.beforeExecuteIterationAsync.tap('cancel', () => OperationStatus.Aborted);
+
+    attachReporterOperationEventSink(graph, rushSession, 'build');
+    await graph.executeAsync({});
+
+    expect(reporterSink.inputs).toContainEqual(
+      expect.objectContaining({
+        type: 'operationCompleted',
+        payload: expect.objectContaining({ status: 'aborted' })
+      })
+    );
+  });
+
+  it('emits a watch-cycle result after each opted-in iteration', async () => {
+    const reporterSink: CapturingReporterSink = new CapturingReporterSink();
+    const rushSession: RushSession = new RushSession({
+      terminalProvider: new StringBufferTerminalProvider(),
+      getIsDebugMode: () => false,
+      reporter: {
+        eventSink: reporterSink,
+        sessionId: 'watch-cycle',
+        operationStreamEnabled: true
+      }
+    });
+
+    const graph: OperationGraph = new OperationGraph(
+      new Set([createOperation('watch', new MockOperationRunner('watch'))]),
+      createGraphOptions(mockWritable, false)
+    );
+
+    attachReporterOperationEventSink(graph, rushSession, 'build', true);
+    await graph.executeAsync({});
+
+    expect(reporterSink.inputs.at(-1)).toMatchObject({
+      type: 'watchCycleCompleted',
+      payload: { iterationId: 1, succeeded: true }
+    });
+  });
+
+  it('does not register a scheduled iteration until it begins execution', async () => {
+    const sink: RecordingSink = new RecordingSink();
+    const graph: OperationGraph = new OperationGraph(
+      new Set([createOperation('scheduled', new MockOperationRunner('scheduled'))]),
+      createGraphOptions(mockWritable, false)
+    );
+    graph.eventSink = sink;
+
+    await graph.scheduleIterationAsync({});
+    await graph.scheduleIterationAsync({});
+
+    expect(sink.registered).toEqual([]);
+    await graph.executeScheduledIterationAsync();
+    expect(sink.registered).toEqual([['scheduled', false]]);
+    expect(sink.registeredIterations).toEqual([2]);
   });
 
   it('does not attach an operation adapter when the session has no reporter sink', () => {
@@ -722,52 +886,6 @@ describe('OperationGraph event sink (dual-emit)', () => {
     expect(reporterSink.inputs.some(({ type }) => type === 'externalOutput')).toBe(false);
   });
 
-  it('isolates diagnostics when the next watch iteration registers before abort completes', async () => {
-    const reporterSink: CapturingReporterSink = new CapturingReporterSink();
-    const rushSession: RushSession = new RushSession({
-      terminalProvider: new StringBufferTerminalProvider(),
-      getIsDebugMode: () => false,
-      reporter: { eventSink: reporterSink, sessionId: 'overlapping-operation-shadow' }
-    });
-    let runCount: number = 0;
-    let resolveFirstRun: ((status: OperationStatus) => void) | undefined;
-    let markFirstRunStarted: (() => void) | undefined;
-    const firstRunStarted: Promise<void> = new Promise<void>((resolve: () => void) => {
-      markFirstRunStarted = resolve;
-    });
-    const runner: MockOperationRunner = new MockOperationRunner('@scope/overlap (phase)', async () => {
-      runCount++;
-      if (runCount === 1) {
-        markFirstRunStarted!();
-        return await new Promise<OperationStatus>((resolve: (status: OperationStatus) => void) => {
-          resolveFirstRun = resolve;
-        });
-      }
-      return OperationStatus.Failure;
-    });
-    const graph: OperationGraph = new OperationGraph(
-      new Set([createOperation('overlap', runner, mockPhase, '@scope/overlap')]),
-      { ...createGraphOptions(mockWritable, false), pauseNextIteration: true }
-    );
-    attachReporterOperationEventSink(graph, rushSession, 'build');
-
-    await graph.scheduleIterationAsync({});
-    const firstExecution: Promise<boolean> = graph.executeScheduledIterationAsync();
-    await firstRunStarted;
-    await graph.scheduleIterationAsync({});
-    const abortPromise: Promise<void> = graph.abortCurrentIterationAsync();
-    resolveFirstRun!(OperationStatus.Failure);
-    await Promise.all([firstExecution, abortPromise]);
-    await graph.executeScheduledIterationAsync();
-
-    expect(
-      reporterSink.inputs.filter(
-        ({ type, payload }) =>
-          type === 'diagnosticEmitted' && (payload as { code?: string }).code === 'RUSH_OPERATION_FAILED'
-      )
-    ).toHaveLength(2);
-  });
-
   it('recomputes grouped silence for each watch-style iteration', async () => {
     const reporterSink: CapturingReporterSink = new CapturingReporterSink();
     const rushSession: RushSession = new RushSession({
@@ -868,16 +986,26 @@ describe('OperationGraph event sink (dual-emit)', () => {
       '@scope/project#_phase:compile',
       '@scope/project#_phase:test'
     ]);
+    expect(registrations.map(({ payload }) => (payload as { iterationId?: number }).iterationId)).toEqual([
+      1, 1, 2, 2
+    ]);
     expect(
       reporterSink.inputs
         .filter(({ type }) => type === 'operationCompleted')
-        .map(({ scope }) => scope?.operationId)
-        .sort()
+        .map(({ scope, payload }) => ({
+          operationId: scope?.operationId,
+          iterationId: (payload as { iterationId?: number }).iterationId
+        }))
+        .sort((a, b) =>
+          a.operationId === b.operationId
+            ? (a.iterationId ?? 0) - (b.iterationId ?? 0)
+            : (a.operationId ?? '').localeCompare(b.operationId ?? '')
+        )
     ).toEqual([
-      '@scope/project#_phase:compile',
-      '@scope/project#_phase:compile',
-      '@scope/project#_phase:test',
-      '@scope/project#_phase:test'
+      { operationId: '@scope/project#_phase:compile', iterationId: 1 },
+      { operationId: '@scope/project#_phase:compile', iterationId: 2 },
+      { operationId: '@scope/project#_phase:test', iterationId: 1 },
+      { operationId: '@scope/project#_phase:test', iterationId: 2 }
     ]);
     for (const event of reporterSink.inputs.filter(({ type }) => type === 'operationStatusChanged')) {
       expect(event.scope?.operationId).toBe(`@scope/project#${event.scope?.phaseName}`);

--- a/libraries/rush-lib/src/pluginFramework/RushSession.ts
+++ b/libraries/rush-lib/src/pluginFramework/RushSession.ts
@@ -61,6 +61,13 @@ export interface IRushSessionReporterOptions {
    * @internal
    */
   readonly operationStreamEnabled?: boolean;
+
+  /**
+   * Flushes and closes the frontend-owned reporters before an explicit process exit.
+   *
+   * @internal
+   */
+  readonly flushAsync?: () => Promise<void>;
 }
 
 /**
@@ -492,6 +499,24 @@ export function _getRushSessionOperationStreamEmitter(
   return state.options.reporter?.operationStreamEnabled
     ? _createOperationStreamEmitter(state.reporting, scope)
     : undefined;
+}
+
+/**
+ * Returns whether the frontend enabled reporter-owned operation presentation.
+ *
+ * @internal
+ */
+export function _isRushSessionOperationStreamEnabled(rushSession: RushSession): boolean {
+  return _getSessionState(rushSession).options.reporter?.operationStreamEnabled === true;
+}
+
+/**
+ * Flushes the frontend-owned reporter host, when available.
+ *
+ * @internal
+ */
+export function _flushRushSessionReporterAsync(rushSession: RushSession): Promise<void> {
+  return _getSessionState(rushSession).options.reporter?.flushAsync?.() ?? Promise.resolve();
 }
 
 /**


### PR DESCRIPTION
Part of #5978

## Stack

Parent: #5996 (`copilot/reporter-r5a-operation-adapter`)

This PR is based directly on the R5A operation adapter and intentionally excludes the parallel R6 #5993 bootstrap work. Keep auto-merge disabled while stack ancestors remain open.

## Demo path

The direct current-version `rush build` path now transfers visible operation presentation to the frontend-selected reporters when either an explicit non-legacy `--reporter` is present or the repository `useRushReporter` experiment is enabled.

- the selected primary reporter owns its visible destination;
- the always-on file reporter owns a complete invocation log under `common/temp/rush-logs`;
- the retained `StreamCollator` writes to a no-op destination, preserving scheduling/writer completion semantics without duplicate terminal output;
- non-operation Rush terminal messages are converted into semantic reporter messages, while operation summaries come from authoritative `operationCompleted` events;
- `RUSH_REPORTER=legacy` removes reporter controls before launching Rush and returns immediately to the existing legacy path.

The file reporter spools active operation output to owner-only temporary files, then appends each operation as a grouped block in completion order. This preserves stdout/stderr chunk order without unbounded heap buffering.

## Reproducible demo

```sh
rush build --to @microsoft/rush
node apps/rush/src/test/sandbox/reporter-demo/run.mjs
```

The script exercises:

```sh
node apps/rush/bin/rush build --only @rushstack/rush-reporter
node apps/rush/bin/rush build --only @rushstack/rush-reporter --reporter=plaintext
node apps/rush/bin/rush build --only @rushstack/rush-reporter --reporter=json --log-level=debug
node apps/rush/bin/rush build --only @rushstack/rush-reporter --reporter=ai
RUSH_REPORTER=legacy node apps/rush/bin/rush build --only @rushstack/rush-reporter --reporter=json
```

Observed result:

- plaintext reconstructs phase-aware grouped operation output and prints an absolute full-log path;
- JSON stdout is valid payload-only NDJSON with no blank/control lines;
- AI emits bounded status/final records, suppresses warning details on failure, and includes the exact full-log path;
- legacy rollback matches the feature-off transcript after normalizing runtime durations;
- failed parser/selection paths retain their actionable message and flush through `sessionCompleted`.

Repository opt-in remains `"useRushReporter": true` in `common/config/rush/experiments.json`; removing it or setting `RUSH_REPORTER=legacy` provides immediate rollback.

## Validation

- `rush test --only @rushstack/rush-reporter --only @microsoft/rush-lib --only @microsoft/rush --verbose`
  - reporter: 301 tests
  - rush-lib: 770 tests
  - apps/rush: 25 tests
- `rush build --only @rushstack/rush-reporter --only @microsoft/rush-lib --only @microsoft/rush --verbose`
- reporter snapshots/goldens in the targeted suite
- `rush check`
- `rush change --verify --no-fetch`
- direct demo matrix above
- direct failed JSON invocation confirmed final `commandResult`, `commandCompleted`, and `sessionCompleted`, with the actionable error in the full log

Coverage includes success, cache hit, warnings, operation failure, blocked and aborted operations, silent operations, parallel grouping, stdout/stderr ordering, TTY/non-TTY behavior, quiet/verbose/debug controls, watch-cycle completion, and legacy flag-off parity.

## Non-goals

- no `install-run-rush` or bootstrap handoff ownership (R6 / #5993);
- no Heft child descriptors or problem-matcher protocol changes (R7);
- no agent auto-selection (R8 / #5981);
- no terminal API removal, Rush 6 default flip, or later-major cleanup (R9+).
