### PR TITLE
Fix mergeWith prototype pollution

### DIFF
--- a/common/changes/@rushstack/node-core-library/mojazayeri-prevent-merge-prototype-pollution_2026-08-28-23-45.json
+++ b/common/changes/@rushstack/node-core-library/mojazayeri-prevent-merge-prototype-pollution_2026-08-28-23-45.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@rushstack/node-core-library",
+      "comment": "Prevent prototype pollution when Objects.mergeWith() processes attacker-controlled properties.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@rushstack/node-core-library",
+  "email": "mojazayeri@users.noreply.github.com"
+}

--- a/libraries/node-core-library/src/objects/mergeWith.ts
+++ b/libraries/node-core-library/src/objects/mergeWith.ts
@@ -30,16 +30,31 @@ export function mergeWith<TTarget extends object, TSource extends object>(
   const targetRecord: Record<string, unknown> = target as unknown as Record<string, unknown>;
   const sourceRecord: Record<string, unknown> = source as unknown as Record<string, unknown>;
   for (const [key, srcValue] of Object.entries(sourceRecord)) {
-    const objValue: unknown = targetRecord[key];
+    const objValue: unknown = Object.hasOwnProperty.call(targetRecord, key)
+      ? targetRecord[key]
+      : undefined;
     const customized: unknown = customizer?.(objValue, srcValue, key);
     if (customized !== undefined) {
-      targetRecord[key] = customized;
+      _setProperty(targetRecord, key, customized);
     } else if (isRecord(srcValue) && isRecord(objValue)) {
       mergeWith(objValue, srcValue, customizer);
     } else {
-      targetRecord[key] = srcValue;
+      _setProperty(targetRecord, key, srcValue);
     }
   }
 
   return target;
+}
+
+function _setProperty(target: Record<string, unknown>, key: string, value: unknown): void {
+  if (key === '__proto__') {
+    Object.defineProperty(target, key, {
+      configurable: true,
+      enumerable: true,
+      value,
+      writable: true
+    });
+  } else {
+    target[key] = value;
+  }
 }

--- a/libraries/node-core-library/src/objects/test/mergeWith.test.ts
+++ b/libraries/node-core-library/src/objects/test/mergeWith.test.ts
@@ -72,6 +72,28 @@ describe(mergeWith.name, () => {
       mergeWith(target, { a: 1 });
       expect(target).toEqual({ a: 1 });
     });
+
+    it('does not merge into inherited target properties', () => {
+      const prototype: { settings: Record<string, unknown> } = { settings: { inherited: true } };
+      const target: Record<string, unknown> = Object.create(prototype);
+
+      mergeWith(target, { settings: { own: true } });
+
+      expect(prototype.settings).toEqual({ inherited: true });
+      expect(target.settings).toEqual({ own: true });
+      expect(Object.hasOwnProperty.call(target, 'settings')).toBe(true);
+    });
+
+    it('does not pollute Object.prototype through __proto__', () => {
+      const source: Record<string, unknown> = JSON.parse('{"__proto__":{"polluted":true}}');
+      const target: Record<string, unknown> = {};
+
+      mergeWith(target, source);
+
+      expect((Object.prototype as Record<string, unknown>).polluted).toBeUndefined();
+      expect(Object.hasOwnProperty.call(target, '__proto__')).toBe(true);
+      expect(target.__proto__).toEqual({ polluted: true });
+    });
   });
 
   describe('customizer behavior', () => {


### PR DESCRIPTION
## Summary

Fixes a prototype pollution vulnerability in `Objects.mergeWith()` when merging attacker-controlled objects, including values produced by `JSON.parse()`.

Previously, a source property named `__proto__` caused the merge to read the inherited `Object.prototype` value from the target and recursively merge into it. This could add attacker-controlled properties to every ordinary object in the process.

## Details

- Only considers own properties on the target when deciding whether to recursively merge. Inherited values are treated as absent rather than mutated.
- Assigns `__proto__` with `Object.defineProperty()` so it becomes an ordinary own data property instead of invoking the legacy prototype setter.
- Preserves the existing behavior for normal own properties, recursive object merges, customizers, arrays, primitives, and `null` values.
- Adds a patch change entry for `@rushstack/node-core-library`.

The change intentionally prevents merges from mutating objects reachable only through the target's prototype chain. This is the security boundary needed to prevent prototype pollution and should not affect normal merges of own properties.

## How it was tested

- Added a regression test using `JSON.parse('{"__proto__":{"polluted":true}}')` and verified that `Object.prototype` remains unchanged while the target receives a safe own `__proto__` property.
- Added coverage confirming inherited nested objects are not mutated and the source value is instead installed as an own target property.
- Ran `rush test --to @rushstack/node-core-library` successfully.