### PR TITLE
Fix split package publishing flows

### DIFF
--- a/common/config/azure-pipelines/esrp-publish-rush.yaml
+++ b/common/config/azure-pipelines/esrp-publish-rush.yaml
@@ -30,6 +30,10 @@ parameters:
     displayName: 'Commit SHA Override (for testing)'
     type: string
     default: $(Build.SourceVersion)
+  - name: BumpPipelineRunIdOverride
+    displayName: 'Bump pipeline run ID override (for recovery)'
+    type: number
+    default: 0
 
 variables:
   - name: FORCE_COLOR
@@ -68,3 +72,4 @@ extends:
           NpmTag: ${{ parameters.NpmTag }}
           DryRun: ${{ parameters.DryRun }}
           CommitShaOverride: ${{ parameters.CommitShaOverride }}
+          BumpPipelineRunIdOverride: ${{ parameters.BumpPipelineRunIdOverride }}

--- a/common/config/azure-pipelines/esrp-publish-rushstack.yaml
+++ b/common/config/azure-pipelines/esrp-publish-rushstack.yaml
@@ -30,6 +30,10 @@ parameters:
     displayName: 'Commit SHA Override (for testing)'
     type: string
     default: $(Build.SourceVersion)
+  - name: BumpPipelineRunIdOverride
+    displayName: 'Bump pipeline run ID override (for recovery)'
+    type: number
+    default: 0
 
 variables:
   - name: FORCE_COLOR
@@ -68,3 +72,4 @@ extends:
           NpmTag: ${{ parameters.NpmTag }}
           DryRun: ${{ parameters.DryRun }}
           CommitShaOverride: ${{ parameters.CommitShaOverride }}
+          BumpPipelineRunIdOverride: ${{ parameters.BumpPipelineRunIdOverride }}

--- a/common/config/azure-pipelines/templates/bump-versions-stages.yaml
+++ b/common/config/azure-pipelines/templates/bump-versions-stages.yaml
@@ -71,9 +71,24 @@ stages:
 
           - template: /common/config/azure-pipelines/templates/build.yaml@self
 
+          # "noRush" is a pipeline cohort, not a Rush version policy. The old publishing flow
+          # achieved the separation by processing non-Rush changes before the Rush lockstep bump.
+          # Preserve that behavior while the two cohorts run in independent pipelines.
+          - script: >
+              node common/scripts/publish-cohort.js partition-changes
+              --cohort ${{ parameters.VersionPolicyName }}
+              --backup-path $(Agent.TempDirectory)/excluded-publish-changes
+            displayName: 'Select ${{ parameters.VersionPolicyName }} change files'
+
           - template: /common/config/azure-pipelines/templates/bump-versions.yaml@self
             parameters:
               VersionPolicyName: ${{ parameters.VersionPolicyName }}
+
+          - script: >
+              node common/scripts/publish-cohort.js restore-changes
+              --backup-path $(Agent.TempDirectory)/excluded-publish-changes
+            displayName: 'Restore other publishing cohort change files'
+            condition: succeededOrFailed()
 
           - bash: |
               git add -u -- common/changes
@@ -116,6 +131,13 @@ stages:
           - template: /common/config/azure-pipelines/templates/pack.yaml@self
             parameters:
               VersionPolicyName: ${{ parameters.VersionPolicyName }}
+
+          - bash: |
+              if [ "$(HasChanges)" = "true" ] && [ "$(HasPackages)" != "true" ]; then
+                echo "##[error]Version bump produced no unpublished package tarballs."
+                exit 1
+              fi
+            displayName: 'Verify package artifact'
 
           - template: /common/config/azure-pipelines/templates/post-publish.yaml@self
 

--- a/common/config/azure-pipelines/templates/esrp-publish-stages.yaml
+++ b/common/config/azure-pipelines/templates/esrp-publish-stages.yaml
@@ -24,6 +24,10 @@ parameters:
     type: boolean
   - name: CommitShaOverride
     type: string
+  # Allows a packaging run to be replayed when a previous release artifact was incomplete.
+  - name: BumpPipelineRunIdOverride
+    type: number
+    default: 0
 
 stages:
   - stage: Prepare${{ parameters.StageNameSuffix }}
@@ -60,13 +64,23 @@ stages:
             displayName: 'Initialize artifact staging directories'
             condition: always()
 
-          - template: /common/config/azure-pipelines/templates/find-bump-pipeline-run.yaml@self
-            parameters:
-              PipelineId: ${{ parameters.BumpPipelineId }}
-              CommitSha: ${{ coalesce(parameters.CommitShaOverride, '$(Build.SourceVersion)') }}
-              TeamProject: ${{ parameters.BumpPipelineProject }}
-              Name: FindBumpRun
-              WorkingDirectory: $(Build.SourcesDirectory)
+          - ${{ if gt(parameters.BumpPipelineRunIdOverride, 0) }}:
+              - bash: |
+                  echo "Using bump pipeline run override ${{ parameters.BumpPipelineRunIdOverride }}"
+                  echo "##vso[task.setvariable variable=IsVersionBumpMerge;isOutput=true]true"
+                  echo "##vso[task.setvariable variable=BumpPipelineDefinitionId;isOutput=true]${{ parameters.BumpPipelineId }}"
+                  echo "##vso[task.setvariable variable=BumpPipelineRunId;isOutput=true]${{ parameters.BumpPipelineRunIdOverride }}"
+                name: FindBumpRun
+                displayName: 'Use Bump Pipeline Run Override'
+
+          - ${{ else }}:
+              - template: /common/config/azure-pipelines/templates/find-bump-pipeline-run.yaml@self
+                parameters:
+                  PipelineId: ${{ parameters.BumpPipelineId }}
+                  CommitSha: ${{ coalesce(parameters.CommitShaOverride, '$(Build.SourceVersion)') }}
+                  TeamProject: ${{ parameters.BumpPipelineProject }}
+                  Name: FindBumpRun
+                  WorkingDirectory: $(Build.SourcesDirectory)
 
           - task: DownloadPipelineArtifact@2
             condition: eq(variables['FindBumpRun.IsVersionBumpMerge'], 'true')

--- a/common/config/azure-pipelines/templates/pack.yaml
+++ b/common/config/azure-pipelines/templates/pack.yaml
@@ -1,5 +1,4 @@
 parameters:
-  # Only the packages belonging to this version policy are packed.
   - name: VersionPolicyName
     type: string
 
@@ -9,13 +8,31 @@ steps:
       Arguments: '--help'
       DisplayName: 'Install Rush'
 
-  - template: /common/config/azure-pipelines/templates/install-run-rush.yaml@self
-    parameters:
-      Arguments: >
-        publish
-        --publish
-        --pack
-        --include-all
-        --version-policy ${{ parameters.VersionPolicyName }}
-        --release-folder $(Build.ArtifactStagingDirectory)/packages
-      DisplayName: 'Rush Pack (Policy: ${{ parameters.VersionPolicyName }})'
+  - ${{ if eq(parameters.VersionPolicyName, 'noRush') }}:
+      - template: /common/config/azure-pipelines/templates/install-run-rush.yaml@self
+        parameters:
+          Arguments: >
+            publish
+            --publish
+            --pack
+            --include-all
+            --release-folder $(Build.ArtifactStagingDirectory)/packages
+          DisplayName: 'Rush Pack (Policy: ${{ parameters.VersionPolicyName }})'
+
+  - ${{ else }}:
+      - template: /common/config/azure-pipelines/templates/install-run-rush.yaml@self
+        parameters:
+          Arguments: >
+            publish
+            --publish
+            --pack
+            --include-all
+            --version-policy ${{ parameters.VersionPolicyName }}
+            --release-folder $(Build.ArtifactStagingDirectory)/packages
+          DisplayName: 'Rush Pack (Policy: ${{ parameters.VersionPolicyName }})'
+
+  - script: >
+      node common/scripts/publish-cohort.js filter-packages
+      --cohort ${{ parameters.VersionPolicyName }}
+      --packages-path $(Build.ArtifactStagingDirectory)/packages
+    displayName: 'Filter unpublished ${{ parameters.VersionPolicyName }} packages'

--- a/common/config/rush/.npmrc
+++ b/common/config/rush/.npmrc
@@ -1,1 +1,2 @@
 omit-lockfile-registry-resolved=true
+registry=https://packagefeedproxy.microsoft.io/npm/

--- a/common/scripts/publish-cohort.js
+++ b/common/scripts/publish-cohort.js
@@ -4,8 +4,6 @@ const childProcess = require('node:child_process');
 const fs = require('node:fs');
 const path = require('node:path');
 
-const PUBLISH_REGISTRY_URL = 'https://packagefeedproxy.microsoft.io/npm/';
-
 function parseArguments() {
   const [command, ...args] = process.argv.slice(2);
   const options = new Map();
@@ -190,11 +188,6 @@ function filterPackages(repoPath, packagesPath, cohort) {
     throw new Error('Unable to determine the publish registry from .npmrc-publish.');
   }
   const registryUrl = registryMatch[1].trim();
-  if (registryUrl !== PUBLISH_REGISTRY_URL) {
-    throw new Error(
-      `Publishing must use the feed proxy registry ${PUBLISH_REGISTRY_URL}; found ${registryUrl}.`
-    );
-  }
   let retainedPackageCount = 0;
 
   for (const tarballPath of getFilesRecursively(packagesPath, '.tgz')) {

--- a/common/scripts/publish-cohort.js
+++ b/common/scripts/publish-cohort.js
@@ -1,0 +1,253 @@
+#!/usr/bin/env node
+
+const childProcess = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const PUBLISH_REGISTRY_URL = 'https://packagefeedproxy.microsoft.io/npm/';
+
+function parseArguments() {
+  const [command, ...args] = process.argv.slice(2);
+  const options = new Map();
+
+  for (let index = 0; index < args.length; index += 2) {
+    const name = args[index];
+    const value = args[index + 1];
+    if (!name?.startsWith('--') || value === undefined) {
+      throw new Error(`Invalid argument: ${name || '<missing>'}`);
+    }
+    options.set(name.slice(2), value);
+  }
+
+  return { command, options };
+}
+
+function getRequiredOption(options, name) {
+  const value = options.get(name);
+  if (!value) {
+    throw new Error(`Missing required option: --${name}`);
+  }
+  return value;
+}
+
+function loadProjects(repoPath) {
+  const result = childProcess.spawnSync(
+    process.execPath,
+    [path.join(repoPath, 'common/scripts/install-run-rush.js'), 'list', '--json'],
+    {
+      cwd: repoPath,
+      encoding: 'utf8',
+      env: process.env
+    }
+  );
+
+  if (result.status !== 0) {
+    process.stderr.write(result.stdout);
+    process.stderr.write(result.stderr);
+    throw new Error('Unable to read the Rush project list.');
+  }
+
+  const jsonStart = result.stdout.indexOf('{');
+  if (jsonStart < 0) {
+    throw new Error('Rush list did not produce JSON output.');
+  }
+
+  const projectList = JSON.parse(result.stdout.slice(jsonStart));
+  return new Map(projectList.projects.map((project) => [project.name, project]));
+}
+
+function isProjectInCohort(project, cohort) {
+  if (cohort === 'rush') {
+    return project.versionPolicyName === 'rush';
+  }
+  if (cohort === 'noRush') {
+    return !project.versionPolicyName;
+  }
+  throw new Error(`Unsupported publishing cohort: ${cohort}`);
+}
+
+function getFilesRecursively(folderPath, extension) {
+  if (!fs.existsSync(folderPath)) {
+    return [];
+  }
+
+  const result = [];
+  for (const entry of fs.readdirSync(folderPath, { withFileTypes: true })) {
+    const entryPath = path.join(folderPath, entry.name);
+    if (entry.isDirectory()) {
+      result.push(...getFilesRecursively(entryPath, extension));
+    } else if (!extension || entry.name.endsWith(extension)) {
+      result.push(entryPath);
+    }
+  }
+  return result;
+}
+
+function writeJson(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(value, undefined, 2)}\n`);
+}
+
+function partitionChanges(repoPath, backupPath, cohort) {
+  const projects = loadProjects(repoPath);
+  const changesPath = path.join(repoPath, 'common/changes');
+
+  fs.rmSync(backupPath, { recursive: true, force: true });
+
+  for (const changeFilePath of getFilesRecursively(changesPath, '.json')) {
+    const changeFileText = fs.readFileSync(changeFilePath, 'utf8');
+    const changeFile = JSON.parse(changeFileText);
+    const includedChanges = [];
+    const excludedChanges = [];
+
+    for (const change of changeFile.changes) {
+      const project = projects.get(change.packageName);
+      if (!project) {
+        throw new Error(`${changeFilePath} references unknown project ${change.packageName}.`);
+      }
+
+      (isProjectInCohort(project, cohort) ? includedChanges : excludedChanges).push(change);
+    }
+
+    const relativePath = path.relative(changesPath, changeFilePath);
+    if (excludedChanges.length > 0) {
+      const backupFilePath = path.join(backupPath, relativePath);
+      if (includedChanges.length === 0) {
+        fs.mkdirSync(path.dirname(backupFilePath), { recursive: true });
+        fs.writeFileSync(backupFilePath, changeFileText);
+      } else {
+        writeJson(backupFilePath, { ...changeFile, changes: excludedChanges });
+      }
+    }
+
+    if (includedChanges.length > 0) {
+      writeJson(changeFilePath, { ...changeFile, changes: includedChanges });
+    } else {
+      fs.rmSync(changeFilePath);
+    }
+  }
+}
+
+function restoreChanges(repoPath, backupPath) {
+  const changesPath = path.join(repoPath, 'common/changes');
+
+  for (const backupFilePath of getFilesRecursively(backupPath, '.json')) {
+    const relativePath = path.relative(backupPath, backupFilePath);
+    const changeFilePath = path.join(changesPath, relativePath);
+    const backupChangeFile = JSON.parse(fs.readFileSync(backupFilePath, 'utf8'));
+
+    if (fs.existsSync(changeFilePath)) {
+      const currentChangeFile = JSON.parse(fs.readFileSync(changeFilePath, 'utf8'));
+      writeJson(changeFilePath, {
+        ...backupChangeFile,
+        changes: [...currentChangeFile.changes, ...backupChangeFile.changes]
+      });
+    } else {
+      writeJson(changeFilePath, backupChangeFile);
+    }
+  }
+}
+
+function readPackageJsonFromTarball(tarballPath) {
+  const result = childProcess.spawnSync('tar', ['-xOf', tarballPath, 'package/package.json'], {
+    encoding: 'utf8'
+  });
+  if (result.status !== 0) {
+    process.stderr.write(result.stderr);
+    throw new Error(`Unable to read package.json from ${tarballPath}.`);
+  }
+  return JSON.parse(result.stdout);
+}
+
+function packageIsPublished(packageName, version, repoPath, registryUrl) {
+  const result = childProcess.spawnSync(
+    'npm',
+    ['view', `${packageName}@${version}`, 'version', '--json', '--registry', registryUrl],
+    {
+      cwd: repoPath,
+      encoding: 'utf8',
+      env: process.env
+    }
+  );
+
+  if (result.status === 0) {
+    return true;
+  }
+  if (result.stderr.includes('E404')) {
+    return false;
+  }
+
+  process.stderr.write(result.stdout);
+  process.stderr.write(result.stderr);
+  throw new Error(`Unable to determine whether ${packageName}@${version} is published.`);
+}
+
+function filterPackages(repoPath, packagesPath, cohort) {
+  const projects = loadProjects(repoPath);
+  const npmrcPublish = fs.readFileSync(path.join(repoPath, 'common/config/rush/.npmrc-publish'), 'utf8');
+  const registryMatch = npmrcPublish.match(/^registry=(.+)$/m);
+  if (!registryMatch) {
+    throw new Error('Unable to determine the publish registry from .npmrc-publish.');
+  }
+  const registryUrl = registryMatch[1].trim();
+  if (registryUrl !== PUBLISH_REGISTRY_URL) {
+    throw new Error(
+      `Publishing must use the feed proxy registry ${PUBLISH_REGISTRY_URL}; found ${registryUrl}.`
+    );
+  }
+  let retainedPackageCount = 0;
+
+  for (const tarballPath of getFilesRecursively(packagesPath, '.tgz')) {
+    const packageJson = readPackageJsonFromTarball(tarballPath);
+    const project = projects.get(packageJson.name);
+    if (!project) {
+      throw new Error(`${tarballPath} contains unknown project ${packageJson.name}.`);
+    }
+
+    const retainPackage =
+      isProjectInCohort(project, cohort) &&
+      project.shouldPublish &&
+      !packageIsPublished(packageJson.name, packageJson.version, repoPath, registryUrl);
+
+    if (retainPackage) {
+      retainedPackageCount++;
+      console.log(`Retaining ${packageJson.name}@${packageJson.version}`);
+    } else {
+      fs.rmSync(tarballPath);
+    }
+  }
+
+  console.log(`Retained ${retainedPackageCount} unpublished ${cohort} package(s).`);
+  console.log(
+    `##vso[task.setvariable variable=HasPackages]${retainedPackageCount > 0 ? 'true' : 'false'}`
+  );
+}
+
+function main() {
+  const { command, options } = parseArguments();
+  const repoPath = path.resolve(options.get('repo-path') || process.cwd());
+
+  switch (command) {
+    case 'partition-changes':
+      partitionChanges(
+        repoPath,
+        path.resolve(getRequiredOption(options, 'backup-path')),
+        getRequiredOption(options, 'cohort')
+      );
+      break;
+    case 'restore-changes':
+      restoreChanges(repoPath, path.resolve(getRequiredOption(options, 'backup-path')));
+      break;
+    case 'filter-packages':
+      filterPackages(
+        repoPath,
+        path.resolve(getRequiredOption(options, 'packages-path')),
+        getRequiredOption(options, 'cohort')
+      );
+      break;
+    default:
+      throw new Error(`Unsupported command: ${command || '<missing>'}`);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary

Restore the publishing behavior that was lost when the Rush and non-Rush flows were split.

- Partition change files so each bump pipeline consumes only its own cohort
- Pack non-Rush packages using the former broad-pack behavior, then retain only unpublished non-Rush tarballs
- Read the registry from `common/config/rush/.npmrc-publish`
- Fail version-bump runs that produce changes without package tarballs
- Allow ESRP recovery publishing from a specific bump pipeline run ID
- Configure repository npm operations to use the approved feed proxy

## Root cause

`noRush` is a pipeline cohort label, not a real Rush version policy. Passing it to `rush publish --version-policy` produced an empty package artifact. Separately, `rush version --bump --version-policy rush` still applied individual package changes, so both split bump pipelines changed the same packages.

This left `@rushstack/node-core-library@5.24.1` merged without a publishable non-Rush artifact.

## Recovery

Once this PR is available to the pipeline, queue the non-Rush bump pipeline from this branch. Its artifact will retain unpublished `@rushstack/node-core-library@5.24.1`. Then queue the non-Rush ESRP pipeline with `BumpPipelineRunIdOverride` set to that bump run ID.