### PR TITLE
[api-extractor] Reduce package name lookup overhead

### DIFF
--- a/apps/api-extractor/src/analyzer/TypeScriptInternals.ts
+++ b/apps/api-extractor/src/analyzer/TypeScriptInternals.ts
@@ -14,6 +14,30 @@ export interface IGlobalVariableAnalyzer {
   hasGlobalName(name: string): boolean;
 }
 
+interface IProgramInternals {
+  forEachResolvedModule?(
+    callback: (
+      resolution: ts.ResolvedModuleWithFailedLookupLocations,
+      moduleName: string,
+      mode: ts.ResolutionMode,
+      filePath: ts.Path
+    ) => void,
+    file?: ts.SourceFile
+  ): void;
+
+  forEachResolvedTypeReferenceDirective?(
+    callback: (
+      resolution: ts.ResolvedTypeReferenceDirectiveWithFailedLookupLocations,
+      moduleName: string,
+      mode: ts.ResolutionMode,
+      filePath: ts.Path
+    ) => void,
+    file?: ts.SourceFile
+  ): void;
+
+  getAutomaticTypeDirectiveResolutions?(): ts.ModeAwareCache<ts.ResolvedTypeReferenceDirectiveWithFailedLookupLocations>;
+}
+
 export class TypeScriptInternals {
   public static getImmediateAliasedSymbol(symbol: ts.Symbol, typeChecker: ts.TypeChecker): ts.Symbol {
     // Compiler internal:
@@ -96,6 +120,57 @@ export class TypeScriptInternals {
       mode
     );
     return result?.resolvedModule;
+  }
+
+  /**
+   * Builds a mapping from SourceFiles to their package names using the compiler's cached module resolutions.
+   */
+  public static getPackageNamesBySourceFile(program: ts.Program): ReadonlyMap<ts.SourceFile, string> {
+    const packageNamesBySourceFile: Map<ts.SourceFile, string> = new Map<ts.SourceFile, string>();
+    const ambiguousSourceFiles: Set<ts.SourceFile> = new Set<ts.SourceFile>();
+
+    const collectPackageName = (
+      resolvedFileName: string | undefined,
+      packageId: ts.PackageId | undefined
+    ): void => {
+      if (!resolvedFileName || !packageId?.name) {
+        return;
+      }
+
+      const sourceFile: ts.SourceFile | undefined = program.getSourceFile(resolvedFileName);
+      if (!sourceFile || ambiguousSourceFiles.has(sourceFile)) {
+        return;
+      }
+
+      const existingPackageName: string | undefined = packageNamesBySourceFile.get(sourceFile);
+      if (existingPackageName === undefined) {
+        packageNamesBySourceFile.set(sourceFile, packageId.name);
+      } else if (existingPackageName !== packageId.name) {
+        packageNamesBySourceFile.delete(sourceFile);
+        ambiguousSourceFiles.add(sourceFile);
+      }
+    };
+
+    const programInternals: IProgramInternals = program as IProgramInternals;
+    programInternals.forEachResolvedModule?.(({ resolvedModule }) => {
+      collectPackageName(resolvedModule?.resolvedFileName, resolvedModule?.packageId);
+    });
+    programInternals.forEachResolvedTypeReferenceDirective?.(({ resolvedTypeReferenceDirective }) => {
+      collectPackageName(
+        resolvedTypeReferenceDirective?.resolvedFileName,
+        resolvedTypeReferenceDirective?.packageId
+      );
+    });
+    programInternals
+      .getAutomaticTypeDirectiveResolutions?.()
+      .forEach(({ resolvedTypeReferenceDirective }) => {
+        collectPackageName(
+          resolvedTypeReferenceDirective?.resolvedFileName,
+          resolvedTypeReferenceDirective?.packageId
+        );
+      });
+
+    return packageNamesBySourceFile;
   }
 
   /**

--- a/apps/api-extractor/src/api/test/Extractor-package-name.test.ts
+++ b/apps/api-extractor/src/api/test/Extractor-package-name.test.ts
@@ -1,0 +1,103 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import * as path from 'node:path';
+import type * as ts from 'typescript';
+
+import { PackageJsonLookup } from '@rushstack/node-core-library';
+
+import { TypeScriptInternals } from '../../analyzer/TypeScriptInternals';
+import { CompilerState } from '../CompilerState';
+import { Extractor, type ExtractorResult } from '../Extractor';
+import { ExtractorConfig } from '../ExtractorConfig';
+
+const testDataFolder: string = path.join(__dirname, 'test-data', 'package-name-resolution');
+
+describe('Extractor package name resolution', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it.each([
+    { description: 'disabled', configFileName: 'api-extractor.json' },
+    { description: 'enabled', configFileName: 'api-extractor-preserve-symlinks.json' }
+  ])('reuses cached package metadata when preserveSymlinks is $description', ({ configFileName }) => {
+    const extractorConfig: ExtractorConfig = ExtractorConfig.loadFileAndPrepare(
+      path.join(testDataFolder, configFileName)
+    );
+    const compilerState: CompilerState = CompilerState.create(extractorConfig);
+    const program: ts.Program = compilerState.program as ts.Program;
+    const packageNamesBySourceFile: ReadonlyMap<ts.SourceFile, string> =
+      TypeScriptInternals.getPackageNamesBySourceFile(program);
+
+    expect(
+      packageNamesBySourceFile.get(
+        _getSourceFile(program, ['@microsoft', 'tsdoc', 'lib-commonjs', 'beta', 'DeclarationReference.d.ts'])
+      )
+    ).toBe('@microsoft/tsdoc');
+    expect(packageNamesBySourceFile.get(_getSourceFile(program, ['@types', 'resolve', 'index.d.ts']))).toBe(
+      '@types/resolve'
+    );
+    expect(packageNamesBySourceFile.get(_getSourceFile(program, ['@types', 'semver', 'index.d.ts']))).toBe(
+      '@types/semver'
+    );
+
+    const packageJsonLookupSpy: jest.SpiedFunction<PackageJsonLookup['tryLoadNodePackageJsonFor']> =
+      jest.spyOn(PackageJsonLookup.prototype, 'tryLoadNodePackageJsonFor');
+
+    const extractorResult: ExtractorResult = Extractor.invoke(extractorConfig, {
+      compilerState,
+      localBuild: true
+    });
+
+    expect(extractorResult.succeeded).toBe(true);
+    expect(_getDeclarationReferenceLookupCalls(packageJsonLookupSpy)).toHaveLength(0);
+  });
+
+  it('falls back to package.json lookup when resolution metadata is unavailable', () => {
+    const extractorConfig: ExtractorConfig = ExtractorConfig.loadFileAndPrepare(
+      path.join(testDataFolder, 'api-extractor.json')
+    );
+    const compilerState: CompilerState = CompilerState.create(extractorConfig);
+    jest.spyOn(TypeScriptInternals, 'getPackageNamesBySourceFile').mockReturnValue(new Map());
+    const packageJsonLookupSpy: jest.SpiedFunction<PackageJsonLookup['tryLoadNodePackageJsonFor']> =
+      jest.spyOn(PackageJsonLookup.prototype, 'tryLoadNodePackageJsonFor');
+
+    const extractorResult: ExtractorResult = Extractor.invoke(extractorConfig, {
+      compilerState,
+      localBuild: true
+    });
+
+    expect(extractorResult.succeeded).toBe(true);
+    expect(_getDeclarationReferenceLookupCalls(packageJsonLookupSpy)).toHaveLength(1);
+  });
+});
+
+function _getSourceFile(program: ts.Program, pathSegments: string[]): ts.SourceFile {
+  const fileNameSuffix: string = path.join(...pathSegments);
+  const sourceFile: ts.SourceFile | undefined = program
+    .getSourceFiles()
+    .find(({ fileName }) => fileName.endsWith(fileNameSuffix));
+
+  if (!sourceFile) {
+    throw new Error(`Unable to find source file ending with: ${fileNameSuffix}`);
+  }
+
+  return sourceFile;
+}
+
+function _getDeclarationReferenceLookupCalls(
+  packageJsonLookupSpy: jest.SpiedFunction<PackageJsonLookup['tryLoadNodePackageJsonFor']>
+): unknown[][] {
+  const declarationReferencePathSuffix: string = path.join(
+    '@microsoft',
+    'tsdoc',
+    'lib-commonjs',
+    'beta',
+    'DeclarationReference.d.ts'
+  );
+
+  return packageJsonLookupSpy.mock.calls.filter(([filePath]) =>
+    filePath.endsWith(declarationReferencePathSuffix)
+  );
+}

--- a/apps/api-extractor/src/api/test/test-data/package-name-resolution/api-extractor-preserve-symlinks.json
+++ b/apps/api-extractor/src/api/test/test-data/package-name-resolution/api-extractor-preserve-symlinks.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
+
+  "extends": "./api-extractor.json",
+
+  "compiler": {
+    "tsconfigFilePath": "<projectFolder>/tsconfig-preserve-symlinks.json"
+  }
+}

--- a/apps/api-extractor/src/api/test/test-data/package-name-resolution/api-extractor.json
+++ b/apps/api-extractor/src/api/test/test-data/package-name-resolution/api-extractor.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
+
+  "mainEntryPointFilePath": "<projectFolder>/index.d.ts",
+
+  "apiReport": {
+    "enabled": false
+  },
+
+  "docModel": {
+    "enabled": false
+  },
+
+  "dtsRollup": {
+    "enabled": false
+  },
+
+  "tsdocMetadata": {
+    "enabled": false
+  },
+
+  "compiler": {
+    "tsconfigFilePath": "<projectFolder>/tsconfig.json"
+  }
+}

--- a/apps/api-extractor/src/api/test/test-data/package-name-resolution/index.d.ts
+++ b/apps/api-extractor/src/api/test/test-data/package-name-resolution/index.d.ts
@@ -1,0 +1,8 @@
+/// <reference types="resolve" />
+
+import type { DeclarationReference } from '@microsoft/tsdoc/lib-commonjs/beta/DeclarationReference';
+
+/** @public */
+export interface PackageNameResolution {
+  declarationReference: DeclarationReference;
+}

--- a/apps/api-extractor/src/api/test/test-data/package-name-resolution/package.json
+++ b/apps/api-extractor/src/api/test/test-data/package-name-resolution/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "package-name-resolution",
+  "version": "1.0.0"
+}

--- a/apps/api-extractor/src/api/test/test-data/package-name-resolution/tsconfig-preserve-symlinks.json
+++ b/apps/api-extractor/src/api/test/test-data/package-name-resolution/tsconfig-preserve-symlinks.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "http://json.schemastore.org/tsconfig",
+
+  "extends": "./tsconfig.json",
+
+  "compilerOptions": {
+    "preserveSymlinks": true
+  }
+}

--- a/apps/api-extractor/src/api/test/test-data/package-name-resolution/tsconfig.json
+++ b/apps/api-extractor/src/api/test/test-data/package-name-resolution/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json.schemastore.org/tsconfig",
+
+  "compilerOptions": {
+    "lib": ["es2020"],
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "preserveSymlinks": false,
+    "strict": true,
+    "types": ["semver"]
+  }
+}

--- a/apps/api-extractor/src/generators/DeclarationReferenceGenerator.ts
+++ b/apps/api-extractor/src/generators/DeclarationReferenceGenerator.ts
@@ -23,9 +23,11 @@ export class DeclarationReferenceGenerator {
   public static readonly unknownReference: string = '?';
 
   private _collector: Collector;
+  private readonly _packageNamesBySourceFile: ReadonlyMap<ts.SourceFile, string>;
 
   public constructor(collector: Collector) {
     this._collector = collector;
+    this._packageNamesBySourceFile = TypeScriptInternals.getPackageNamesBySourceFile(collector.program);
   }
 
   /**
@@ -265,6 +267,11 @@ export class DeclarationReferenceGenerator {
 
   private _getPackageName(sourceFile: ts.SourceFile): string {
     if (this._collector.program.isSourceFileFromExternalLibrary(sourceFile)) {
+      const resolvedPackageName: string | undefined = this._packageNamesBySourceFile.get(sourceFile);
+      if (resolvedPackageName) {
+        return resolvedPackageName;
+      }
+
       const packageJson: INodePackageJson | undefined =
         this._collector.packageJsonLookup.tryLoadNodePackageJsonFor(sourceFile.fileName);
 

--- a/common/changes/@microsoft/api-extractor/perf-api-extractor-package-name-lookup_2026-08-31-01-54-33.json
+++ b/common/changes/@microsoft/api-extractor/perf-api-extractor-package-name-lookup_2026-08-31-01-54-33.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "Improve API Extractor performance by reusing TypeScript package resolution metadata when identifying external package names",
+      "type": "patch",
+      "packageName": "@microsoft/api-extractor"
+    }
+  ],
+  "packageName": "@microsoft/api-extractor",
+  "email": "322952417+gwosti@users.noreply.github.com"
+}


### PR DESCRIPTION
## Summary
- Reduce external package-name lookup filesystem work by reusing TypeScript's cached module and type-reference resolutions. This complements #5891 without depending on it.
- Preserve existing package-name behavior with a package.json fallback and regression coverage for deep imports, `@types`, and symlinks.

## Benchmarks
`node ../api-extractor/bin/api-extractor run --local; for i in 1 2 3 4 5; do strace -qq -f -e trace=statx -o /tmp/ae-$i.strace node ../api-extractor/bin/api-extractor run --local; awk '/AT_SYMLINK_NOFOLLOW/{n++} END{print n+0}' /tmp/ae-$i.strace; done` from `apps/rush-mcp-server` on Node 22.18.0, median of 5 runs after 1 warmup.

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| `AT_SYMLINK_NOFOLLOW` calls | 1,183 | 1,059 | -124 (-10.48%) |

## Validation
- `(cd apps/api-extractor && ./node_modules/.bin/heft test --clean --test-path-pattern Extractor-package-name)`
- `node common/scripts/install-run-rush.js test --to @microsoft/api-extractor --production`
- `node common/scripts/install-run-rush.js test -t tag:api-extractor-tests --production`
