### PR TITLE
[rush] Use Azure Pipelines app for version bump PRs

### DIFF
--- a/common/config/azure-pipelines/npm-publish-rush.yaml
+++ b/common/config/azure-pipelines/npm-publish-rush.yaml
@@ -40,6 +40,10 @@ extends:
   parameters:
     settings:
       networkIsolationPolicy: CFSClean,CFSClean2,CFSClean3,DefaultDeny
+    sdl:
+      sourceRepositoriesToScan:
+        include:
+          - repository: rushstackGitHubApp
     pool:
       name: Azure-Pipelines-1ESPT-ExDShared
       os: windows

--- a/common/config/azure-pipelines/npm-publish-rush.yaml
+++ b/common/config/azure-pipelines/npm-publish-rush.yaml
@@ -29,6 +29,11 @@ resources:
       type: git
       name: 1ESPipelineTemplates/1ESPipelineTemplates
       ref: refs/tags/release
+    - repository: rushstackGitHubApp
+      type: github
+      name: microsoft/rushstack
+      endpoint: GitHubProjects
+      ref: refs/heads/main
 
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
@@ -44,6 +49,7 @@ extends:
           VersionPolicyName: rush
           StageName: BumpRushVersions
           StageDisplayName: 'Bump Rush Versions and Create PR'
+          CheckoutRepository: rushstackGitHubApp
           FeatureBranch: 'automated/bump-versions-rush'
           PrTitle: 'Bump Rush package versions'
           PrDescription: |

--- a/common/config/azure-pipelines/npm-publish.yaml
+++ b/common/config/azure-pipelines/npm-publish.yaml
@@ -40,6 +40,10 @@ extends:
   parameters:
     settings:
       networkIsolationPolicy: CFSClean,CFSClean2,CFSClean3,DefaultDeny
+    sdl:
+      sourceRepositoriesToScan:
+        include:
+          - repository: rushstackGitHubApp
     pool:
       name: Azure-Pipelines-1ESPT-ExDShared
       os: windows

--- a/common/config/azure-pipelines/npm-publish.yaml
+++ b/common/config/azure-pipelines/npm-publish.yaml
@@ -29,6 +29,11 @@ resources:
       type: git
       name: 1ESPipelineTemplates/1ESPipelineTemplates
       ref: refs/tags/release
+    - repository: rushstackGitHubApp
+      type: github
+      name: microsoft/rushstack
+      endpoint: GitHubProjects
+      ref: refs/heads/main
 
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
@@ -44,6 +49,7 @@ extends:
           VersionPolicyName: noRush
           StageName: BumpRushstackVersions
           StageDisplayName: 'Bump Rushstack Versions and Create PR'
+          CheckoutRepository: rushstackGitHubApp
           FeatureBranch: 'automated/bump-versions-rushstack'
           PrTitle: 'Bump Rushstack package versions'
           PrDescription: |

--- a/common/config/azure-pipelines/templates/bump-versions-stages.yaml
+++ b/common/config/azure-pipelines/templates/bump-versions-stages.yaml
@@ -53,10 +53,7 @@ stages:
               targetPath: $(Build.ArtifactStagingDirectory)/package-versions
               artifactName: package-versions
         steps:
-          # Keep the repository at the traditional single-checkout location so existing scripts and
-          # $(Build.SourcesDirectory) continue to resolve to the Rush Stack repository root.
           - checkout: ${{ parameters.CheckoutRepository }}
-            path: s
             persistCredentials: true
 
           - template: /common/config/azure-pipelines/templates/configure-git-user.yaml@self

--- a/common/config/azure-pipelines/templates/bump-versions-stages.yaml
+++ b/common/config/azure-pipelines/templates/bump-versions-stages.yaml
@@ -102,6 +102,14 @@ stages:
               DisplayName: 'Generate change files'
               Condition: "and(succeeded(), eq(variables.HasChanges, 'true'))"
 
+          - template: /common/config/azure-pipelines/templates/install-run-rush.yaml@self
+            parameters:
+              Arguments: >
+                change
+                --verify
+              DisplayName: 'Verify generated change files'
+              Condition: "and(succeeded(), eq(variables.HasChanges, 'true'))"
+
           - script: 'node libraries/rush-lib/scripts/plugins-prepublish.js'
             displayName: 'Prepublish workaround for rush-lib'
 

--- a/common/config/azure-pipelines/templates/bump-versions-stages.yaml
+++ b/common/config/azure-pipelines/templates/bump-versions-stages.yaml
@@ -12,6 +12,9 @@ parameters:
     type: string
   - name: StageDisplayName
     type: string
+  - name: CheckoutRepository
+    type: string
+    default: self
   - name: FeatureBranch
     type: string
   - name: PrTitle
@@ -50,12 +53,19 @@ stages:
               targetPath: $(Build.ArtifactStagingDirectory)/package-versions
               artifactName: package-versions
         steps:
-          - checkout: self
+          # Keep the repository at the traditional single-checkout location so existing scripts and
+          # $(Build.SourcesDirectory) continue to resolve to the Rush Stack repository root.
+          - checkout: ${{ parameters.CheckoutRepository }}
+            path: s
             persistCredentials: true
 
           - template: /common/config/azure-pipelines/templates/configure-git-user.yaml@self
 
           - bash: |
+              # Repository resources resolve independently from the self trigger. Restore the exact
+              # commit that selected this pipeline YAML before creating the automated branch.
+              git fetch --no-tags origin "$(Build.SourceVersion)"
+              git checkout --detach "$(Build.SourceVersion)"
               git checkout -b ${{ parameters.FeatureBranch }}
               echo "Created feature branch: ${{ parameters.FeatureBranch }}"
             displayName: 'Create Feature Branch'

--- a/common/config/azure-pipelines/templates/bump-versions-stages.yaml
+++ b/common/config/azure-pipelines/templates/bump-versions-stages.yaml
@@ -92,24 +92,6 @@ stages:
               fi
             displayName: 'Commit Version Bumps'
 
-          - template: /common/config/azure-pipelines/templates/install-run-rush.yaml@self
-            parameters:
-              Arguments: >
-                change
-                --bulk
-                --bump-type none
-                --commit-message "chore: generate change files for version bump"
-              DisplayName: 'Generate change files'
-              Condition: "and(succeeded(), eq(variables.HasChanges, 'true'))"
-
-          - template: /common/config/azure-pipelines/templates/install-run-rush.yaml@self
-            parameters:
-              Arguments: >
-                change
-                --verify
-              DisplayName: 'Verify generated change files'
-              Condition: "and(succeeded(), eq(variables.HasChanges, 'true'))"
-
           - script: 'node libraries/rush-lib/scripts/plugins-prepublish.js'
             displayName: 'Prepublish workaround for rush-lib'
 

--- a/common/config/azure-pipelines/templates/bump-versions-stages.yaml
+++ b/common/config/azure-pipelines/templates/bump-versions-stages.yaml
@@ -92,6 +92,16 @@ stages:
               fi
             displayName: 'Commit Version Bumps'
 
+          - template: /common/config/azure-pipelines/templates/install-run-rush.yaml@self
+            parameters:
+              Arguments: >
+                change
+                --bulk
+                --bump-type none
+                --commit-message "chore: generate change files for version bump"
+              DisplayName: 'Generate change files'
+              Condition: "and(succeeded(), eq(variables.HasChanges, 'true'))"
+
           - script: 'node libraries/rush-lib/scripts/plugins-prepublish.js'
             displayName: 'Prepublish workaround for rush-lib'
 


### PR DESCRIPTION
## Summary

Create the Rush and Rush Stack version-bump PRs using the `azure-pipelines[bot]` GitHub App identity instead of the Rushbot user, and keep the generated bump branches compatible with the current published Rush release.

## Details

Both bump pipelines now check out `microsoft/rushstack` through the existing `GitHubProjects` GitHub service connection. The shared stage explicitly restores `$(Build.SourceVersion)` before creating the bump branch, so triggers and build-SHA tagging retain their existing semantics. The persisted checkout credential is then reused for the force-push and GitHub PR API calls.

After committing the version bump, the pipeline temporarily runs `rush change --bulk --bump-type none` and commits the generated change files, then runs `rush change --verify` before packing or pushing. This handles dependency and peer-dependency range edits generated by `rush version --bump`, which the current published Rush exemption does not yet recognize and which caused the automated PR failures in #6009 and #6010.

The underlying Rush fix is tracked by #6012. This compatibility step remains necessary until that fix is merged, published, and selected by this repository.

## How it was tested

- Parsed the changed YAML files and checked them with Prettier.
- Confirmed the `GitHubProjects` service connection uses the `InstallationToken` authentication scheme.
- Compiled Azure Pipelines definitions 10 and 12 through the server-side preview API.