### PR TITLE
Prepare Rush for a minor release

### DIFF
--- a/common/config/rush/version-policies.json
+++ b/common/config/rush/version-policies.json
@@ -103,7 +103,7 @@
     "policyName": "rush",
     "definitionName": "lockStepVersion",
     "version": "5.178.1",
-    "nextBump": "patch",
+    "nextBump": "minor",
     "mainProject": "@microsoft/rush"
   }
 ]


### PR DESCRIPTION
## Summary

Set the Rush lockstep version policy's `nextBump` from `patch` to `minor` so the next release includes the pending minor changes.

## Validation

- `rush check`
- `git diff --check`